### PR TITLE
python API: Work with LDAP-connected harbor

### DIFF
--- a/contrib/sdk/harbor-py/README.md
+++ b/contrib/sdk/harbor-py/README.md
@@ -16,6 +16,8 @@ The supported APIs are:
   - [ ] Get project member
   - [ ] Get project and user member
 - [x] Users APIs
+  - [x] Logging in
+  - [x] Logging out
   - [x] [Get users](./examples/get_users.py)
   - [x] [Create user](./examples/create_user.py)
   - [x] [Update user profile](./examples/update_user_profile.py)
@@ -32,6 +34,8 @@ The supported APIs are:
   - [x] [Get statistics](./examples/get_statistics.py)
   - [x] [Get top accessed repositories](./examples/get_top_accessed_repositories.py)
   - [x] [Get logs](./examples/get_logs.py)
+
+Note: _User APIs_ will not work if harbor is connected to an LDAP server.
 
 ## Installation
 

--- a/contrib/sdk/harbor-py/harborclient/harborclient.py
+++ b/contrib/sdk/harbor-py/harborclient/harborclient.py
@@ -7,6 +7,17 @@ import requests
 logger = logging.getLogger(__name__)
 
 class HarborClient(object):
+    '''
+    This is a fairly lightweight python wrapper around the harbor RESTful
+    interface.
+
+    Note that not all APIs are available in all configurations. For instance,
+    most user-related APIs, including /login and /logout, are only available
+    in stand-alone mode (when not connected to an LDAP server).
+
+    See src/ui/router.go for the full API list.
+    '''
+
     def __init__(self, host, user, password, protocol="http"):
         self.host = host
         self.user = user

--- a/contrib/sdk/harbor-py/harborclient/harborclient.py
+++ b/contrib/sdk/harbor-py/harborclient/harborclient.py
@@ -12,9 +12,11 @@ class HarborClient(object):
         self.user = user
         self.password = password
         self.protocol = protocol
+        self.session_id = None
 
     def __del__(self):
-        self.logout()
+        if self.session_id:
+            self.logout()
 
     def login(self):
         login_data = requests.post('%s://%s/login' %(self.protocol, self.host),


### PR DESCRIPTION
The code currently assumes that every instance of HarborClient will call login() before being destroyed. But login() is only needed for non-LDAP-connected harbor instances, and even then not for all APIs.

This updates the code to work with an LDAP-connected harbor instance and updates the README.md file and HarborClient class doc to clarify that.