### PR TITLE
Fix Permission Denied

### DIFF
--- a/make/photon/mariadb/Dockerfile
+++ b/make/photon/mariadb/Dockerfile
@@ -14,7 +14,7 @@ RUN tdnf distro-sync -y \
     && tdnf clean all
 
 COPY docker-entrypoint.sh /usr/local/bin/
-RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+RUN chmod 555 /usr/local/bin/docker-entrypoint.sh
 COPY my.cnf /etc/
 RUN ln -s usr/local/bin/docker-entrypoint.sh /
 

--- a/make/photon/ui/Dockerfile
+++ b/make/photon/ui/Dockerfile
@@ -11,6 +11,7 @@ HEALTHCHECK CMD curl -s -o /dev/null -w "%{http_code}" 127.0.0.1:8080/api/system
 COPY ./make/dev/ui/harbor_ui ./src/favicon.ico ./make/photon/ui/start.sh ./VERSION /harbor/
 COPY ./src/ui/views /harbor/views
 COPY ./src/ui/static /harbor/static
+RUN chmod a+r -R /harbor
 
 RUN chmod u+x /harbor/start.sh /harbor/harbor_ui
 WORKDIR /harbor/


### PR DESCRIPTION
When executing the command:
```bash
docker run vmware/harbor-db:dev
```
With `chmod +x` I get this error:
(Using set -x to debug the script)
```bash
+ exec sudo -u mysql -E /usr/local/bin/docker-entrypoint.sh mysqld
/bin/bash: /usr/local/bin/docker-entrypoint.sh: Permission denied
```
This was fixed giving also permission to read `chmod 555`