### PR TITLE
edit Harbor license info so that GitHub recognizes it

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,12 +1,4 @@
-﻿LICENSE
-
-Harbor 
-
-Copyright (c) 2016-2018 VMware, Inc.  All rights reserved.
-
-This product is licensed to you under the Apache License version 2.0 (the “License”).  
-You may not use this product except in compliance with the License.
-
+﻿
                            Apache License
                      Version 2.0, January 2004
                   http://www.apache.org/licenses/
@@ -195,7 +187,7 @@ file or class name and description of purpose be included on the
 same "printed page" as the copyright notice for easier
 identification within third-party archives.
 
-Copyright [yyyy] [name of copyright owner]
+Copyright VMware, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ We welcome contributions from the community. If you wish to contribute code and 
 * ![play](docs/img/video.png) **Image Replication** ( [youtube](https://www.youtube.com/watch?v=1NPlzrm5ozE) , [Tencent Video](https://v.qq.com/x/page/a0553wc7fs9.html) )
 * ![play](docs/img/video.png) **VMworld 2017** ( [youtube](https://www.youtube.com/watch?v=tI5xMe24fJ4) )
 
-### License
+### Licensing
 Harbor is available under the [Apache 2 license](LICENSE).
 
 This project uses open source components which have additional licensing terms.  The official docker images and licensing terms for these open source components can be found at the following locations:


### PR DESCRIPTION
Hello! 👋

(CCing @dankohn who has requested this work so that the license will appear correctly in https://landscape.cncf.io/selected=harbor)

GitHub uses a library called Licensee to identify a project's license
type. It shows this information in the status bar and via the API if it
can unambiguously identify the license.

This commit updates the LICENSE file so that it contains the exact text
of the Apache 2.0 license. It also updates the README file header to
"Licensing" (from "License"), which allows Licensee to ignore the
README when checking for the repository's license type.

Collectively, these changes allow Licensee to successfully identify
the license type of Harbor's codebase as Apache 2.0.