### PR TITLE
add a environment variable to migrating container to allow upgrades on remote mysql database

### DIFF
--- a/tools/migration/Dockerfile
+++ b/tools/migration/Dockerfile
@@ -1,7 +1,7 @@
 FROM vmware/mariadb-photon:10.2.8
 
-RUN tdnf distro-sync -y \
-    && tdnf install -y mariadb-devel python2 python2-devel python-pip gcc \
+#RUN tdnf distro-sync -y \ # Removed due errors...
+RUN tdnf install -y mariadb-devel python2 python2-devel python-pip gcc \
     linux-api-headers glibc-devel binutils zlib-devel openssl-devel \
     && pip install mysqlclient alembic \
     && tdnf clean all \

--- a/tools/migration/db/alembic.tpl
+++ b/tools/migration/db/alembic.tpl
@@ -30,7 +30,8 @@ script_location = /harbor-migration/db/migration_harbor
 # are written from script.py.mako
 # output_encoding = utf-8
 
-sqlalchemy.url = mysql://$DB_USR:$DB_PWD@localhost:3306/registry?unix_socket=/var/run/mysqld/mysqld.sock
+
+sqlalchemy.url = mysql://$DB_USR:$DB_PWD@${TEMPLATE_CONNECTION_STRING}
 
 # Logging configuration
 [loggers]


### PR DESCRIPTION
Add tree new environ variables:
```
DB_HOST
DB_PORT
DATABASE_NAME
```
This allows the migrator connects on a remote database and make the upgrade without the need start a local database, mount local files.... 
If the environment variable DB_HOST is not set, the same behavior will be keeped.

Github Issue: #4878