### PR TITLE
Fix Makefile to run harbor locally in  MacOS for dev

### DIFF
--- a/tests/e2e-image/dockerd-entrypoint.sh
+++ b/tests/e2e-image/dockerd-entrypoint.sh
@@ -17,7 +17,7 @@
 set -e
 
 # Only give socker support by default, use bash arguments to add dockerd parameters
-# Use unix:///var/run/docker-local.sock to avoid collison with /var/run/docker.sock
+# Use unix:///var/run/docker-local.sock to avoid collision with /var/run/docker.sock
 
 # no arguments passed
 # or first arg is `-f` or `--some-option`


### PR DESCRIPTION
Fix the Makefile for MacOS to run harbor locally for dev:

```bash
$ sudo -i
$ make install CLARITYIMAGE=goharbor/harbor-clarity-ui-builder:1.6.0 CLAIRFLAG=true NOTARYFLAG=true
```

Changes made are:

- fix `sed -i` in MacOS, BSD sed and Linux sed are different, use `sed -i -e` instead
- set file mode to 644 in MacOS, instead of 600
- change target name from `version` to `ui_version`
- fix `cleandockercomposefile` target to clean all generated docker-compose files