### PR TITLE
provide manual installation documentation for sdk/harbor-py

### DIFF
--- a/contrib/sdk/harbor-py/README.md
+++ b/contrib/sdk/harbor-py/README.md
@@ -35,8 +35,15 @@ The supported APIs are:
 
 ## Installation
 
+### Installation from PyPI
 ```
 pip install harbor-py
+```
+### Local Installation from Source Code
+```
+git clone https://github.com/vmware/harbor.git
+cd harbor/contrib/sdk/harbor-py
+python setup.py install --root /
 ```
 
 ## Usage


### PR DESCRIPTION
The version of harbor-py installed from PiPY is old, We can provide documentation installed from source code.