### PR TITLE
Fix continuous integration pipeline following move to goharbor org

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -67,9 +67,9 @@ pipeline:
         target: slack_webhook
     username: drone
     template: >
-      build https://ci-vic.vmware.com/vmware/harbor/{{ build.number }} finished with a {{ build.status }} status. Please find logs at https://storage.googleapis.com/harbor-ci-logs/integration_logs_{{ build.number }}_{{ build.commit }}.tar.gz
+      build https://ci-vic.vmware.com/goharbor/harbor/{{ build.number }} finished with a {{ build.status }} status. Please find logs at https://storage.googleapis.com/harbor-ci-logs/integration_logs_{{ build.number }}_{{ build.commit }}.tar.gz
     when:
-      repo: vmware/harbor
+      repo: goharbor/harbor
       event: [push, tag, deployment]
       branch: [ master, release-*, refs/tags/* ]
       status: [ failure, success ]
@@ -83,7 +83,7 @@ pipeline:
     repositories:
        - vmware/vic-product
     when:
-      repo: vmware/harbor
+      repo: goharbor/harbor
       event: [ push, tag ]
       branch: [ master, release-*, refs/tags/* ]
       status: success

--- a/.drone.yml
+++ b/.drone.yml
@@ -22,7 +22,7 @@ pipeline:
     commands:
       - echo ${DRONE_COMMIT_AUTHOR}
       - echo $SKIP_CHECK_MEMBERSHIP
-      - if $SKIP_CHECK_MEMBERSHIP == true; then echo 'check-org-membership step skipped'; else /bin/bash -c '[[ ! $(curl --silent "https://api.github.com/orgs/vmware/members/${DRONE_COMMIT_AUTHOR}?access_token=$GITHUB_AUTOMATION_API_KEY") ]]'; fi
+      - if [ "$SKIP_CHECK_MEMBERSHIP" = "true" ]; then echo 'check-org-membership step skipped'; else /bin/bash -c '[[ ! $(curl --silent "https://api.github.com/orgs/vmware/members/${DRONE_COMMIT_AUTHOR}?access_token=$GITHUB_AUTOMATION_API_KEY") ]]'; fi
     when:
       status: success
 

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -18,7 +18,7 @@ gsutil version -l
 set +x
 
 ## -------------------------------------------- Pre-condition --------------------------------------------
-if [[ $DRONE_REPO != "vmware/harbor" ]]; then
+if [[ $DRONE_REPO != "goharbor/harbor" ]]; then
     echo "Only run tests again Harbor Repo."
     exit 1
 fi


### PR DESCRIPTION
### Fix syntax error in check-org-membership

Currently, check-org-membership results in a bash syntax error, which seems to be preventing CI from running.

### Refer to goharbor/harbor in the integration logic

An incomplete update to the integration testing logic to replace some instances of vmware/harbor with goharbor/harbor to get CI working.

---

For examples of failures this addresses, see:
 * https://ci-vic.vmware.com/goharbor/harbor/3/3
 * https://ci-vic.vmware.com/goharbor/harbor/7/4