### PR TITLE
Update CFG migrator to match the new redis setting

### DIFF
--- a/tools/migration/cfg/migrator_1_6_0/__init__.py
+++ b/tools/migration/cfg/migrator_1_6_0/__init__.py
@@ -19,7 +19,6 @@ keys = [
     'db_password',
     'db_port',
     'db_user',
-    'redis_url',
     'clair_db_host',
     'clair_db_password',
     'clair_db_port',

--- a/tools/migration/cfg/migrator_1_6_0/harbor.cfg.tpl
+++ b/tools/migration/cfg/migrator_1_6_0/harbor.cfg.tpl
@@ -140,8 +140,6 @@ db_user = $db_user
 
 ##### End of Harbor DB configuration#######
 
-#The redis server address. Only needed in HA installation.
-redis_url = $redis_url
 
 ##########Clair DB configuration############
 
@@ -165,6 +163,22 @@ clair_db = $clair_db
 clair_updaters_interval = 12
 
 ##########End of Clair DB configuration############
+
+##########Redis server configuration.############
+#Redis connection address
+redis_host = redis
+
+#Redis connection port
+redis_port = 6379
+
+#Redis connection password
+redis_password =
+
+#Redis connection db index
+#db_index 1,2,3 is for registry, jobservice and chartmuseum.
+#db_index 0 is for UI, it's unchangeable
+redis_db_index = 1,2,3
+##########Redis server configuration.############
 
 #The following attributes only need to be set when auth mode is uaa_auth
 uaa_endpoint = $uaa_endpoint


### PR DESCRIPTION
There's a limitation in the new harbor.cfg file the redis url will be
hard coded to the internal redis instance.  We expect user to manually
edit the .cfg file if he's using a customized redis, this would be a
very rare case.  We'll mention it in the release note of 1.6