### PR TITLE
Remove step to trigger downstream product in CI pipeline

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -73,17 +73,3 @@ pipeline:
       event: [push, tag, deployment]
       branch: [ master, release-*, refs/tags/* ]
       status: [ failure, success ]
-
-  trigger:
-    image: plugins/downstream
-    server: https://ci-vic.vmware.com
-    secrets:
-      - downstream_token
-    fork: true
-    repositories:
-       - vmware/vic-product
-    when:
-      repo: goharbor/harbor
-      event: [ push, tag ]
-      branch: [ master, release-*, refs/tags/* ]
-      status: success


### PR DESCRIPTION
As for move to goharbor, the CI should not align with any other products. This commit is to remove the step to trigger downstream project vic in Drone CI pipeline, which is a designed step in vmware/harbor repo.