### PR TITLE
Allow to define own env vars to the chartmuseum

### DIFF
--- a/contrib/helm/harbor/templates/chartmuseum/chartmuseum-cm.yaml
+++ b/contrib/helm/harbor/templates/chartmuseum/chartmuseum-cm.yaml
@@ -12,7 +12,6 @@ data:
   CACHE_REDIS_DB: "{{ template "harbor.redis.databaseIndex" }}"
   BASIC_AUTH_USER: "chart_controller"
   DEPTH: "1"
-  STORAGE: "local"
   STORAGE_LOCAL_ROOTDIR: "/chart_storage"
   DEBUG: "false"
   LOG_JSON: "true"
@@ -30,4 +29,9 @@ data:
   MAX_UPLOAD_SIZE: "20971520"
   CHART_POST_FORM_FIELD_NAME: "chart"
   PROV_POST_FORM_FIELD_NAME: "prov"
+{{- range $name, $value := .Values.chartmuseum.env.open }}
+{{- if not (empty $value) }}
+  {{ $name }}: {{ $value | quote }}
+{{- end }}
+{{- end }}
 {{- end }}

--- a/contrib/helm/harbor/templates/chartmuseum/chartmuseum-secret.yaml
+++ b/contrib/helm/harbor/templates/chartmuseum/chartmuseum-secret.yaml
@@ -9,4 +9,13 @@ type: Opaque
 data:
   CACHE_REDIS_PASSWORD: "{{ template "harbor.redis.password" }}"
   BASIC_AUTH_PASS: {{ .Values.ui.secret | b64enc | quote }}
+{{- range $name, $value := .Values.chartmuseum.env.secret }}
+{{- if not (empty $value) }}
+{{- if eq $name "GOOGLE_CREDENTIALS_JSON" }}
+  {{ $name }}: {{ $value }}
+  {{- else }}
+  {{ $name }}: {{ $value | b64enc }}
+{{- end }}
+{{- end }}
+{{- end }}
 {{- end }}

--- a/contrib/helm/harbor/values.yaml
+++ b/contrib/helm/harbor/values.yaml
@@ -225,6 +225,10 @@ chartmuseum:
       # storageClass: "-"
       accessMode: ReadWriteOnce
       size: 5Gi
+  env:
+    open: {}
+    secret: {}
+
   # resources:
   #  requests:
   #    memory: 256Mi


### PR DESCRIPTION
This is may required, if an admin wants to use S3 or Google Cloud Storage.

I got this idea from here: https://github.com/helm/charts/tree/master/stable/chartmuseum