### PR TITLE
Remove registry controller from release-1.6.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -224,7 +224,6 @@ DOCKERSAVE_PARA=$(DOCKERIMAGENAME_ADMINSERVER):$(VERSIONTAG) \
 		$(DOCKERIMAGENAME_LOG):$(VERSIONTAG) \
 		$(DOCKERIMAGENAME_DB):$(VERSIONTAG) \
 		$(DOCKERIMAGENAME_JOBSERVICE):$(VERSIONTAG) \
-		$(DOCKERIMAGENAME_REGCTL):$(VERSIONTAG) \
 		goharbor/redis-photon:$(REDISVERSION) \
 		goharbor/nginx-photon:$(NGINXVERSION) goharbor/registry-photon:$(REGISTRYVERSION)-$(VERSIONTAG)
 
@@ -297,10 +296,6 @@ compile_golangimage: compile_clarity
 
 	@echo "compiling binary for jobservice (golang image)..."
 	@$(DOCKERCMD) run --rm -v $(BUILDPATH):$(GOBUILDPATH) -w $(GOBUILDPATH_JOBSERVICE) $(GOBUILDIMAGE) $(GOIMAGEBUILD) -o $(GOBUILDMAKEPATH_JOBSERVICE)/$(JOBSERVICEBINARYNAME)
-	@echo "Done."
-
-	@echo "compiling binary for harbor regsitry controller (golang image)..."
-	@$(DOCKERCMD) run --rm -v $(BUILDPATH):$(GOBUILDPATH) -w $(GOBUILDPATH_REGISTRYCTL) $(GOBUILDIMAGE) $(GOIMAGEBUILD) -o $(GOBUILDMAKEPATH_REGISTRYCTL)/$(REGISTRYCTLBINARYNAME)
 	@echo "Done."
 
 compile:check_environment compile_golangimage

--- a/make/docker-compose.tpl
+++ b/make/docker-compose.tpl
@@ -29,27 +29,6 @@ services:
       options:  
         syslog-address: "tcp://127.0.0.1:1514"
         tag: "registry"
-  registryctl:
-    image: goharbor/harbor-registryctl:__version__
-    container_name: registryctl
-    env_file:
-      - ./common/config/registryctl/env
-    restart: always
-    volumes:
-      - /data/registry:/storage:z
-      - ./common/config/registry/:/etc/registry/:z
-      - ./common/config/registryctl/config.yml:/etc/registryctl/config.yml:z
-    networks:
-      - harbor
-    environment:
-      - GODEBUG=netdns=cgo
-    depends_on:
-      - log
-    logging:
-      driver: "syslog"
-      options:  
-        syslog-address: "tcp://127.0.0.1:1514"
-        tag: "registryctl"
   postgresql:
     image: goharbor/harbor-db:__version__
     container_name: harbor-db

--- a/make/photon/Makefile
+++ b/make/photon/Makefile
@@ -203,7 +203,7 @@ define _get_binary
 	$(WGET) --timeout 30 --no-check-certificate $1 -O $2
 endef
 
-build: _build_db _build_adminiserver _build_ui _build_jobservice _build_log _build_nginx _build_registry _build_registryctl _build_notary _build_clair _build_redis _build_migrator _build_chart_server
+build: _build_db _build_adminiserver _build_ui _build_jobservice _build_log _build_nginx _build_registry _build_notary _build_clair _build_redis _build_migrator _build_chart_server
 
 cleanimage:
 	@echo "cleaning image for photon..."

--- a/src/ui/router.go
+++ b/src/ui/router.go
@@ -91,11 +91,6 @@ func initRouters() {
 	beego.Router("/api/jobs/replication/:id([0-9]+)/log", &api.RepJobAPI{}, "get:GetLog")
 	beego.Router("/api/jobs/scan/:id([0-9]+)/log", &api.ScanJobAPI{}, "get:GetLog")
 
-	beego.Router("/api/system/gc", &api.GCAPI{}, "get:List")
-	beego.Router("/api/system/gc/:id", &api.GCAPI{}, "get:GetGC")
-	beego.Router("/api/system/gc/:id([0-9]+)/log", &api.GCAPI{}, "get:GetLog")
-	beego.Router("/api/system/gc/schedule", &api.GCAPI{}, "get:Get;put:Put;post:Post")
-
 	beego.Router("/api/policies/replication/:id([0-9]+)", &api.RepPolicyAPI{})
 	beego.Router("/api/policies/replication", &api.RepPolicyAPI{}, "get:List")
 	beego.Router("/api/policies/replication", &api.RepPolicyAPI{}, "post:Post")


### PR DESCRIPTION
1, remove the API to call registry ctl
2, remove the registryctl image from docker-compose
3, do not package registryctl into offline installer
4, do not compile registryctl binary