### PR TITLE
Add clean registry cache to gc job

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -299,7 +299,7 @@ compile_golangimage: compile_clarity
 	@$(DOCKERCMD) run --rm -v $(BUILDPATH):$(GOBUILDPATH) -w $(GOBUILDPATH_JOBSERVICE) $(GOBUILDIMAGE) $(GOIMAGEBUILD) -o $(GOBUILDMAKEPATH_JOBSERVICE)/$(JOBSERVICEBINARYNAME)
 	@echo "Done."
 
-	@echo "compiling binary for harbor regsitry controller (golang image)..."
+	@echo "compiling binary for harbor registry controller (golang image)..."
 	@$(DOCKERCMD) run --rm -v $(BUILDPATH):$(GOBUILDPATH) -w $(GOBUILDPATH_REGISTRYCTL) $(GOBUILDIMAGE) $(GOIMAGEBUILD) -o $(GOBUILDMAKEPATH_REGISTRYCTL)/$(REGISTRYCTLBINARYNAME)
 	@echo "Done."
 

--- a/make/common/templates/ui/env
+++ b/make/common/templates/ui/env
@@ -8,3 +8,5 @@ UAA_CA_ROOT=/etc/ui/certificates/uaa_ca.pem
 _REDIS_URL=$redis_host:$redis_port,100,$redis_password
 SYNC_REGISTRY=false
 CHART_CACHE_DRIVER=$chart_cache_driver
+_REDIS_URL_REG=$redis_url_reg
+

--- a/make/prepare
+++ b/make/prepare
@@ -304,10 +304,13 @@ redis_db_index_chart = db_indexs[2]
 
 #redis://[arbitrary_username:password@]ipaddress:port/database_index
 redis_url_js = ''
+redis_url_reg = ''
 if len(redis_password) > 0:
     redis_url_js = "redis://anonymous:%s@%s:%s/%s" % (redis_password, redis_host, redis_port, redis_db_index_js)
+    redis_url_reg = "redis://anonymous:%s@%s:%s/%s" % (redis_password, redis_host, redis_port, redis_db_index_reg)
 else:
     redis_url_js = "redis://%s:%s/%s" % (redis_host, redis_port, redis_db_index_js)
+    redis_url_reg = "redis://%s:%s/%s" % (redis_host, redis_port, redis_db_index_reg)
 
 if rcp.has_option("configuration", "skip_reload_env_pattern"):
     skip_reload_env_pattern = rcp.get("configuration", "skip_reload_env_pattern")
@@ -463,8 +466,8 @@ render(os.path.join(templates_dir, "ui", "env"),
         redis_port=redis_port,
         redis_password=redis_password,
         adminserver_url = adminserver_url,
-        chart_cache_driver = chart_cache_driver
-        )
+        chart_cache_driver = chart_cache_driver,
+        redis_url_reg = redis_url_reg)
 
 registry_config_file_ha = "config_ha.yml"
 registry_config_file = "config.yml"

--- a/src/ui/api/models/reg_gc.go
+++ b/src/ui/api/models/reg_gc.go
@@ -39,9 +39,10 @@ const (
 
 // GCReq holds request information for admin job
 type GCReq struct {
-	Schedule *ScheduleParam `json:"schedule"`
-	Status   string         `json:"status"`
-	ID       int64          `json:"id"`
+	Schedule   *ScheduleParam         `json:"schedule"`
+	Status     string                 `json:"status"`
+	ID         int64                  `json:"id"`
+	Parameters map[string]interface{} `json:"parameters"`
 }
 
 //ScheduleParam defines the parameter of schedule trigger
@@ -88,8 +89,9 @@ func (gr *GCReq) ToJob() (*models.JobData, error) {
 	}
 
 	jobData := &models.JobData{
-		Name:     job.ImageGC,
-		Metadata: metadata,
+		Name:       job.ImageGC,
+		Parameters: gr.Parameters,
+		Metadata:   metadata,
 		StatusHook: fmt.Sprintf("%s/service/notifications/jobs/adminjob/%d",
 			config.InternalUIURL(), gr.ID),
 	}

--- a/src/ui/api/reg_gc.go
+++ b/src/ui/api/reg_gc.go
@@ -17,6 +17,7 @@ package api
 import (
 	"fmt"
 	"net/http"
+	"os"
 	"strconv"
 
 	"github.com/vmware/harbor/src/common/dao"
@@ -209,6 +210,9 @@ func (gc *GCAPI) submitJob(gr *models.GCReq) {
 		return
 	}
 	gr.ID = id
+	gr.Parameters = map[string]interface{}{
+		"redis_url_reg": os.Getenv("_REDIS_URL_REG"),
+	}
 	job, err := gr.ToJob()
 	if err != nil {
 		gc.HandleInternalServerError(fmt.Sprintf("%v", err))


### PR DESCRIPTION
Signed-off-by: wangyan <wangyan@vmware.com>

To workaround the issue: https://github.com/docker/distribution/issues/2094. GC needs to clean cache before to call the docker reigstry api to delete blobs. Otherwise, the following docker push will not be performed as docker registry does not clean cache in GC, it thinks the image is still there, and the new blobs will be uploaded.