### PR TITLE
Fix issue ldap_group_admin_dn doesn't take effect

### DIFF
--- a/src/ui/api/user.go
+++ b/src/ui/api/user.go
@@ -116,6 +116,7 @@ func (ua *UserAPI) Get() {
 			ua.CustomAbort(http.StatusInternalServerError, "Internal error.")
 		}
 		u.Password = ""
+		u.HasAdminRole = ua.SecurityCtx.IsSysAdmin()
 		ua.Data["json"] = u
 		ua.ServeJSON()
 		return


### PR DESCRIPTION
When login with some user which previously not an admin user, it doesn't have admin role after define ldap_group_admin_dn

Signed-off-by: stonezdj <daojunz@vmware.com>