### PR TITLE
Fix issue ldap_group_admin_dn doesn't take effect

### DIFF
--- a/src/ui/api/user.go
+++ b/src/ui/api/user.go
@@ -116,7 +116,12 @@ func (ua *UserAPI) Get() {
 			ua.CustomAbort(http.StatusInternalServerError, "Internal error.")
 		}
 		u.Password = ""
-		if ua.userID == ua.currentUserID {
+		authMode, err := config.AuthMode()
+		if err != nil {
+			log.Errorf("Error occurred in GetUser, error: %v", err)
+			ua.CustomAbort(http.StatusInternalServerError, "Internal error.")
+		}
+		if authMode == common.LDAPAuth && ua.userID == ua.currentUserID {
 			u.HasAdminRole = ua.SecurityCtx.IsSysAdmin()
 		}
 		ua.Data["json"] = u


### PR DESCRIPTION
If current user is in the group defined ldap_group_admin_dn, it doesn't have the harbor admin role.
The current solution only fix the /api/users/currentuser, but for /api/users/:id it can display the real information. see issue #5620

Signed-off-by: stonezdj <stonezdj@gmail.com>