### PR TITLE
Update registry image to enable inject root cert (1.6 cherry pick)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ make/common/config/*
 make/dev/adminserver/harbor_adminserver
 make/dev/ui/harbor_ui
 make/dev/jobservice/harbor_jobservice
+make/photon/*/binary/
+
 src/adminserver/adminserver
 src/ui/ui
 src/jobservice/jobservice

--- a/make/harbor.cfg
+++ b/make/harbor.cfg
@@ -191,6 +191,9 @@ registry_storage_provider_name = filesystem
 #registry_storage_provider_config is a comma separated "key: value" pairs, e.g. "key1: value, key2: value2".
 #Refer to https://docs.docker.com/registry/configuration/#storage for all available configuration.
 registry_storage_provider_config =
+#registry_custom_ca_bundle is the path to the custom root ca certificate, which will be injected into the truststore
+#of registry's container.  This is usually needed when the user hosts a internal storage with self signed certificate.
+registry_custom_ca_bundle = 
 
 #If reload_config=true, all settings which present in harbor.cfg take effect after prepare and restart harbor, it overwrites exsiting settings.
 #reload_config=true

--- a/make/photon/registry/entrypoint.sh
+++ b/make/photon/registry/entrypoint.sh
@@ -17,6 +17,21 @@ if [ -d /storage ]; then
     fi
 fi
 
+if [ ! -f /etc/pki/tls/certs/ca-bundle.crt.original ]; then
+    cp /etc/pki/tls/certs/ca-bundle.crt /etc/pki/tls/certs/ca-bundle.crt.original
+fi
+
+if [ -f /etc/registry/custom-ca-bundle.crt ]; then
+    if grep -q "Photon" /etc/lsb-release; then
+        echo "Appending custom ca bundle ..."
+        cp /etc/pki/tls/certs/ca-bundle.crt.original /etc/pki/tls/certs/ca-bundle.crt
+        cat /etc/registry/custom-ca-bundle.crt >> /etc/pki/tls/certs/ca-bundle.crt
+        echo "Done."
+    else
+        echo "Current OS is not Photon, skip appending ca bundle"
+    fi
+fi
+
 case "$1" in
     *.yaml|*.yml) set -- registry serve "$@" ;;
     serve|garbage-collect|help|-*) set -- registry "$@" ;;

--- a/make/prepare
+++ b/make/prepare
@@ -317,6 +317,7 @@ storage_provider_name = rcp.get("configuration", "registry_storage_provider_name
 storage_provider_config = rcp.get("configuration", "registry_storage_provider_config").strip()
 # yaml requires 1 or more spaces between the key and value
 storage_provider_config = storage_provider_config.replace(":", ": ", 1)
+registry_custom_ca_bundle_path = rcp.get("configuration", "registry_custom_ca_bundle").strip()
 ui_secret = ''.join(random.choice(string.ascii_letters+string.digits) for i in range(16))  
 jobservice_secret = ''.join(random.choice(string.ascii_letters+string.digits) for i in range(16))
 
@@ -466,8 +467,7 @@ render(os.path.join(templates_dir, "ui", "env"),
         chart_cache_driver = chart_cache_driver
         )
 
-registry_config_file_ha = "config_ha.yml"
-registry_config_file = "config.yml"
+registry_config_file = "config_ha.yml" if args.ha_mode else "config.yml"
 if storage_provider_name == "filesystem":
     if not storage_provider_config:
         storage_provider_config = "rootdirectory: /storage"
@@ -478,16 +478,6 @@ storage_provider_conf_list = [storage_provider_name + ':']
 for c in storage_provider_config.split(","):
     storage_provider_conf_list.append(c.strip())
 storage_provider_info = ('\n' + ' ' * 4).join(storage_provider_conf_list)
-render(os.path.join(templates_dir, "registry", registry_config_file_ha),
-    registry_conf,
-    storage_provider_info=storage_provider_info,
-    public_url=public_url,
-    ui_url=ui_url,
-    redis_host=redis_host,
-    redis_port=redis_port,
-    redis_password=redis_password,
-    redis_db_index_reg=redis_db_index_reg)
-
 render(os.path.join(templates_dir, "registry", registry_config_file),
     registry_conf,
     storage_provider_info=storage_provider_info,
@@ -597,6 +587,10 @@ else:
     shutil.copyfile(os.path.join(templates_dir, "ui", "private_key.pem"), os.path.join(ui_config_dir, "private_key.pem"))
     print("Copied configuration file: %s" % registry_config_dir + "root.crt")
     shutil.copyfile(os.path.join(templates_dir, "registry", "root.crt"), os.path.join(registry_config_dir, "root.crt"))
+
+if len(registry_custom_ca_bundle_path) > 0 and os.path.isfile(registry_custom_ca_bundle_path):
+    shutil.copyfile(registry_custom_ca_bundle_path, os.path.join(registry_config_dir, "custom-ca-bundle.crt"))
+    print("Copied custom ca bundle: %s" % os.path.join(registry_config_dir, "custom-ca-bundle.crt"))
 
 if args.notary_mode:
     notary_config_dir = prep_conf_dir(config_dir, "notary")

--- a/tools/migration/cfg/migrator_1_6_0/harbor.cfg.tpl
+++ b/tools/migration/cfg/migrator_1_6_0/harbor.cfg.tpl
@@ -194,3 +194,7 @@ registry_storage_provider_name = $registry_storage_provider_name
 #registry_storage_provider_config is a comma separated "key: value" pairs, e.g. "key1: value, key2: value2".
 #Refer to https://docs.docker.com/registry/configuration/#storage for all available configuration.
 registry_storage_provider_config = $registry_storage_provider_config
+#registry_custom_ca_bundle is the path to the custom root ca certificate, which will be injected into the truststore
+#of registry's container.  This is usually needed when the user hosts a internal storage with self signed certificate.
+registry_custom_ca_bundle =
+


### PR DESCRIPTION
In some user's environment, there's local object storage hosted with
self-signed certificate.
Because registry process runs in a photon container, it has to trust
the certificate in the photon level such that the registry can access
the storage service.

This commit updates the registry image to append custom cert to the root
bundle when the container is started.  And make the customer cert
configurable in `harbor.cfg`

Signed-off-by: Daniel Jiang <jiangd@vmware.com>