### PR TITLE
Fix module not found error in API test

### DIFF
--- a/tests/apitests/python/library/Harbor.py
+++ b/tests/apitests/python/library/Harbor.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-
+import site
+reload(site)
 import project
 import label
 import registry


### PR DESCRIPTION
Reload the python path to fix the module not found error in API E2E test

Signed-off-by: Wenkai Yin <yinw@vmware.com>