### PR TITLE
[Cherry-pick]Add VOLUME definition in Dockerfile of chart museum

### DIFF
--- a/make/photon/chartserver/Dockerfile
+++ b/make/photon/chartserver/Dockerfile
@@ -10,6 +10,7 @@ RUN tdnf distro-sync -y \
 COPY ./binary/chartm /chartserver/
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 
+VOLUME ["/chart_storage"]
 EXPOSE 9999
 
 RUN chown -R 10000:10000 /chartserver \


### PR DESCRIPTION
The VOLUME definition in Dockerfile of chart museum will mount a volume automatically by docker if no specific volume is provided.

Signed-off-by: Wenkai Yin <yinw@vmware.com>