### PR TITLE
Fix volume capacity when run in MacOS

### DIFF
--- a/src/adminserver/systeminfo/imagestorage/driver.go
+++ b/src/adminserver/systeminfo/imagestorage/driver.go
@@ -17,7 +17,7 @@ package imagestorage
 // GlobalDriver is a global image storage driver
 var GlobalDriver Driver
 
-// Capacity holds information about capaticy of image storage
+// Capacity holds information about capacity of image storage
 type Capacity struct {
 	// total size(byte)
 	Total uint64 `json:"total"`

--- a/src/adminserver/systeminfo/imagestorage/filesystem/driver.go
+++ b/src/adminserver/systeminfo/imagestorage/filesystem/driver.go
@@ -57,6 +57,11 @@ func (d *driver) Cap() (*storage.Capacity, error) {
 		return nil, err
 	}
 
+	// When container is run in MacOS, `bsize` obtained by `statfs` syscall is not the fundamental block size,
+	// but the `iosize` (optimal transfer block size) instead, it's usually 1024 times larger than the `bsize`.
+	// for example `4096 * 1024`. To get the correct block size, we should use `frsize`. But `frsize` isn't
+	// guaranteed to be supported everywhere, so we need to check whether it's supported before use it.
+	// For more details, please refer to: https://github.com/docker/for-mac/issues/2136
 	bSize := uint64(stat.Bsize)
 	field := reflect.ValueOf(&stat).Elem().FieldByName("Frsize")
 	if field.IsValid() {

--- a/src/adminserver/systeminfo/imagestorage/filesystem/driver.go
+++ b/src/adminserver/systeminfo/imagestorage/filesystem/driver.go
@@ -16,6 +16,7 @@ package filesystem
 
 import (
 	"os"
+	"reflect"
 	"syscall"
 
 	storage "github.com/vmware/harbor/src/adminserver/systeminfo/imagestorage"
@@ -56,8 +57,18 @@ func (d *driver) Cap() (*storage.Capacity, error) {
 		return nil, err
 	}
 
+	bSize := uint64(stat.Bsize)
+	field := reflect.ValueOf(&stat).Elem().FieldByName("Frsize")
+	if field.IsValid() {
+		if field.Kind() == reflect.Uint64 {
+			bSize = field.Uint()
+		} else {
+			bSize = uint64(field.Int())
+		}
+	}
+
 	return &storage.Capacity{
-		Total: stat.Blocks * uint64(stat.Bsize),
-		Free:  stat.Bavail * uint64(stat.Bsize),
+		Total: stat.Blocks * bSize,
+		Free:  stat.Bavail * bSize,
 	}, nil
 }


### PR DESCRIPTION
When run Harbor in MacOS, volume capacity is incorrect due to the use of `statfs`.

Refer to: https://github.com/docker/for-mac/issues/2136

This PR fix: https://github.com/goharbor/harbor/issues/5694