### PR TITLE
Temporarily disable updaters of clair -- cherry-pick 1.6

### DIFF
--- a/make/harbor.cfg
+++ b/make/harbor.cfg
@@ -173,7 +173,7 @@ clair_db_username = postgres
 clair_db = postgres
 
 #The interval of clair updaters, the unit is hour, set to 0 to disable the updaters.
-clair_updaters_interval = 12
+clair_updaters_interval = 0
 
 ##########End of Clair DB configuration############
 


### PR DESCRIPTION
Set the updater interval to "0" to mitigate the impact of Apline URL
change that cause clair keep polling vuln data.

Signed-off-by: Daniel Jiang <jiangd@vmware.com>