### PR TITLE
[Upload Build] Resume clair updater

### DIFF
--- a/make/harbor.cfg
+++ b/make/harbor.cfg
@@ -173,7 +173,7 @@ clair_db_username = postgres
 clair_db = postgres
 
 #The interval of clair updaters, the unit is hour, set to 0 to disable the updaters.
-clair_updaters_interval = 0
+clair_updaters_interval = 12
 
 ##########End of Clair DB configuration############
 


### PR DESCRIPTION
Alpine adjusted the setting of the web server such that `git clone` can
be redirected correctly, things should work without change at the Clair
side.

Signed-off-by: Daniel Jiang <jiangd@vmware.com>