### PR TITLE
Support repo list sorting

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -894,8 +894,9 @@ paths:
     get:
       summary: Get repositories accompany with relevant project and repo name.
       description: >
-        This endpoint let user search repositories accompanying with relevant
-        project ID and repo name.
+        This endpoint lets user search repositories accompanying with relevant
+        project ID and repo name. Repositories can be sorted by repo name, creation_time,
+        update_time in either ascending or descending order.
       parameters:
         - name: project_id
           in: query
@@ -908,6 +909,13 @@ paths:
           type: string
           required: false
           description: Repo name for filtering results.
+        - name: sort
+          in: query
+          type: string
+          required: false
+          description: >
+            Sort method, valid values include: 'name', '-name', 'creation_time', '-creation_time',
+            'update_time', '-update_time'. Here '-' stands for descending order.
         - name: label_id
           in: query
           type: integer

--- a/src/common/dao/repository.go
+++ b/src/common/dao/repository.go
@@ -22,16 +22,16 @@ import (
 	"github.com/goharbor/harbor/src/common/models"
 )
 
-var orderMap = map[string]string {
-	"name": "name asc",
-	"+name": "name asc",
-	"-name": "name desc",
-	"creation_time": "creation_time asc",
+var orderMap = map[string]string{
+	"name":           "name asc",
+	"+name":          "name asc",
+	"-name":          "name desc",
+	"creation_time":  "creation_time asc",
 	"+creation_time": "creation_time asc",
 	"-creation_time": "creation_time desc",
-	"update_time": "update_time asc",
-	"+update_time": "update_time asc",
-	"-update_time": "update_time desc",
+	"update_time":    "update_time asc",
+	"+update_time":   "update_time asc",
+	"-update_time":   "update_time desc",
 }
 
 // AddRepository adds a repo to the database.

--- a/src/common/dao/repository.go
+++ b/src/common/dao/repository.go
@@ -22,6 +22,18 @@ import (
 	"github.com/goharbor/harbor/src/common/models"
 )
 
+var orderMap = map[string]string {
+	"name": "name asc",
+	"+name": "name asc",
+	"-name": "name desc",
+	"creation_time": "creation_time asc",
+	"+creation_time": "creation_time asc",
+	"-creation_time": "creation_time desc",
+	"update_time": "update_time asc",
+	"+update_time": "update_time asc",
+	"-update_time": "update_time desc",
+}
+
 // AddRepository adds a repo to the database.
 func AddRepository(repo models.RepoRecord) error {
 	if repo.ProjectID == 0 {
@@ -116,10 +128,16 @@ func GetTotalOfRepositories(query ...*models.RepositoryQuery) (int64, error) {
 // GetRepositories ...
 func GetRepositories(query ...*models.RepositoryQuery) ([]*models.RepoRecord, error) {
 	repositories := []*models.RepoRecord{}
+	order := "name asc"
+	if len(query) > 0 && query[0] != nil {
+		if s, ok := orderMap[query[0].Sort]; ok {
+			order = s
+		}
+	}
 
-	sql, params := repositoryQueryConditions(query...)
-	sql = `select r.repository_id, r.name, r.project_id, r.description, r.pull_count, 
-	r.star_count, r.creation_time, r.update_time ` + sql + `order by r.name `
+	condition, params := repositoryQueryConditions(query...)
+	sql := fmt.Sprintf(`select r.repository_id, r.name, r.project_id, r.description, r.pull_count, 
+	r.star_count, r.creation_time, r.update_time %s order by r.%s `, condition, order)
 	if len(query) > 0 && query[0] != nil {
 		page, size := query[0].Page, query[0].Size
 		if size > 0 {

--- a/src/common/models/project.go
+++ b/src/common/models/project.go
@@ -125,7 +125,7 @@ type ProjectQueryParam struct {
 	ProjectIDs []int64      // project ID list
 }
 
-// MemberQuery fitler by member's username and role
+// MemberQuery filter by member's username and role
 type MemberQuery struct {
 	Name      string       // the username of member
 	Role      int          // the role of the member has to the project
@@ -136,6 +136,11 @@ type MemberQuery struct {
 type Pagination struct {
 	Page int64
 	Size int64
+}
+
+// Sorting sort by given field, ascending or descending
+type Sorting struct {
+	Sort string // in format [+-]?<FIELD_NAME>, e.g. '+creation_time', '-creation_time'
 }
 
 // BaseProjectCollection contains the query conditions which can be used

--- a/src/common/models/repo.go
+++ b/src/common/models/repo.go
@@ -45,4 +45,5 @@ type RepositoryQuery struct {
 	ProjectName string
 	LabelID     int64
 	Pagination
+	Sorting
 }


### PR DESCRIPTION
Support repo list sorting.

Add parameter `sort` to API `/api/repositories`. Support sorting based on:

- name
- creation_time
- update_time

Default to name ascending ordering.


Related to issue: https://github.com/goharbor/harbor/issues/5481