### PR TITLE
Return more data of the job when reporting status info via webhook

### DIFF
--- a/src/jobservice/models/models.go
+++ b/src/jobservice/models/models.go
@@ -71,9 +71,10 @@ type JobActionRequest struct {
 
 //JobStatusChange is designed for reporting the status change via hook.
 type JobStatusChange struct {
-	JobID   string `json:"job_id"`
-	Status  string `json:"status"`
-	CheckIn string `json:"check_in,omitempty"`
+	JobID    string       `json:"job_id"`
+	Status   string       `json:"status"`
+	CheckIn  string       `json:"check_in,omitempty"`
+	Metadata *JobStatData `json:"metadata,omitempty"`
 }
 
 //Message is designed for sub/pub messages

--- a/src/jobservice/opm/redis_job_stats_mgr.go
+++ b/src/jobservice/opm/redis_job_stats_mgr.go
@@ -339,6 +339,20 @@ func (rjs *RedisJobStatsManager) reportStatus(jobID string, hookURL, status, che
 		Status:  status,
 		CheckIn: checkIn,
 	}
+	//Return the whole metadata of the job.
+	//To support forward compatibility, keep the original fields `Status` and `CheckIn`.
+	//TODO: If querying job stats causes performance issues, a two-level cache should be enabled.
+	jobStats, err := rjs.getJobStats(jobID)
+	if err != nil {
+		//Just logged
+		logger.Warningf("Retrieving stats of job %s for hook reporting failed with error: %s", jobID, err)
+	} else {
+		//Override status/check in message
+		//Just double confirmation
+		jobStats.Stats.CheckIn = checkIn
+		jobStats.Stats.Status = status
+		reportingStatus.Metadata = jobStats.Stats
+	}
 
 	return DefaultHookClient.ReportStatus(hookURL, reportingStatus)
 }


### PR DESCRIPTION
**Return more data of the job when reporting status info via webhook**
- update the status report func `RedisJobStatsManager.reportStatus`
- update the UT case for the above change

tracked by issue https://github.com/goharbor/harbor/issues/5353

Signed-off-by: Steven Zou <szou@vmware.com>