### PR TITLE
Append latest version of the chart when returning the chart list

### DIFF
--- a/src/chartserver/chart_operator.go
+++ b/src/chartserver/chart_operator.go
@@ -46,6 +46,7 @@ type DigitalSignature struct {
 type ChartInfo struct {
 	Name          string
 	TotalVersions uint32 `json:"total_versions"`
+	LatestVersion string `json:"latest_version"`
 	Created       time.Time
 	Updated       time.Time
 	Icon          string
@@ -134,6 +135,7 @@ func (cho *ChartOperator) GetChartList(content []byte) ([]*ChartInfo, error) {
 			chartInfo.Home = lVersion.Home
 			chartInfo.Icon = lVersion.Icon
 			chartInfo.Deprecated = lVersion.Deprecated
+			chartInfo.LatestVersion = lVersion.GetVersion()
 			chartList = append(chartList, chartInfo)
 		}
 	}

--- a/src/chartserver/chart_operator_test.go
+++ b/src/chartserver/chart_operator_test.go
@@ -39,4 +39,8 @@ func TestGetChartList(t *testing.T) {
 	if firstInSortedList.Name != "harbor" {
 		t.Fatalf("Expect the fist item of the sorted list to be 'harbor' but got '%s'", firstInSortedList.Name)
 	}
+
+	if firstInSortedList.LatestVersion != "0.2.0" {
+		t.Fatalf("Expect latest version '0.2.0' but got '%s'", firstInSortedList.LatestVersion)
+	}
 }


### PR DESCRIPTION
**Append latest version of the chart when returning the chart list**
- append `LatestVersion` to the `ChartInfo` model
- update the UT case to check the `LatestVersion`

Signed-off-by: Steven Zou <szou@vmware.com>