### PR TITLE
Add the encoding to the data converter script

### DIFF
--- a/tools/migration/db/util/mysql_pgsql_data_converter.py
+++ b/tools/migration/db/util/mysql_pgsql_data_converter.py
@@ -129,7 +129,7 @@ def write_table(pgsql_dump, table_lines):
 
 def write_insert(pgsql_dump, insert_lines):
     for item in insert_lines:
-        pgsql_dump.write("%s\n" % item)
+        pgsql_dump.write("%s\n" % item.encode('utf-8'))
 
 def write_foreign_key(pgsql_dump):
     pgsql_dump.write('\n')


### PR DESCRIPTION
This commit is to fix bug reported by community to upgrade v1.6.0, for the details
just refer to #5788, the fix is to add the encoding for the converter when to convert
the mysql data to pqsql data. Already passed on test with Chinese.

Signed-off-by: wang yan <wangyan@vmware.com>