### PR TITLE
Test TCP connection before upgrading database schema

### DIFF
--- a/src/adminserver/systemcfg/systemcfg.go
+++ b/src/adminserver/systemcfg/systemcfg.go
@@ -262,10 +262,6 @@ func Init() (err error) {
 		return err
 	}
 	db := GetDatabaseFromCfg(envCfgs)
-	//Initialize the schema, then register the DB.
-	if err := dao.UpgradeSchema(db); err != nil {
-		return err
-	}
 	if err := dao.InitDatabase(db); err != nil {
 		return err
 	}

--- a/src/common/dao/base.go
+++ b/src/common/dao/base.go
@@ -61,15 +61,6 @@ func InitClairDB(clairDB *models.PostGreSQL) error {
 	return nil
 }
 
-// UpgradeSchema will call the internal migrator to upgrade schema based on the setting of database.
-func UpgradeSchema(database *models.Database) error {
-	db, err := getDatabase(database)
-	if err != nil {
-		return err
-	}
-	return db.UpgradeSchema()
-}
-
 // InitDatabase registers the database
 func InitDatabase(database *models.Database) error {
 	db, err := getDatabase(database)
@@ -81,6 +72,14 @@ func InitDatabase(database *models.Database) error {
 	if err := db.Register(); err != nil {
 		return err
 	}
+	log.Info("Register database completed")
+
+	log.Info("Upgrading schema...")
+	if err = db.UpgradeSchema(); err != nil {
+		return err
+	}
+	log.Info("Upgrade schema completed")
+
 	version, err := GetSchemaVersion()
 	if err != nil {
 		return err
@@ -90,7 +89,6 @@ func InitDatabase(database *models.Database) error {
 			SchemaVersion, version.Version)
 	}
 
-	log.Info("Register database completed")
 	return nil
 }
 

--- a/src/common/utils/utils.go
+++ b/src/common/utils/utils.go
@@ -88,15 +88,17 @@ func TestTCPConn(addr string, timeout, interval int) error {
 	cancel := make(chan int)
 
 	go func() {
+		n := 1
 		for {
 			select {
 			case <-cancel:
 				break
 			default:
-				conn, err := net.DialTimeout("tcp", addr, time.Duration(timeout)*time.Second)
+				conn, err := net.DialTimeout("tcp", addr, time.Duration(n)*time.Second)
 				if err != nil {
 					log.Errorf("failed to connect to tcp://%s, retry after %d seconds :%v",
 						addr, interval, err)
+					n = n * 2
 					time.Sleep(time.Duration(interval) * time.Second)
 					continue
 				}


### PR DESCRIPTION
This commit moves the database schema upgrading after database register. The register process will test TCP connection.

Signed-off-by: Wenkai Yin <yinw@vmware.com>