### PR TITLE
Test TCP connection before upgrading database schema

### DIFF
--- a/src/adminserver/systemcfg/systemcfg.go
+++ b/src/adminserver/systemcfg/systemcfg.go
@@ -262,13 +262,16 @@ func Init() (err error) {
 		return err
 	}
 	db := GetDatabaseFromCfg(envCfgs)
-	// Initialize the schema, then register the DB.
-	if err := dao.UpgradeSchema(db); err != nil {
-		return err
-	}
 	if err := dao.InitDatabase(db); err != nil {
 		return err
 	}
+	if err := dao.UpgradeSchema(db); err != nil {
+		return err
+	}
+	if err := dao.CheckSchemaVersion(); err != nil {
+		return err
+	}
+
 	if err := initCfgStore(); err != nil {
 		return err
 	}

--- a/src/common/dao/base.go
+++ b/src/common/dao/base.go
@@ -81,6 +81,13 @@ func InitDatabase(database *models.Database) error {
 	if err := db.Register(); err != nil {
 		return err
 	}
+
+	log.Info("Register database completed")
+	return nil
+}
+
+// CheckSchemaVersion checks that whether the schema version matches with the expected one
+func CheckSchemaVersion() error {
 	version, err := GetSchemaVersion()
 	if err != nil {
 		return err
@@ -89,8 +96,6 @@ func InitDatabase(database *models.Database) error {
 		return fmt.Errorf("unexpected database schema version, expected %s, got %s",
 			SchemaVersion, version.Version)
 	}
-
-	log.Info("Register database completed")
 	return nil
 }
 

--- a/src/common/utils/utils.go
+++ b/src/common/utils/utils.go
@@ -88,15 +88,17 @@ func TestTCPConn(addr string, timeout, interval int) error {
 	cancel := make(chan int)
 
 	go func() {
+		n := 1
 		for {
 			select {
 			case <-cancel:
 				break
 			default:
-				conn, err := net.DialTimeout("tcp", addr, time.Duration(timeout)*time.Second)
+				conn, err := net.DialTimeout("tcp", addr, time.Duration(n)*time.Second)
 				if err != nil {
 					log.Errorf("failed to connect to tcp://%s, retry after %d seconds :%v",
 						addr, interval, err)
+					n = n * 2
 					time.Sleep(time.Duration(interval) * time.Second)
 					continue
 				}


### PR DESCRIPTION
This commit moves the database schema upgrading after database initialization. The init will test TCP connection.

Signed-off-by: Wenkai Yin <yinw@vmware.com>