### PR TITLE
Fix `TestTCPConn` break issue.

### DIFF
--- a/src/common/utils/utils.go
+++ b/src/common/utils/utils.go
@@ -89,10 +89,12 @@ func TestTCPConn(addr string, timeout, interval int) error {
 
 	go func() {
 		n := 1
+
+	loop:
 		for {
 			select {
 			case <-cancel:
-				break
+				break loop
 			default:
 				conn, err := net.DialTimeout("tcp", addr, time.Duration(n)*time.Second)
 				if err != nil {
@@ -106,7 +108,7 @@ func TestTCPConn(addr string, timeout, interval int) error {
 					log.Errorf("failed to close the connection: %v", err)
 				}
 				success <- 1
-				break
+				break loop
 			}
 		}
 	}()


### PR DESCRIPTION
Currently, the `TestTCPConn` is a helper to test connection issue between harbor and database, and it may cause an uncontrolled goroutine issue while do `TestTCPConn` without break out the whole loop. The break inside dial goroutine would ONLY break out the select-case statement, rather than the whole for loop.

See the [golang specification](https://golang.org/ref/spec#Break_statements), `A "break" statement terminates execution of the innermost "for", "switch" or "select" statement.`

BTW, the test case wasn't broken, due to the go test is the main routine, while it returned, the other goroutine would also exit.

Thanks.