### PR TITLE
Fix the potential issue of causing deadlock problem

### DIFF
--- a/src/chartserver/repo_handler.go
+++ b/src/chartserver/repo_handler.go
@@ -147,7 +147,10 @@ LOOP:
 
 				indexFile, err := rh.getIndexYamlWithNS(ns)
 				if err != nil {
-					errorChan <- err
+					if len(errorChan) == 0 {
+						//One error is enough, it will be an exit signal to the worker loop
+						errorChan <- err
+					}
 					return
 				}
 


### PR DESCRIPTION
**Fix the potential issue of causing deadlock problem**
avoid deadlock may occurred in the 1 len queue

```
if len(errorChan) == 0 {
    //One error is enough, it will be an exit signal to the worker loop
   errorChan <- err
}
```

Signed-off-by: Steven Zou <szou@vmware.com>