### PR TITLE
Let stale bot use the label "staled"

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -6,7 +6,7 @@ daysUntilClose: 7
 exemptLabels:
   - backlog
 # Label to use when marking an issue as stale
-staleLabel: wontfix
+staleLabel: staled
 # Comment to post when marking an issue as stale. Set to `false` to disable
 markComment: >
   This issue has been automatically marked as stale because it has not had


### PR DESCRIPTION
"wontfix" is used to mark the issues that were decided will not be fixed
after triage, so let's use a different label to mark stale issues.

Signed-off-by: Daniel Jiang <jiangd@vmware.com>