### PR TITLE
Normalize (make lowercase) ldap_group_dn during onboarding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ src/portal/typings/
 **/*npm-debug.log.*
 **/*yarn-error.log.*
 .idea/
+*.iml
 .DS_Store
 .project
 .vscode/

--- a/src/common/dao/group/usergroup.go
+++ b/src/common/dao/group/usergroup.go
@@ -116,6 +116,8 @@ func UpdateUserGroupName(id int, groupName string) error {
 // This is used for ldap and uaa authentication, such the usergroup can have an ID in Harbor.
 // the keyAttribute and combinedKeyAttribute are key columns used to check duplicate usergroup in harbor
 func OnBoardUserGroup(g *models.UserGroup, keyAttribute string, combinedKeyAttributes ...string) error {
+	g.LdapGroupDN = utils.TrimLower(g.LdapGroupDN)
+
 	o := dao.GetOrmer()
 	created, ID, err := o.ReadOrCreate(g, keyAttribute, combinedKeyAttributes...)
 	if err != nil {


### PR DESCRIPTION
Fixes #5895 

This is because a user's group DNs are always lowercased, and comparisons are done in a case-sensitive fashion. 

https://github.com/goharbor/harbor/blob/9dca49ba6e4978a6ed22e471e105533322b68e5d/src/ui/auth/ldap/ldap.go#L95-L97

Following the practice in the same file to lowercase the LDAP group DN before persisting into the DB:

https://github.com/goharbor/harbor/blob/dcb518bcdda4fcede33823417273c10c98eee73f/src/common/dao/group/usergroup.go#L37