### PR TITLE
Modify the tooltip to increase and display the full content

### DIFF
--- a/src/portal/src/app/project/create-project/create-project.component.html
+++ b/src/portal/src/app/project/create-project/create-project.component.html
@@ -1,7 +1,7 @@
 <clr-modal [(clrModalOpen)]="createProjectOpened" [clrModalStaticBackdrop]="staticBackdrop" [clrModalClosable]="closable">
     <h3 class="modal-title">{{'PROJECT.NEW_PROJECT' | translate}}</h3>
     <inline-alert class="modal-title"></inline-alert>
-    <div class="modal-body tooltip-style">
+    <div class="modal-body modal-height">
         <form #projectForm="ngForm">
             <section class="form-block">
                 <div class="form-group" style="padding-left: 135px;">

--- a/src/portal/src/app/project/create-project/create-project.component.html
+++ b/src/portal/src/app/project/create-project/create-project.component.html
@@ -1,7 +1,7 @@
 <clr-modal [(clrModalOpen)]="createProjectOpened" [clrModalStaticBackdrop]="staticBackdrop" [clrModalClosable]="closable">
     <h3 class="modal-title">{{'PROJECT.NEW_PROJECT' | translate}}</h3>
     <inline-alert class="modal-title"></inline-alert>
-    <div class="modal-body" style="height: 12.8em; overflow-y: hidden;">
+    <div class="modal-body" style="height: 15.3em; overflow-y: hidden;">
         <form #projectForm="ngForm">
             <section class="form-block">
                 <div class="form-group" style="padding-left: 135px;">
@@ -29,7 +29,7 @@
                         <span class="access-level-label">{{ 'PROJECT.PUBLIC' | translate}}</span>
                         <a href="javascript:void(0)" role="tooltip" aria-haspopup="true" class="tooltip tooltip-md tooltip-bottom-right" style="top:-8px; left:-8px;">
                             <clr-icon shape="info-circle" class="info-tips-icon" size="24"></clr-icon>
-                            <span class="tooltip-content" style="margin-left: 5px;">{{'PROJECT.INLINE_HELP_PUBLIC' | translate }}</span>
+                            <span class="tooltip-content tooltip-right" style="margin-left: 5px;">{{'PROJECT.INLINE_HELP_PUBLIC' | translate }}</span>
                         </a>
                     </div>
                 </div>

--- a/src/portal/src/app/project/create-project/create-project.component.html
+++ b/src/portal/src/app/project/create-project/create-project.component.html
@@ -1,7 +1,7 @@
 <clr-modal [(clrModalOpen)]="createProjectOpened" [clrModalStaticBackdrop]="staticBackdrop" [clrModalClosable]="closable">
     <h3 class="modal-title">{{'PROJECT.NEW_PROJECT' | translate}}</h3>
     <inline-alert class="modal-title"></inline-alert>
-    <div class="modal-body" style="height: 15.3em; overflow-y: hidden;">
+    <div class="modal-body tooltip-style">
         <form #projectForm="ngForm">
             <section class="form-block">
                 <div class="form-group" style="padding-left: 135px;">
@@ -27,9 +27,9 @@
                         <input type="checkbox" id="create_project_public" [(ngModel)]="project.metadata.public" name="public">
                         <label for="create_project_public"></label>
                         <span class="access-level-label">{{ 'PROJECT.PUBLIC' | translate}}</span>
-                        <a href="javascript:void(0)" role="tooltip" aria-haspopup="true" class="tooltip tooltip-md tooltip-bottom-right" style="top:-8px; left:-8px;">
+                        <a href="javascript:void(0)" role="tooltip" aria-haspopup="true" class="tooltip tooltip-md tooltip-right" style="top:-8px; left:-8px;">
                             <clr-icon shape="info-circle" class="info-tips-icon" size="24"></clr-icon>
-                            <span class="tooltip-content tooltip-right" style="margin-left: 5px;">{{'PROJECT.INLINE_HELP_PUBLIC' | translate }}</span>
+                            <span class="tooltip-content" style="margin-left: 5px;">{{'PROJECT.INLINE_HELP_PUBLIC' | translate }}</span>
                         </a>
                     </div>
                 </div>

--- a/src/portal/src/app/project/create-project/create-project.scss
+++ b/src/portal/src/app/project/create-project/create-project.scss
@@ -11,3 +11,7 @@
     top: -6px;
     position: relative;
 }
+.tooltip-style {
+    height: 15.3em;
+    overflow-y: hidden;
+}

--- a/src/portal/src/app/project/create-project/create-project.scss
+++ b/src/portal/src/app/project/create-project/create-project.scss
@@ -11,7 +11,7 @@
     top: -6px;
     position: relative;
 }
-.tooltip-style {
+.modal-height {
     height: 15.3em;
     overflow-y: hidden;
 }


### PR DESCRIPTION
fixed #5885 
Tooltip is truncated in "New Project" dialog ,so modify the tooltip to the right and raise the modal-body to make the tooltip display full.
Signed-off-by: Cheng Fangyuan<1309173081@qq.com>