### PR TITLE
[1.6.0] Fix statuses condition when trigger replication

### DIFF
--- a/src/ui/api/replication.go
+++ b/src/ui/api/replication.go
@@ -64,8 +64,9 @@ func (r *ReplicationAPI) Post() {
 	}
 
 	count, err := dao.GetTotalCountOfRepJobs(&models.RepJobQuery{
-		PolicyID: replication.PolicyID,
-		Statuses: []string{models.RepOpTransfer, models.RepOpDelete},
+		PolicyID:   replication.PolicyID,
+		Statuses:   []string{models.JobPending, models.JobRunning},
+		Operations: []string{models.RepOpTransfer, models.RepOpDelete},
 	})
 	if err != nil {
 		r.HandleInternalServerError(fmt.Sprintf("failed to filter jobs of policy %d: %v",


### PR DESCRIPTION
Signed-off-by: 陈德 <chende@caicloud.io>

When trigger a replication policy, Harbor will check whether the policy has related jobs that are pending or running. But there is some mistake in the check.

```
count, err := dao.GetTotalCountOfRepJobs(&models.RepJobQuery{
	PolicyID: replication.PolicyID,
	Statuses: []string{models.RepOpTransfer, models.RepOpDelete},
})
```