### PR TITLE
Run `chown` to job log directory

### DIFF
--- a/make/photon/jobservice/start.sh
+++ b/make/photon/jobservice/start.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
-
+if [ -d /var/log/jobs ]; then
+    chown -R 10000:10000 /var/log/jobs/
+fi
 sudo -E -u \#10000 "/harbor/harbor_jobservice" "-c" "/etc/jobservice/config.yml"
 


### PR DESCRIPTION
This commit revoke part of the change introduced in commit #1fc4142, by
calling chown to job log directory within the container when the job
service bootstraps.  The reason is we are seeing permission issue in
helm-chart deployment, and we want to reduce effort to handle the
permission on different deployment approaches.

There are some code in `prepare` script to change the ownership of the
JOB_LOG directory, it will be left for now to avoid regression in VIC
integration.

Signed-off-by: Daniel Jiang <jiangd@vmware.com>