### PR TITLE
Fix gc api issues

### DIFF
--- a/src/common/dao/admin_job.go
+++ b/src/common/dao/admin_job.go
@@ -87,12 +87,19 @@ func SetAdminJobUUID(id int64, uuid string) error {
 	return err
 }
 
-// GetTop10AdminJobs ...
-func GetTop10AdminJobs() ([]*models.AdminJob, error) {
-	sql := `select * from admin_job 
-	where deleted = false order by update_time desc limit 10`
+// GetTop10AdminJobsOfName ...
+func GetTop10AdminJobsOfName(name string) ([]*models.AdminJob, error) {
+	o := GetOrmer()
 	jobs := []*models.AdminJob{}
-	_, err := GetOrmer().Raw(sql).QueryRows(&jobs)
+	n, err := o.Raw(`select * from admin_job 
+		where deleted = false and job_name = ? order by update_time desc limit 10`, name).QueryRows(&jobs)
+	if err != nil {
+		return nil, err
+	}
+
+	if n == 0 {
+		return nil, nil
+	}
 	return jobs, err
 }
 

--- a/src/common/dao/admin_job_test.go
+++ b/src/common/dao/admin_job_test.go
@@ -70,6 +70,6 @@ func TestAddAdminJob(t *testing.T) {
 	_, err = AddAdminJob(job)
 	require.Nil(t, err)
 
-	jobs, _ = GetTop10AdminJobs()
-	assert.Equal(t, len(jobs), 3)
+	jobs, _ = GetTop10AdminJobsOfName("job")
+	assert.Equal(t, len(jobs), 2)
 }

--- a/src/core/api/reg_gc.go
+++ b/src/core/api/reg_gc.go
@@ -131,7 +131,7 @@ func (gc *GCAPI) GetGC() {
 
 // List ...
 func (gc *GCAPI) List() {
-	jobs, err := dao.GetTop10AdminJobs()
+	jobs, err := dao.GetTop10AdminJobsOfName(common_job.ImageGC)
 	if err != nil {
 		gc.HandleInternalServerError(fmt.Sprintf("failed to get admin jobs: %v", err))
 		return
@@ -251,11 +251,15 @@ func (gc *GCAPI) submitJob(gr *models.GCReq) {
 
 	// submit job to jobservice
 	log.Debugf("submiting GC admin job to jobservice")
-	_, err = utils_core.GetJobServiceClient().SubmitJob(job)
+	uuid, err := utils_core.GetJobServiceClient().SubmitJob(job)
 	if err != nil {
 		if err := dao.DeleteAdminJob(id); err != nil {
 			log.Debugf("Failed to delete admin job, err: %v", err)
 		}
+		gc.HandleInternalServerError(fmt.Sprintf("%v", err))
+		return
+	}
+	if err := dao.SetAdminJobUUID(id, uuid); err != nil {
 		gc.HandleInternalServerError(fmt.Sprintf("%v", err))
 		return
 	}


### PR DESCRIPTION
1, filter out the scan all jobs in the gc list.
2, make it able to delete unexecuted scheduler.

Signed-off-by: wang yan <wangyan@vmware.com>