### PR TITLE
Use secure transport to access HTTP endpoint

### DIFF
--- a/src/common/utils/notary/helper.go
+++ b/src/common/utils/notary/helper.go
@@ -89,7 +89,7 @@ func GetTargets(notaryEndpoint string, username string, fqRepo string) ([]Target
 	authorizer := &notaryAuthorizer{
 		token: t.Token,
 	}
-	tr := registry.NewTransport(registry.GetHTTPTransport(true), authorizer)
+	tr := registry.NewTransport(registry.GetHTTPTransport(), authorizer)
 	gun := data.GUN(fqRepo)
 	notaryRepo, err := client.NewFileCachedNotaryRepository(notaryCachePath, gun, notaryEndpoint, tr, mockRetriever, trustPin)
 	if err != nil {

--- a/src/jobservice/job/impl/utils/utils.go
+++ b/src/jobservice/job/impl/utils/utils.go
@@ -72,7 +72,7 @@ func BuildBlobURL(endpoint, repository, digest string) string {
 // GetTokenForRepo is used for job handler to get a token for clair.
 func GetTokenForRepo(repository, secret, internalTokenServiceURL string) (string, error) {
 	credential := httpauth.NewSecretAuthorizer(secret)
-	t, err := auth.GetToken(internalTokenServiceURL, true, credential,
+	t, err := auth.GetToken(internalTokenServiceURL, false, credential,
 		[]*token.ResourceActions{{
 			Type:    "repository",
 			Name:    repository,

--- a/src/replication/replicator/replicator.go
+++ b/src/replication/replicator/replicator.go
@@ -98,7 +98,7 @@ func (d *DefaultReplicator) Replicate(replication *Replication) error {
 					"repository":            repository,
 					"tags":                  tags,
 					"src_registry_url":      url,
-					"src_registry_insecure": true,
+					"src_registry_insecure": false,
 					// "src_token_service_url":"",
 					"dst_registry_url":      target.URL,
 					"dst_registry_insecure": target.Insecure,


### PR DESCRIPTION
In various parts of the code, we used insecure transport in http Client
when we assume the endpoint is http.  This causes complaints form
security scanner.  We should use secure transport in such cases.

Signed-off-by: Daniel Jiang <jiangd@vmware.com>