### PR TITLE
Revoke the change in replicator

### DIFF
--- a/src/replication/replicator/replicator.go
+++ b/src/replication/replicator/replicator.go
@@ -98,7 +98,7 @@ func (d *DefaultReplicator) Replicate(replication *Replication) error {
 					"repository":            repository,
 					"tags":                  tags,
 					"src_registry_url":      url,
-					"src_registry_insecure": false,
+					"src_registry_insecure": true,
 					// "src_token_service_url":"",
 					"dst_registry_url":      target.URL,
 					"dst_registry_insecure": target.Insecure,


### PR DESCRIPTION
Revoke the change made to replicator to reset the insecure flag to true
when accessing source registry.  The reason is that the replicator will
use external URL to access source registry, setting it to false will
break replication when Harbor is hosting with self-signed certificate.

Signed-off-by: Daniel Jiang <jiangd@vmware.com>