### PR TITLE
Add nightly badge into goharbor repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/goharbor/harbor)](https://goreportcard.com/report/github.com/goharbor/harbor)
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/2095/badge)](https://bestpractices.coreinfrastructure.org/projects/2095)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/c8d726c9cfd047ffaf681449d673f246)](https://www.codacy.com/app/goharbor/harbor?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=goharbor/harbor&amp;utm_campaign=Badge_Grade)
+[![Nightly Status](https://us-central1-eminent-nation-87317.cloudfunctions.net/harbor-nightly-result)](https://www.googleapis.com/storage/v1/b/harbor-nightly/o)
 
 </br>
 


### PR DESCRIPTION
This commit is to add the nightly result badge into goharbor repo,

1,the badge could index the status of full ci which is running internally.
2,the badge is clickable, and all of the logs can be downloaded.

Signed-off-by: wang yan <wangyan@vmware.com>