### PR TITLE
Create shcema migration table in DB container

### DIFF
--- a/make/photon/db/initial-registry.sql
+++ b/make/photon/db/initial-registry.sql
@@ -1,2 +1,4 @@
 CREATE DATABASE registry ENCODING 'UTF8';
+\c registry;
 
+CREATE TABLE schema_migrations(version bigint not null primary key, dirty boolean not null);


### PR DESCRIPTION
The migrate tool will try to create table schema_migration upon opening
the connection to DB.  This will cause error when there are multiple
instance of adminserver trying to access the migrator upon start.
This commit move the creation of the table during the initialization of
the DB container.

Signed-off-by: Daniel Jiang <jiangd@vmware.com>