### PR TITLE
Modify the dialog information when removing a member of project

### DIFF
--- a/src/portal/src/i18n/lang/en-us-lang.json
+++ b/src/portal/src/i18n/lang/en-us-lang.json
@@ -170,7 +170,7 @@
         "NAME_IS_ILLEGAL": "Project name is invalid.",
         "UNKNOWN_ERROR": "An unknown error occurred while creating the project.",
         "ITEMS": "items",
-        "DELETION_TITLE": "Confirm project deletion",
+        "DELETION_TITLE": "Confirm removal of project members",
         "DELETION_SUMMARY": "Do you want to delete project {{param}}?",
         "FILTER_PLACEHOLDER": "Filter Projects",
         "REPLICATION_RULE": "Replication Rule",

--- a/src/portal/src/i18n/lang/zh-cn-lang.json
+++ b/src/portal/src/i18n/lang/zh-cn-lang.json
@@ -171,7 +171,7 @@
         "UNKNOWN_ERROR": "创建项目时发生未知错误。",
         "OF": "共计",
         "ITEMS": "条记录",
-        "DELETION_TITLE": "删除项目确认",
+        "DELETION_TITLE": "移除项目成员确认",
         "DELETION_SUMMARY": "你确认删除项目 {{param}}？",
         "FILTER_PLACEHOLDER": "过滤项目",
         "REPLICATION_RULE": "复制规则",


### PR DESCRIPTION
fixed #5130 
when removing a user from a project,The dialog information is changed from 'Confirm project deletion' to 'Confirm removal of project members'.
Signed-off-by: FangyuanCheng <fangyuanc@vmware.com>