### PR TITLE
Limit dns search in harbor containers

### DIFF
--- a/make/docker-compose.chartmuseum.tpl
+++ b/make/docker-compose.chartmuseum.tpl
@@ -16,6 +16,7 @@ services:
     restart: always
     networks:
       - harbor-chartmuseum
+    dns_search: ""
     depends_on:
       - redis
     volumes:

--- a/make/docker-compose.clair.tpl
+++ b/make/docker-compose.clair.tpl
@@ -23,6 +23,7 @@ services:
     image: goharbor/clair-photon:__clair_version__
     restart: always
     cpu_quota: 50000
+    dns_search: ""
     depends_on:
       - postgresql
     volumes:

--- a/make/docker-compose.notary.tpl
+++ b/make/docker-compose.notary.tpl
@@ -18,6 +18,7 @@ services:
     networks:
       - notary-sig
       - harbor-notary
+    dns_search: ""
     volumes:
       - ./common/config/notary:/etc/notary:z
     env_file:
@@ -39,6 +40,7 @@ services:
       notary-sig:
         aliases:
           - notarysigner
+    dns_search: ""
     volumes:
       - ./common/config/notary:/etc/notary:z
     env_file:

--- a/make/docker-compose.tpl
+++ b/make/docker-compose.tpl
@@ -4,6 +4,7 @@ services:
     image: goharbor/harbor-log:__version__
     container_name: harbor-log 
     restart: always
+    dns_search: ""
     volumes:
       - /var/log/harbor/:/var/log/docker/:z
       - ./common/config/log/:/etc/logrotate.d/:z
@@ -20,6 +21,7 @@ services:
       - ./common/config/registry/:/etc/registry/:z
     networks:
       - harbor
+    dns_search: ""
     environment:
       - GODEBUG=netdns=cgo
     depends_on:
@@ -41,6 +43,7 @@ services:
       - ./common/config/registryctl/config.yml:/etc/registryctl/config.yml:z
     networks:
       - harbor
+    dns_search: ""
     environment:
       - GODEBUG=netdns=cgo
     depends_on:
@@ -58,6 +61,7 @@ services:
       - /data/database:/var/lib/postgresql/data:z
     networks:
       - harbor
+    dns_search: ""
     env_file:
       - ./common/config/db/env
     depends_on:
@@ -79,6 +83,7 @@ services:
       - /data/:/data/:z
     networks:
       - harbor
+    dns_search: ""
     depends_on:
       - log
     logging:
@@ -101,6 +106,7 @@ services:
       - /data/psc/:/etc/core/token/:z
     networks:
       - harbor
+    dns_search: ""
     depends_on:
       - log
       - adminserver
@@ -116,6 +122,7 @@ services:
     restart: always
     networks:
       - harbor
+    dns_search: ""
     depends_on:
       - log
       - core
@@ -136,6 +143,7 @@ services:
       - ./common/config/jobservice/config.yml:/etc/jobservice/config.yml:z
     networks:
       - harbor
+    dns_search: ""
     depends_on:
       - redis
       - core
@@ -153,6 +161,7 @@ services:
       - /data/redis:/var/lib/redis
     networks:
       - harbor
+    dns_search: ""
     depends_on:
       - log
     logging:
@@ -168,6 +177,7 @@ services:
       - ./common/config/nginx:/etc/nginx:z
     networks:
       - harbor
+    dns_search: ""
     ports:
       - 80:80
       - 443:443


### PR DESCRIPTION
This commit is to set dns search to null in the harbor containers,
that means the dns search domains of docker host doesn't impact
the network IO in the containers.

If do not set this, Harbor notary-server and notary-signer are resolving
the "mysql" alias to the resolv.conf search path instead of to "mysql."
for the notary-db bridge IP, see #6031.

Signed-off-by: wang yan <wangyan@vmware.com>