### PR TITLE
Limit dns search in harbor containers

### DIFF
--- a/make/docker-compose.clair.tpl
+++ b/make/docker-compose.clair.tpl
@@ -19,6 +19,7 @@ services:
     container_name: clair-db
     image: vmware/postgresql-photon:__postgresql_version__
     restart: always
+    dns_search: .
     depends_on:
       - log
     env_file:
@@ -38,6 +39,7 @@ services:
     image: vmware/clair-photon:__clair_version__
     restart: always
     cpu_quota: 150000
+    dns_search: .
     depends_on:
       - postgres
     volumes:

--- a/make/docker-compose.notary.tpl
+++ b/make/docker-compose.notary.tpl
@@ -14,6 +14,7 @@ services:
       - notary-mdb
       - notary-sig
       - harbor-notary
+    dns_search: .
     volumes:
       - ./common/config/notary:/config:z
     depends_on:
@@ -33,6 +34,7 @@ services:
       notary-sig:
         aliases:
           - notarysigner
+    dns_search: .
     volumes:
       - ./common/config/notary:/config:z
     env_file:
@@ -52,6 +54,7 @@ services:
       notary-mdb:
         aliases:
           - mysql
+    dns_search: .
     volumes:
       - ./common/config/notary/mysql-initdb.d:/docker-entrypoint-initdb.d:z
       - /data/notary-db:/var/lib/mysql:z

--- a/make/docker-compose.tpl
+++ b/make/docker-compose.tpl
@@ -11,6 +11,7 @@ services:
       - 127.0.0.1:1514:10514
     networks:
       - harbor
+    dns_search: .
   registry:
     image: vmware/registry-photon:__reg_version__
     container_name: registry
@@ -20,6 +21,7 @@ services:
       - ./common/config/registry/:/etc/registry/:z
     networks:
       - harbor
+    dns_search: .
     environment:
       - GODEBUG=netdns=cgo
     command:
@@ -39,6 +41,7 @@ services:
       - /data/database:/var/lib/mysql:z
     networks:
       - harbor
+    dns_search: .
     env_file:
       - ./common/config/db/env
     depends_on:
@@ -60,6 +63,7 @@ services:
       - /data/:/data/:z
     networks:
       - harbor
+    dns_search: .
     depends_on:
       - log
     logging:
@@ -82,6 +86,7 @@ services:
       - /data/psc/:/etc/ui/token/:z
     networks:
       - harbor
+    dns_search: .
     depends_on:
       - log
       - adminserver
@@ -102,6 +107,7 @@ services:
       - ./common/config/jobservice/config.yml:/etc/jobservice/config.yml:z
     networks:
       - harbor
+    dns_search: .
     depends_on:
       - redis
       - ui
@@ -119,6 +125,7 @@ services:
       - /data/redis:/data
     networks:
       - harbor
+    dns_search: .
     depends_on:
       - log
     logging:
@@ -134,6 +141,7 @@ services:
       - ./common/config/nginx:/etc/nginx:z
     networks:
       - harbor
+    dns_search: .
     ports:
       - 80:80
       - 443:443


### PR DESCRIPTION
This commit is to set dns search to null in the harbor containers,
that means the dns search domains of docker host doesn't impact
the network IO in the containers.

If do not set this, Harbor notary-server and notary-signer are resolving
the "mysql" alias to the resolv.conf search path instead of to "mysql."
for the notary-db bridge IP, see #6031.

According to docker official document, 'Use --dns-search=.' if you don't
wish to set the search domain.

https://docs.docker.com/v17.09/engine/userguide/networking/default_network/configure-dns/

Signed-off-by: wang yan <wangyan@vmware.com>