### PR TITLE
Use docker official way to unset dns search

### DIFF
--- a/make/common/templates/adminserver/env
+++ b/make/common/templates/adminserver/env
@@ -40,7 +40,6 @@ CORE_SECRET=$core_secret
 JOBSERVICE_SECRET=$jobservice_secret
 TOKEN_EXPIRATION=$token_expiration
 CFG_EXPIRATION=5
-GODEBUG=netdns=cgo
 ADMIRAL_URL=$admiral_url
 WITH_NOTARY=$with_notary
 WITH_CLAIR=$with_clair

--- a/make/common/templates/core/env
+++ b/make/common/templates/core/env
@@ -2,7 +2,6 @@ LOG_LEVEL=info
 CONFIG_PATH=/etc/core/app.conf
 CORE_SECRET=$core_secret
 JOBSERVICE_SECRET=$jobservice_secret
-GODEBUG=netdns=cgo
 ADMINSERVER_URL=$adminserver_url
 UAA_CA_ROOT=/etc/core/certificates/uaa_ca.pem
 _REDIS_URL=$redis_host:$redis_port,100,$redis_password

--- a/make/common/templates/jobservice/env
+++ b/make/common/templates/jobservice/env
@@ -1,4 +1,3 @@
 CORE_SECRET=$core_secret
 JOBSERVICE_SECRET=$jobservice_secret
 CORE_URL=$core_url
-GODEBUG=netdns=cgo

--- a/make/docker-compose.chartmuseum.tpl
+++ b/make/docker-compose.chartmuseum.tpl
@@ -16,7 +16,7 @@ services:
     restart: always
     networks:
       - harbor-chartmuseum
-    dns_search: ""
+    dns_search: .
     depends_on:
       - redis
     volumes:

--- a/make/docker-compose.clair.tpl
+++ b/make/docker-compose.clair.tpl
@@ -23,7 +23,7 @@ services:
     image: goharbor/clair-photon:__clair_version__
     restart: always
     cpu_quota: 50000
-    dns_search: ""
+    dns_search: .
     depends_on:
       - postgresql
     volumes:

--- a/make/docker-compose.notary.tpl
+++ b/make/docker-compose.notary.tpl
@@ -18,7 +18,7 @@ services:
     networks:
       - notary-sig
       - harbor-notary
-    dns_search: ""
+    dns_search: .
     volumes:
       - ./common/config/notary:/etc/notary:z
     env_file:
@@ -40,7 +40,7 @@ services:
       notary-sig:
         aliases:
           - notarysigner
-    dns_search: ""
+    dns_search: .
     volumes:
       - ./common/config/notary:/etc/notary:z
     env_file:

--- a/make/docker-compose.tpl
+++ b/make/docker-compose.tpl
@@ -22,8 +22,6 @@ services:
     networks:
       - harbor
     dns_search: .
-    environment:
-      - GODEBUG=netdns=cgo
     depends_on:
       - log
     logging:
@@ -44,8 +42,6 @@ services:
     networks:
       - harbor
     dns_search: .
-    environment:
-      - GODEBUG=netdns=cgo
     depends_on:
       - log
     logging:

--- a/make/docker-compose.tpl
+++ b/make/docker-compose.tpl
@@ -4,7 +4,7 @@ services:
     image: goharbor/harbor-log:__version__
     container_name: harbor-log 
     restart: always
-    dns_search: ""
+    dns_search: .
     volumes:
       - /var/log/harbor/:/var/log/docker/:z
       - ./common/config/log/:/etc/logrotate.d/:z
@@ -21,7 +21,7 @@ services:
       - ./common/config/registry/:/etc/registry/:z
     networks:
       - harbor
-    dns_search: ""
+    dns_search: .
     environment:
       - GODEBUG=netdns=cgo
     depends_on:
@@ -43,7 +43,7 @@ services:
       - ./common/config/registryctl/config.yml:/etc/registryctl/config.yml:z
     networks:
       - harbor
-    dns_search: ""
+    dns_search: .
     environment:
       - GODEBUG=netdns=cgo
     depends_on:
@@ -61,7 +61,7 @@ services:
       - /data/database:/var/lib/postgresql/data:z
     networks:
       - harbor
-    dns_search: ""
+    dns_search: .
     env_file:
       - ./common/config/db/env
     depends_on:
@@ -83,7 +83,7 @@ services:
       - /data/:/data/:z
     networks:
       - harbor
-    dns_search: ""
+    dns_search: .
     depends_on:
       - log
     logging:
@@ -106,7 +106,7 @@ services:
       - /data/psc/:/etc/core/token/:z
     networks:
       - harbor
-    dns_search: ""
+    dns_search: .
     depends_on:
       - log
       - adminserver
@@ -122,7 +122,7 @@ services:
     restart: always
     networks:
       - harbor
-    dns_search: ""
+    dns_search: .
     depends_on:
       - log
       - core
@@ -143,7 +143,7 @@ services:
       - ./common/config/jobservice/config.yml:/etc/jobservice/config.yml:z
     networks:
       - harbor
-    dns_search: ""
+    dns_search: .
     depends_on:
       - redis
       - core
@@ -161,7 +161,7 @@ services:
       - /data/redis:/var/lib/redis
     networks:
       - harbor
-    dns_search: ""
+    dns_search: .
     depends_on:
       - log
     logging:
@@ -177,7 +177,7 @@ services:
       - ./common/config/nginx:/etc/nginx:z
     networks:
       - harbor
-    dns_search: ""
+    dns_search: .
     ports:
       - 80:80
       - 443:443

--- a/tests/docker-compose.test.yml
+++ b/tests/docker-compose.test.yml
@@ -6,8 +6,6 @@ services:
     volumes:
       - /data/registry:/storage
       - ./common/config/registry/:/etc/registry/
-    environment:
-      - GODEBUG=netdns=cgo
     ports:
       - 5000:5000
     command:


### PR DESCRIPTION
According docker official document, use 'dns_search= .' in the docker
compose file if you don't wish to set the search domain.

https://docs.docker.com/v17.09/engine/userguide/networking/default_network/configure-dns/

Signed-off-by: wang yan <wangyan@vmware.com>