### PR TITLE
Upgrade notary compile golang version to 1.9.4

### DIFF
--- a/make/photon/notary/binary.Dockerfile
+++ b/make/photon/notary/binary.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.7.3
+FROM golang:1.9.4
 
 ENV NOTARYPKG github.com/theupdateframework/notary
 

--- a/make/photon/notary/builder
+++ b/make/photon/notary/builder
@@ -23,7 +23,7 @@ cur=$PWD
 TEMP=`mktemp -d /$TMPDIR/notary.XXXXXX`
 git clone -b $VERSION https://github.com/theupdateframework/notary.git $TEMP
 
-echo 'build the notary binary bases on the golang:1.7.3...'
+echo 'build the notary binary bases on the golang:1.9.4...'
 cp binary.Dockerfile $TEMP 
 cd $TEMP
 docker build -f binary.Dockerfile -t notary-golang $TEMP


### PR DESCRIPTION
This commit is to upgrade the golang version to 1.9.4, it because a
bug of golang 17.3 could introduce one dns resolver issue for harbor
mentioned by #6031.

The bug of golang is https://github.com/golang/go/issues/15419, it makes
harbor containers to lookup 'endpoint.' firstly which may cause network
issue.

Signed-off-by: wang yan <wangyan@vmware.com>