### PR TITLE
Allow developers and project admins  administrators to downloadthe harbor certs  from UI.

### DIFF
--- a/src/portal/lib/src/config/system/system-settings.component.ts
+++ b/src/portal/lib/src/config/system/system-settings.component.ts
@@ -1,8 +1,7 @@
 import { Component, Input, Output, EventEmitter, ViewChild, Inject } from '@angular/core';
 import { NgForm } from '@angular/forms';
 import { Configuration } from '../config';
-import { SERVICE_CONFIG, IServiceConfig } from '../../service.config';
-
+import { SERVICE_CONFIG, IServiceConfig, downloadUrl } from '../../service.config';
 @Component({
     selector: 'system-settings',
     templateUrl: './system-settings.component.html',
@@ -10,7 +9,7 @@ import { SERVICE_CONFIG, IServiceConfig } from '../../service.config';
 })
 export class SystemSettingsComponent {
     config: Configuration;
-    downloadLink: string = "/api/systeminfo/getcert";
+    downloadLink: string = downloadUrl;
     @Output() configChange: EventEmitter<Configuration> = new EventEmitter<Configuration>();
 
     @Input()

--- a/src/portal/lib/src/repository-gridview/repository-gridview.component.html
+++ b/src/portal/lib/src/repository-gridview/repository-gridview.component.html
@@ -3,6 +3,10 @@
         <div class="toolbar">
             <div class="row flex-items-xs-right option-right rightPos">
                 <div class="flex-xs-middle">
+                    <a #certDownloadLink [href]="downloadLink" target="_blank" class="btn btn-link btn-font download-link">
+                        <clr-icon shape="download"></clr-icon>
+                        {{'CONFIG.REGISTRY_CERTIFICATE' | translate | uppercase}}
+                    </a>
                     <hbr-push-image-button style="display: inline-block;" [registryUrl]="registryUrl" [projectName]="projectName"></hbr-push-image-button>
                     <hbr-filter [withDivider]="true" filterPlaceholder="{{'REPOSITORY.FILTER_FOR_REPOSITORIES' | translate}}" (filterEvt)="doSearchRepoNames($event)" [currentValue]="lastFilteredRepoName"></hbr-filter>
                     <span class="card-btn" (click)="showCard(true)" (mouseenter) ="mouseEnter('card') "  (mouseleave) ="mouseLeave('card')">

--- a/src/portal/lib/src/repository-gridview/repository-gridview.component.scss
+++ b/src/portal/lib/src/repository-gridview/repository-gridview.component.scss
@@ -8,6 +8,10 @@
     overflow: hidden;
 }
 
+.download-link {
+    font-size: 14px;
+}
+
 .filter-divider {
     display: inline-block;
     height: 16px;

--- a/src/portal/lib/src/repository-gridview/repository-gridview.component.ts
+++ b/src/portal/lib/src/repository-gridview/repository-gridview.component.ts
@@ -35,7 +35,7 @@ import {Tag} from '../service/interface';
 import {GridViewComponent} from '../gridview/grid-view.component';
 import {OperationService} from "../operation/operation.service";
 import {OperateInfo, OperationState, operateChanges} from "../operation/operate";
-
+import { downloadUrl } from '../service.config';
 @Component({
     selector: "hbr-repository-gridview",
     templateUrl: "./repository-gridview.component.html",
@@ -44,6 +44,7 @@ import {OperateInfo, OperationState, operateChanges} from "../operation/operate"
 })
 export class RepositoryGridviewComponent implements OnChanges, OnInit {
     signedCon: { [key: string]: any | string[] } = {};
+    downloadLink: string = downloadUrl;
     @Input() projectId: number;
     @Input() projectName = "unknown";
     @Input() urlPrefix: string;

--- a/src/portal/lib/src/service.config.ts
+++ b/src/portal/lib/src/service.config.ts
@@ -1,7 +1,7 @@
 import { InjectionToken } from '@angular/core';
 
 export let SERVICE_CONFIG = new InjectionToken("service.config");
-
+export const downloadUrl = "/api/systeminfo/getcert";
 export interface IServiceConfig {
     /**
      * The base endpoint of service used to retrieve the system configuration information.

--- a/src/portal/src/i18n/lang/en-us-lang.json
+++ b/src/portal/src/i18n/lang/en-us-lang.json
@@ -583,6 +583,7 @@
         "PRO_CREATION_ADMIN": "Admin Only",
         "ROOT_CERT": "Registry Root Certificate",
         "ROOT_CERT_LINK": "Download",
+        "REGISTRY_CERTIFICATE": "Registry certificate",
         "TOOLTIP": {
             "SELF_REGISTRATION_ENABLE": "Enable sign up.",
             "SELF_REGISTRATION_DISABLE": "Disable sign up.",

--- a/src/portal/src/i18n/lang/es-es-lang.json
+++ b/src/portal/src/i18n/lang/es-es-lang.json
@@ -582,6 +582,7 @@
         "PRO_CREATION_ADMIN": "Solo Administradores",
         "ROOT_CERT": "Registro Certificado Raíz",
         "ROOT_CERT_LINK": "Descargar",
+        "REGISTRY_CERTIFICATE": "Certificado de registro",
         "TOOLTIP": {
             "SELF_REGISTRATION_ENABLE": "Activar registro.",
             "SELF_REGISTRATION_DISABLE": "Disable sign up.",

--- a/src/portal/src/i18n/lang/fr-fr-lang.json
+++ b/src/portal/src/i18n/lang/fr-fr-lang.json
@@ -554,6 +554,7 @@
         "ROOT_CERT": "Enregistrer le Certificat Racine",
         "ROOT_CERT_LINK": "Télécharger",
         "GC": "Garbage Collection",
+        "REGISTRY_CERTIFICATE": "certificat d'enregistrement",
         "TOOLTIP": {
             "SELF_REGISTRATION_ENABLE": "Activer l'inscription.",
             "SELF_REGISTRATION_DISABLE": "Désactiver l'inscription.",

--- a/src/portal/src/i18n/lang/zh-cn-lang.json
+++ b/src/portal/src/i18n/lang/zh-cn-lang.json
@@ -582,6 +582,7 @@
         "PRO_CREATION_ADMIN": "仅管理员",
         "ROOT_CERT": "镜像库根证书",
         "ROOT_CERT_LINK": "下载",
+        "REGISTRY_CERTIFICATE": "注册证书",
         "TOOLTIP": {
             "SELF_REGISTRATION_ENABLE": "激活注册功能。",
             "SELF_REGISTRATION_DISABLE": "禁用注册功能。",


### PR DESCRIPTION
fixes #3117 
Adding links enables developers and project administrators to download registry certificates from UI.
Signed-off-by: FangyuanCheng <fangyuanc@vmware.com>