### PR TITLE
Add a header separator line to the action drop-down menu.

### DIFF
--- a/src/portal/src/app/user/user.component.html
+++ b/src/portal/src/app/user/user.component.html
@@ -16,8 +16,9 @@
                     <clr-dropdown id='member-action' [clrCloseMenuOnItemClick]="false" class="btn btn-sm btn-link" clrDropdownTrigger>
                         <span>{{'BUTTON.ACTIONS' | translate}}<clr-icon shape="caret down"></clr-icon></span>
                         <clr-dropdown-menu *clrIfOpen>
-                            <button type="button" class="btn btn-sm btn-secondary" id="changePwd" [hidden]="!canCreateUser" [disabled]="!(selectedRow.length==1)" (click)="openChangePwdModal()" ><clr-icon shape="edit" size="16"></clr-icon>&nbsp;{{'RESET_PWD.TITLE'  | translate | uppercase}}</button>
-                            <button type="button" class="btn btn-sm btn-secondary" (click)="deleteUsers(selectedRow)" [disabled]="!selectedRow.length || onlySelf || !canCreateUser"><clr-icon shape="times" size="16"></clr-icon>&nbsp;{{'USER.DEL_ACTION' | translate | uppercase}}</button>
+                            <button type="button" class="btn btn-sm btn-secondary" id="changePwd" [hidden]="!canCreateUser" [disabled]="!(selectedRow.length==1)" (click)="openChangePwdModal()" ><clr-icon shape="edit" size="16"></clr-icon>&nbsp;{{'RESET_PWD.TITLE'  | translate}}</button>
+                            <div class="dropdown-divider"></div>
+                            <button type="button" class="btn btn-sm btn-secondary" (click)="deleteUsers(selectedRow)" [disabled]="!selectedRow.length || onlySelf || !canCreateUser"><clr-icon shape="times" size="16"></clr-icon>&nbsp;{{'USER.DEL_ACTION' | translate}}</button>
                         </clr-dropdown-menu>
                     </clr-dropdown>
                 </clr-dg-action-bar>


### PR DESCRIPTION
fixed #5301 
1, add the header separator line in the action drop-down menu of user options.
2. Modify the text in the drop-down menu as initial letter.
Signed-off-by: FangyuanCheng <fangyuanc@vmware.com>