### PR TITLE
Vulnerability scan cancel editing to make UI into orginal status

### DIFF
--- a/src/portal/lib/src/config/vulnerability/vulnerability-config.component.html
+++ b/src/portal/lib/src/config/vulnerability/vulnerability-config.component.html
@@ -28,7 +28,7 @@
             <span>{{ (scanningType ? 'SCHEDULE.'+ scanningType.toUpperCase(): "") | translate }}</span>
             <span [hidden]="scanningType===SCHEDULE_TYPE.NONE">{{'SCHEDULE.AT' | translate}}</span>
             <span [hidden]="scanningType===SCHEDULE_TYPE.NONE">{{ dailyTime | translate }}</span>
-            <button class="btn btn-outline btn-sm"  (click)="editSchedule()">{{'BUTTON.EDIT' | translate}}</button>
+            <button class="btn btn-outline btn-sm"  (click)="editSchedule()" id="editSchedule">{{'BUTTON.EDIT' | translate}}</button>
         </div>
         <div class="form-group vertical-center" *ngIf="isEditMode">
             <label for="scanAllPolicy">{{ 'CONFIG.SCANNING.SCAN_ALL' | translate }}</label>

--- a/src/portal/lib/src/config/vulnerability/vulnerability-config.component.ts
+++ b/src/portal/lib/src/config/vulnerability/vulnerability-config.component.ts
@@ -9,7 +9,7 @@ import {
     ConfigurationService
 } from '../../service/index';
 import { ErrorHandler } from '../../error-handler/index';
-import { toPromise, isEmptyObject } from '../../utils';
+import { toPromise, isEmptyObject, clone} from '../../utils';
 import { TranslateService } from '@ngx-translate/core';
 import { ClairDetail } from '../../service/interface';
 const ONE_HOUR_SECONDS: number = 3600;
@@ -252,7 +252,7 @@ export class VulnerabilityConfigComponent implements OnInit {
     getConfigurations(): void {
         toPromise<Configuration>(this.configService.getConfigurations())
             .then((config: Configuration) => {
-                this.configCopy = Object.assign({}, config);
+                this.configCopy = clone(config);
                 this.config = config;
             })
             .catch(error => {
@@ -346,7 +346,7 @@ export class VulnerabilityConfigComponent implements OnInit {
         let getchanges = this.config.scan_all_policy.value;
         let changes = {"scan_all_policy": getchanges};
         for (let prop of Object.keys(changes)) {
-            this.config[prop] = Object.assign({}, this.configCopy[prop]);
+            this.config[prop] = clone(this.configCopy[prop]);
         }
     }
 }

--- a/tests/resources/Harbor-Pages/Vulnerability.robot
+++ b/tests/resources/Harbor-Pages/Vulnerability.robot
@@ -7,6 +7,7 @@ Resource  ../../resources/Util.robot
  
 *** Keywords ***
 Disable Scan Schedule
+     Click Element  //vulnerability-config//button[@id="editSchedule"]
      Click Element  //vulnerability-config//select[@id="scanAllPolicy"]
      Click Element  //vulnerability-config//select[@id="scanAllPolicy"]//option[contains(.,'None')]
      Click Element  //button[contains(.,'SAVE')]


### PR DESCRIPTION
fixed： #6080 
Modify the vulnerability scan page to cancel the edit button so that the page is displayed as the initial data after clicking
Signed-off-by: Cheng Fangyuan <fangyuanc@vmware.com>