### PR TITLE
Fix permission issue in rsyslog container.

### DIFF
--- a/make/photon/log/Dockerfile
+++ b/make/photon/log/Dockerfile
@@ -14,7 +14,7 @@ COPY ./make/photon/log/rsyslog_docker.conf /etc/rsyslog.d/
 RUN mv /etc/cron.daily/logrotate /etc/cron.hourly/logrotate
 
 COPY ./make/photon/log/start.sh /usr/local/bin/
-RUN chmod +x /usr/local/bin/start.sh && \
+RUN chmod +x /usr/local/bin/start.sh /etc/rsyslog.d/ && \
     chown -R 10000:10000 /etc/rsyslog.conf /etc/rsyslog.d/ /run 
 
 HEALTHCHECK CMD netstat -ltu|grep 10514

--- a/make/photon/log/rsyslog.conf
+++ b/make/photon/log/rsyslog.conf
@@ -41,9 +41,9 @@ $RepeatedMsgReduction on
 #
 # Set the default permissions for all log files.
 #
-$FileOwner syslog
-$FileGroup adm
-$FileCreateMode 0640
+#$FileOwner syslog
+#$FileGroup adm
+$FileCreateMode 0644
 $DirCreateMode 0755
 $Umask 0022
 #$PrivDropToUser syslog


### PR DESCRIPTION
This commit fixes the permission issues introduced after migration to photon:2.0 base image.

Signed-off-by: Daniel Jiang <jiangd@vmware.com>