### PR TITLE
Fix: Show image description info based on locale setting

### DIFF
--- a/src/portal/lib/src/repository-gridview/repository-gridview.component.html
+++ b/src/portal/lib/src/repository-gridview/repository-gridview.component.html
@@ -73,7 +73,7 @@
                 </div>
                 <div class="card-block">
                     <div class="card-text">
-                        {{getRepoDescrition(item)}}
+                        {{item.description || ('REPOSITORY.NO_INFO' | translate)}}
                     </div>
                     <div class="form-group">
                         <label>{{'REPOSITORY.TAGS_COUNT' | translate}}</label>

--- a/src/portal/lib/src/repository-gridview/repository-gridview.component.ts
+++ b/src/portal/lib/src/repository-gridview/repository-gridview.component.ts
@@ -456,13 +456,6 @@ export class RepositoryGridviewComponent implements OnChanges, OnInit {
         return "/container-image-icons?container-image=" + repo.name;
     }
 
-    getRepoDescrition(repo: RepositoryItem): string {
-        if (repo && repo.description) {
-            return repo.description;
-        }
-        return "No description for this repo. You can add it to this repository.";
-    }
-
     showCard(cardView: boolean) {
         if (this.isCardView === cardView) {
             return;

--- a/src/portal/src/i18n/lang/en-us-lang.json
+++ b/src/portal/src/i18n/lang/en-us-lang.json
@@ -465,7 +465,7 @@
         "NOTARY_IS_UNDETERMINED": "Cannot determine the signature of this tag.",
         "PLACEHOLDER": "We couldn't find any repositories!",
         "INFO": "Info",
-        "NO_INFO": "No description info for this repository",
+        "NO_INFO": "No description for this repo. You can add it to this repository.",
         "IMAGE": "Images",
         "LABELS": "Labels",
         "ADD_TO_IMAGE": "Add labels to this image",

--- a/src/portal/src/i18n/lang/fr-fr-lang.json
+++ b/src/portal/src/i18n/lang/fr-fr-lang.json
@@ -442,6 +442,7 @@
         "COPY": "Copier",
         "NOTARY_IS_UNDETERMINED": "Ne peut pas déterminer la signature de ce tag.",
         "PLACEHOLDER": "Nous ne trouvons aucun dépôt !",
+        "NO_INFO": "No description for this repo. You can add it to this repository.",
         "IMAGE": "Images",
         "LABELS": "Labels",
         "ADD_TO_IMAGE": "Add labels to this image",


### PR DESCRIPTION
Descrition info not present based on locale info before, translate it before showing on page.

Signed-off-by: Qian Deng <dengq@vmware.com>