### PR TITLE
Fix install issue with default hostname commented

### DIFF
--- a/make/install.sh
+++ b/make/install.sh
@@ -84,7 +84,7 @@ workdir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd $workdir
 
 # The hostname in harbor.cfg has not been modified
-if grep 'hostname = reg.mydomain.com' &> /dev/null harbor.cfg
+if grep '^[[:blank:]]*hostname = reg.mydomain.com' &> /dev/null harbor.cfg
 then
 	warn "$usage"
 	exit 1
@@ -212,7 +212,7 @@ then
 protocol=${BASH_REMATCH[1]}
 fi
 
-if [[ $(grep 'hostname[[:blank:]]*=' ./harbor.cfg) =~ hostname[[:blank:]]*=[[:blank:]]*(.*) ]]
+if [[ $(grep '^[[:blank:]]*hostname[[:blank:]]*=' ./harbor.cfg) =~ hostname[[:blank:]]*=[[:blank:]]*(.*) ]]
 then
 hostname=${BASH_REMATCH[1]}
 fi


### PR DESCRIPTION
Update the `grep` filter to anchor at the start of the line
and allow for whitespace characters, in order to correctly
determine the hostname being set if the default is merely
commented out and the custom one added, instead of overridden.

Fixes #6117

Signed-off-by: Christian Witts <cwitts@gmail.com>