### PR TITLE
Send 308 status on redirect from http to https

### DIFF
--- a/make/common/templates/nginx/nginx.https.conf
+++ b/make/common/templates/nginx/nginx.https.conf
@@ -141,6 +141,6 @@ http {
     server {
       listen 80;
       #server_name harbordomain.com;
-      return 301 https://$$host$$request_uri;
+      return 308 https://$$host$$request_uri;
   } 
 }


### PR DESCRIPTION
Modify nginx configuration to use 308 instead of 301 on the http to
https redirect.
Fix problems with some clients on POST requests that are transformed to
GET on 301 redirect (per HTTP 1.1 standard).
See [RFC7538](https://tools.ietf.org/html/rfc7538).