### PR TITLE
Modify the  image path of download the harbor certs in the user guide.

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -312,7 +312,7 @@ Go into the repository and select the "Info" tab, and click the "EDIT" button.  
 
 Users  can click the "registry certificate" link to download the registry certificate.
 
-![browse project](img\download_harbor_certs.png)
+![browse project](img/download_harbor_certs.png)
 
 ###  Deleting repositories  
 


### PR DESCRIPTION
Picture can not be displayed in GitHub to modify the picture path.
Signed-off-by: FangyuanCheng <fangyuanc@vmware.com>