### PR TITLE
Adding copyright header

### DIFF
--- a/src/replication/models/policy.go
+++ b/src/replication/models/policy.go
@@ -1,3 +1,17 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package models
 
 import (


### PR DESCRIPTION
Adding header to replication/models/policy.go file as it was previously missing.

Signed-off-by: clouderati <35942204+clouderati@users.noreply.github.com>