### PR TITLE
Support longer UserName

### DIFF
--- a/src/core/api/user.go
+++ b/src/core/api/user.go
@@ -353,7 +353,7 @@ func (ua *UserAPI) modifiable() bool {
 // validate only validate when user register
 func validate(user models.User) error {
 
-	if isIllegalLength(user.Username, 1, 20) {
+	if isIllegalLength(user.Username, 1, 255) {
 		return fmt.Errorf("username with illegal length")
 	}
 	if isContainIllegalChar(user.Username, []string{",", "~", "#", "$", "%"}) {

--- a/src/portal/src/app/shared/new-user-form/new-user-form.component.html
+++ b/src/portal/src/app/shared/new-user-form/new-user-form.component.html
@@ -4,7 +4,7 @@
             <div class="form-group form-group-override">
                 <label for="username" class="required form-group-label-override">{{'PROFILE.USER_NAME' | translate}}</label>
                 <label for="username" aria-haspopup="true" role="tooltip" class="tooltip tooltip-validation tooltip-md tooltip-bottom-left" [class.invalid]='getValidationState("username")'>
-                    <input type="text" required pattern='[^"~#$%]+' maxLengthExt="255" #usernameInput="ngModel" name="username" [(ngModel)]="newUser.username" id="username" size="30" 
+                    <input type="text" required pattern='[^"~#$%]+' maxLengthExt="80" #usernameInput="ngModel" name="username" [(ngModel)]="newUser.username" id="username" size="30"
                     (input)='handleValidation("username", false)' 
                     (blur)='handleValidation("username", true)'>
                     <span class="tooltip-content">

--- a/src/portal/src/app/shared/new-user-form/new-user-form.component.html
+++ b/src/portal/src/app/shared/new-user-form/new-user-form.component.html
@@ -4,7 +4,7 @@
             <div class="form-group form-group-override">
                 <label for="username" class="required form-group-label-override">{{'PROFILE.USER_NAME' | translate}}</label>
                 <label for="username" aria-haspopup="true" role="tooltip" class="tooltip tooltip-validation tooltip-md tooltip-bottom-left" [class.invalid]='getValidationState("username")'>
-                    <input type="text" required pattern='[^"~#$%]+' maxLengthExt="80" #usernameInput="ngModel" name="username" [(ngModel)]="newUser.username" id="username" size="30"
+                    <input type="text" required pattern='[^"~#$%]+' maxLengthExt="255" #usernameInput="ngModel" name="username" [(ngModel)]="newUser.username" id="username" size="30"
                     (input)='handleValidation("username", false)' 
                     (blur)='handleValidation("username", true)'>
                     <span class="tooltip-content">

--- a/src/portal/src/i18n/lang/en-us-lang.json
+++ b/src/portal/src/i18n/lang/en-us-lang.json
@@ -51,7 +51,7 @@
     },
     "TOOLTIP": {
         "EMAIL": "Email should be a valid email address like name@example.com.",
-        "USER_NAME": "Cannot contain special characters and maximum length should be 80 characters.",
+        "USER_NAME": "Cannot contain special characters and maximum length should be 255 characters.",
         "FULL_NAME": "Maximum length should be 20 characters.",
         "COMMENT": "Length of comment should be less than 20 characters.",
         "CURRENT_PWD": "Current password is required.",

--- a/src/portal/src/i18n/lang/en-us-lang.json
+++ b/src/portal/src/i18n/lang/en-us-lang.json
@@ -51,7 +51,7 @@
     },
     "TOOLTIP": {
         "EMAIL": "Email should be a valid email address like name@example.com.",
-        "USER_NAME": "Cannot contain special characters and maximum length should be 20 characters.",
+        "USER_NAME": "Cannot contain special characters and maximum length should be 80 characters.",
         "FULL_NAME": "Maximum length should be 20 characters.",
         "COMMENT": "Length of comment should be less than 20 characters.",
         "CURRENT_PWD": "Current password is required.",

--- a/src/portal/src/i18n/lang/es-es-lang.json
+++ b/src/portal/src/i18n/lang/es-es-lang.json
@@ -51,7 +51,7 @@
     },
     "TOOLTIP": {
         "EMAIL": "El email debe ser una dirección válida como nombre@ejemplo.com.",
-        "USER_NAME": "Debe tener una longitud máxima de 20 caracteres y no puede contener caracteres especiales.",
+        "USER_NAME": "Debe tener una longitud máxima de 255 caracteres y no puede contener caracteres especiales.",
         "FULL_NAME": "La longitud máxima debería ser de 20 caracteres.",
         "COMMENT": "La longitud del comentario debería ser menor de 20 caracteres.",
         "CURRENT_PWD": "Es obligatorio introducir la contraseña actual.",

--- a/src/portal/src/i18n/lang/fr-fr-lang.json
+++ b/src/portal/src/i18n/lang/fr-fr-lang.json
@@ -40,7 +40,7 @@
     },
     "TOOLTIP": {
         "EMAIL": "L'email doit être une adresse email valide comme name@example.com.",
-        "USER_NAME": "Ne peut pas contenir de caractères spéciaux et la longueur maximale doit être de 20 caractères.",
+        "USER_NAME": "Ne peut pas contenir de caractères spéciaux et la longueur maximale doit être de 255 caractères.",
         "FULL_NAME": "La longueur maximale doit être de 20 caractères.",
         "COMMENT": "La longueur des commentaires doit être inférieure à 20 caractères.",
         "CURRENT_PWD": "Le mot de passe actuel est requis.",

--- a/src/portal/src/i18n/lang/pt-br-lang.json
+++ b/src/portal/src/i18n/lang/pt-br-lang.json
@@ -51,7 +51,7 @@
     },
     "TOOLTIP": {
         "EMAIL": "Email deve ser um  endereço de email válido como nome@exemplo.com.",
-        "USER_NAME": "Não pode conter caracteres especiais e o tamanho máximo deve ser de 20 caracteres.",
+        "USER_NAME": "Não pode conter caracteres especiais e o tamanho máximo deve ser de 255 caracteres.",
         "FULL_NAME": "Tamanho máximo deve ser de 20 caracteres.",
         "COMMENT": "Tamanho do comentário deve ser menor que 20 caracteres.",
         "CURRENT_PWD": "A senha atual é obrigatória.",

--- a/src/portal/src/i18n/lang/zh-cn-lang.json
+++ b/src/portal/src/i18n/lang/zh-cn-lang.json
@@ -51,7 +51,7 @@
     },
     "TOOLTIP": {
         "EMAIL": "请使用正确的邮箱地址，比如name@example.com。",
-        "USER_NAME": "不能包含特殊字符且长度不能超过80。",
+        "USER_NAME": "不能包含特殊字符且长度不能超过255。",
         "FULL_NAME": "长度不能超过20。",
         "COMMENT": "长度不能超过20。",
         "CURRENT_PWD": "当前密码为必填项。",

--- a/src/portal/src/i18n/lang/zh-cn-lang.json
+++ b/src/portal/src/i18n/lang/zh-cn-lang.json
@@ -51,7 +51,7 @@
     },
     "TOOLTIP": {
         "EMAIL": "请使用正确的邮箱地址，比如name@example.com。",
-        "USER_NAME": "不能包含特殊字符且长度不能超过20。",
+        "USER_NAME": "不能包含特殊字符且长度不能超过80。",
         "FULL_NAME": "长度不能超过20。",
         "COMMENT": "长度不能超过20。",
         "CURRENT_PWD": "当前密码为必填项。",


### PR DESCRIPTION
Signed-off-by: peimingming

the fix(commit 571384cdb290be980616aeb86f5e7d34b6f13492) for this issue has some problem.
and limit length of user name to 80 in UI is reasonable, for it will look strange from UI if length is too long.
and user name length to 255 when creating by API. https://github.com/goharbor/harbor/issues/6086