### PR TITLE
Add new parameter ldap_group_membership_attribute

### DIFF
--- a/make/common/templates/adminserver/env
+++ b/make/common/templates/adminserver/env
@@ -1,5 +1,5 @@
 PORT=8080
-LOG_LEVEL=info
+LOG_LEVEL=debug
 EXT_ENDPOINT=$public_url
 AUTH_MODE=$auth_mode
 SELF_REGISTRATION=$self_registration
@@ -23,6 +23,7 @@ LDAP_GROUP_BASEDN=$ldap_group_basedn
 LDAP_GROUP_FILTER=$ldap_group_filter
 LDAP_GROUP_GID=$ldap_group_gid
 LDAP_GROUP_SCOPE=$ldap_group_scope
+LDAP_GROUP_MEMBERSHIP_ATTRIBUTE=$ldap_group_membership_attribute
 REGISTRY_URL=$registry_url
 TOKEN_SERVICE_URL=$token_service_url
 EMAIL_HOST=$email_host

--- a/make/harbor.cfg
+++ b/make/harbor.cfg
@@ -5,7 +5,7 @@ _version = 1.6.0
 #The IP address or hostname to access admin UI and registry service.
 #DO NOT use localhost or 127.0.0.1, because Harbor needs to be accessed by external clients.
 #DO NOT comment out this line, modify the value of "hostname" directly, or the installation will fail.
-hostname = reg.mydomain.com
+hostname = hola.com
 
 #The protocol for accessing the UI and token/notification service, by default it is http.
 #It can be set to https if ssl is enabled on nginx.
@@ -68,6 +68,8 @@ email_insecure = false
 #Change the admin password from UI after launching Harbor.
 harbor_admin_password = Harbor12345
 
+# --------------------------------------------
+
 ##By default the auth mode is db_auth, i.e. the credentials are stored in a local database.
 #Set it to ldap_auth if you want to verify a user's credentials against an LDAP server.
 auth_mode = db_auth
@@ -111,6 +113,11 @@ ldap_group_gid = cn
 
 #The scope to search for ldap groups. 0-LDAP_SCOPE_BASE, 1-LDAP_SCOPE_ONELEVEL, 2-LDAP_SCOPE_SUBTREE
 ldap_group_scope = 2
+
+# ------------------------------------------------------
+# The membership attribute name AD/openldap=memberof Oracle=ismemberof
+ldap_group_membership_attribute = ismemberof
+# -------------------------------------------------------
 
 #Turn on or off the self-registration feature
 self_registration = on

--- a/make/prepare
+++ b/make/prepare
@@ -179,6 +179,7 @@ ldap_group_basedn = rcp.get("configuration", "ldap_group_basedn")
 ldap_group_filter = rcp.get("configuration", "ldap_group_filter")
 ldap_group_gid = rcp.get("configuration", "ldap_group_gid")
 ldap_group_scope = rcp.get("configuration", "ldap_group_scope")
+ldap_group_membership_attribute =  rcp.get("configuration", "ldap_group_membership_attribute")
 db_password = rcp.get("configuration", "db_password")
 db_host = rcp.get("configuration", "db_host")
 db_user = rcp.get("configuration", "db_user")
@@ -328,6 +329,7 @@ render(os.path.join(templates_dir, "adminserver", "env"),
         ldap_timeout=ldap_timeout,
         ldap_group_basedn=ldap_group_basedn,
         ldap_group_filter=ldap_group_filter,
+        ldap_group_membership_attribute=ldap_group_membership_attribute,
         ldap_group_gid=ldap_group_gid,
         ldap_group_scope=ldap_group_scope,
         ldap_group_admin_dn=ldap_group_admin_dn,

--- a/src/adminserver/systemcfg/systemcfg.go
+++ b/src/adminserver/systemcfg/systemcfg.go
@@ -94,6 +94,7 @@ var (
 		common.LDAPGroupBaseDN:        "LDAP_GROUP_BASEDN",
 		common.LDAPGroupSearchFilter:  "LDAP_GROUP_FILTER",
 		common.LDAPGroupAttributeName: "LDAP_GROUP_GID",
+                common.LDAPGroupMembershipAttribute: "LDAP_GROUP_MEMBERSHIP_ATTRIBUTE",
 		common.LDAPGroupSearchScope: &parser{
 			env:   "LDAP_GROUP_SCOPE",
 			parse: parseStringToInt,

--- a/src/common/const.go
+++ b/src/common/const.go
@@ -63,6 +63,7 @@ const (
 	LDAPGroupBaseDN                   = "ldap_group_base_dn"
 	LDAPGroupSearchFilter             = "ldap_group_search_filter"
 	LDAPGroupAttributeName            = "ldap_group_attribute_name"
+        LDAPGroupMembershipAttribute      = "ldap_group_membership_attribute"
 	LDAPGroupSearchScope              = "ldap_group_search_scope"
 	TokenServiceURL                   = "token_service_url"
 	RegistryURL                       = "registry_url"

--- a/src/common/models/ldap.go
+++ b/src/common/models/ldap.go
@@ -34,6 +34,7 @@ type LdapGroupConf struct {
 	LdapGroupNameAttribute string `json:"ldap_group_name_attribute,omitempty"`
 	LdapGroupSearchScope   int    `json:"ldap_group_search_scope"`
 	LdapGroupAdminDN       string `json:"ldap_group_admin_dn,omitempty"`
+        LdapGroupMembershipAttribute string `json:"ldap_group_membership_attribute,omitempty"`
 }
 
 // LdapUser ...

--- a/src/common/utils/ldap/ldap.go
+++ b/src/common/utils/ldap/ldap.go
@@ -227,7 +227,7 @@ func (session *Session) SearchUser(username string) ([]models.LdapUser, error) {
 				u.Email = val
 			case "email":
 				u.Email = val
-			case "memberof":
+			case  strings.ToLower(session.ldapGroupConfig.LdapGroupMembershipAttribute):
 				for _, dnItem := range attr.Values {
 					groupDNList = append(groupDNList, strings.TrimSpace(dnItem))
 					log.Debugf("Found memberof %v", dnItem)
@@ -281,12 +281,17 @@ func (session *Session) Open() error {
 
 // SearchLdap to search ldap with the provide filter
 func (session *Session) SearchLdap(filter string) (*goldap.SearchResult, error) {
-	attributes := []string{"uid", "cn", "mail", "email", "memberof"}
+	attributes := []string{"uid", "cn", "mail", "email"}
 	lowerUID := strings.ToLower(session.ldapConfig.LdapUID)
 
 	if lowerUID != "uid" && lowerUID != "cn" && lowerUID != "mail" && lowerUID != "email" {
 		attributes = append(attributes, session.ldapConfig.LdapUID)
 	}
+
+        // Add the Group membership attribute
+        log.Debugf("Membership attribute: %s\n", session.ldapGroupConfig.LdapGroupMembershipAttribute)
+        attributes = append(attributes, session.ldapGroupConfig.LdapGroupMembershipAttribute)
+
 	return session.SearchLdapAttribute(session.ldapConfig.LdapBaseDn, filter, attributes)
 }
 

--- a/src/core/config/config.go
+++ b/src/core/config/config.go
@@ -243,6 +243,10 @@ func LDAPGroupConf() (*models.LdapGroupConf, error) {
 	if _, ok := cfg[common.LDAPGroupAttributeName]; ok {
 		ldapGroupConf.LdapGroupNameAttribute = utils.SafeCastString(cfg[common.LDAPGroupAttributeName])
 	}
+        if _, ok := cfg[common.LDAPGroupMembershipAttribute]; ok {
+                ldapGroupConf.LdapGroupMembershipAttribute = utils.SafeCastString(cfg[common.LDAPGroupMembershipAttribute])
+        }
+
 	if _, ok := cfg[common.LDAPGroupSearchScope]; ok {
 		if scopeStr, ok := cfg[common.LDAPGroupSearchScope].(string); ok {
 			ldapGroupConf.LdapGroupSearchScope, err = strconv.Atoi(scopeStr)


### PR DESCRIPTION
New parameter for LDAP membership, with this new parameter we can used virtual attribute "membeof" and "ismemberof", this allows Harbor to be compatible with more LDAP providers such as Oracle.