### PR TITLE
Fix failure on GC test case

### DIFF
--- a/tests/robot-cases/Group1-Nightly/Common.robot
+++ b/tests/robot-cases/Group1-Nightly/Common.robot
@@ -58,7 +58,7 @@ Test Case - Garbage Collection
     Sleep  1
     Wait Until Page Contains  Finished
 
-    ${rc}  ${output}=  Run And Return Rc And Output  curl -u ${HARBOR_ADMIN}:${HARBOR_PASSWORD} -s --insecure -H "Content-Type: application/json" -X GET "https://${ip}/api/system/gc/2/log"
+    ${rc}  ${output}=  Run And Return Rc And Output  curl -u ${HARBOR_ADMIN}:${HARBOR_PASSWORD} -i --insecure -H "Content-Type: application/json" -X GET "https://${ip}/api/system/gc/1/log"
     Log To Console  ${output}
     Should Be Equal As Integers  ${rc}  0
     Should Contain  ${output}  3 blobs eligible for deletion


### PR DESCRIPTION
As the changes on scan all, the default schedule was removed from source code,
hence the gc job should be the first admin job, to change to job id to 1.

Signed-off-by: wang yan <wangyan@vmware.com>