### PR TITLE
Add TestOnBorrow check func of redis pool to verify the getting conn

### DIFF
--- a/src/jobservice/runtime/bootstrap.go
+++ b/src/jobservice/runtime/bootstrap.go
@@ -192,6 +192,14 @@ func (bs *Bootstrap) loadAndRunRedisWorkerPool(ctx *env.Context, cfg *config.Con
 				redis.DialWriteTimeout(dialWriteTimeout),
 			)
 		},
+		TestOnBorrow: func(c redis.Conn, t time.Time) error {
+			if time.Since(t) < time.Minute {
+				return nil
+			}
+
+			_, err := c.Do("PING")
+			return err
+		},
 	}
 
 	redisWorkerPool := pool.NewGoCraftWorkPool(ctx,


### PR DESCRIPTION
An issue `use of closed network connection` of redis message server is reported. To avoid that case, add `TestOnBorrow` check func to the redis pool to verify the connections in the pool are usable.

Signed-off-by: Steven Zou <szou@vmware.com>