### PR TITLE
remove switch tab confirmation

### DIFF
--- a/src/portal/lib/src/config/system/system-settings.component.ts
+++ b/src/portal/lib/src/config/system/system-settings.component.ts
@@ -38,15 +38,6 @@ export class SystemSettingsComponent {
         return this.systemSettingsForm && this.systemSettingsForm.valid;
     }
 
-    public hasUnsavedChanges(allChanges: any): boolean {
-        for (let prop in allChanges) {
-            if (prop === 'token_expiration' || prop === 'read_only') {
-                return true;
-            }
-        }
-        return false;
-    }
-
     public getSystemChanges(allChanges: any) {
         let changes = {};
         for (let prop in allChanges) {

--- a/src/portal/src/app/config/auth/config-auth.component.ts
+++ b/src/portal/src/app/config/auth/config-auth.component.ts
@@ -196,19 +196,6 @@ export class ConfigurationAuthComponent implements OnChanges {
         }
     }
 
-    public hasUnsavedChanges(allChanges: any) {
-        for (let prop in allChanges) {
-            if (prop.startsWith('ldap_')
-            || prop.startsWith('uaa_')
-            || prop === 'auth_mode'
-            || prop === 'project_creattion_restriction'
-            || prop === 'self_registration') {
-                return true;
-            }
-        }
-        return false;
-    }
-
     retrieveConfig(): void {
         this.onGoing = true;
         this.configService.getConfiguration()

--- a/src/portal/src/app/config/config.component.ts
+++ b/src/portal/src/app/config/config.component.ts
@@ -20,7 +20,6 @@ import { ConfirmationTargets, ConfirmationState } from '../shared/shared.const';
 import { SessionService } from '../shared/session.service';
 import { confirmUnsavedChanges} from './config.msg.utils';
 import { ConfirmationDialogService } from '../shared/confirmation-dialog/confirmation-dialog.service';
-import { ConfirmationMessage } from '../shared/confirmation-dialog/confirmation-message';
 import { MessageHandlerService } from '../shared/message-handler/message-handler.service';
 
 import { AppConfigService } from '../app-config.service';
@@ -91,33 +90,6 @@ export class ConfigurationComponent implements OnInit, OnDestroy {
         return TabLinkContentMap[this.currentTabId] === contentId;
     }
 
-    hasUnsavedChangesOfCurrentTab(allChanges: any): boolean {
-        if (isEmpty(allChanges)) {
-            return false;
-        }
-
-        let properties = [];
-        switch (this.currentTabId) {
-            case 'config-auth':
-                return this.authConfig.hasUnsavedChanges(allChanges);
-            case 'config-email':
-                return this.mailConfig.hasUnsavedChanges(allChanges);
-            case 'config-replication':
-                properties = ['verify_remote_cert'];
-                break;
-            case 'config-system':
-                return this.systemSettingsConfig.hasUnsavedChanges(allChanges);
-        }
-
-        for (let prop in allChanges) {
-            if (properties.indexOf(prop) !== -1) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
     ngOnInit(): void {
         // First load
         // Double confirm the current use has admin role
@@ -159,15 +131,7 @@ export class ConfigurationComponent implements OnInit, OnDestroy {
 
 
     public tabLinkClick(tabLink: string) {
-        let allChanges = getChanges(this.originalCopy, this.allConfig);
-        // Whether has unsaved changes in current tab
-        let hasChanges = this.hasUnsavedChangesOfCurrentTab(allChanges);
-        if (!hasChanges) {
-            this.currentTabId = tabLink;
-            return;
-        }
-
-        this.confirmUnsavedTabChanges(allChanges, tabLink);
+        this.currentTabId = tabLink;
     }
 
     public getSystemChanges() {
@@ -239,21 +203,6 @@ export class ConfigurationComponent implements OnInit, OnDestroy {
 
     public get hideBtn(): boolean {
         return this.currentTabId !== 'config-system';
-    }
-
-    confirmUnsavedTabChanges(changes: any, tabId: string) {
-        let msg = new ConfirmationMessage(
-            'CONFIG.CONFIRM_TITLE',
-            'CONFIG.CONFIRM_SUMMARY',
-            '',
-            {
-                'changes': changes,
-                'tabId': tabId
-            },
-            ConfirmationTargets.CONFIG_TAB
-        );
-
-        this.confirmService.openComfirmDialog(msg);
     }
 
     retrieveConfig(): void {

--- a/src/portal/src/app/config/email/config-email.component.ts
+++ b/src/portal/src/app/config/email/config-email.component.ts
@@ -53,15 +53,6 @@ export class ConfigurationEmailComponent implements OnChanges {
         return  !isEmpty(this.getChanges());
     }
 
-    public hasUnsavedChanges(allChanges: any) {
-        for (let prop in allChanges) {
-            if (prop.startsWith('email_')) {
-                return true;
-            }
-        }
-        return false;
-    }
-
     public getChanges() {
         let allChanges = getChanges(this.originalConfig, this.currentConfig);
         let changes = {};


### PR DESCRIPTION
Because currently, each page only have changes on its own page, we don't need this confirmation box to force user to save changes in the tab. 