### PR TITLE
Build clair version into clair image

### DIFF
--- a/make/photon/clair/Dockerfile.binary
+++ b/make/photon/clair/Dockerfile.binary
@@ -3,4 +3,5 @@ FROM golang:1.9.2
 ADD .   /go/src/github.com/coreos/clair/
 WORKDIR /go/src/github.com/coreos/clair/
 
-RUN go install -v github.com/coreos/clair/cmd/clair
+RUN export CLAIR_VERSION=$(git describe --tag --always --dirty) && \
+	go build -ldflags "-X github.com/coreos/clair/pkg/version.Version=$CLAIR_VERSION" github.com/coreos/clair/cmd/clair

--- a/make/photon/clair/builder
+++ b/make/photon/clair/builder
@@ -29,7 +29,7 @@ docker build -f $TEMP/Dockerfile.binary -t clair-golang $TEMP
 
 echo 'copy the clair binary to local...'
 ID=$(docker create clair-golang)
-docker cp $ID:/go/bin/clair binary
+docker cp $ID:/go/src/github.com/coreos/clair/clair binary
 
 docker rm -f $ID
 docker rmi -f clair-golang


### PR DESCRIPTION
This commit is to add the clair_version into the harbor images, then clair
will use it in the user-agent, and helpful for the debugging.

Signed-off-by: wang yan <wangyan@vmware.com>