### PR TITLE
Let the retag error prompt show complete

### DIFF
--- a/src/portal/lib/src/tag/tag.component.scss
+++ b/src/portal/lib/src/tag/tag.component.scss
@@ -202,7 +202,7 @@
 
 .retag-modal-body {
   overflow-y: hidden;
-  min-height: 172px;
+  min-height: 184px;
   padding-top: 16px;
 }
 


### PR DESCRIPTION
Increase the height of the retag to make the tooltip display complete
Signed-off-by: FangyuanCheng <fangyuanc@vmware.com>