### PR TITLE
Clair image should accept parms

### DIFF
--- a/make/photon/clair/docker-entrypoint.sh
+++ b/make/photon/clair/docker-entrypoint.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -e
-sudo -E -H -u \#10000 sh -c "/dumb-init -- /clair/clair -config /etc/clair/config.yaml"
+sudo -E -H -u \#10000 sh -c "/dumb-init -- /clair/clair -config /etc/clair/config.yaml $*"
 set +e


### PR DESCRIPTION
Update the entrypoint to allow the image accept other parms,
to help debug in the future.

If replace "$*" with "$@" only one parm will be passed to dumbinit

Signed-off-by: Daniel Jiang <jiangd@vmware.com>