### PR TITLE
Replace ui with core for no_proxy in harbor.cfg

### DIFF
--- a/make/harbor.cfg
+++ b/make/harbor.cfg
@@ -38,10 +38,10 @@ log_rotate_count = 50
 log_rotate_size = 200M
 
 #Config http proxy for Clair, e.g. http://my.proxy.com:3128
-#Clair doesn't need to connect to harbor ui container via http proxy.
+#Clair doesn't need to connect to harbor internal components via http proxy.
 http_proxy =
 https_proxy =
-no_proxy = 127.0.0.1,localhost,ui,registry
+no_proxy = 127.0.0.1,localhost,core,registry
 
 #NOTES: The properties between BEGIN INITIAL PROPERTIES and END INITIAL PROPERTIES
 #only take effect in the first boot, the subsequent changes of these properties 


### PR DESCRIPTION
As we split UI into two components: portal and core, the value of no_proxy needs to be updated

Signed-off-by: Wenkai Yin <yinw@vmware.com>