### PR TITLE
Create os trusted certificate for registry, clair, chartmuseum

### DIFF
--- a/make/docker-compose.chartmuseum.tpl
+++ b/make/docker-compose.chartmuseum.tpl
@@ -22,6 +22,7 @@ services:
     volumes:
       - /data/chart_storage:/chart_storage:z
       - ./common/config/chartserver:/etc/chartserver:z
+      - ./common/config/ca-bundle.crt:/etc/pki/tls/certs/ca-bundle.crt:z
     logging:
       driver: "syslog"
       options:  

--- a/make/docker-compose.clair.tpl
+++ b/make/docker-compose.clair.tpl
@@ -28,6 +28,7 @@ services:
       - postgresql
     volumes:
       - ./common/config/clair/config.yaml:/etc/clair/config.yaml:z
+      - ./common/config/ca-bundle.crt:/etc/pki/tls/certs/ca-bundle.crt:z
     logging:
       driver: "syslog"
       options:  

--- a/make/docker-compose.tpl
+++ b/make/docker-compose.tpl
@@ -19,6 +19,7 @@ services:
     volumes:
       - /data/registry:/storage:z
       - ./common/config/registry/:/etc/registry/:z
+      - ./common/config/ca-bundle.crt:/etc/pki/tls/certs/ca-bundle.crt:z
     networks:
       - harbor
     dns_search: .

--- a/make/photon/chartserver/docker-entrypoint.sh
+++ b/make/photon/chartserver/docker-entrypoint.sh
@@ -7,22 +7,6 @@ if [ -d /chart_storage ]; then
     chown 10000:10000 -R /chart_storage
 fi
 
-#Config the custom ca bundle
-if [ -f /etc/chartserver/custom-ca-bundle.crt ]; then
-    if grep -q "Photon" /etc/lsb-release; then
-        if [ ! -f /etc/pki/tls/certs/ca-bundle.crt.original ]; then
-            cp /etc/pki/tls/certs/ca-bundle.crt /etc/pki/tls/certs/ca-bundle.crt.original
-        fi
-
-        echo "Appending custom ca bundle ..."
-        cp /etc/pki/tls/certs/ca-bundle.crt.original /etc/pki/tls/certs/ca-bundle.crt
-        cat /etc/chartserver/custom-ca-bundle.crt >> /etc/pki/tls/certs/ca-bundle.crt
-        echo "Done."
-    else
-        echo "Current OS is not Photon, skip appending ca bundle"
-    fi
-fi
-
 #Start the server process
 sudo -E -H -u \#10000 sh -c "/chartserver/chartm" #Parameters are set by ENV
 set +e

--- a/make/photon/registry/entrypoint.sh
+++ b/make/photon/registry/entrypoint.sh
@@ -17,21 +17,6 @@ if [ -d /storage ]; then
     fi
 fi
 
-if [ ! -f /etc/pki/tls/certs/ca-bundle.crt.original ]; then
-    cp /etc/pki/tls/certs/ca-bundle.crt /etc/pki/tls/certs/ca-bundle.crt.original
-fi
-
-if [ -f /etc/registry/custom-ca-bundle.crt ]; then
-    if grep -q "Photon" /etc/lsb-release; then
-        echo "Appending custom ca bundle ..."
-        cp /etc/pki/tls/certs/ca-bundle.crt.original /etc/pki/tls/certs/ca-bundle.crt
-        cat /etc/registry/custom-ca-bundle.crt >> /etc/pki/tls/certs/ca-bundle.crt
-        echo "Done."
-    else
-        echo "Current OS is not Photon, skip appending ca bundle"
-    fi
-fi
-
 case "$1" in
     *.yaml|*.yml) set -- registry serve "$@" ;;
     serve|garbage-collect|help|-*) set -- registry "$@" ;;

--- a/make/prepare
+++ b/make/prepare
@@ -531,9 +531,14 @@ else:
     print("Copied configuration file: %s" % registry_config_dir + "root.crt")
     shutil.copyfile(os.path.join(templates_dir, "registry", "root.crt"), os.path.join(registry_config_dir, "root.crt"))
 
+# Create os trusted certificate for registry, clair, chartmuseum
+common_cert_path = os.path.join(config_dir, "ca-bundle.crt")
+version_output = subprocess.check_output("grep  goharbor/registry-photon docker-compose.yml  |grep image", shell=True)
+registry_version = version_output.split(":")[2].strip()
+os.system("docker run -i --rm goharbor/registry-photon:"+registry_version+" cat  /etc/pki/tls/certs/ca-bundle.crt > " + common_cert_path)
+
 if len(registry_custom_ca_bundle_path) > 0 and os.path.isfile(registry_custom_ca_bundle_path):
-    shutil.copyfile(registry_custom_ca_bundle_path, os.path.join(registry_config_dir, "custom-ca-bundle.crt"))
-    print("Copied custom ca bundle: %s" % os.path.join(registry_config_dir, "custom-ca-bundle.crt"))
+    os.system("cat  "+registry_custom_ca_bundle_path+" >> " + common_cert_path )
 
 if args.notary_mode:
     notary_config_dir = prep_conf_dir(config_dir, "notary")
@@ -638,11 +643,6 @@ if args.chart_mode:
     if not os.path.isdir(chartm_config_dir):
         print ("Create config folder: %s" % chartm_config_dir)
         os.makedirs(chartm_config_dir)
-
-    # handle custom ca bundle
-    if len(registry_custom_ca_bundle_path) > 0 and os.path.isfile(registry_custom_ca_bundle_path):
-        shutil.copyfile(registry_custom_ca_bundle_path, os.path.join(chartm_config_dir, "custom-ca-bundle.crt"))
-        print("Copied custom ca bundle: %s" % os.path.join(chartm_config_dir, "custom-ca-bundle.crt"))
     
     # process redis info
     cache_store = "redis"


### PR DESCRIPTION
Fix the issue when registry using a customized s3 storage, the registry , clair, chartmuseum need to trust the certificates.
Signed-off-by: stonezdj <stonezdj@gmail.com>