### PR TITLE
Uncomment the harbor configuration injection code block 

### DIFF
--- a/src/jobservice/README.md
+++ b/src/jobservice/README.md
@@ -340,6 +340,7 @@ So far, only the following two backends are supported:
 ### Configure loggers
 
 Logger configuration options:
+
 |     Option   |         Description       |
 |--------------|---------------------------|
 | loggers[x].name | The unique name of the logger backend |

--- a/src/jobservice/main.go
+++ b/src/jobservice/main.go
@@ -16,10 +16,14 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 
+	"github.com/goharbor/harbor/src/adminserver/client"
 	"github.com/goharbor/harbor/src/jobservice/config"
+	"github.com/goharbor/harbor/src/jobservice/env"
+	"github.com/goharbor/harbor/src/jobservice/job/impl"
 	"github.com/goharbor/harbor/src/jobservice/logger"
 	"github.com/goharbor/harbor/src/jobservice/runtime"
 	"github.com/goharbor/harbor/src/jobservice/utils"
@@ -51,7 +55,7 @@ func main() {
 	}
 
 	// Set job context initializer
-	/*runtime.JobService.SetJobContextInitializer(func(ctx *env.Context) (env.JobContext, error) {
+	runtime.JobService.SetJobContextInitializer(func(ctx *env.Context) (env.JobContext, error) {
 		secret := config.GetAuthSecret()
 		if utils.IsEmptyStr(secret) {
 			return nil, errors.New("empty auth secret")
@@ -65,7 +69,7 @@ func main() {
 		}
 
 		return jobCtx, nil
-	})*/
+	})
 
 	// Start
 	runtime.JobService.LoadAndRun(ctx, cancel)


### PR DESCRIPTION
Uncomment the harbor configuration injection code block and also fix a typo in the jobservice README doc.

Signed-off-by: Steven Zou <szou@vmware.com>