### PR TITLE
Recover repository.py to initial version

### DIFF
--- a/tests/apitests/python/library/repository.py
+++ b/tests/apitests/python/library/repository.py
@@ -24,7 +24,7 @@ class Repository(base.Base):
 
     def list_tags(self, repository, **kwargs):
         client = self._get_client(**kwargs)
-        return client.repositories_repo_name_tags_get_with_http_info(repository)
+        return client.repositories_repo_name_tags_get(repository)
 
     def image_exists(self, repository, tag, **kwargs):
         tags = self.list_tags(repository, **kwargs)


### PR DESCRIPTION
Recover repository.py to initial version for calling the wrong API function.
Signed-off-by: danfengliu <danfengl@vmware.com>