### PR TITLE
Fix: Nightly test fail from time to time

### DIFF
--- a/tests/resources/Harbor-Pages/Project-Helmcharts.robot
+++ b/tests/resources/Harbor-Pages/Project-Helmcharts.robot
@@ -48,5 +48,4 @@ Go Back To Versions And Delete
     Click Element  xpath=${version_checkbox}
     Click Element  xpath=${version_delete}
     Click Element  xpath=${version_confirm_delete}
-    Sleep  2
-    Page Should Contain Element  xpath=${helmchart_content}
+    Wait Until Page Contains  xpath=${helmchart_content}


### PR DESCRIPTION
Sometimes the time span of back to helm chart list is longer then 2 seconds.

Signed-off-by: Qian Deng <dengq@vmware.com>