### PR TITLE
compile_guide should require Docker 17.05+

### DIFF
--- a/docs/compile_guide.md
+++ b/docs/compile_guide.md
@@ -9,7 +9,7 @@ Harbor is deployed as several Docker containers and most of the code is written 
 
 Software              | Required Version
 ----------------------|--------------------------
-docker                | 1.12.0 +
+docker                | 17.05 +
 docker-compose        | 1.11.0 +
 python                | 2.7 +
 git                   | 1.9.1 +

--- a/tests/travis/api_run.sh
+++ b/tests/travis/api_run.sh
@@ -29,15 +29,13 @@ docker ps
 # run db auth api cases
 if [ "$1" = 'DB' ]; then
     pybot -v ip:$2 -v HARBOR_PASSWORD:Harbor12345 /home/travis/gopath/src/github.com/goharbor/harbor/tests/robot-cases/Group0-BAT/API_DB.robot
-fi
-# run ldap api cases
-if [ "$1" = 'LDAP' ]; then
+elif [ "$1" = 'LDAP' ]; then
+    # run ldap api cases
     pybot -v ip:$2 -v HARBOR_PASSWORD:Harbor12345 /home/travis/gopath/src/github.com/goharbor/harbor/tests/robot-cases/Group0-BAT/API_LDAP.robot
+else
+    rc=999
 fi
-
 rc=$?
-echo $rc
-
 ## --------------------------------------------- Upload Harbor CI Logs -------------------------------------------
 timestamp=$(date +%s)
 outfile="integration_logs_$timestamp$TRAVIS_COMMIT.tar.gz"

--- a/tests/travis/api_run.sh
+++ b/tests/travis/api_run.sh
@@ -29,13 +29,15 @@ docker ps
 # run db auth api cases
 if [ "$1" = 'DB' ]; then
     pybot -v ip:$2 -v HARBOR_PASSWORD:Harbor12345 /home/travis/gopath/src/github.com/goharbor/harbor/tests/robot-cases/Group0-BAT/API_DB.robot
-elif [ "$1" = 'LDAP' ]; then
-    # run ldap api cases
-    pybot -v ip:$2 -v HARBOR_PASSWORD:Harbor12345 /home/travis/gopath/src/github.com/goharbor/harbor/tests/robot-cases/Group0-BAT/API_LDAP.robot
-else
-    rc=999
 fi
+# run ldap api cases
+if [ "$1" = 'LDAP' ]; then
+    pybot -v ip:$2 -v HARBOR_PASSWORD:Harbor12345 /home/travis/gopath/src/github.com/goharbor/harbor/tests/robot-cases/Group0-BAT/API_LDAP.robot
+fi
+
 rc=$?
+echo $rc
+
 ## --------------------------------------------- Upload Harbor CI Logs -------------------------------------------
 timestamp=$(date +%s)
 outfile="integration_logs_$timestamp$TRAVIS_COMMIT.tar.gz"


### PR DESCRIPTION
As described in #6278 the Dockerfile workflow requires
Docker 17.05+ in order to support multistage builds.

This update changes the compile guide to reflect that.

Closes #6278 