### PR TITLE
Fix panic if ExtEndpoint is empty

### DIFF
--- a/src/common/utils/test/test.go
+++ b/src/common/utils/test/test.go
@@ -50,11 +50,11 @@ type Response struct {
 	StatusCode int
 	// Headers are the headers of the response
 	Headers map[string]string
-	// Boby is the body of the response
+	// Body is the body of the response
 	Body []byte
 }
 
-// Handler returns a handler function which handle requst according to
+// Handler returns a handler function which handle request according to
 // the response provided
 func Handler(resp *Response) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {

--- a/src/core/config/config.go
+++ b/src/core/config/config.go
@@ -283,7 +283,7 @@ func ExtURL() (string, error) {
 		return "", err
 	}
 	l := strings.Split(endpoint, "://")
-	if len(l) > 0 {
+	if len(l) > 1 {
 		return l[1], nil
 	}
 	return endpoint, nil

--- a/src/core/config/config_test.go
+++ b/src/core/config/config_test.go
@@ -168,11 +168,26 @@ func TestConfig(t *testing.T) {
 		t.Errorf(`extURL should be "host01.com".`)
 	}
 
+	// Test ExtURL with empty string
+	adminServerDefaultConfig[common.ExtEndpoint] = ""
+	if err := Load(); err != nil {
+		t.Fatalf("failed to load configurations: %v", err)
+	}
+	extURL, err = ExtURL()
+	if err != nil {
+		t.Errorf("Unexpected error getting external URL: %v", err)
+	}
+
+	if extURL != "" {
+		t.Errorf(`extURL expected "", got "%s".`, extURL)
+	}
+
 	// reset configurations
 	if err = Reset(); err != nil {
 		t.Errorf("failed to reset configurations: %v", err)
 		return
 	}
+
 	mode, err = AuthMode()
 	if err != nil {
 		t.Fatalf("failed to get auth mode: %v", err)


### PR DESCRIPTION
Fix panic if `ExternalEndpoint` is empty, see the panic snapshot:

![image](https://user-images.githubusercontent.com/1621082/48890499-f8f11900-ee73-11e8-9629-e26387a5e4c0.png)

Signed-off-by: Xiaoxi He <xxhe@alauda.io>