### PR TITLE
Add dependencies to Gopkg.toml

### DIFF
--- a/src/Gopkg.toml
+++ b/src/Gopkg.toml
@@ -103,3 +103,11 @@ ignored = ["github.com/vmware/harbor/tests*"]
 [[constraint]]
   name = "github.com/gocraft/work"
   version = "=0.5.1"
+
+[[constraint]]
+  name = "github.com/robfig/cron"
+  version = "=1.0"
+
+[[constraint]]
+  name = "gopkg.in/yaml.v2"
+  version = "=2.1.1"


### PR DESCRIPTION
During the legal process for 1.7.0 I found some dependencies are not tracked in
Gopkg.toml.
This commit explicitly add depedencies on these packages.

Signed-off-by: Daniel Jiang <jiangd@vmware.com>