### PR TITLE
Fix the malformat json data of chart list API

### DIFF
--- a/src/chartserver/chart_operator.go
+++ b/src/chartserver/chart_operator.go
@@ -55,14 +55,14 @@ type DigitalSignature struct {
 
 // ChartInfo keeps the information of the chart
 type ChartInfo struct {
-	Name          string
-	TotalVersions uint32 `json:"total_versions"`
-	LatestVersion string `json:"latest_version"`
-	Created       time.Time
-	Updated       time.Time
-	Icon          string
-	Home          string
-	Deprecated    bool
+	Name          string    `json:"name"`
+	TotalVersions uint32    `json:"total_versions"`
+	LatestVersion string    `json:"latest_version"`
+	Created       time.Time `json:"created"`
+	Updated       time.Time `json:"updated"`
+	Icon          string    `json:"icon"`
+	Home          string    `json:"home"`
+	Deprecated    bool      `json:"deprecated"`
 }
 
 // ChartOperator is designed to process the contents of


### PR DESCRIPTION
Call API: /chartrepo/{repo}/charts GET

Expected response data format is:

```"[
  {
    "name": "mariadb",
    "total_versions": 1,
    "latest_version": "4.3.1",
    "created": "2018-11-26T06:25:05.966719842Z",
    "updated": "0001-01-01T00:00:00Z",
    "icon": "https://bitnami.com/assets/stacks/mariadb/img/mariadb-stack-220x234.png",
    "home": "https://mariadb.org",
    "deprecated": false
  }
]" 
```

Actual behavior is:

```"[
{
    "Name": "mariadb",
    "total_versions": 1,
    "latest_version": "4.3.1",
    "Created": "2018-11-26T06:25:05.966719842Z",
    "Updated": "0001-01-01T00:00:00Z",
    "Icon": "https://bitnami.com/assets/stacks/mariadb/img/mariadb-stack-220x234.png",
    "Home": "https://mariadb.org",
    "Deprecated": false
  }
]"```



Signed-off-by: Steven Zou <szou@vmware.com>