### PR TITLE
Fix status code for permission check in retag, use 403

### DIFF
--- a/src/core/api/repository.go
+++ b/src/core/api/repository.go
@@ -479,14 +479,14 @@ func (ra *RepositoryAPI) Retag() {
 	// Check whether use has read permission to source project
 	if !ra.SecurityCtx.HasReadPerm(srcImage.Project) {
 		log.Errorf("user has no read permission to project '%s'", srcImage.Project)
-		ra.HandleUnauthorized()
+		ra.HandleForbidden(ra.SecurityCtx.GetUsername())
 		return
 	}
 
 	// Check whether user has write permission to target project
 	if !ra.SecurityCtx.HasWritePerm(project) {
 		log.Errorf("user has no write permission to project '%s'", project)
-		ra.HandleUnauthorized()
+		ra.HandleForbidden(ra.SecurityCtx.GetUsername())
 		return
 	}
 


### PR DESCRIPTION
Signed-off-by: 陈德 <chende@caicloud.io>

Fix issue: [Retag kicks user back to login when the user doesn't have sufficient permission](https://github.com/goharbor/harbor/issues/6327])

Use status code `403` when permission not allowed, instead of `401`.