### PR TITLE
Corrected errors in photon build

### DIFF
--- a/make/photon/portal/Dockerfile
+++ b/make/photon/portal/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10.7.0
+FROM node:10.7.0 as nodeportal
 
 RUN mkdir -p /portal_src
 RUN mkdir -p /build_dir
@@ -24,7 +24,7 @@ RUN tdnf install -y nginx >> /dev/null \
 EXPOSE 80
 VOLUME /var/cache/nginx /var/log/nginx /run
 
-COPY --from=0 /build_dir/dist /usr/share/nginx/html
+COPY --from=nodeportal /build_dir/dist /usr/share/nginx/html
 COPY make/photon/portal/nginx.conf /etc/nginx/nginx.conf
 
 STOPSIGNAL SIGQUIT

--- a/tools/migration/Dockerfile
+++ b/tools/migration/Dockerfile
@@ -7,7 +7,7 @@ RUN tdnf distro-sync -y \
     && tdnf install -y sed shadow procps-ng gawk gzip sudo net-tools >> /dev/null\
     && groupadd -r -g 10000 mysql && useradd --no-log-init -r -g 10000 -u 10000 mysql \
     && tdnf install -y mariadb-server mariadb mariadb-devel python2 python2-devel python-pip gcc \
-    && linux-api-headers glibc-devel binutils zlib-devel openssl-devel postgresql >> /dev/null \
+    linux-api-headers glibc-devel binutils zlib-devel openssl-devel postgresql >> /dev/null \
     && pip install mysqlclient alembic psycopg2 \
     && mkdir /docker-entrypoint-initdb.d /docker-entrypoint-updatedb.d \
     && rm -fr /var/lib/mysql \

--- a/tools/migration/Dockerfile
+++ b/tools/migration/Dockerfile
@@ -7,7 +7,7 @@ RUN tdnf distro-sync -y \
     && tdnf install -y sed shadow procps-ng gawk gzip sudo net-tools >> /dev/null\
     && groupadd -r -g 10000 mysql && useradd --no-log-init -r -g 10000 -u 10000 mysql \
     && tdnf install -y mariadb-server mariadb mariadb-devel python2 python2-devel python-pip gcc \
-    linux-api-headers glibc-devel binutils zlib-devel openssl-devel postgresql >> /dev/null\
+    && linux-api-headers glibc-devel binutils zlib-devel openssl-devel postgresql >> /dev/null \
     && pip install mysqlclient alembic psycopg2 \
     && mkdir /docker-entrypoint-initdb.d /docker-entrypoint-updatedb.d \
     && rm -fr /var/lib/mysql \


### PR DESCRIPTION
Corrected issues found during build on Photon 2.0. 

harbor\make\photon\portal\Dockerfile -> Set alias for first stage of build due to error when using COPY --from=0

harbor\tools\migration\Dockerfile -> correct syntax in bash command which was preventing package installation.