### PR TITLE
Support unique job constraints (both unique queue and running jobs)

### DIFF
--- a/src/jobservice/config.yml
+++ b/src/jobservice/config.yml
@@ -29,7 +29,7 @@ job_loggers:
   - name: "FILE"
     level: "DEBUG"
     settings: # Customized settings of logger
-      base_dir: "tmp/job_logs"
+      base_dir: "/tmp/job_logs"
     sweeper:
       duration: 1 #days
       settings: # Customized settings of sweeper

--- a/src/jobservice/pool/de_duplicator.go
+++ b/src/jobservice/pool/de_duplicator.go
@@ -1,0 +1,94 @@
+package pool
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/goharbor/harbor/src/jobservice/models"
+	"github.com/goharbor/harbor/src/jobservice/utils"
+	"github.com/gomodule/redigo/redis"
+)
+
+// DeDuplicator is designed to handle the uniqueness of the job.
+// Once a job is declared to be unique, the job can be enqueued only if
+// no same job (same job name and parameters) in the queue or running in progress.
+// Adopt the same unique mechanism with the upstream framework.
+type DeDuplicator struct {
+	// Redis namespace
+	namespace string
+	// Redis conn pool
+	pool *redis.Pool
+}
+
+// NewDeDuplicator is constructor of DeDuplicator
+func NewDeDuplicator(ns string, pool *redis.Pool) *DeDuplicator {
+	return &DeDuplicator{
+		namespace: ns,
+		pool:      pool,
+	}
+}
+
+// Unique checks if the job is unique and set unique flag if it is not set yet.
+func (dd *DeDuplicator) Unique(jobName string, params models.Parameters) error {
+	uniqueKey, err := redisKeyUniqueJob(dd.namespace, jobName, params)
+	if err != nil {
+		return fmt.Errorf("unique job error: %s", err)
+	}
+
+	conn := dd.pool.Get()
+	defer conn.Close()
+
+	args := []interface{}{
+		uniqueKey,
+		1,
+		"NX",
+		"EX",
+		86400,
+	}
+
+	res, err := redis.String(conn.Do("SET", args...))
+	if err == nil && strings.ToUpper(res) == "OK" {
+		return nil
+	}
+
+	return errors.New("unique job error: duplicated")
+}
+
+// DelUniqueSign delete the job unique sign
+func (dd *DeDuplicator) DelUniqueSign(jobName string, params models.Parameters) error {
+	uniqueKey, err := redisKeyUniqueJob(dd.namespace, jobName, params)
+	if err != nil {
+		return fmt.Errorf("delete unique job error: %s", err)
+	}
+
+	conn := dd.pool.Get()
+	defer conn.Close()
+
+	if _, err := conn.Do("DEL", uniqueKey); err != nil {
+		return fmt.Errorf("delete unique job error: %s", err)
+	}
+
+	return nil
+}
+
+// Same key with upstream framework
+func redisKeyUniqueJob(namespace, jobName string, args map[string]interface{}) (string, error) {
+	var buf bytes.Buffer
+
+	buf.WriteString(utils.KeyNamespacePrefix(namespace))
+	buf.WriteString("unique:running:")
+	buf.WriteString(jobName)
+	buf.WriteRune(':')
+
+	if args != nil {
+		err := json.NewEncoder(&buf).Encode(args)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	return buf.String(), nil
+}

--- a/src/jobservice/pool/de_duplicator_test.go
+++ b/src/jobservice/pool/de_duplicator_test.go
@@ -1,0 +1,28 @@
+package pool
+
+import (
+	"testing"
+
+	"github.com/goharbor/harbor/src/jobservice/tests"
+)
+
+func TestDeDuplicator(t *testing.T) {
+	jobName := "fake_job"
+	jobParams := map[string]interface{}{
+		"image": "ubuntu:latest",
+	}
+
+	rdd := NewRedisDeDuplicator(tests.GiveMeTestNamespace(), rPool)
+
+	if err := rdd.Unique(jobName, jobParams); err != nil {
+		t.Error(err)
+	}
+
+	if err := rdd.Unique(jobName, jobParams); err == nil {
+		t.Errorf("expect duplicated error but got nil error")
+	}
+
+	if err := rdd.DelUniqueSign(jobName, jobParams); err != nil {
+		t.Error(err)
+	}
+}

--- a/src/jobservice/pool/redis_job_wrapper.go
+++ b/src/jobservice/pool/redis_job_wrapper.go
@@ -37,11 +37,11 @@ type RedisJob struct {
 	job          interface{}         // the real job implementation
 	context      *env.Context        // context
 	statsManager opm.JobStatsManager // job stats manager
-	deDuplicator *DeDuplicator       // handle unique job
+	deDuplicator DeDuplicator        // handle unique job
 }
 
 // NewRedisJob is constructor of RedisJob
-func NewRedisJob(j interface{}, ctx *env.Context, statsManager opm.JobStatsManager, deDuplicator *DeDuplicator) *RedisJob {
+func NewRedisJob(j interface{}, ctx *env.Context, statsManager opm.JobStatsManager, deDuplicator DeDuplicator) *RedisJob {
 	return &RedisJob{
 		job:          j,
 		context:      ctx,

--- a/src/jobservice/pool/redis_job_wrapper.go
+++ b/src/jobservice/pool/redis_job_wrapper.go
@@ -37,14 +37,16 @@ type RedisJob struct {
 	job          interface{}         // the real job implementation
 	context      *env.Context        // context
 	statsManager opm.JobStatsManager // job stats manager
+	deDuplicator *DeDuplicator       // handle unique job
 }
 
 // NewRedisJob is constructor of RedisJob
-func NewRedisJob(j interface{}, ctx *env.Context, statsManager opm.JobStatsManager) *RedisJob {
+func NewRedisJob(j interface{}, ctx *env.Context, statsManager opm.JobStatsManager, deDuplicator *DeDuplicator) *RedisJob {
 	return &RedisJob{
 		job:          j,
 		context:      ctx,
 		statsManager: statsManager,
+		deDuplicator: deDuplicator,
 	}
 }
 
@@ -113,6 +115,14 @@ func (rj *RedisJob) Run(j *work.Job) error {
 			}
 		}
 	}()
+
+	if j.Unique {
+		defer func() {
+			if err := rj.deDuplicator.DelUniqueSign(j.Name, j.Args); err != nil {
+				logger.Errorf("delete job unique sign error: %s", err)
+			}
+		}()
+	}
 
 	// Start to run
 	rj.jobRunning(j.ID)

--- a/src/jobservice/pool/redis_job_wrapper_test.go
+++ b/src/jobservice/pool/redis_job_wrapper_test.go
@@ -50,7 +50,8 @@ func TestJobWrapper(t *testing.T) {
 		WG:            &sync.WaitGroup{},
 		ErrorChan:     make(chan error, 1), // with 1 buffer
 	}
-	wrapper := NewRedisJob((*fakeParentJob)(nil), envContext, mgr)
+	deDuplicator := NewRedisDeDuplicator(tests.GiveMeTestNamespace(), rPool)
+	wrapper := NewRedisJob((*fakeParentJob)(nil), envContext, mgr, deDuplicator)
 	j := &work.Job{
 		ID:         "FAKE",
 		Name:       "DEMO",

--- a/src/jobservice/pool/redis_pool.go
+++ b/src/jobservice/pool/redis_pool.go
@@ -59,7 +59,7 @@ type GoCraftWorkPool struct {
 	scheduler     period.Interface
 	statsManager  opm.JobStatsManager
 	messageServer *MessageServer
-	deDuplicator  *DeDuplicator
+	deDuplicator  DeDuplicator
 
 	// no need to sync as write once and then only read
 	// key is name of known job
@@ -80,7 +80,7 @@ func NewGoCraftWorkPool(ctx *env.Context, namespace string, workerCount uint, re
 	scheduler := period.NewRedisPeriodicScheduler(ctx, namespace, redisPool, statsMgr)
 	sweeper := period.NewSweeper(namespace, redisPool, client)
 	msgServer := NewMessageServer(ctx.SystemContext, namespace, redisPool)
-	deDepulicator := NewDeDuplicator(namespace, redisPool)
+	deDepulicator := NewRedisDeDuplicator(namespace, redisPool)
 	return &GoCraftWorkPool{
 		namespace:     namespace,
 		redisPool:     redisPool,


### PR DESCRIPTION
Currently, the uniqueness checking only covers the job queue. The running job is not taken into consideration.
In this PR, the unique scope is expanded to job queue and running jobs. That means if the job is declared to be unique, there will be only one job running at the same time.

Signed-off-by: Steven Zou <szou@vmware.com>