### PR TITLE
Remove the Scan all in-memory marker

### DIFF
--- a/src/common/utils/timemarker.go
+++ b/src/common/utils/timemarker.go
@@ -15,8 +15,6 @@
 package utils
 
 import (
-	"os"
-	"strconv"
 	"sync"
 	"time"
 )
@@ -55,23 +53,6 @@ func (t *TimeMarker) Next() time.Time {
 	t.RLock()
 	defer t.RUnlock()
 	return t.next
-}
-
-// ScanAllMarker ...
-func ScanAllMarker() *TimeMarker {
-	once.Do(func() {
-		a := os.Getenv("HARBOR_SCAN_ALL_INTERVAL")
-		if m, err := strconv.Atoi(a); err == nil {
-			scanAllMarker = &TimeMarker{
-				interval: time.Duration(m) * time.Minute,
-			}
-		} else {
-			scanAllMarker = &TimeMarker{
-				interval: 2 * time.Hour,
-			}
-		}
-	})
-	return scanAllMarker
 }
 
 // ScanOverviewMarker ...

--- a/src/common/utils/timemarker_test.go
+++ b/src/common/utils/timemarker_test.go
@@ -16,7 +16,6 @@ package utils
 
 import (
 	"github.com/stretchr/testify/assert"
-	"os"
 	"testing"
 	"time"
 )
@@ -35,15 +34,4 @@ func TestTimeMarker(t *testing.T) {
 	time.Sleep(2 * time.Second)
 	r3 := m.Check()
 	assert.True(r3)
-}
-
-func TestScanMarkers(t *testing.T) {
-	assert := assert.New(t)
-	os.Setenv("HARBOR_SCAN_ALL_INTERVAL", "5")
-	sm := ScanAllMarker()
-	d := sm.Next().Sub(time.Now())
-	assert.True(d <= 5*time.Minute)
-	som := ScanOverviewMarker()
-	d = som.Next().Sub(time.Now())
-	assert.True(d <= 15*time.Second)
 }

--- a/src/core/api/repository.go
+++ b/src/core/api/repository.go
@@ -1012,18 +1012,11 @@ func (ra *RepositoryAPI) ScanAll() {
 		ra.HandleForbidden(ra.SecurityCtx.GetUsername())
 		return
 	}
-	if !utils.ScanAllMarker().Check() {
-		log.Warningf("There is a scan all scheduled at: %v, the request will not be processed.", utils.ScanAllMarker().Next())
-		ra.RenderError(http.StatusPreconditionFailed, "Unable handle frequent scan all requests")
-		return
-	}
-
 	if err := coreutils.ScanAllImages(); err != nil {
 		log.Errorf("Failed triggering scan all images, error: %v", err)
 		ra.HandleInternalServerError(fmt.Sprintf("Error: %v", err))
 		return
 	}
-	utils.ScanAllMarker().Mark()
 	ra.Ctx.ResponseWriter.WriteHeader(http.StatusAccepted)
 }
 

--- a/src/core/api/systeminfo.go
+++ b/src/core/api/systeminfo.go
@@ -98,7 +98,6 @@ type GeneralInfo struct {
 	SelfRegistration            bool                             `json:"self_registration"`
 	HasCARoot                   bool                             `json:"has_ca_root"`
 	HarborVersion               string                           `json:"harbor_version"`
-	NextScanAll                 int64                            `json:"next_scan_all"`
 	ClairVulnStatus             *models.ClairVulnerabilityStatus `json:"clair_vulnerability_status,omitempty"`
 	RegistryStorageProviderName string                           `json:"registry_storage_provider_name"`
 	ReadOnly                    bool                             `json:"read_only"`
@@ -187,11 +186,6 @@ func (sia *SystemInfoAPI) GetGeneralInfo() {
 	}
 	if info.WithClair {
 		info.ClairVulnStatus = getClairVulnStatus()
-		t := utils.ScanAllMarker().Next().UTC().Unix()
-		if t < 0 {
-			t = 0
-		}
-		info.NextScanAll = t
 	}
 	sia.Data["json"] = info
 	sia.ServeJSON()


### PR DESCRIPTION
Previously there was a in-memory marker to prevent user from frequently
calling the "scan all" API.  This has become problematic in HA
deployment, and is no longer needed after enhancement in jobservice.

This commit removes the marker for "scan all" api, however, we need to
review the mechanism and rework to make it stateless.

Signed-off-by: Daniel Jiang <jiangd@vmware.com>