### PR TITLE
Corrected DOCKERCMD to fix portal multistage build

### DIFF
--- a/make/photon/Makefile
+++ b/make/photon/Makefile
@@ -17,7 +17,7 @@ WGET=$(shell which wget)
 
 # docker parameters
 DOCKERCMD=$(shell which docker)
-DOCKERBUILD=$(DOCKERCMD) build --pull
+DOCKERBUILD=$(DOCKERCMD) build
 DOCKERRMIMAGE=$(DOCKERCMD) rmi
 DOCKERIMASES=$(DOCKERCMD) images
 


### PR DESCRIPTION
removed --pull from DOCKERCMD variable, missed this update with last commit.
Signed-off-by: Brett Johnson <brett@sdbrett.com>