### PR TITLE
Remove the permission checking for getcert API

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -2279,10 +2279,6 @@ paths:
       responses:
         '200':
           description: Get default root certificate successfully.
-        '401':
-          description: User need to log in first.
-        '403':
-          description: User does not have permission of admin role.
         '404':
           description: Not found the default root certificate.
         '500':

--- a/src/core/api/systeminfo.go
+++ b/src/core/api/systeminfo.go
@@ -140,7 +140,6 @@ func (sia *SystemInfoAPI) GetVolumeInfo() {
 
 // GetCert gets default self-signed certificate.
 func (sia *SystemInfoAPI) GetCert() {
-	sia.validate()
 	if _, err := os.Stat(defaultRootCert); err == nil {
 		sia.Ctx.Output.Header("Content-Type", "application/octet-stream")
 		sia.Ctx.Output.Header("Content-Disposition", "attachment; filename=ca.crt")

--- a/src/core/api/systeminfo_test.go
+++ b/src/core/api/systeminfo_test.go
@@ -73,15 +73,16 @@ func TestGetCert(t *testing.T) {
 	apiTest := newHarborAPI()
 
 	// case 1: get cert without admin role
-	code, _, err := apiTest.CertGet(*testUser)
+	code, content, err := apiTest.CertGet(*testUser)
 	if err != nil {
 		t.Error("Error occurred while get system cert")
 		t.Log(err)
 	} else {
-		assert.Equal(403, code, "Get system cert should be 403")
+		assert.Equal(200, code, "Get system cert should be 200")
+		assert.Equal("test for ca.crt.\n", string(content), "Get system cert content should be equal")
 	}
 	// case 2: get cert with admin role
-	code, content, err := apiTest.CertGet(*admin)
+	code, content, err = apiTest.CertGet(*admin)
 	if err != nil {
 		t.Error("Error occurred while get system cert")
 		t.Log(err)


### PR DESCRIPTION
The Harbor root cert can be downloaded by all users now, so the permission checking is not needed anymore

Signed-off-by: Wenkai Yin <yinw@vmware.com>