### PR TITLE
Modify the error message when adding members

### DIFF
--- a/src/portal/src/app/shared/shared.utils.ts
+++ b/src/portal/src/app/shared/shared.utils.ts
@@ -26,6 +26,9 @@ import { httpStatusCode, AlertType } from './shared.const';
  * returns {string}
  */
 export const errorHandler = function (error: any): string {
+    if (typeof error === "string") {
+        return error;
+    }
     if (error && error._body) {
         // treat as string message
         if (typeof error._body === "string") {


### PR DESCRIPTION
fix #6422 
When the response is a string, add judgement to return error directly
Signed-off-by: FangyuanCheng <fangyuanc@vmware.com>