### PR TITLE
Return 409 when there is a scan all job running

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1342,6 +1342,8 @@ paths:
           description: User needs to login or call the API with correct credentials.
         '403':
           description: User doesn't have permission to perform the action.
+        '409':
+          description: There is a "scanall" job in progress, so the request cannot be served.
         '415':
           $ref: '#/responses/UnsupportedMediaType'
         '500':

--- a/src/core/api/repository.go
+++ b/src/core/api/repository.go
@@ -28,6 +28,7 @@ import (
 	"github.com/docker/distribution/manifest/schema2"
 	"github.com/goharbor/harbor/src/common"
 	"github.com/goharbor/harbor/src/common/dao"
+	commonhttp "github.com/goharbor/harbor/src/common/http"
 	"github.com/goharbor/harbor/src/common/models"
 	"github.com/goharbor/harbor/src/common/utils"
 	"github.com/goharbor/harbor/src/common/utils/clair"
@@ -1014,6 +1015,10 @@ func (ra *RepositoryAPI) ScanAll() {
 	}
 	if err := coreutils.ScanAllImages(); err != nil {
 		log.Errorf("Failed triggering scan all images, error: %v", err)
+		if httpErr, ok := err.(*commonhttp.Error); ok && httpErr.Code == http.StatusConflict {
+			ra.HandleConflict("Conflict when triggering scan all images, please try again later.")
+			return
+		}
 		ra.HandleInternalServerError(fmt.Sprintf("Error: %v", err))
 		return
 	}


### PR DESCRIPTION
Fixes #6418, that when multiple "scan all" jobs are
triggered, the API should not return 500.

Signed-off-by: Daniel Jiang <jiangd@vmware.com>