### PR TITLE
Refine migration guide for 1.7

### DIFF
--- a/docs/migration_guide.md
+++ b/docs/migration_guide.md
@@ -26,19 +26,23 @@ or above it's not necessary to call the migrator tool to migrate the schema.
     ```
 
 2.  Back up Harbor's current files so that you can roll back to the current version when it is necessary.
-    ```sh
-    cd ..
+    ```
     mv harbor /my_backup_dir/harbor
+    ```
+    Back up database (by default in diretory `/data/database`)
+    ```
+    cp -r /data/database /my_backup_dir/
     ```
 
 3. Get the latest Harbor release package from Github:
    https://github.com/goharbor/harbor/releases
 
 4. Before upgrading Harbor, perform migration first.  The migration tool is delivered as a docker image, so you should pull the image from docker hub. Replace [tag] with the release version of Harbor (e.g. v1.5.0) in the below command:
+    ```
+    docker pull goharbor/harbor-migrator:[tag]
+    ```
 
-5. Back up database and `harbor.cfg` to a directory such as `/path/to/backup`. You need to create the directory if it does not exist. Also, note that the username and password to access the db are provided via environment variable "DB_USR" and "DB_PWD". 
-
-6. Upgrade `harbor.cfg`.
+5. Upgrade `harbor.cfg`.
     **NOTE:** The ${harbor_cfg} will be overwritten, you must move it to your installation directory after migration.
     ```
     docker run -it --rm -v ${harbor_cfg}:/harbor-migration/harbor-cfg/harbor.cfg goharbor/harbor-migrator:[tag] --cfg up
@@ -46,7 +50,7 @@ or above it's not necessary to call the migrator tool to migrate the schema.
     **NOTE:** The schema upgrade and data migration of Database is performed by adminserver when Harbor starts, if the migration fails, 
     please check the log of adminserver to debug.
 
-7. Under the directory `./harbor`, run the `./install.sh` script to install the new Harbor instance. If you choose to install Harbor with components like Notary, Clair, and chartmuseum, refer to [Installation & Configuration Guide](../docs/installation_guide.md) for more information.
+6. Under the directory `./harbor`, run the `./install.sh` script to install the new Harbor instance. If you choose to install Harbor with components like Notary, Clair, and chartmuseum, refer to [Installation & Configuration Guide](../docs/installation_guide.md) for more information.
 
 
 ### Roll back from an upgrade
@@ -70,9 +74,7 @@ For any reason, if you want to roll back to the previous version of Harbor, foll
     mv /my_backup_dir/harbor harbor
     ```
     
-4. Restore database and `harbor.cfg` from backup files in `/path/to/backup/` 
-    To restore the data in database, simply copy the data files from backup directory to you data volume, by default `/data/database`. 
-    For `harbor.cfg`, similarly, copy the backup file to the path where harbor is installed. 
+4. Restore database, copy the data files from backup directory to you data volume, by default `/data/database`. 
 
 5. Restart Harbor service using the previous configuration.  
    If previous version of Harbor was installed by a release build:


### PR DESCRIPTION
Fixes #6449

1. Simplify the steps for backing up database.
2. Add the missing command to pull migrator image.

Signed-off-by: Daniel Jiang <jiangd@vmware.com>
