### PR TITLE
Return unknow when about dialog cannot get harbor version

### DIFF
--- a/src/portal/src/app/app-config.ts
+++ b/src/portal/src/app/app-config.ts
@@ -42,7 +42,7 @@ export class AppConfig {
         this.project_creation_restriction = "everyone";
         this.self_registration = true;
         this.has_ca_root = false;
-        this.harbor_version = "1.2.0";
+        this.harbor_version = "unknown";
         this.clair_vulnerability_status = {
             overall_last_update: 0,
             details: []

--- a/src/portal/src/app/shared/about-dialog/about-dialog.component.ts
+++ b/src/portal/src/app/shared/about-dialog/about-dialog.component.ts
@@ -47,7 +47,7 @@ export class AboutDialogComponent implements OnInit {
 
     public get version(): string {
         let appConfig = this.appConfigService.getConfig();
-        return appConfig ? appConfig.harbor_version : "n/a";
+        return appConfig.harbor_version;
     }
 
     public open(): void {


### PR DESCRIPTION
About dialog returns unknow instead of 1.2.0 when harbor version is not available
Signed-off-by: FangyuanCheng <fangyuanc@vmware.com>