### PR TITLE
cherry-pick:Remove the border of default label when filtering images by label

### DIFF
--- a/src/portal/lib/src/tag/tag.component.html
+++ b/src/portal/lib/src/tag/tag.component.html
@@ -27,7 +27,7 @@
     <div class="row flex-items-xs-right rightPos">
       <div id="filterArea">
         <div class='filterLabelPiece' *ngIf="!withAdmiral" [hidden]="!openLabelFilterPiece" [style.left.px]='filterLabelPieceWidth'>
-          <hbr-label-piece [hidden]='!filterOneLabel' [label]="filterOneLabel" [labelWidth]="130"></hbr-label-piece>
+          <hbr-label-piece *ngIf="showlabel" [hidden]='!filterOneLabel' [label]="filterOneLabel" [labelWidth]="130"></hbr-label-piece>
         </div>
         <div class="flex-xs-middle">
           <hbr-filter [withDivider]="true" filterPlaceholder="{{'TAG.FILTER_FOR_TAGS' | translate}}" (filterEvt)="doSearchTagNames($event)"

--- a/src/portal/lib/src/tag/tag.component.ts
+++ b/src/portal/lib/src/tag/tag.component.ts
@@ -103,6 +103,7 @@ export class TagComponent implements OnInit, AfterViewInit {
   openLabelFilterPanel: boolean;
   openLabelFilterPiece: boolean;
   retagSrcImage: string;
+  showlabel: boolean;
 
   createdComparator: Comparator<Tag> = new CustomComparator<Tag>("created", "date");
 
@@ -394,8 +395,10 @@ export class TagComponent implements OnInit, AfterViewInit {
     if (labelInfo) {
       if (!labelInfo.iconsShow) {
         this.filterLabel(labelInfo);
+        this.showlabel = true;
       } else {
         this.unFilterLabel(labelInfo);
+        this.showlabel = false;
       }
     }
   }


### PR DESCRIPTION
The default label is displayed when filtering images by label, and the page is not friendly, so set the label to be hidden by default.
Signed-off-by: FangyuanCheng <fangyuanc@vmware.com>