### PR TITLE
Modify Project name's regexp when creating new Project

### DIFF
--- a/src/core/api/project.go
+++ b/src/core/api/project.go
@@ -535,7 +535,7 @@ func validateProjectReq(req *models.ProjectRequest) error {
 	validProjectName = regexp.MustCompile(`api(?:[._-][a-z0-9]+)*`)
 	legal = validProjectName.MatchString(pn)
 	if legal {
-		return fmt.Errorf("project name is not started with /'api/'")
+		return fmt.Errorf("project name is not started with 'api'")
 	}
 
 	metas, err := validateProjectMetadata(req.Metadata)

--- a/src/core/api/project.go
+++ b/src/core/api/project.go
@@ -532,6 +532,12 @@ func validateProjectReq(req *models.ProjectRequest) error {
 		return fmt.Errorf("project name is not in lower case or contains illegal characters")
 	}
 
+	validProjectName = regexp.MustCompile(`api(?:[._-][a-z0-9]+)*`)
+	legal = validProjectName.MatchString(pn)
+	if legal {
+		return fmt.Errorf("project name is not started with /'api/'")
+	}
+
 	metas, err := validateProjectMetadata(req.Metadata)
 	if err != nil {
 		return err

--- a/src/portal/src/app/project/create-project/create-project.component.html
+++ b/src/portal/src/app/project/create-project/create-project.component.html
@@ -7,11 +7,11 @@
                 <div class="form-group" style="padding-left: 135px;">
                     <label for="create_project_name" class="col-md-3 form-group-label-override required">{{'PROJECT.NAME' | translate}}</label>
                     <label for="create_project_name" aria-haspopup="true" role="tooltip" [class.invalid]="!isNameValid" class="tooltip tooltip-validation tooltip-md tooltip-bottom-left">
-            <input type="text" id="create_project_name"  [(ngModel)]="project.name" 
+            <input type="text" id="create_project_name"  [(ngModel)]="project.name"
             name="create_project_name" size="255"  style="width: 296px;"
             required
-            pattern="^[a-z0-9]+(?:[._-][a-z0-9]+)*$"
-            minlength="2" 
+            pattern="^(?!api)[a-z0-9]+(?:[._-][a-z0-9]+)*$"
+            minlength="2"
             #projectName="ngModel"
                    autocomplete="off"
             (keyup)='handleValidation()'>


### PR DESCRIPTION
When I created new project named 'api-gateway' in harbor, portal didn't show project list. It only showed error message about Internal server error. This bug was caused by new Project name started with 'api'.  I think that the name started with 'api' caused a crash against a ingress path using '/api'.
So I changed regular expression in project name check code. I changed them in portal and core.
I also changed warning-msg in English. I know only English in provided languages.