### PR TITLE
Update migrator version to v1.6.3

### DIFF
--- a/docs/migration_guide.md
+++ b/docs/migration_guide.md
@@ -5,6 +5,8 @@ When upgrading your existing Habor instance to a newer version, you may need to 
 *If your install Harbor for the first time, or the database version is the same as that of the lastest version, you do not need any database migration.*
 
 **NOTE:**
+- Please use `goharbor/harbor-db-migrator:1.6.3` instead if you're performing migration, as the v1.6.3 includes a fix for issue https://github.com/goharbor/harbor/issues/6465.
+
 - From v1.6.0 on, Harbor migrates DB from MariaDB to Postgresql, and combines Harbor, Notary and Clair DB into one. 
 
 - From v1.5.0 on, the migration tool add support for the harbor.cfg migration, which supports upgrade from v1.2.x, v1.3.x and v1.4.x.


### PR DESCRIPTION
The migrator v1.6.3 includes a fix for issue #6465, this issue blocks user to
sign image after updates with goharbor/harbor-migrator:v1.6.0/1/2.

Signed-off-by: wang yan <wangyan@vmware.com>