### PR TITLE
Read ssl mode param from the adminserver to init the connection with database

### DIFF
--- a/src/jobservice/job/impl/context.go
+++ b/src/jobservice/job/impl/context.go
@@ -230,6 +230,7 @@ func getDBFromConfig(cfg map[string]interface{}) *models.Database {
 	postgresql.Username = cfg[common.PostGreSQLUsername].(string)
 	postgresql.Password = cfg[common.PostGreSQLPassword].(string)
 	postgresql.Database = cfg[common.PostGreSQLDatabase].(string)
+	postgresql.SSLMode = cfg[common.PostGreSQLSSLMode].(string)
 	database.PostGreSQL = postgresql
 
 	return database


### PR DESCRIPTION
This commit adds the ssl mode as a param when establishing the connection with database

Signed-off-by: Wenkai Yin <yinw@vmware.com>