### PR TITLE
Support building on host that requires proxy

### DIFF
--- a/make/photon/Makefile
+++ b/make/photon/Makefile
@@ -17,7 +17,7 @@ WGET=$(shell which wget)
 
 # docker parameters
 DOCKERCMD=$(shell which docker)
-DOCKERBUILD=$(DOCKERCMD) build --pull
+DOCKERBUILD=$(DOCKERCMD) build --pull --build-arg=http_proxy=${http_proxy} --build-arg=https_proxy=${https_proxy}
 DOCKERRMIMAGE=$(DOCKERCMD) rmi
 DOCKERIMASES=$(DOCKERCMD) images
 


### PR DESCRIPTION
Add docker build arg for proxy if defined on the host.

Signed-off-by: Niklas Wik <niklas.wik@nokia.com>