### PR TITLE
Add support for http proxy in transport

### DIFF
--- a/src/common/http/client.go
+++ b/src/common/http/client.go
@@ -39,7 +39,11 @@ func NewClient(c *http.Client, modifiers ...modifier.Modifier) *Client {
 		client: c,
 	}
 	if client.client == nil {
-		client.client = &http.Client{}
+		client.client = &http.Client{
+			Transport: &http.Transport{
+				Proxy: http.ProxyFromEnvironment,
+			},
+		}
 	}
 	if len(modifiers) > 0 {
 		client.modifiers = modifiers

--- a/src/common/utils/registry/registry.go
+++ b/src/common/utils/registry/registry.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+
 	// "time"
 
 	"github.com/goharbor/harbor/src/common/utils"
@@ -39,11 +40,13 @@ func init() {
 	defaultHTTPTransport = &http.Transport{}
 
 	secureHTTPTransport = &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: false,
 		},
 	}
 	insecureHTTPTransport = &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: true,
 		},

--- a/src/common/utils/uaa/client.go
+++ b/src/common/utils/uaa/client.go
@@ -41,7 +41,7 @@ const (
 	UsersURLSuffix = "/Users"
 )
 
-var uaaTransport = &http.Transport{}
+var uaaTransport = &http.Transport{Proxy: http.ProxyFromEnvironment}
 
 // Client provides funcs to interact with UAA.
 type Client interface {

--- a/src/core/config/config.go
+++ b/src/core/config/config.go
@@ -135,6 +135,7 @@ func initProjectManager() error {
 		}
 		AdmiralClient = &http.Client{
 			Transport: &http.Transport{
+				Proxy: http.ProxyFromEnvironment,
 				TLSClientConfig: &tls.Config{
 					RootCAs: pool,
 				},


### PR DESCRIPTION
Adds support for the transport https/http proxy.
To use the proxy one can set http_proxy and https_proxy enviroment variables. Eq. in jobservice to enable proxy set your proxy and also set no_proxy for harbor services, eq. adminserver, registry, core. 

Improvement on helm chart should be made to enable more seamless no_proxy integration.

Fixes #5864 

Signed-off-by: Niklas Wik <niklas.wik@nokia.com>