### PR TITLE
Pull a more smaller size of docker image and also make timeout value longer

### DIFF
--- a/tests/apitests/python/library/repository.py
+++ b/tests/apitests/python/library/repository.py
@@ -95,7 +95,7 @@ class Repository(base.Base):
             raise Exception("Image should be <Not Scanned> state!")
 
     def check_image_scan_result(self, repo_name, tag, expected_scan_status = "finished", **kwargs):
-        timeout_count = 20
+        timeout_count = 30
         while True:
             time.sleep(5)
             timeout_count = timeout_count - 1

--- a/tests/apitests/python/test_scan_image.py
+++ b/tests/apitests/python/test_scan_image.py
@@ -73,8 +73,8 @@ class TestProjects(unittest.TestCase):
         #Note: Please make sure that this Image has never been pulled before by any other cases,
         #          so it is a not-scanned image rigth after rpository creation.
         #image = "tomcat"
-        image = "pypy"
-        src_tag = "latest"
+        image = "docker"
+        src_tag = "1.13"
         #5. Create a new repository(RA) and tag(TA) in project(PA) by user(UA);
         TestProjects.repo_name, tag = push_image_to_project(project_scan_image_name, harbor_server, user_scan_image_name, user_001_password, image, src_tag)
 


### PR DESCRIPTION
Change a small docker image to pull and make timeout value longer.
Signed-off-by: danfengliu <danfengl@vmware.com>