### PR TITLE
fix nightly test of retag

### DIFF
--- a/tests/resources/Harbor-Pages/Project-Retag_Elements.robot
+++ b/tests/resources/Harbor-Pages/Project-Retag_Elements.robot
@@ -12,3 +12,4 @@ ${target_image_name}  target-alpine
 ${target_tag_value}  3.2.10-target
 ${tag_value_xpath}  //clr-dg-row[contains(.,'${target_tag_value}')]
 ${image_tag}  3.2.10-alpine
+${modal-dialog}  div.modal-dialog

--- a/tests/robot-cases/Group1-Nightly/Common.robot
+++ b/tests/robot-cases/Group1-Nightly/Common.robot
@@ -713,6 +713,7 @@ Test Case - Retag A Image Tag
     Go Into Repo  project${random_num1}/redis
     Retag Image  ${image_tag}  project${random_num2}  ${target_image_name}  ${target_tag_value}
 
+    Wait Until Element Is Not Visible  css=${modal-dialog}
     Back To projects
     Go Into Project  project${random_num2}
     Sleep  1


### PR DESCRIPTION
After  clicks the retag confirmation button, the request will be sent, so that the retag dialog cannot disappear immediately. The existence of the modal-backdrop cause the project button can not be clicked, so add the judgment. When the modal popup disappears, click the project button.

Signed-off-by: FangyuanCheng <fangyuanc@vmware.com>