### PR TITLE
Robot script refactor for keyword sign-in-harbor

### DIFF
--- a/tests/resources/Harbor-Pages/HomePage.robot
+++ b/tests/resources/Harbor-Pages/HomePage.robot
@@ -23,19 +23,15 @@ ${HARBOR_VERSION}  v1.1.1
 Sign In Harbor
     [Arguments]  ${url}  ${user}  ${pw}
     Go To    ${url}
-    Sleep  5
-    ${title}=  Get Title
-    Log To Console  ${title}
-    Run Keyword If  "${title}" != "Harbor"  Capture Screenshot And Source  ELSE  Log  The title is Harbor
-    Should Be Equal  ${title}  Harbor
-    Sleep  2
-    Input Text  login_username  ${user}
-    Input Text  login_password  ${pw}
-    Sleep  2
-    Click button  css=.btn
-    sleep  5
+    Wait Until Element Is Enabled  ${harbor_span_title}
+    Wait Until Element Is Visible  ${login_name}
+    Wait Until Element Is Visible  ${login_pwd}
+    Input Text  ${login_name}  ${user}
+    Input Text  ${login_pwd}  ${pw}
+    Wait Until Element Is Visible  ${login_btn}
+    Click button  ${login_btn}
     Log To Console  ${user}
-    Wait Until Page Contains  ${user}
+    Wait Until Element Is Visible  xpath=//span[contains(., '${user}')]
 
 Capture Screenshot And Source
     Capture Page Screenshot
@@ -47,34 +43,28 @@ Sign Up Should Not Display
 Create An New User
     [Arguments]  ${url}  ${username}  ${email}  ${realname}  ${newPassword}  ${comment}
     Go To    ${url}
-    sleep  5
-    ${title}=  Get Title
-    Log To Console  ${title}
-    Should Be Equal  ${title}  Harbor
-    ${d}=    Get Current Date    result_format=%m%s
-    Sleep  5
+    Wait Until Element Is Visible  ${harbor_span_title}
+    Wait Until Element Is Visible  xpath=${sign_up_for_an_account_xpath}
     Click Element  xpath=${sign_up_for_an_account_xpath}
-    sleep  3
+    Wait Until Element Is Visible  xpath=${username_xpath}
     Input Text  xpath=${username_xpath}  ${username}
-    sleep  1
+    Wait Until Element Is Visible  xpath=${email_xpath}
     Input Text  xpath=${email_xpath}  ${email}
-    sleep  1
+    Wait Until Element Is Visible  xpath=${realname_xpath}
     Input Text  xpath=${realname_xpath}  ${realname}
-    sleep  1
+    Wait Until Element Is Visible  xpath=${newPassword_xpath}
     Input Text  xpath=${newPassword_xpath}  ${newPassword}
-    sleep  1
+    Wait Until Element Is Visible  xpath=${confirmPassword_xpath}
     Input Text  xpath=${confirmPassword_xpath}  ${newPassword}
-    sleep  1
+    Wait Until Element Is Visible  xpath=${comment_xpath}
     Input Text  xpath=${comment_xpath}  ${comment}
-    sleep  2
+    Wait Until Element Is Visible  xpath=${signup_xpath}
     Click button  xpath=${signup_xpath}
-    sleep  5
-    Input Text  login_username  ${username}
-    Input Text  login_password  ${newPassword}
-    sleep  2
-    Click button  css=.btn
-    sleep  5
-    Wait Until Page Contains  ${username}
-    Sleep  3
-
-
+    Sleep  2
+    Wait Until Element Is Visible  ${login_name}
+    Input Text  ${login_name}  ${username}
+    Wait Until Element Is Visible  ${login_pwd}
+    Input Text  ${login_pwd}  ${newPassword}
+    Wait Until Element Is Visible  ${login_btn}
+    Click button  ${login_btn}
+    Wait Until Element Is Visible  xpath=//span[contains(., '${username}')]

--- a/tests/resources/Harbor-Pages/HomePage_Elements.robot
+++ b/tests/resources/Harbor-Pages/HomePage_Elements.robot
@@ -26,4 +26,10 @@ ${confirmPassword_xpath}  //*[@id="confirmPassword"]
 ${comment_xpath}  //*[@id="comment"]
 ${signup_xpath}  //clr-modal/div/div[1]/div/div/div[3]/button[2]
 
+${signup_xpath}  /html/body/harbor-app/harbor-shell/clr-main-container/div/div/sign-in/sign-up/clr-modal/div/div[1]/div/div[1]/div/div[3]/button[2]
+${search_input}  xpath=//*[@id='search_input']
+${login_btn}  css=.btn
+${harbor_span_title}  xpath=//span[contains(., 'Harbor')]
+${login_name}  id=login_username
+${login_pwd}  id=login_password
 

--- a/tests/resources/Harbor-Pages/Project-Members.robot
+++ b/tests/resources/Harbor-Pages/Project-Members.robot
@@ -21,15 +21,14 @@ ${HARBOR_VERSION}  v1.1.1
 
 *** Keywords ***
 Go Into Project
-    [Arguments]  ${project}
-    Sleep  2
-    Click Element  xpath=//*[@id="search_input"]
-    Sleep  2
-    Input Text  xpath=//*[@id="search_input"]  ${project}
-    Sleep  8
+    [Arguments]  ${project}  ${has_image}=${true}
+    Wait Until Element Is Visible  ${search_input}
+    Input Text  ${search_input}  ${project}
     Wait Until Page Contains  ${project}
-    Click Element  xpath=//*[@id="project-results"]//clr-dg-cell[contains(.,"${project}")]/a
-    Sleep  2
+    Wait Until Element Is Visible  xpath=//*[@id='project-results']//clr-dg-cell[contains(.,'${project}')]/a
+    Click Element  xpath=//*[@id='project-results']//clr-dg-cell[contains(.,'${project}')]/a
+    Run Keyword If  ${has_image}==${false}  Wait Until Element Is Visible  xpath=//clr-dg-placeholder[contains(.,\"We couldn\'t find any repositories!\")]
+    ...  ELSE  Wait Until Element Is Visible  xpath=//clr-dg-cell[contains(.,'${project}/')]
     Capture Page Screenshot  gointo_${project}.png
 
 Add User To Project Admin
@@ -131,9 +130,9 @@ User Should Not Be A Member Of Project
     Cannot Push image  ${ip}  ${user}  ${pwd}  ${project}  ${ip}/${project}/hello-world
 
 Manage Project Member
-    [Arguments]  ${admin}  ${pwd}  ${project}  ${user}  ${op}
+    [Arguments]  ${admin}  ${pwd}  ${project}  ${user}  ${op}  ${has_image}=${true}
     Sign In Harbor  ${HARBOR_URL}  ${admin}  ${pwd}
-    Go Into Project  ${project}
+    Go Into Project  ${project}  ${has_image}
     Switch To Member
     Run Keyword If  '${op}' == 'Add'  Add Guest Member To Project  ${user}
     ...    ELSE IF  '${op}' == 'Remove'  Delete Project Member  ${user}

--- a/tests/resources/Harbor-Pages/Project.robot
+++ b/tests/resources/Harbor-Pages/Project.robot
@@ -54,6 +54,8 @@ Switch To Member
     Sleep  1
 
 Switch To Log
+    Wait Until Element Is Enabled  xpath=${log_xpath}
+    Wait Until Element Is Visible  xpath=${log_xpath}
     Click Element  xpath=${log_xpath}
     Sleep  1
 
@@ -62,6 +64,8 @@ Switch To Replication
     Sleep  1
 
 Back To projects
+    Wait Until Element Is Enabled  xpath=${projects_xpath}
+    Wait Until Element Is Visible  xpath=${projects_xpath}
     Click Element  xpath=${projects_xpath}
     Sleep  2
 

--- a/tests/robot-cases/Group1-Nightly/Common.robot
+++ b/tests/robot-cases/Group1-Nightly/Common.robot
@@ -32,7 +32,7 @@ Test Case - Vulnerability Data Not Ready
 #This case must run before vulnerability db ready
     Init Chrome Driver
     Sign In Harbor  ${HARBOR_URL}  ${HARBOR_ADMIN}  ${HARBOR_PASSWORD}
-    Go Into Project  library
+    Go Into Project  library  has_image=${false}
     Vulnerability Not Ready Project Hint
     Switch To Configure
     Go To Vulnerability Config
@@ -164,7 +164,7 @@ Test Case - Project Level Policy Public
     ${d}=  Get Current Date    result_format=%m%s
     Sign In Harbor  ${HARBOR_URL}  ${HARBOR_ADMIN}  ${HARBOR_PASSWORD}
     Create An New Project  project${d}
-    Go Into Project  project${d}
+    Go Into Project  project${d}  has_image=${false}
     Goto Project Config
     Click Project Public
     Save Project Config
@@ -477,7 +477,7 @@ Test Case - Delete Multi Member
     ${d}=   Get Current Date    result_format=%m%s
     Sign In Harbor  ${HARBOR_URL}  user016  Test1@34    
     Create An New Project  project${d}
-    Go Into Project  project${d}
+    Go Into Project  project${d}  has_image=${false}
     Switch To Member
     Add Guest Member To Project  user017
     Add Guest Member To Project  user018
@@ -490,7 +490,7 @@ Test Case - Project Admin Operate Labels
     ${d}=   Get Current Date    result_format=%m%s
     Sign In Harbor  ${HARBOR_URL}  user019  Test1@34
     Create An New Project  project${d}
-    Go Into Project  project${d}
+    Go Into Project  project${d}  has_image=${false}
     Sleep  2
     # Add labels
     Switch To Project Label
@@ -531,11 +531,11 @@ Test Case - Developer Operate Labels
     Create An New Project  project${d}
     Logout Harbor
     
-    Manage Project Member  user021  Test1@34  project${d}  user022  Add
+    Manage Project Member  user021  Test1@34  project${d}  user022  Add  ${false}
     Change User Role In Project  user021  Test1@34  project${d}  user022  Developer
 
     Sign In Harbor  ${HARBOR_URL}  user022  Test1@34
-    Go Into Project  project${d}
+    Go Into Project  project${d}  has_image=${false}
     Sleep  3
     Page Should Not Contain Element  xpath=//a[contains(.,'Labels')]
     Close Browser
@@ -546,9 +546,9 @@ Test Case - Scan A Tag In The Repo
 
     Sign In Harbor  ${HARBOR_URL}  user023  Test1@34
     Create An New Project  project${d}
-
-    Go Into Project  project${d}    
+    Go Into Project  project${d}  has_image=${false}    
     Push Image  ${ip}  user023  Test1@34  project${d}  hello-world
+    Sleep  5
     Go Into Project  project${d}
     Go Into Repo  project${d}/hello-world
     Scan Repo  latest  Succeed
@@ -641,7 +641,7 @@ Test Case - List Helm Charts
 
     Sign In Harbor  ${HARBOR_URL}  user027  Test1@34
     Create An New Project  project${d}
-    Go Into Project  project${d}
+    Go Into Project  project${d}  has_image=${false}
     Sleep  2
     
     Switch To Project Charts
@@ -706,7 +706,7 @@ Test Case - Retag A Image Tag
     Create An New Project  project${random_num1}
     Create An New Project  project${random_num2}
     
-    Go Into Project  project${random_num1}
+    Go Into Project  project${random_num1}  has_image=${false}
     Sleep  1
     Push Image With Tag  ${ip}  user028  Test1@34  project${random_num1}  redis  ${image_tag}
     Sleep  1

--- a/tests/robot-cases/Group1-Nightly/LDAP.robot
+++ b/tests/robot-cases/Group1-Nightly/LDAP.robot
@@ -47,7 +47,7 @@ Test Case - System Admin On-board New Member
     Page Should Not Contain  mike02
     Back To Projects
     Create An New Project  project${d}
-    Go Into Project  project${d}
+    Go Into Project  project${d}  has_image=${false}
     Switch To Member
     Add Guest Member To Project  mike02
     Page Should Contain  mike02
@@ -58,7 +58,7 @@ Test Case - LDAP User On-borad New Member
     ${d}=    Get Current Date    result_format=%m%s
     Sign In Harbor  ${HARBOR_URL}  mike03  zhu88jie
     Create An New Project  project${d}
-    Go Into Project  project${d}
+    Go Into Project  project${d}  has_image=${false}
     Switch To Member
     Page Should Not Contain  mike04
     Add Guest Member To Project  mike04
@@ -93,7 +93,7 @@ Test Case - Ldap User Create Project
     Sign In Harbor  ${HARBOR_URL}  mike  zhu88jie
     Create An New Project  project${d}
     Logout Harbor
-    Manage Project Member  ${HARBOR_ADMIN}  ${HARBOR_PASSWORD}  project${d}  mike02  Add
+    Manage Project Member  ${HARBOR_ADMIN}  ${HARBOR_PASSWORD}  project${d}  mike02  Add  has_image=${false}
     Close Browser
 
 Test Case - Ldap User Push An Image

--- a/tests/robot-cases/Group1-Nightly/Nightly.robot
+++ b/tests/robot-cases/Group1-Nightly/Nightly.robot
@@ -33,7 +33,7 @@ Test Case - Vulnerability Data Not Ready
 #This case must run before vulnerability db ready
     Init Chrome Driver
     Sign In Harbor  ${HARBOR_URL}  ${HARBOR_ADMIN}  ${HARBOR_PASSWORD}
-    Go Into Project  library
+    Go Into Project  library  has_image=${false}
     Vulnerability Not Ready Project Hint
     Switch To Configure
     Go To Vulnerability Config
@@ -215,7 +215,7 @@ Test Case - Project Level Policy Public
     ${d}=  Get Current Date    result_format=%m%s
     Sign In Harbor  ${HARBOR_URL}  ${HARBOR_ADMIN}  ${HARBOR_PASSWORD}
     Create An New Project  project${d}
-    Go Into Project  project${d}
+    Go Into Project  project${d}  has_image=${false}
     Goto Project Config
     Click Project Public
     Save Project Config
@@ -348,7 +348,7 @@ TestCase - Project Admin Operate Labels
     ${d}=   Get Current Date    result_format=%m%s
     Create An New Project With New User  url=${HARBOR_URL}  username=test${d}  email=test${d}@vmware.com  realname=test${d}  newPassword=Test1@34  comment=harbor  projectname=project${d}  public=false
 
-    Go Into Project  project${d}
+    Go Into Project  project${d}  has_image=${false}
     Sleep  2
     # Add labels
     Switch To Project Label
@@ -391,11 +391,11 @@ TestCase - Developer Operate Labels
     Create An New User  url=${HARBOR_URL}  username=bob${d}  email=bob${d}@vmware.com  realname=bob${d}  newPassword=Test1@34  comment=habor
     Logout Harbor
 
-    Manage Project Member  test${d}  Test1@34  project${d}  bob${d}  Add
+    Manage Project Member  test${d}  Test1@34  project${d}  bob${d}  Add  has_image=${false}
     Change User Role In Project  test${d}  Test1@34  project${d}  bob${d}  Developer
 
     Sign In Harbor  ${HARBOR_URL}  bob${d}  Test1@34
-    Go Into Project  project${d}
+    Go Into Project  project${d}  has_image=${false}
     Sleep  3
     Page Should Not Contain Element  xpath=//a[contains(.,'Labels')]
     Close Browser
@@ -613,7 +613,7 @@ Test Case - Delete Multi Member
     Logout Harbor
     Create An New User  ${HARBOR_URL}  test${d}  test${d}@vmware.com  test${d}  Test1@34  harbor
     Create An New Project  project${d}
-    Go Into Project  project${d}
+    Go Into Project  project${d}  has_image=${false}
     Switch To Member
     Add Guest Member to project  testa${d}
     Add Guest Member to project  testb${d}

--- a/tests/robot-cases/Group1-Nightly/Replication.robot
+++ b/tests/robot-cases/Group1-Nightly/Replication.robot
@@ -182,7 +182,7 @@ Test Case - Project LeveL Replication Operation
     ${d} =  Get Current Date    result_format=%m%s
     Sign In Harbor  ${HARBOR_URL}  ${HARBOR_ADMIN}  ${HARBOR_PASSWORD}
     Create An New Project  proj${d}
-    Go Into Project  proj${d}
+    Go Into Project  proj${d}  has_image=${false}
     Switch To Replication
     Project Create A Rule With Existing Endpoint  rule${d}  proj${d}  edp  Manual
     Push Image  ${ip}  ${HARBOR_ADMIN}  ${HARBOR_PASSWORD}  proj${d}  hello-world


### PR DESCRIPTION
Robot scripts refactor for keyword sign-in-harbor and other few keywords, mainly on replacing 'sleep' to 'wait until', and also add a checkpoint in "Go Into Project" keyword to verify the result of loading a project page.

Signed-off-by: danfengliu <danfengl@vmware.com>
fixed  #6684 ##6563