### PR TITLE
When harbor is deployed in http mode, the registry certificate download button is not displayed in the project page.

### DIFF
--- a/src/portal/lib/src/repository-gridview/repository-gridview.component.html
+++ b/src/portal/lib/src/repository-gridview/repository-gridview.component.html
@@ -3,7 +3,7 @@
         <div class="toolbar">
             <div class="row flex-items-xs-right option-right rightPos">
                 <div class="flex-xs-middle">
-                    <a #certDownloadLink [href]="downloadLink" target="_blank" class="btn btn-link btn-font download-link">
+                    <a #certDownloadLink *ngIf="canDownloadCert" [href]="downloadLink" target="_blank" class="btn btn-link btn-font download-link">
                         <clr-icon shape="download"></clr-icon>
                         {{'CONFIG.REGISTRY_CERTIFICATE' | translate | uppercase}}
                     </a>

--- a/src/portal/lib/src/repository-gridview/repository-gridview.component.ts
+++ b/src/portal/lib/src/repository-gridview/repository-gridview.component.ts
@@ -51,6 +51,7 @@ export class RepositoryGridviewComponent implements OnChanges, OnInit {
     @Input() urlPrefix: string;
     @Input() hasSignedIn: boolean;
     @Input() hasProjectAdminRole: boolean;
+    @Input() hasCAFile: boolean = false;
     @Input() mode = "admiral";
     @Output() repoClickEvent = new EventEmitter<RepositoryItem>();
     @Output() repoProvisionEvent = new EventEmitter<RepositoryItem>();
@@ -116,6 +117,10 @@ export class RepositoryGridviewComponent implements OnChanges, OnInit {
 
     public get showDBStatusWarning(): boolean {
         return this.withClair && !this.isClairDBReady;
+    }
+
+    get canDownloadCert(): boolean {
+        return this.hasCAFile;
     }
 
     ngOnChanges(changes: SimpleChanges): void {

--- a/src/portal/src/app/repository/repository-page.component.html
+++ b/src/portal/src/app/repository/repository-page.component.html
@@ -1,5 +1,5 @@
 <div>
-    <hbr-repository-gridview [projectId]="projectId" [projectName]="projectName" [hasSignedIn]="hasSignedIn"
+    <hbr-repository-gridview [projectId]="projectId" [projectName]="projectName" [hasSignedIn]="hasSignedIn" [hasCAFile]="hasCAFile"
     [hasProjectAdminRole]="hasProjectAdminRole" [mode]="mode"
     (repoClickEvent)="watchRepoClickEvent($event)"></hbr-repository-gridview>
 </div>

--- a/src/portal/src/app/repository/repository-page.component.ts
+++ b/src/portal/src/app/repository/repository-page.component.ts
@@ -17,7 +17,7 @@ import { RepositoryItem } from '@harbor/ui';
 
 import { Project } from '../project/project';
 import { SessionService } from '../shared/session.service';
-
+import { AppConfigService } from '../app-config.service';
 @Component({
   selector: 'repository',
   templateUrl: 'repository-page.component.html'
@@ -32,7 +32,8 @@ export class RepositoryPageComponent implements OnInit {
   constructor(
     private route: ActivatedRoute,
     private session: SessionService,
-    private router: Router
+    private router: Router,
+    private appConfigService: AppConfigService,
   ) {
   }
 
@@ -50,5 +51,9 @@ export class RepositoryPageComponent implements OnInit {
   watchRepoClickEvent(repoEvt: RepositoryItem): void {
     let linkUrl = ['harbor', 'projects', repoEvt.project_id, 'repositories', repoEvt.name];
     this.router.navigate(linkUrl);
+  }
+
+  public get hasCAFile(): boolean {
+    return this.appConfigService.getConfig().has_ca_root;
   }
 }


### PR DESCRIPTION
fixed #6591 
Download certificate link is not displayed when  harbor is deployed in http mode 
Signed-off-by: FangyuanCheng <fangyuanc@vmware.com>