### PR TITLE
Fix the issue of naming project with 'api' which is a segment of URL

### DIFF
--- a/src/core/api/chart_repository_test.go
+++ b/src/core/api/chart_repository_test.go
@@ -6,6 +6,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/goharbor/harbor/src/common/dao"
+
 	"github.com/goharbor/harbor/src/chartserver"
 	"github.com/goharbor/harbor/src/common/models"
 	"github.com/goharbor/harbor/src/core/promgr/metamgr"
@@ -92,13 +94,35 @@ func TestGetHealthStatus(t *testing.T) {
 	}
 }
 
-// Test get index by repo
+// Test getting index by repo
 func TestGetIndexByRepo(t *testing.T) {
 	runCodeCheckingCases(t, &codeCheckingCase{
 		request: &testingRequest{
 			url:        "/chartrepo/library/index.yaml",
 			method:     http.MethodGet,
 			credential: projDeveloper,
+		},
+		code: http.StatusOK,
+	})
+}
+
+// Test getting index by repository name 'api'
+func TestGetIndexByRepoNameApi(t *testing.T) {
+	// Create project with name `api`
+	id, err := dao.AddProject(models.Project{
+		Name:    "api",
+		OwnerID: 1, // Use `admin`
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dao.DeleteProject(id)
+
+	runCodeCheckingCases(t, &codeCheckingCase{
+		request: &testingRequest{
+			url:        "/chartrepo/api/index.yaml",
+			method:     http.MethodGet,
+			credential: sysAdmin,
 		},
 		code: http.StatusOK,
 	})

--- a/src/testing/chart_utility.go
+++ b/src/testing/chart_utility.go
@@ -97,6 +97,16 @@ var MockChartRepoHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.
 			w.Write([]byte("{}"))
 			return
 		}
+	case "/PWFwaT0=/index.yaml":
+		if r.Method == http.MethodGet {
+			w.Write([]byte(repo1IndexYaml))
+			return
+		}
+	case "/PUFQST0=/index.yaml":
+		if r.Method == http.MethodGet {
+			w.Write([]byte(repo2IndexYaml))
+			return
+		}
 	default:
 		if r.Method == http.MethodGet {
 			if strings.HasSuffix(r.RequestURI, "/index.yaml") {


### PR DESCRIPTION
As the `api` is part of the chartmesum URL, there will be problem when creating a project with name `api`. The url path `/api/index.yaml` will be parsed as API interface but there is no handler to handle it. 404 error will be thrown out!

See issue #6596 

Signed-off-by: Steven Zou <szou@vmware.com>