### PR TITLE
disable retag function if integrate with admiral

### DIFF
--- a/src/portal/lib/package.json
+++ b/src/portal/lib/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@harbor/ui",
-    "version": "1.0.0-rc7",
+    "version": "1.7.1-rc1",
     "description": "Harbor shared UI components based on Clarity and Angular6",
     "author": "CNCF",
     "module": "index.js",

--- a/src/portal/lib/src/tag/tag.component.html
+++ b/src/portal/lib/src/tag/tag.component.html
@@ -75,7 +75,7 @@
             </div>
             </clr-dropdown-menu>
           </clr-dropdown>
-          <button type="button" class="btn btn-sm btn-secondary" [disabled]="!(selectedRow.length===1 && guestRoleOrAbove)" (click)="retag(selectedRow)"><clr-icon shape="copy" size="16"></clr-icon>&nbsp;{{'REPOSITORY.RETAG' | translate}}</button>
+          <button type="button" class="btn btn-sm btn-secondary" *ngIf="!withAdmiral" [disabled]="!(selectedRow.length===1 && guestRoleOrAbove)" (click)="retag(selectedRow)"><clr-icon shape="copy" size="16"></clr-icon>&nbsp;{{'REPOSITORY.RETAG' | translate}}</button>
           <button type="button" class="btn btn-sm btn-secondary" *ngIf="hasProjectAdminRole" (click)="deleteTags(selectedRow)" [disabled]="!selectedRow.length"><clr-icon shape="times" size="16"></clr-icon>&nbsp;{{'REPOSITORY.DELETE' | translate}}</button>
         </clr-dg-action-bar>
         <clr-dg-column style="width: 120px;" [clrDgField]="'name'">{{'REPOSITORY.TAG' | translate}}</clr-dg-column>

--- a/src/portal/package.json
+++ b/src/portal/package.json
@@ -1,6 +1,6 @@
 {
     "name": "harbor",
-    "version": "1.7.0",
+    "version": "1.7.1",
     "description": "Harbor UI with Clarity",
     "angular-cli": {},
     "scripts": {


### PR DESCRIPTION
retag api is hard coded in harbor frontend, this lead to wrong admiral api cal if harbor is a component integrated with admiral. For the requirement of vic release. We need to toggle of this feature if integrate with admiral. 