### PR TITLE
[DON'T MERGE]:remove pm dependence of token service

### DIFF
--- a/src/core/service/token/authutils.go
+++ b/src/core/service/token/authutils.go
@@ -29,7 +29,6 @@ import (
 	"github.com/goharbor/harbor/src/common/security"
 	"github.com/goharbor/harbor/src/common/utils/log"
 	"github.com/goharbor/harbor/src/core/config"
-	"github.com/goharbor/harbor/src/core/promgr"
 )
 
 const (
@@ -80,8 +79,7 @@ func GetResourceActions(scopes []string) []*token.ResourceActions {
 }
 
 // filterAccess iterate a list of resource actions and try to use the filter that matches the resource type to filter the actions.
-func filterAccess(access []*token.ResourceActions, ctx security.Context,
-	pm promgr.ProjectManager, filters map[string]accessFilter) error {
+func filterAccess(access []*token.ResourceActions, ctx security.Context, filters map[string]accessFilter) error {
 	var err error
 	for _, a := range access {
 		f, ok := filters[a.Type]
@@ -90,7 +88,7 @@ func filterAccess(access []*token.ResourceActions, ctx security.Context,
 			log.Warningf("No filter found for access type: %s, skip filter, the access of resource '%s' will be set empty.", a.Type, a.Name)
 			continue
 		}
-		err = f.filter(ctx, pm, a)
+		err = f.filter(ctx, a)
 		log.Debugf("user: %s, access: %v", ctx.GetUsername(), a)
 		if err != nil {
 			return err

--- a/src/core/service/token/token_test.go
+++ b/src/core/service/token/token_test.go
@@ -287,19 +287,19 @@ func TestFilterAccess(t *testing.T) {
 	}
 	err = filterAccess(a1, &fakeSecurityContext{
 		isAdmin: true,
-	}, nil, registryFilterMap)
+	}, registryFilterMap)
 	assert.Nil(t, err, "Unexpected error: %v", err)
 	assert.Equal(t, ra1, *a1[0], "Mismatch after registry filter Map")
 
 	err = filterAccess(a2, &fakeSecurityContext{
 		isAdmin: true,
-	}, nil, notaryFilterMap)
+	}, notaryFilterMap)
 	assert.Nil(t, err, "Unexpected error: %v", err)
 	assert.Equal(t, ra2, *a2[0], "Mismatch after notary filter Map")
 
 	err = filterAccess(a3, &fakeSecurityContext{
 		isAdmin: false,
-	}, nil, registryFilterMap)
+	}, registryFilterMap)
 	assert.Nil(t, err, "Unexpected error: %v", err)
 	assert.Equal(t, ra2, *a3[0], "Mismatch after registry filter Map")
 }


### PR DESCRIPTION
To introduce robot account, it has to support docker login with the token, but without creating a project manager in the instance of the robot security context.

But, the token service depends on the pm to issue token to docker registry, this commit is to remove the dependence as it's not necessary.

Signed-off-by: wang yan <wangyan@vmware.com>