### PR TITLE
Fix: data not reload when global serach navigate to same location

### DIFF
--- a/src/portal/package-lock.json
+++ b/src/portal/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "harbor",
-    "version": "1.7.0",
+    "version": "1.7.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/src/portal/src/app/harbor-routing.module.ts
+++ b/src/portal/src/app/harbor-routing.module.ts
@@ -199,7 +199,7 @@ const harborRoutes: Routes = [
 
 @NgModule({
   imports: [
-    RouterModule.forRoot(harborRoutes)
+    RouterModule.forRoot(harborRoutes, {onSameUrlNavigation: 'reload'})
   ],
   exports: [RouterModule]
 })


### PR DESCRIPTION

Just add a reload option on router module. This feature is introduced in angular5, we can solve this issue easily.

Signed-off-by: Qian Deng <dengq@vmware.com>