### PR TITLE
Fix Swagger client generation for a few chartrepo endpoints

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -2851,7 +2851,9 @@ paths:
           description: The chart name
       responses:
         '200':
-          $ref: '#/definitions/ChartVersions'
+          description: Retrieved all versions of the specified chart
+          schema:
+            $ref: '#/definitions/ChartVersions'
         '401':
           $ref: '#/definitions/UnauthorizedChartAPIError'
         '403':
@@ -2911,7 +2913,9 @@ paths:
           description: The chart version
       responses:
         '200':
-          $ref: '#/definitions/ChartVersionDetails'
+          description: Successfully retrieved the chart version
+          schema:
+            $ref: '#/definitions/ChartVersionDetails'
         '401':
           $ref: '#/definitions/UnauthorizedChartAPIError'
         '403':


### PR DESCRIPTION
It looks like the Swagger for `ChartVersions` and `ChartVersionDetails`
were missing fields to properly generate a client.

This fixes the problem by adding the correct `refs` so that the client
produces an output when making an API call.

In Go, this generates something like:

```Go
/*GetChartrepoRepoChartsNameVersionOK handles this case with default header values.

Successfully retrieved the chart version
*/
type GetChartrepoRepoChartsNameVersionOK struct {
	Payload *models.ChartVersionDetails
}

...

/*GetChartrepoRepoChartsNameOK handles this case with default header values.

Retrieved all versions of the specified chart
*/
type GetChartrepoRepoChartsNameOK struct {
	Payload models.ChartVersions
}
```

Signed-off-by: Dan Norris <dan.norris@netapp.com>