### PR TITLE
add retry for making swagger client

### DIFF
--- a/tests/resources/APITest-Util.robot
+++ b/tests/resources/APITest-Util.robot
@@ -1,8 +1,12 @@
 *** Keywords ***
-Setup API Test
+Make Swagger Client
     ${rc}  ${output}=  Run And Return Rc And Output  make swagger_client 
     Log  ${output}
-    Should Be Equal As Integers  ${rc}  0
+    [Return]  ${rc}
+
+Setup API Test
+    Retry Keyword When Error  Make Swagger Client
+
 Harbor API Test 
     [Arguments]  ${testcase_name}
     ${current_dir}=  Run  pwd

--- a/tests/resources/Util.robot
+++ b/tests/resources/Util.robot
@@ -78,3 +78,13 @@ Wait Unitl Vul Data Ready
     \    Exit For Loop If  ${contains}
     \    Sleep  ${interval}
     Run Keyword If  ${i+1}==${n}  Fail  The vul data is not ready
+
+Retry Keyword When Error
+    [Arguments]  ${keyword}  ${times}=6
+    :For  ${n}  IN RANGE  1  ${times}
+    \    Log To Console  Attampt to ${keyword} ${n} times ...
+    \    ${out}  Run Keyword And Ignore Error  ${keyword}
+    \    Log To Console  Return value is ${out}
+    \    Exit For Loop If  '${out[0]}'=='PASS'
+    \    Sleep  3
+    Should Be Equal As Strings  '${out[0]}'  'PASS'


### PR DESCRIPTION
Before running robot test cases, make swagger client is requested, but it fails occasionally, so we add retry to avoid this impact.

Signed-off-by: danfengliu <danfengl@vmware.com>
Fixed: #6385