### PR TITLE
Add keyword <Go Into Project> into <Create An New Project> for result verification

### DIFF
--- a/tests/resources/Harbor-Pages/Project.robot
+++ b/tests/resources/Harbor-Pages/Project.robot
@@ -22,28 +22,21 @@ ${HARBOR_VERSION}  v1.1.1
 *** Keywords ***
 Create An New Project
     [Arguments]  ${projectname}  ${public}=false
-    ${element}=  Set Variable  css=${create_project_button_css}
-    Wait Until Element Is Visible And Enabled  ${element}
-    Click Button  ${element}
+    Navigate To Projects
+    ${element_create_project_button}=  Set Variable  xpath=${create_project_button_xpath}
+    Wait Until Element Is Visible And Enabled  ${element_create_project_button}
+    Click Button  ${element_create_project_button}
     Log To Console  Project Name: ${projectname}
-    ${element}=  Set Variable  xpath=${project_name_xpath}
-    Wait Until Element Is Visible And Enabled  ${element}
-    Input Text  ${element}  ${projectname}
-    ${element}=  Set Variable  xpath=${project_public_xpath}
-    Run Keyword If  '${public}' == 'true'  Run Keywords  Wait Until Element Is Visible And Enabled  ${element}  AND  Click Element  ${element}
-    ${element}=  Set Variable  xpath=//button[contains(.,'OK')]
-    Wait Until Element Is Visible And Enabled  ${element}
-    Click Element  ${element}
-    #Try to get Project Infomation 5 times at most and sleep 1 second each time if we fail to get it.
-    ${found_project}=  Set Variable  ${false}
-    :For  ${n}  IN RANGE  1  5
-    \    ${rc}  ${output}=  Run And Return Rc And Output  curl -u ${HARBOR_ADMIN}:${HARBOR_PASSWORD} -k -X GET --header 'Accept: application/json' ${HARBOR_URL}/api/projects?name=${projectname}
-    \    Log To Console  ${output}
-    \    ${match}  ${regexp_project_name}  Should Match Regexp  ${output}  \"name\"\\s*:\\s*\"(\\w+)\"\\s*,
-    \    ${found_project}  Set Variable If  '${rc}' == '0' and '${regexp_project_name}' == '${projectname}'  ${true}
-    \    Run Keyword If  ${found_project} == ${true}  Exit For Loop
-    \    Sleep  1
-    Should Be Equal  ${found_project}  ${true}
+    ${elemen_project_name}=  Set Variable  xpath=${project_name_xpath}
+    Wait Until Element Is Visible And Enabled  ${elemen_project_name}
+    Input Text  ${elemen_project_name}  ${projectname}
+    ${element_project_public}=  Set Variable  xpath=${project_public_xpath}
+    Run Keyword If  '${public}' == 'true'  Run Keywords  Wait Until Element Is Visible And Enabled  ${element_project_public}  AND  Click Element  ${element_project_public}
+    ${element_create_project_OK_button_xpath}=  Set Variable  ${create_project_OK_button_xpath}
+    Wait Until Element Is Visible And Enabled  ${element_create_project_OK_button_xpath}
+    Click Element  ${element_create_project_OK_button_xpath}
+    Wait Until Page Does Not Contain Element  ${create_project_CANCEL_button_xpath}
+    Go Into Project  ${projectname}  has_image=${false}
 
 Create An New Project With New User
     [Arguments]  ${url}  ${username}  ${email}  ${realname}  ${newPassword}  ${comment}  ${projectname}  ${public}
@@ -72,7 +65,7 @@ Switch To Replication
     Click Element  xpath=${project_replication_xpath}
     Sleep  1
 
-Back To Projects
+Navigate To Projects
     ${element}=  Set Variable  xpath=${projects_xpath}  
     Wait Until Element Is Visible And Enabled  ${element}
     Click Element  ${element}
@@ -118,11 +111,15 @@ Make Project Public
 
 Delete Repo
     [Arguments]  ${projectname}
-    Click Element  xpath=//clr-dg-row[contains(.,"${projectname}")]//clr-checkbox-wrapper//label
-    Wait Until Element Is Enabled  //button[contains(.,"Delete")]
-    Click Element  xpath=//button[contains(.,"Delete")]
-    Wait Until Element Is Visible  //clr-modal//button[2]
-    Click Element  xpath=//clr-modal//button[2]
+    ${element_repo_checkbox}=  Set Variable  xpath=//clr-dg-row[contains(.,"${projectname}")]//clr-checkbox-wrapper//label
+    Retry Keyword With Element When Error  Wait Until Element Is Visible And Enabled  ${element_repo_checkbox}
+    Retry Keyword With Element When Error  Click Element  ${element_repo_checkbox}
+    ${element_delete_btn}=  Set Variable  xpath=//button[contains(.,"Delete")]
+    Retry Keyword With Element When Error  Wait Until Element Is Visible And Enabled  ${element_delete_btn}
+    Retry Keyword With Element When Error  Click Element  ${element_delete_btn}
+    ${element_delete_confirm_btn}=  Set Variable  xpath=//clr-modal//button[2]
+    Retry Keyword With Element When Error  Wait Until Element Is Visible And Enabled  ${element_delete_confirm_btn}
+    Retry Keyword With Element When Error  Click Element  ${element_delete_confirm_btn}
 
 Delete Repo on CardView
     [Arguments]  ${reponame}
@@ -134,6 +131,7 @@ Delete Repo on CardView
 
 Delete Project
     [Arguments]  ${projectname}
+    Navigate To Projects
     Sleep  1
     Click Element  xpath=//clr-dg-row[contains(.,"${projectname}")]//clr-checkbox-wrapper//label
     Sleep  1

--- a/tests/resources/Harbor-Pages/Project_Elements.robot
+++ b/tests/resources/Harbor-Pages/Project_Elements.robot
@@ -16,7 +16,7 @@
 Documentation  This resource provides any keywords related to the Harbor private registry appliance
 
 *** Variables ***
-${create_project_button_css}  .btn
+${create_project_button_xpath}  //clr-main-container//button[contains(., 'New Project')]
 ${project_name_xpath}  //*[@id="create_project_name"]
 ${project_public_xpath}  //input[@name='public']/..//label
 ${project_save_css}  html body.no-scrolling harbor-app harbor-shell clr-main-container.main-container div.content-container div.content-area.content-area-override project div.row div.col-lg-12.col-md-12.col-sm-12.col-xs-12 div.row.flex-items-xs-between div.option-left create-project clr-modal div.modal div.modal-dialog div.modal-content div.modal-footer button.btn.btn-primary
@@ -25,3 +25,8 @@ ${projects_xpath}  //clr-main-container//clr-vertical-nav//a[contains(.,'Project
 ${project_replication_xpath}  //project-detail//a[contains(.,'Replication')]
 ${project_log_xpath}  //project-detail//li[contains(.,'Logs')]
 ${project_member_xpath}  //project-detail//li[contains(.,'Members')]
+
+${create_project_OK_button_xpath}  xpath=//button[contains(.,'OK')]
+${create_project_CANCEL_button_xpath}  xpath=//button[contains(.,'CANCEL')]
+${project_statistics_private_repository_icon}  xpath=//project/div/div/div[1]/div/statistics-panel/div/div[2]/div[1]/div[2]/div[2]/statistics/div/span[1]
+

--- a/tests/resources/Harbor-Pages/ToolKit.robot
+++ b/tests/resources/Harbor-Pages/ToolKit.robot
@@ -59,7 +59,6 @@ Multi-delete Object
     \    ${element}=  Set Variable  xpath=//clr-dg-row[contains(.,'${obj}')]//label
     \    Wait Until Element Is Visible And Enabled  ${element}
     \    Click Element  ${element}
-
     Capture Page Screenshot
     ${element}=  Set Variable  xpath=//button[contains(.,'Delete')]
     Wait Until Element Is Visible And Enabled  ${element}

--- a/tests/resources/Harbor-Pages/Verify.robot
+++ b/tests/resources/Harbor-Pages/Verify.robot
@@ -40,7 +40,7 @@ Verify Image Tag
     \    Go Into Project  ${project}  has_image=${has_image}
     \    @{repo}=  Get Value From Json  ${json}  $.projects[?(@name=${project})]..repo..name
     \    Loop Image Repo  @{repo}
-    \    Back To Projects
+    \    Navigate To Projects
     Close Browser
 
 Loop Image Repo
@@ -60,7 +60,7 @@ Verify Member Exist
     \   Switch To Member
     \   @{members}=  Get Value From Json  ${json}  $.projects[?(@name=${project})].member..name
     \   Loop Member  @{members}
-    \   Back To Projects
+    \   Navigate To Projects
     Close Browser
 
 Loop Member
@@ -102,7 +102,7 @@ Verify Project Label
     \    @{projectlabel}=  Get Value From Json  ${json}  $.projects[?(@.name=${project})]..labels..name
     \    :For    ${label}    In    @{label}
     \    \    Page Should Contain    ${projectlabel}
-    \    Back To Projects
+    \    Navigate To Projects
    Close Browser
       
 Verify Endpoint

--- a/tests/resources/Util.robot
+++ b/tests/resources/Util.robot
@@ -88,3 +88,15 @@ Retry Keyword When Error
     \    Exit For Loop If  '${out[0]}'=='PASS'
     \    Sleep  3
     Should Be Equal As Strings  '${out[0]}'  'PASS'
+
+Retry Keyword With Element When Error
+    [Arguments]  ${keyword}  ${element}  ${times}=6
+    #To prevent waiting for a fixed-period of time for page loading and failure caused by exception, we add loop to re-run <Wait Until Element Is Visible And Enabled> when
+    #    exception was caught.
+    :For  ${n}  IN RANGE  1  ${times}
+    \    Log To Console  Attampt to wait for ${n} times ...
+    \    ${out}  Run Keyword And Ignore Error  ${keyword}  ${element}
+    \    Log To Console  Return value is ${out}
+    \    Exit For Loop If  '${out[0]}'=='PASS'
+    \    Sleep  2
+    Should Be Equal As Strings  '${out[0]}'  'PASS'

--- a/tests/robot-cases/Group1-Nightly/Common.robot
+++ b/tests/robot-cases/Group1-Nightly/Common.robot
@@ -83,7 +83,7 @@ Test Case - Delete A Project
     Project Should Not Be Deleted  project${d}
     Go Into Project  project${d}
     Delete Repo  project${d}
-    Back To Projects
+    Navigate To Projects
     Project Should Be Deleted  project${d}
     Close Browser
 
@@ -115,7 +115,8 @@ Test Case - Staticsinfo
     Init Chrome Driver
     ${d}=  Get Current Date    result_format=%m%s
     Sign In Harbor  ${HARBOR_URL}  ${HARBOR_ADMIN}  ${HARBOR_PASSWORD}
-    Wait Until Element Is Visible  //project/div/div/div[1]/div/statistics-panel/div/div[2]/div[1]/div[2]/div[2]/statistics/div/span[1]
+    ${element}=  Set Variable  ${project_statistics_private_repository_icon}
+    Wait Until Element Is Visible  ${element}
     ${privaterepocount1}=  Get Statics Private Repo
     ${privateprojcount1}=  Get Statics Private Project
     ${publicrepocount1}=  Get Statics Public Repo
@@ -133,9 +134,10 @@ Test Case - Staticsinfo
     ${publicrepocount}=  evaluate  ${publicrepocount1}+1
     ${totalrepocount}=  evaluate  ${totalrepocount1}+2
     ${totalprojcount}=  evaluate  ${totalprojcount1}+2
-    Wait Until Element Is Visible  //project/div/div/div[1]/div/statistics-panel/div/div[2]/div[1]/div[2]/div[2]/statistics/div/span[1]
+    Navigate To Projects
+    Wait Until Element Is Visible  ${element}
     ${privaterepocountStr}=  Convert To String  ${privaterepocount}
-    Wait Until Element Contains  //project/div/div/div[1]/div/statistics-panel/div/div[2]/div[1]/div[2]/div[2]/statistics/div/span[1]  ${privaterepocountStr}
+    Wait Until Element Contains  ${element}  ${privaterepocountStr}
     ${privaterepocount2}=  Get Statics Private Repo
     ${privateprojcount2}=  get statics private project
     ${publicrepocount2}=  get statics public repo
@@ -418,6 +420,7 @@ Test Case - Delete Multi Project
     Create An New Project  projecta${d}
     Create An New Project  projectb${d}
     Push Image  ${ip}  user012  Test1@34  projecta${d}  hello-world
+    Navigate To Projects
     Filter Object  project
     Wait Until Element Is Not Visible  //clr-datagrid/div/div[2]
     Multi-delete Object  projecta  projectb
@@ -587,7 +590,7 @@ Test Case - Manual Scan All
     Switch To Configure
     Go To Vulnerability Config
     Trigger Scan Now
-    Back To Projects
+    Navigate To Projects
     Go Into Project  library
     Go Into Repo  redis
     Summary Chart Should Display  latest
@@ -671,7 +674,7 @@ Test Case - Retag A Image Tag
     Retag Image  ${image_tag}  project${random_num2}  ${target_image_name}  ${target_tag_value}
 
     Wait Until Element Is Not Visible  css=${modal-dialog}
-    Back To Projects
+    Navigate To Projects
     Go Into Project  project${random_num2}
     Sleep  1
     Page Should Contain  ${target_image_name}
@@ -688,7 +691,7 @@ Test Case - Scan Image On Push
     Goto Project Config
     Enable Scan On Push
     Push Image  ${ip}  ${HARBOR_ADMIN}  ${HARBOR_PASSWORD}  library  memcached
-    Back To Projects
+    Navigate To Projects
     Go Into Project  library
     Go Into Repo  memcached
     Summary Chart Should Display  latest
@@ -717,7 +720,7 @@ Test Case - Project Level Image Serverity Policy
     Go Into Project  project${d}
     Go Into Repo  haproxy
     Scan Repo  latest  Succeed
-    Back To Projects
+    Navigate To Projects
     Go Into Project  project${d}
     Set Vulnerabilty Serverity  0
     Cannot pull image  ${ip}  ${HARBOR_ADMIN}  ${HARBOR_PASSWORD}  project${d}  haproxy

--- a/tests/robot-cases/Group1-Nightly/LDAP.robot
+++ b/tests/robot-cases/Group1-Nightly/LDAP.robot
@@ -45,7 +45,7 @@ Test Case - System Admin On-board New Member
     Sign In Harbor  ${HARBOR_URL}  ${HARBOR_ADMIN}  ${HARBOR_PASSWORD}
     Switch To User Tag
     Page Should Not Contain  mike02
-    Back To Projects
+    Navigate To Projects
     Create An New Project  project${d}
     Go Into Project  project${d}  has_image=${false}
     Switch To Member

--- a/tests/robot-cases/Group1-Nightly/Nightly.robot
+++ b/tests/robot-cases/Group1-Nightly/Nightly.robot
@@ -455,7 +455,7 @@ Test Case - Manual Scan All
     Switch To Configure
     Go To Vulnerability Config
     Trigger Scan Now
-    Back To Projects
+    Navigate To Projects
     Go Into Project  library
     Go Into Repo  redis
     Summary Chart Should Display  latest
@@ -468,7 +468,7 @@ Test Case - Project Level Image Serverity Policy
     Go Into Project  library
     Go Into Repo  haproxy
     Scan Repo  latest  Succeed
-    Back To Projects
+    Navigate To Projects
     Go Into Project  library
     Set Vulnerabilty Serverity  0
     Cannot pull image  ${ip}  ${HARBOR_ADMIN}  ${HARBOR_PASSWORD}  library  haproxy
@@ -524,7 +524,7 @@ Test Case - Delete A Project
     Project Should Not Be Deleted  project${d}
     Go Into Project  project${d}
     Delete Repo  project${d}
-    Back To Projects
+    Navigate To Projects
     Project Should Be Deleted  project${d}
     Close Browser
 
@@ -680,7 +680,7 @@ Test Case - Scan Image On Push
     Goto Project Config
     Enable Scan On Push
     Push Image  ${ip}  ${HARBOR_ADMIN}  ${HARBOR_PASSWORD}  library  memcached
-    Back To Projects
+    Navigate To Projects
     Go Into Project  library
     Go Into Repo  memcached
     Summary Chart Should Display  latest


### PR DESCRIPTION
The former way to verify project creation is by API calling, but it's not a GUI operation, which is not a goal for operator, so I replace it with GUI verification

Signed-off-by: danfengliu <danfengl@vmware.com>
Fixed: #6814 #6817 #6826