### PR TITLE
Update harbor.cfg with ldap_group_admin_dn parameter

### DIFF
--- a/make/harbor.cfg
+++ b/make/harbor.cfg
@@ -11,7 +11,7 @@ hostname = reg.mydomain.com
 #It can be set to https if ssl is enabled on nginx.
 ui_url_protocol = http
 
-#Maximum number of job workers in job service  
+#Maximum number of job workers in job service
 max_job_workers = 10 
 
 #Determine whether or not to generate certificate for the registry's token.
@@ -32,8 +32,8 @@ admiral_url = NA
 
 #Log files are rotated log_rotate_count times before being removed. If count is 0, old versions are removed rather than rotated.
 log_rotate_count = 50
-#Log files are rotated only if they grow bigger than log_rotate_size bytes. If size is followed by k, the size is assumed to be in kilobytes. 
-#If the M is used, the size is in megabytes, and if G is used, the size is in gigabytes. So size 100, size 100k, size 100M and size 100G 
+#Log files are rotated only if they grow bigger than log_rotate_size bytes. If size is followed by k, the size is assumed to be in kilobytes.
+#If the M is used, the size is in megabytes, and if G is used, the size is in gigabytes. So size 100, size 100k, size 100M and size 100G
 #are all valid.
 log_rotate_size = 200M
 
@@ -63,7 +63,7 @@ email_from = admin <sample_admin@mydomain.com>
 email_ssl = false
 email_insecure = false
 
-##The initial password of Harbor admin, only works for the first time when Harbor starts. 
+##The initial password of Harbor admin, only works for the first time when Harbor starts.
 #It has no effect after the first launch of Harbor.
 #Change the admin password from UI after launching Harbor.
 harbor_admin_password = Harbor12345
@@ -75,7 +75,7 @@ auth_mode = db_auth
 #The url for an ldap endpoint.
 ldap_url = ldaps://ldap.mydomain.com
 
-#A user's DN who has the permission to search the LDAP/AD server. 
+#A user's DN who has the permission to search the LDAP/AD server.
 #If your LDAP/AD server does not support anonymous search, you should configure this DN and ldap_search_pwd.
 #ldap_searchdn = uid=searchuser,ou=people,dc=mydomain,dc=com
 
@@ -88,13 +88,13 @@ ldap_basedn = ou=people,dc=mydomain,dc=com
 #Search filter for LDAP/AD, make sure the syntax of the filter is correct.
 #ldap_filter = (objectClass=person)
 
-# The attribute used in a search to match a user, it could be uid, cn, email, sAMAccountName or other attributes depending on your LDAP/AD  
-ldap_uid = uid 
+# The attribute used in a search to match a user, it could be uid, cn, email, sAMAccountName or other attributes depending on your LDAP/AD
+ldap_uid = uid
 
 #the scope to search for users, 0-LDAP_SCOPE_BASE, 1-LDAP_SCOPE_ONELEVEL, 2-LDAP_SCOPE_SUBTREE
-ldap_scope = 2 
+ldap_scope = 2
 
-#Timeout (in seconds)  when connecting to an LDAP Server. The default value (and most reasonable) is 5 seconds.
+#Timeout (in seconds) when connecting to an LDAP Server. The default value (and most reasonable) is 5 seconds.
 ldap_timeout = 5
 
 #Verify certificate from LDAP server
@@ -112,6 +112,9 @@ ldap_group_gid = cn
 #The scope to search for ldap groups. 0-LDAP_SCOPE_BASE, 1-LDAP_SCOPE_ONELEVEL, 2-LDAP_SCOPE_SUBTREE
 ldap_group_scope = 2
 
+#Members of this LDAP/AD group will have administrator rights in Harbor
+ldap_group_admin_dn = 
+
 #Turn on or off the self-registration feature
 self_registration = on
 
@@ -119,7 +122,7 @@ self_registration = on
 token_expiration = 30
 
 #The flag to control what users have permission to create projects
-#The default value "everyone" allows everyone to creates a project. 
+#The default value "everyone" allows everyone to create a project.
 #Set to "adminonly" so that only admin user can create project.
 project_creation_restriction = everyone
 
@@ -153,7 +156,7 @@ redis_port = 6379
 redis_password = 
 
 #Redis connection db index
-#db_index 1,2,3 is for registry, jobservice and chartmuseum. 
+#db_index 1,2,3 is for registry, jobservice and chartmuseum.
 #db_index 0 is for UI, it's unchangeable
 redis_db_index = 1,2,3
 
@@ -161,7 +164,7 @@ redis_db_index = 1,2,3
 
 ##########Clair DB configuration############
 
-#Clair DB host address. Only change it when using an exteral DB.
+#Clair DB host address. Only change it when using an external DB.
 clair_db_host = postgresql
 #The password of the Clair's postgres database. Only effective when Harbor is deployed with Clair.
 #Please update it before deployment. Subsequent update will cause Clair's API server and Harbor unable to access Clair's database.
@@ -198,7 +201,7 @@ registry_storage_provider_config =
 #of registry's and chart repository's containers.  This is usually needed when the user hosts a internal storage with self signed certificate.
 registry_custom_ca_bundle = 
 
-#If reload_config=true, all settings which present in harbor.cfg take effect after prepare and restart harbor, it overwrites exsiting settings.
+#If reload_config=true, all settings which present in harbor.cfg take effect after prepare and restart harbor, it overwrites existing settings.
 #reload_config=true
 #Regular expression to match skipped environment variables
 #skip_reload_env_pattern=(^EMAIL.*)|(^LDAP.*)


### PR DESCRIPTION
Update the harbor.cfg config file with the `ldap_group_admin_dn` parameter by default.

Also remove trailing spaces and fix a few typos, since we're editing the file already,

Hope you're having a great day! :)
