### PR TITLE
Remove password hash from user objects when listing

### DIFF
--- a/src/core/api/user.go
+++ b/src/core/api/user.go
@@ -161,6 +161,10 @@ func (ua *UserAPI) List() {
 		return
 	}
 
+	for _, user := range users {
+		user.Password = ""
+	}
+
 	ua.SetPaginationHeader(total, page, size)
 	ua.Data["json"] = users
 	ua.ServeJSON()

--- a/src/core/api/user_test.go
+++ b/src/core/api/user_test.go
@@ -201,6 +201,7 @@ func TestUsersGet(t *testing.T) {
 		assert.Equal(200, code, "Get users status should be 200")
 		assert.Equal(1, len(users), "Get users record should be 1 ")
 		testUser0002ID = users[0].UserId
+		assert.Equal("", users[0].Password)
 	}
 }
 


### PR DESCRIPTION
The output from `/api/users` includes the full password hash that is
stored in the database for all users.

This fixes the problem by sanitizing the password field in the list of
user structs before passing it to the JSON handler.

Fixes #6838