### PR TITLE
Fixed display problems caused by formatting

### DIFF
--- a/src/portal/src/app/project/robot-account/robot-account.component.html
+++ b/src/portal/src/app/project/robot-account/robot-account.component.html
@@ -4,8 +4,7 @@
       <div class="flex-xs-middle option-left">
       </div>
       <div class="flex-xs-middle option-right">
-        <hbr-filter [withDivider]="true" filterPlaceholder='{{"
-          ROBOT_ACCOUNT.FILTER_PLACEHOLDER" | translate}}'
+        <hbr-filter [withDivider]="true" filterPlaceholder='{{"ROBOT_ACCOUNT.FILTER_PLACEHOLDER" | translate}}'
           (filterEvt)="doSearch($event)" [currentValue]="searchRobot"></hbr-filter>
         <span class="refresh-btn" (click)="retrieve()">
           <clr-icon shape="refresh"></clr-icon>


### PR DESCRIPTION
Placement holder in search input cannot be displayed due to the formatting of VScode，Let placehoder display in one line to solve this problem
![image](https://user-images.githubusercontent.com/40712758/51954191-38db0a80-247a-11e9-9894-a9e27d1e9234.png)
Signed-off-by: FangyuanCheng <fangyuanc@vmware.com>