### PR TITLE
Remove the token attribute from robot table

### DIFF
--- a/make/migrations/postgresql/0004_add_robot_account.up.sql
+++ b/make/migrations/postgresql/0004_add_robot_account.up.sql
@@ -1,10 +1,6 @@
 CREATE TABLE robot (
  id SERIAL PRIMARY KEY NOT NULL,
  name varchar(255),
- /*
-  The maximum length of token is 7k
-*/
- token varchar(7168),
  description varchar(1024),
  project_id int,
  disabled boolean DEFAULT false NOT NULL,

--- a/src/common/dao/robot_test.go
+++ b/src/common/dao/robot_test.go
@@ -27,7 +27,6 @@ func TestAddRobot(t *testing.T) {
 	robotName := "test1"
 	robot := &models.Robot{
 		Name:        robotName,
-		Token:       "rKgjKEMpMEK23zqejkWn5GIVvgJps1vKACTa6tnGXXyOlOTsXFESccDvgaJx047q1",
 		Description: "test1 description",
 		ProjectID:   1,
 	}
@@ -46,7 +45,6 @@ func TestGetRobot(t *testing.T) {
 	robotName := "test2"
 	robot := &models.Robot{
 		Name:        robotName,
-		Token:       "rKgjKEMpMEK23zqejkWn5GIVvgJps1vKACTa6tnGXXyOlOTsXFESccDvgaJx047q2",
 		Description: "test2 description",
 		ProjectID:   1,
 	}
@@ -66,7 +64,6 @@ func TestListRobots(t *testing.T) {
 	robotName := "test3"
 	robot := &models.Robot{
 		Name:        robotName,
-		Token:       "rKgjKEMpMEK23zqejkWn5GIVvgJps1vKACTa6tnGXXyOlOTsXFESccDvgaJx047q3",
 		Description: "test3 description",
 		ProjectID:   1,
 	}
@@ -86,7 +83,6 @@ func TestDisableRobot(t *testing.T) {
 	robotName := "test4"
 	robot := &models.Robot{
 		Name:        robotName,
-		Token:       "rKgjKEMpMEK23zqejkWn5GIVvgJps1vKACTa6tnGXXyOlOTsXFESccDvgaJx047q4",
 		Description: "test4 description",
 		ProjectID:   1,
 	}
@@ -111,7 +107,6 @@ func TestEnableRobot(t *testing.T) {
 	robotName := "test5"
 	robot := &models.Robot{
 		Name:        robotName,
-		Token:       "rKgjKEMpMEK23zqejkWn5GIVvgJps1vKACTa6tnGXXyOlOTsXFESccDvgaJx047q5",
 		Description: "test5 description",
 		Disabled:    true,
 		ProjectID:   1,
@@ -137,7 +132,6 @@ func TestDeleteRobot(t *testing.T) {
 	robotName := "test6"
 	robot := &models.Robot{
 		Name:        robotName,
-		Token:       "rKgjKEMpMEK23zqejkWn5GIVvgJps1vKACTa6tnGXXyOlOTsXFESccDvgaJx047q6",
 		Description: "test6 description",
 		ProjectID:   1,
 	}

--- a/src/common/models/robot.go
+++ b/src/common/models/robot.go
@@ -27,7 +27,6 @@ const RobotTable = "robot"
 type Robot struct {
 	ID           int64     `orm:"pk;auto;column(id)" json:"id"`
 	Name         string    `orm:"column(name)" json:"name"`
-	Token        string    `orm:"column(token)" json:"token"`
 	Description  string    `orm:"column(description)" json:"description"`
 	ProjectID    int64     `orm:"column(project_id)" json:"project_id"`
 	Disabled     bool      `orm:"column(disabled)" json:"disabled"`


### PR DESCRIPTION
This commit is to remove the token attribute as harbor doesn't store the token in DB.

Signed-off-by: wang yan <wangyan@vmware.com>