### PR TITLE
Add a flag judging on building migrator

### DIFF
--- a/make/photon/Makefile
+++ b/make/photon/Makefile
@@ -204,9 +204,11 @@ _build_redis:
 	@echo "Done."
 
 _build_migrator:
-	@echo "building db migrator container for photon..."
-	@cd $(DOCKERFILEPATH_MIGRATOR) && $(DOCKERBUILD) -f $(DOCKERFILEPATH_MIGRATOR)/$(DOCKERFILENAME_MIGRATOR) -t $(DOCKERIMAGENAME_MIGRATOR):$(MIGRATORVERSION) .
-	@echo "Done."
+    @if [ "$(MIGRATORFLAG)" = "true" ] ; then \
+        echo "building db migrator container for photon..."; \
+        cd $(DOCKERFILEPATH_MIGRATOR) && $(DOCKERBUILD) -f $(DOCKERFILEPATH_MIGRATOR)/$(DOCKERFILENAME_MIGRATOR) -t $(DOCKERIMAGENAME_MIGRATOR):$(MIGRATORVERSION) . ; \
+        echo "Done."; \
+    fi
 
 define _get_binary
 	$(WGET) --timeout 30 --no-check-certificate $1 -O $2

--- a/tools/migration/Dockerfile
+++ b/tools/migration/Dockerfile
@@ -1,4 +1,4 @@
-FROM photon:1.0
+FROM photon:2.0
 
 ENV PGDATA /var/lib/postgresql/data
 


### PR DESCRIPTION
This commit is to add a flag judging when to build image of migator, which is not necessary.

Signed-off-by: wang yan <wangyan@vmware.com>