### PR TITLE
Fix bug where name and token cannot be displayed due to api changes

### DIFF
--- a/src/portal/src/app/project/robot-account/add-robot/add-robot.component.ts
+++ b/src/portal/src/app/project/robot-account/add-robot/add-robot.component.ts
@@ -130,8 +130,8 @@ export class AddRobotComponent implements OnInit, OnDestroy {
       .subscribe(
         response => {
           this.isSubmitOnGoing = false;
-          this.robotToken = response.Token;
-          this.robotAccount = response.Name;
+          this.robotToken = response.token;
+          this.robotAccount = response.name;
           this.copyToken = true;
           this.create.emit(true);
           this.translate


### PR DESCRIPTION
Change the Name to name and the Token to token when getting the object returned by the backend
Signed-off-by: FangyuanCheng <fangyuanc@vmware.com>