### PR TITLE
Prevent an out-of-bounds array access in address parsing.

### DIFF
--- a/src/core/config/config.go
+++ b/src/core/config/config.go
@@ -283,8 +283,7 @@ func ExtURL() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	l := strings.Split(endpoint, "://")
-	if len(l) > 0 {
+	if l := strings.SplitN(endpoint, "://", 2); len(l) == 2 {
 		return l[1], nil
 	}
 	return endpoint, nil


### PR DESCRIPTION
When starting the core process with almost no environment variables
set/configurations passed in, the core process may crash as follows:

```
2019-02-14T12:41:11Z [INFO] initializing configurations...
2019-02-14T12:41:11Z [INFO] key path: /etc/core/key
2019-02-14T12:41:11Z [INFO] initializing client for adminserver http://adminserver:8080 ...
2019-02-14T12:41:11Z [INFO] initializing the project manager based on local database...
2019-02-14T12:41:11Z [INFO] configurations initialization completed
panic: runtime error: index out of range

goroutine 1 [running]:
github.com/goharbor/harbor/src/core/config.ExtURL(0xcbde80, 0xc420438240, 0xdb354f, 0x8)
	/go/src/github.com/goharbor/harbor/src/core/config/config.go:287 +0x108
github.com/goharbor/harbor/src/core/service/token.InitCreators()
	/go/src/github.com/goharbor/harbor/src/core/service/token/creator.go:52 +0x1da
main.main()
	/go/src/github.com/goharbor/harbor/src/core/main.go:90 +0x1ea
```

This is due to the fact that the check right before the array access
only tests whether the list is empty and continues to access the element
at index 1.

As the intent of this code is to strip off a protocol at the start, use
SplitN() with a limit of 2 and only return the string at index 1 if the
string can be split properly.