### PR TITLE
[Do NOT Merge]Remove the workaround to clean cache in GC job

### DIFF
--- a/src/common/api/base.go
+++ b/src/common/api/base.go
@@ -21,7 +21,6 @@ import (
 	"strconv"
 
 	"github.com/astaxie/beego/validation"
-	commonhttp "github.com/goharbor/harbor/src/common/http"
 	"github.com/goharbor/harbor/src/common/utils/log"
 
 	"github.com/astaxie/beego"
@@ -48,76 +47,9 @@ func (b *BaseAPI) GetInt64FromPath(key string) (int64, error) {
 	return strconv.ParseInt(value, 10, 64)
 }
 
-// HandleNotFound ...
-func (b *BaseAPI) HandleNotFound(text string) {
-	log.Info(text)
-	b.RenderError(http.StatusNotFound, text)
-}
-
-// HandleUnauthorized ...
-func (b *BaseAPI) HandleUnauthorized() {
-	log.Info("unauthorized")
-	b.RenderError(http.StatusUnauthorized, "")
-}
-
-// HandleForbidden ...
-func (b *BaseAPI) HandleForbidden(text string) {
-	log.Infof("forbidden: %s", text)
-	b.RenderError(http.StatusForbidden, text)
-}
-
-// HandleBadRequest ...
-func (b *BaseAPI) HandleBadRequest(text string) {
-	log.Info(text)
-	b.RenderError(http.StatusBadRequest, text)
-}
-
-// HandleStatusPreconditionFailed ...
-func (b *BaseAPI) HandleStatusPreconditionFailed(text string) {
-	log.Info(text)
-	b.RenderError(http.StatusPreconditionFailed, text)
-}
-
-// HandleConflict ...
-func (b *BaseAPI) HandleConflict(text ...string) {
-	msg := ""
-	if len(text) > 0 {
-		msg = text[0]
-	}
-	log.Infof("conflict: %s", msg)
-
-	b.RenderError(http.StatusConflict, msg)
-}
-
-// HandleInternalServerError ...
-func (b *BaseAPI) HandleInternalServerError(text string) {
-	log.Error(text)
-	b.RenderError(http.StatusInternalServerError, "")
-}
-
-// ParseAndHandleError : if the err is an instance of utils/error.Error,
-// return the status code and the detail message contained in err, otherwise
-// return 500
-func (b *BaseAPI) ParseAndHandleError(text string, err error) {
-	if err == nil {
-		return
-	}
-	log.Errorf("%s: %v", text, err)
-	if e, ok := err.(*commonhttp.Error); ok {
-		b.RenderError(e.Code, e.Message)
-		return
-	}
-	b.RenderError(http.StatusInternalServerError, "")
-}
-
 // Render returns nil as it won't render template
 func (b *BaseAPI) Render() error {
 	return nil
-}
-
-// RenderError provides shortcut to render http error
-func (b *BaseAPI) RenderError(code int, text string) {
-	http.Error(b.Ctx.ResponseWriter, text, code)
 }
 
 // DecodeJSONReq decodes a json request

--- a/src/common/utils/registry/repository.go
+++ b/src/common/utils/registry/repository.go
@@ -103,6 +103,7 @@ func (r *Repository) ListTag() ([]string, error) {
 	} else if resp.StatusCode == http.StatusNotFound {
 
 		// TODO remove the logic if the bug of registry is fixed
+		// ISSUE: #936 in docker distribution
 		// It's a workaround for a bug of registry: when listing tags of
 		// a repository which is being pushed, a "NAME_UNKNOWN" error will
 		// been returned, while the catalog API can list this repository.

--- a/src/core/api/base.go
+++ b/src/core/api/base.go
@@ -17,7 +17,7 @@ package api
 import (
 	"net/http"
 
-	yaml "github.com/ghodss/yaml"
+	"github.com/ghodss/yaml"
 	"github.com/goharbor/harbor/src/common/api"
 	"github.com/goharbor/harbor/src/common/security"
 	"github.com/goharbor/harbor/src/common/utils/log"
@@ -25,6 +25,7 @@ import (
 	"github.com/goharbor/harbor/src/core/filter"
 	"github.com/goharbor/harbor/src/core/promgr"
 	"github.com/goharbor/harbor/src/core/utils"
+	commonhttp "github.com/goharbor/harbor/src/common/http"
 )
 
 const (
@@ -67,40 +68,64 @@ func (b *BaseController) Prepare() {
 }
 
 // RenderFormatedError renders errors with well formted style `{"error": "This is an error"}`
-func (b *BaseController) RenderFormatedError(code int, err error) {
-	formatedErr := utils.WrapError(err)
+func (b *BaseController) RenderFormatedError(statusCode, errorCode int, err error) {
+	formatedErr := utils.WrapError(errorCode, err)
 	log.Errorf("%s %s failed with error: %s", b.Ctx.Request.Method, b.Ctx.Request.URL.String(), formatedErr.Error())
-	b.RenderError(code, formatedErr.Error())
+	b.RenderError(statusCode, formatedErr.Error())
+}
+
+func (b *BaseController) RenderError(code int, text string) {
+	http.Error(b.Ctx.ResponseWriter, text, code)
+}
+
+// ParseAndHandleError : if the err is an instance of utils/error.Error,
+// return the status code and the detail message contained in err, otherwise
+// return 500
+func (b *BaseController) ParseAndHandleError(text string, err error) {
+	if err == nil {
+		return
+	}
+	log.Errorf("%s: %v", text, err)
+	if e, ok := err.(*commonhttp.Error); ok {
+		b.RenderError(e.Code, e.Message)
+		return
+	}
+	b.RenderError(http.StatusInternalServerError, "")
 }
 
 // SendUnAuthorizedError sends unauthorized error to the client.
 func (b *BaseController) SendUnAuthorizedError(err error) {
-	b.RenderFormatedError(http.StatusUnauthorized, err)
+	b.RenderFormatedError(http.StatusUnauthorized, http.StatusUnauthorized, err)
 }
 
 // SendConflictError sends conflict error to the client.
 func (b *BaseController) SendConflictError(err error) {
-	b.RenderFormatedError(http.StatusConflict, err)
+	b.RenderFormatedError(http.StatusConflict, http.StatusConflict, err)
 }
 
 // SendNotFoundError sends not found error to the client.
 func (b *BaseController) SendNotFoundError(err error) {
-	b.RenderFormatedError(http.StatusNotFound, err)
+	b.RenderFormatedError(http.StatusNotFound, http.StatusNotFound, err)
 }
 
 // SendBadRequestError sends bad request error to the client.
 func (b *BaseController) SendBadRequestError(err error) {
-	b.RenderFormatedError(http.StatusBadRequest, err)
+	b.RenderFormatedError(http.StatusBadRequest, http.StatusBadRequest, err)
 }
 
 // SendInternalServerError sends internal server error to the client.
 func (b *BaseController) SendInternalServerError(err error) {
-	b.RenderFormatedError(http.StatusInternalServerError, err)
+	b.RenderFormatedError(http.StatusInternalServerError, http.StatusInternalServerError, err)
 }
 
 // SendForbiddenError sends forbidden error to the client.
 func (b *BaseController) SendForbiddenError(err error) {
-	b.RenderFormatedError(http.StatusForbidden, err)
+	b.RenderFormatedError(http.StatusForbidden, http.StatusForbidden, err)
+}
+
+// SendPreconditionFailedError sends forbidden error to the client.
+func (b *BaseController) SendPreconditionFailedError(err error) {
+	b.RenderFormatedError(http.StatusPreconditionFailed, http.StatusPreconditionFailed, err)
 }
 
 // WriteJSONData writes the JSON data to the client.

--- a/src/core/api/chart_label.go
+++ b/src/core/api/chart_label.go
@@ -61,7 +61,7 @@ func (cla *ChartLabelAPI) requireAccess(action rbac.Action) bool {
 	resource := rbac.NewProjectNamespace(cla.project.ProjectID).Resource(rbac.ResourceHelmChartVersionLabel)
 
 	if !cla.SecurityCtx.Can(action, resource) {
-		cla.HandleForbidden(cla.SecurityCtx.GetUsername())
+		cla.SendForbiddenError(errors.New(cla.SecurityCtx.GetUsername()))
 		return false
 	}
 

--- a/src/core/api/chart_repository.go
+++ b/src/core/api/chart_repository.go
@@ -95,7 +95,7 @@ func (cra *ChartRepositoryAPI) requireAccess(action rbac.Action, subresource ...
 		if !cra.SecurityCtx.IsAuthenticated() {
 			cra.SendUnAuthorizedError(errors.New("Unauthorized"))
 		} else {
-			cra.HandleForbidden(cra.SecurityCtx.GetUsername())
+			cra.SendForbiddenError(errors.New(cra.SecurityCtx.GetUsername()))
 		}
 
 		return false

--- a/src/core/api/label.go
+++ b/src/core/api/label.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"errors"
 
 	"github.com/goharbor/harbor/src/common"
 	"github.com/goharbor/harbor/src/common/dao"
@@ -44,25 +45,25 @@ func (l *LabelAPI) Prepare() {
 
 	// POST, PUT, DELETE need login first
 	if !l.SecurityCtx.IsAuthenticated() {
-		l.HandleUnauthorized()
+		l.SendUnAuthorizedError(errors.New("UnAuthorized"))
 		return
 	}
 
 	if method == http.MethodPut || method == http.MethodDelete {
 		id, err := l.GetInt64FromPath(":id")
 		if err != nil || id <= 0 {
-			l.HandleBadRequest("invalid label ID")
+			l.SendBadRequestError(errors.New("invalid lable ID"))
 			return
 		}
 
 		label, err := dao.GetLabel(id)
 		if err != nil {
-			l.HandleInternalServerError(fmt.Sprintf("failed to get label %d: %v", id, err))
+			l.SendInternalServerError(fmt.Errorf("failed to get label %d: %v", id, err))
 			return
 		}
 
 		if label == nil || label.Deleted {
-			l.HandleNotFound(fmt.Sprintf("label %d not found", id))
+			l.SendNotFoundError(fmt.Errorf("label %d not found", id))
 			return
 		}
 
@@ -86,9 +87,9 @@ func (l *LabelAPI) requireAccess(label *models.Label, action rbac.Action, subres
 
 	if !hasPermission {
 		if !l.SecurityCtx.IsAuthenticated() {
-			l.HandleUnauthorized()
+			l.SendUnAuthorizedError(errors.New("UnAuthorized"))
 		} else {
-			l.HandleForbidden(l.SecurityCtx.GetUsername())
+			l.SendForbiddenError(errors.New(l.SecurityCtx.GetUsername()))
 		}
 		return false
 	}
@@ -108,12 +109,12 @@ func (l *LabelAPI) Post() {
 	case common.LabelScopeProject:
 		exist, err := l.ProjectMgr.Exists(label.ProjectID)
 		if err != nil {
-			l.HandleInternalServerError(fmt.Sprintf("failed to check the existence of project %d: %v",
+			l.SendInternalServerError(fmt.Errorf("failed to check the existence of project %d: %v",
 				label.ProjectID, err))
 			return
 		}
 		if !exist {
-			l.HandleNotFound(fmt.Sprintf("project %d not found", label.ProjectID))
+			l.SendNotFoundError(fmt.Errorf("project %d not found", label.ProjectID))
 			return
 		}
 	}
@@ -129,17 +130,17 @@ func (l *LabelAPI) Post() {
 		ProjectID: label.ProjectID,
 	})
 	if err != nil {
-		l.HandleInternalServerError(fmt.Sprintf("failed to list labels: %v", err))
+		l.SendInternalServerError(fmt.Errorf("failed to list labels: %v", err))
 		return
 	}
 	if len(labels) > 0 {
-		l.HandleConflict()
+		l.SendConflictError(errors.New("conflict label"))
 		return
 	}
 
 	id, err := dao.AddLabel(label)
 	if err != nil {
-		l.HandleInternalServerError(fmt.Sprintf("failed to create label: %v", err))
+		l.SendInternalServerError(fmt.Errorf("failed to create label: %v", err))
 		return
 	}
 
@@ -150,18 +151,18 @@ func (l *LabelAPI) Post() {
 func (l *LabelAPI) Get() {
 	id, err := l.GetInt64FromPath(":id")
 	if err != nil || id <= 0 {
-		l.HandleBadRequest(fmt.Sprintf("invalid label ID: %s", l.GetStringFromPath(":id")))
+		l.SendBadRequestError(fmt.Errorf("invalid label ID: %s", l.GetStringFromPath(":id")))
 		return
 	}
 
 	label, err := dao.GetLabel(id)
 	if err != nil {
-		l.HandleInternalServerError(fmt.Sprintf("failed to get label %d: %v", id, err))
+		l.SendInternalServerError(fmt.Errorf("failed to get label %d: %v", id, err))
 		return
 	}
 
 	if label == nil || label.Deleted {
-		l.HandleNotFound(fmt.Sprintf("label %d not found", id))
+		l.SendNotFoundError(fmt.Errorf("label %d not found", id))
 		return
 	}
 
@@ -183,7 +184,7 @@ func (l *LabelAPI) List() {
 
 	scope := l.GetString("scope")
 	if scope != common.LabelScopeGlobal && scope != common.LabelScopeProject {
-		l.HandleBadRequest(fmt.Sprintf("invalid scope: %s", scope))
+		l.SendBadRequestError(fmt.Errorf("invalid scope: %s", scope))
 		return
 	}
 	query.Scope = scope
@@ -191,22 +192,22 @@ func (l *LabelAPI) List() {
 	if scope == common.LabelScopeProject {
 		projectIDStr := l.GetString("project_id")
 		if len(projectIDStr) == 0 {
-			l.HandleBadRequest("project_id is required")
+			l.SendBadRequestError(errors.New("project_id is required"))
 			return
 		}
 		projectID, err := strconv.ParseInt(projectIDStr, 10, 64)
 		if err != nil || projectID <= 0 {
-			l.HandleBadRequest(fmt.Sprintf("invalid project_id: %s", projectIDStr))
+			l.SendBadRequestError(fmt.Errorf("invalid project_id: %s", projectIDStr))
 			return
 		}
 
 		resource := rbac.NewProjectNamespace(projectID).Resource(rbac.ResourceLabel)
 		if !l.SecurityCtx.Can(rbac.ActionList, resource) {
 			if !l.SecurityCtx.IsAuthenticated() {
-				l.HandleUnauthorized()
+				l.SendUnAuthorizedError(errors.New("UnAuthorized"))
 				return
 			}
-			l.HandleForbidden(l.SecurityCtx.GetUsername())
+			l.SendForbiddenError(errors.New(l.SecurityCtx.GetUsername()))
 			return
 		}
 		query.ProjectID = projectID
@@ -214,7 +215,7 @@ func (l *LabelAPI) List() {
 
 	total, err := dao.GetTotalOfLabels(query)
 	if err != nil {
-		l.HandleInternalServerError(fmt.Sprintf("failed to get total count of labels: %v", err))
+		l.SendInternalServerError(fmt.Errorf("failed to get total count of labels: %v", err))
 		return
 	}
 
@@ -222,7 +223,7 @@ func (l *LabelAPI) List() {
 
 	labels, err := dao.ListLabels(query)
 	if err != nil {
-		l.HandleInternalServerError(fmt.Sprintf("failed to list labels: %v", err))
+		l.SendInternalServerError(fmt.Errorf("failed to list labels: %v", err))
 		return
 	}
 
@@ -257,17 +258,17 @@ func (l *LabelAPI) Put() {
 			ProjectID: l.label.ProjectID,
 		})
 		if err != nil {
-			l.HandleInternalServerError(fmt.Sprintf("failed to list labels: %v", err))
+			l.SendInternalServerError(fmt.Errorf("failed to list labels: %v", err))
 			return
 		}
 		if len(labels) > 0 {
-			l.HandleConflict()
+			l.SendConflictError(errors.New("conflict label"))
 			return
 		}
 	}
 
 	if err := dao.UpdateLabel(l.label); err != nil {
-		l.HandleInternalServerError(fmt.Sprintf("failed to update label %d: %v", l.label.ID, err))
+		l.SendInternalServerError(fmt.Errorf("failed to update label %d: %v", l.label.ID, err))
 		return
 	}
 
@@ -281,11 +282,11 @@ func (l *LabelAPI) Delete() {
 
 	id := l.label.ID
 	if err := dao.DeleteResourceLabelByLabel(id); err != nil {
-		l.HandleInternalServerError(fmt.Sprintf("failed to delete resource label mappings of label %d: %v", id, err))
+		l.SendInternalServerError(fmt.Errorf("failed to delete resource label mappings of label %d: %v", id, err))
 		return
 	}
 	if err := dao.DeleteLabel(id); err != nil {
-		l.HandleInternalServerError(fmt.Sprintf("failed to delete label %d: %v", id, err))
+		l.SendInternalServerError(fmt.Errorf("failed to delete label %d: %v", id, err))
 		return
 	}
 }
@@ -294,18 +295,18 @@ func (l *LabelAPI) Delete() {
 func (l *LabelAPI) ListResources() {
 	id, err := l.GetInt64FromPath(":id")
 	if err != nil || id <= 0 {
-		l.HandleBadRequest("invalid label ID")
+		l.SendBadRequestError(errors.New("invalid label ID"))
 		return
 	}
 
 	label, err := dao.GetLabel(id)
 	if err != nil {
-		l.HandleInternalServerError(fmt.Sprintf("failed to get label %d: %v", id, err))
+		l.SendInternalServerError(fmt.Errorf("failed to get label %d: %v", id, err))
 		return
 	}
 
 	if label == nil || label.Deleted {
-		l.HandleNotFound(fmt.Sprintf("label %d not found", id))
+		l.SendNotFoundError(fmt.Errorf("label %d not found", id))
 		return
 	}
 
@@ -315,7 +316,7 @@ func (l *LabelAPI) ListResources() {
 
 	result, err := core.GlobalController.GetPolicies(rep_models.QueryParameter{})
 	if err != nil {
-		l.HandleInternalServerError(fmt.Sprintf("failed to get policies: %v", err))
+		l.SendInternalServerError(fmt.Errorf("failed to get policies: %v", err))
 		return
 	}
 	policies := []*rep_models.ReplicationPolicy{}

--- a/src/core/api/metadata.go
+++ b/src/core/api/metadata.go
@@ -25,6 +25,7 @@ import (
 	"github.com/goharbor/harbor/src/common/rbac"
 	"github.com/goharbor/harbor/src/common/utils/log"
 	"github.com/goharbor/harbor/src/core/promgr/metamgr"
+	"github.com/pkg/errors"
 )
 
 // MetadataAPI ...
@@ -56,7 +57,7 @@ func (m *MetadataAPI) Prepare() {
 		} else {
 			text += fmt.Sprintf("%d", id)
 		}
-		m.HandleBadRequest(text)
+		m.SendBadRequestError(errors.New(text))
 		return
 	}
 
@@ -67,7 +68,7 @@ func (m *MetadataAPI) Prepare() {
 	}
 
 	if project == nil {
-		m.HandleNotFound(fmt.Sprintf("project %d not found", id))
+		m.SendNotFoundError(fmt.Errorf("project %d not found", id))
 		return
 	}
 
@@ -78,11 +79,11 @@ func (m *MetadataAPI) Prepare() {
 		m.name = name
 		metas, err := m.metaMgr.Get(project.ProjectID, name)
 		if err != nil {
-			m.HandleInternalServerError(fmt.Sprintf("failed to get metadata of project %d: %v", project.ProjectID, err))
+			m.SendInternalServerError(fmt.Errorf("failed to get metadata of project %d: %v", project.ProjectID, err))
 			return
 		}
 		if len(metas) == 0 {
-			m.HandleNotFound(fmt.Sprintf("metadata %s of project %d not found", name, project.ProjectID))
+			m.SendNotFoundError(fmt.Errorf("metadata %s of project %d not found", name, project.ProjectID))
 			return
 		}
 	}
@@ -93,9 +94,9 @@ func (m *MetadataAPI) requireAccess(action rbac.Action) bool {
 
 	if !m.SecurityCtx.Can(action, resource) {
 		if !m.SecurityCtx.IsAuthenticated() {
-			m.HandleUnauthorized()
+			m.SendUnAuthorizedError(errors.New("Unauthorized"))
 		} else {
-			m.HandleForbidden(m.SecurityCtx.GetUsername())
+			m.SendForbiddenError(errors.New(m.SecurityCtx.GetUsername()))
 		}
 		return false
 	}
@@ -118,7 +119,7 @@ func (m *MetadataAPI) Get() {
 	}
 
 	if err != nil {
-		m.HandleInternalServerError(fmt.Sprintf("failed to get metadata %s of project %d: %v", m.name, m.project.ProjectID, err))
+		m.SendInternalServerError(fmt.Errorf("failed to get metadata %s of project %d: %v", m.name, m.project.ProjectID, err))
 		return
 	}
 	m.Data["json"] = metas
@@ -136,29 +137,29 @@ func (m *MetadataAPI) Post() {
 
 	ms, err := validateProjectMetadata(metas)
 	if err != nil {
-		m.HandleBadRequest(err.Error())
+		m.SendBadRequestError(err)
 		return
 	}
 
 	if len(ms) != 1 {
-		m.HandleBadRequest("invalid request: has no valid key/value pairs or has more than one valid key/value pairs")
+		m.SendBadRequestError(errors.New("invalid request: has no valid key/value pairs or has more than one valid key/value pairs"))
 		return
 	}
 
 	keys := reflect.ValueOf(ms).MapKeys()
 	mts, err := m.metaMgr.Get(m.project.ProjectID, keys[0].String())
 	if err != nil {
-		m.HandleInternalServerError(fmt.Sprintf("failed to get metadata for project %d: %v", m.project.ProjectID, err))
+		m.SendInternalServerError(fmt.Errorf("failed to get metadata for project %d: %v", m.project.ProjectID, err))
 		return
 	}
 
 	if len(mts) != 0 {
-		m.HandleConflict()
+		m.SendConflictError(errors.New("conflict metadata"))
 		return
 	}
 
 	if err := m.metaMgr.Add(m.project.ProjectID, ms); err != nil {
-		m.HandleInternalServerError(fmt.Sprintf("failed to create metadata for project %d: %v", m.project.ProjectID, err))
+		m.SendInternalServerError(fmt.Errorf("failed to create metadata for project %d: %v", m.project.ProjectID, err))
 		return
 	}
 
@@ -176,7 +177,7 @@ func (m *MetadataAPI) Put() {
 
 	meta, exist := metas[m.name]
 	if !exist {
-		m.HandleBadRequest(fmt.Sprintf("must contains key %s", m.name))
+		m.SendBadRequestError(fmt.Errorf("must contains key %s", m.name))
 		return
 	}
 
@@ -184,14 +185,14 @@ func (m *MetadataAPI) Put() {
 		m.name: meta,
 	})
 	if err != nil {
-		m.HandleBadRequest(err.Error())
+		m.SendBadRequestError(err)
 		return
 	}
 
 	if err := m.metaMgr.Update(m.project.ProjectID, map[string]string{
 		m.name: ms[m.name],
 	}); err != nil {
-		m.HandleInternalServerError(fmt.Sprintf("failed to update metadata %s of project %d: %v", m.name, m.project.ProjectID, err))
+		m.SendInternalServerError(fmt.Errorf("failed to update metadata %s of project %d: %v", m.name, m.project.ProjectID, err))
 		return
 	}
 }
@@ -203,7 +204,7 @@ func (m *MetadataAPI) Delete() {
 	}
 
 	if err := m.metaMgr.Delete(m.project.ProjectID, m.name); err != nil {
-		m.HandleInternalServerError(fmt.Sprintf("failed to delete metadata %s of project %d: %v", m.name, m.project.ProjectID, err))
+		m.SendInternalServerError(fmt.Errorf("failed to delete metadata %s of project %d: %v", m.name, m.project.ProjectID, err))
 		return
 	}
 }

--- a/src/core/api/projectmember.go
+++ b/src/core/api/projectmember.go
@@ -49,7 +49,7 @@ func (pma *ProjectMemberAPI) Prepare() {
 	pma.BaseController.Prepare()
 
 	if !pma.SecurityCtx.IsAuthenticated() {
-		pma.HandleUnauthorized()
+		pma.SendUnAuthorizedError(errors.New("Unauthorized"))
 		return
 	}
 	pid, err := pma.GetInt64FromPath(":pid")
@@ -60,7 +60,7 @@ func (pma *ProjectMemberAPI) Prepare() {
 		} else {
 			text += fmt.Sprintf("%d", pid)
 		}
-		pma.HandleBadRequest(text)
+		pma.SendBadRequestError(errors.New(text))
 		return
 	}
 	project, err := pma.ProjectMgr.Get(pid)
@@ -69,7 +69,7 @@ func (pma *ProjectMemberAPI) Prepare() {
 		return
 	}
 	if project == nil {
-		pma.HandleNotFound(fmt.Sprintf("project %d not found", pid))
+		pma.SendNotFoundError(fmt.Errorf("project %d not found", pid))
 		return
 	}
 	pma.project = project
@@ -79,7 +79,7 @@ func (pma *ProjectMemberAPI) Prepare() {
 		log.Warningf("Failed to get pmid from path, error %v", err)
 	}
 	if pmid <= 0 && (pma.Ctx.Input.IsPut() || pma.Ctx.Input.IsDelete()) {
-		pma.HandleBadRequest(fmt.Sprintf("The project member id is invalid, pmid:%s", pma.GetStringFromPath(":pmid")))
+		pma.SendBadRequestError(fmt.Errorf("The project member id is invalid, pmid:%s", pma.GetStringFromPath(":pmid")))
 		return
 	}
 	pma.id = int(pmid)
@@ -90,9 +90,9 @@ func (pma *ProjectMemberAPI) requireAccess(action rbac.Action) bool {
 
 	if !pma.SecurityCtx.Can(action, resource) {
 		if !pma.SecurityCtx.IsAuthenticated() {
-			pma.HandleUnauthorized()
+			pma.SendUnAuthorizedError(errors.New("Unauthorized"))
 		} else {
-			pma.HandleForbidden(pma.SecurityCtx.GetUsername())
+			pma.SendForbiddenError(errors.New(pma.SecurityCtx.GetUsername()))
 		}
 
 		return false
@@ -114,7 +114,7 @@ func (pma *ProjectMemberAPI) Get() {
 		entityname := pma.GetString("entityname")
 		memberList, err := project.SearchMemberByName(projectID, entityname)
 		if err != nil {
-			pma.HandleInternalServerError(fmt.Sprintf("Failed to query database for member list, error: %v", err))
+			pma.SendInternalServerError(fmt.Errorf("Failed to query database for member list, error: %v", err))
 			return
 		}
 		if len(memberList) > 0 {
@@ -126,11 +126,11 @@ func (pma *ProjectMemberAPI) Get() {
 		queryMember.ID = pma.id
 		memberList, err := project.GetProjectMember(queryMember)
 		if err != nil {
-			pma.HandleInternalServerError(fmt.Sprintf("Failed to query database for member list, error: %v", err))
+			pma.SendInternalServerError(fmt.Errorf("Failed to query database for member list, error: %v", err))
 			return
 		}
 		if len(memberList) == 0 {
-			pma.HandleNotFound(fmt.Sprintf("The project member does not exit, pmid:%v", pma.id))
+			pma.SendNotFoundError(fmt.Errorf("The project member does not exit, pmid:%v", pma.id))
 			return
 		}
 
@@ -154,22 +154,22 @@ func (pma *ProjectMemberAPI) Post() {
 
 	pmid, err := AddProjectMember(projectID, request)
 	if err == auth.ErrorGroupNotExist || err == auth.ErrorUserNotExist {
-		pma.HandleNotFound(fmt.Sprintf("Failed to add project member, error: %v", err))
+		pma.SendNotFoundError(fmt.Errorf("Failed to add project member, error: %v", err))
 		return
 	} else if err == auth.ErrDuplicateLDAPGroup {
-		pma.HandleConflict(fmt.Sprintf("Failed to add project member, already exist LDAP group or project member, groupDN:%v", request.MemberGroup.LdapGroupDN))
+		pma.SendConflictError(fmt.Errorf("Failed to add project member, already exist LDAP group or project member, groupDN:%v", request.MemberGroup.LdapGroupDN))
 		return
 	} else if err == ErrDuplicateProjectMember {
-		pma.HandleConflict(fmt.Sprintf("Failed to add project member, already exist LDAP group or project member, groupMemberID:%v", request.MemberGroup.ID))
+		pma.SendConflictError(fmt.Errorf("Failed to add project member, already exist LDAP group or project member, groupMemberID:%v", request.MemberGroup.ID))
 		return
 	} else if err == ErrInvalidRole {
-		pma.HandleBadRequest(fmt.Sprintf("Invalid role ID, role ID %v", request.Role))
+		pma.SendBadRequestError(fmt.Errorf("Invalid role ID, role ID %v", request.Role))
 		return
 	} else if err == auth.ErrInvalidLDAPGroupDN {
-		pma.HandleBadRequest(fmt.Sprintf("Invalid LDAP DN: %v", request.MemberGroup.LdapGroupDN))
+		pma.SendBadRequestError(fmt.Errorf("Invalid LDAP DN: %v", request.MemberGroup.LdapGroupDN))
 		return
 	} else if err != nil {
-		pma.HandleInternalServerError(fmt.Sprintf("Failed to add project member, error: %v", err))
+		pma.SendInternalServerError(fmt.Errorf("Failed to add project member, error: %v", err))
 		return
 	}
 	pma.Redirect(http.StatusCreated, strconv.FormatInt(int64(pmid), 10))
@@ -185,12 +185,12 @@ func (pma *ProjectMemberAPI) Put() {
 	var req models.Member
 	pma.DecodeJSONReq(&req)
 	if req.Role < 1 || req.Role > 4 {
-		pma.HandleBadRequest(fmt.Sprintf("Invalid role id %v", req.Role))
+		pma.SendBadRequestError(fmt.Errorf("Invalid role id %v", req.Role))
 		return
 	}
 	err := project.UpdateProjectMemberRole(pmID, req.Role)
 	if err != nil {
-		pma.HandleInternalServerError(fmt.Sprintf("Failed to update DB to add project user role, project id: %d, pmid : %d, role id: %d", pid, pmID, req.Role))
+		pma.SendInternalServerError(fmt.Errorf("Failed to update DB to add project user role, project id: %d, pmid : %d, role id: %d", pid, pmID, req.Role))
 		return
 	}
 }
@@ -203,7 +203,7 @@ func (pma *ProjectMemberAPI) Delete() {
 	pmid := pma.id
 	err := project.DeleteProjectMemberByID(pmid)
 	if err != nil {
-		pma.HandleInternalServerError(fmt.Sprintf("Failed to delete project roles for user, project member id: %d, error: %v", pmid, err))
+		pma.SendInternalServerError(fmt.Sprintf("Failed to delete project roles for user, project member id: %d, error: %v", pmid, err))
 		return
 	}
 }

--- a/src/core/api/reg_gc.go
+++ b/src/core/api/reg_gc.go
@@ -242,6 +242,8 @@ func (gc *GCAPI) submitJob(gr *models.GCReq) {
 	gr.ID = id
 	gr.Parameters = map[string]interface{}{
 		"redis_url_reg": os.Getenv("_REDIS_URL_REG"),
+		// keep the capability to clean cache in GC Job.
+		"cache_clean": false,
 	}
 	job, err := gr.ToJob()
 	if err != nil {

--- a/src/core/api/replication.go
+++ b/src/core/api/replication.go
@@ -16,7 +16,6 @@ package api
 
 import (
 	"fmt"
-	"net/http"
 	"strings"
 
 	"github.com/goharbor/harbor/src/common/dao"
@@ -29,6 +28,7 @@ import (
 	"github.com/goharbor/harbor/src/replication/event/topic"
 
 	"github.com/docker/distribution/uuid"
+	"github.com/pkg/errors"
 )
 
 // ReplicationAPI handles API calls for replication
@@ -40,12 +40,12 @@ type ReplicationAPI struct {
 func (r *ReplicationAPI) Prepare() {
 	r.BaseController.Prepare()
 	if !r.SecurityCtx.IsAuthenticated() {
-		r.HandleUnauthorized()
+		r.SendUnAuthorizedError(errors.New("Unauthorized"))
 		return
 	}
 
 	if !r.SecurityCtx.IsSysAdmin() && !r.SecurityCtx.IsSolutionUser() {
-		r.HandleForbidden(r.SecurityCtx.GetUsername())
+		r.SendForbiddenError(errors.New(r.SecurityCtx.GetUsername()))
 		return
 	}
 }
@@ -57,12 +57,12 @@ func (r *ReplicationAPI) Post() {
 
 	policy, err := core.GlobalController.GetPolicy(replication.PolicyID)
 	if err != nil {
-		r.HandleInternalServerError(fmt.Sprintf("failed to get replication policy %d: %v", replication.PolicyID, err))
+		r.SendInternalServerError(fmt.Errorf("failed to get replication policy %d: %v", replication.PolicyID, err))
 		return
 	}
 
 	if policy.ID == 0 {
-		r.HandleNotFound(fmt.Sprintf("replication policy %d not found", replication.PolicyID))
+		r.SendNotFoundError(fmt.Errorf("replication policy %d not found", replication.PolicyID))
 		return
 	}
 
@@ -72,18 +72,18 @@ func (r *ReplicationAPI) Post() {
 		Operations: []string{models.RepOpTransfer, models.RepOpDelete},
 	})
 	if err != nil {
-		r.HandleInternalServerError(fmt.Sprintf("failed to filter jobs of policy %d: %v",
+		r.SendInternalServerError(fmt.Errorf("failed to filter jobs of policy %d: %v",
 			replication.PolicyID, err))
 		return
 	}
 	if count > 0 {
-		r.RenderError(http.StatusPreconditionFailed, "policy has running/pending jobs, new replication can not be triggered")
+		r.SendPreconditionFailedError(errors.New("policy has running/pending jobs, new replication can not be triggered"))
 		return
 	}
 
 	opUUID, err := startReplication(replication.PolicyID)
 	if err != nil {
-		r.HandleInternalServerError(fmt.Sprintf("failed to publish replication topic for policy %d: %v", replication.PolicyID, err))
+		r.SendInternalServerError(fmt.Errorf("failed to publish replication topic for policy %d: %v", replication.PolicyID, err))
 		return
 	}
 	log.Infof("replication signal for policy %d sent", replication.PolicyID)

--- a/src/core/api/replication_job.go
+++ b/src/core/api/replication_job.go
@@ -19,9 +19,9 @@ import (
 	"net/http"
 	"strconv"
 	"time"
+	"errors"
 
 	"github.com/goharbor/harbor/src/common/dao"
-	common_http "github.com/goharbor/harbor/src/common/http"
 	common_job "github.com/goharbor/harbor/src/common/job"
 	"github.com/goharbor/harbor/src/common/models"
 	"github.com/goharbor/harbor/src/common/rbac"
@@ -41,19 +41,19 @@ type RepJobAPI struct {
 func (ra *RepJobAPI) Prepare() {
 	ra.BaseController.Prepare()
 	if !ra.SecurityCtx.IsAuthenticated() {
-		ra.HandleUnauthorized()
+		ra.SendUnAuthorizedError(errors.New("Unauthorized"))
 		return
 	}
 
 	if !(ra.Ctx.Request.Method == http.MethodGet || ra.SecurityCtx.IsSysAdmin()) {
-		ra.HandleForbidden(ra.SecurityCtx.GetUsername())
+		ra.SendForbiddenError(errors.New(ra.SecurityCtx.GetUsername()))
 		return
 	}
 
 	if len(ra.GetStringFromPath(":id")) != 0 {
 		id, err := ra.GetInt64FromPath(":id")
 		if err != nil {
-			ra.HandleBadRequest(fmt.Sprintf("invalid ID: %s", ra.GetStringFromPath(":id")))
+			ra.SendBadRequestError(fmt.Errorf("invalid ID: %s", ra.GetStringFromPath(":id")))
 			return
 		}
 		ra.jobID = id
@@ -66,24 +66,25 @@ func (ra *RepJobAPI) List() {
 
 	policyID, err := ra.GetInt64("policy_id")
 	if err != nil || policyID <= 0 {
-		ra.HandleBadRequest(fmt.Sprintf("invalid policy_id: %s", ra.GetString("policy_id")))
+		ra.SendBadRequestError(fmt.Errorf("invalid policy_id: %s", ra.GetString("policy_id")))
 		return
 	}
 
 	policy, err := core.GlobalController.GetPolicy(policyID)
 	if err != nil {
 		log.Errorf("failed to get policy %d: %v", policyID, err)
-		ra.CustomAbort(http.StatusInternalServerError, "")
+		ra.SendInternalServerError(fmt.Errorf("failed to get policy %d: %v", policyID, err))
+		return
 	}
 
 	if policy.ID == 0 {
-		ra.HandleNotFound(fmt.Sprintf("policy %d not found", policyID))
+		ra.SendNotFoundError(fmt.Errorf("policy %d not found", policyID))
 		return
 	}
 
 	resource := rbac.NewProjectNamespace(policy.ProjectIDs[0]).Resource(rbac.ResourceReplicationJob)
 	if !ra.SecurityCtx.Can(rbac.ActionList, resource) {
-		ra.HandleForbidden(ra.SecurityCtx.GetUsername())
+		ra.SendForbiddenError(errors.New(ra.SecurityCtx.GetUsername()))
 		return
 	}
 
@@ -102,7 +103,7 @@ func (ra *RepJobAPI) List() {
 	if len(startTimeStr) != 0 {
 		i, err := strconv.ParseInt(startTimeStr, 10, 64)
 		if err != nil {
-			ra.HandleBadRequest(fmt.Sprintf("invalid start_time: %s", startTimeStr))
+			ra.SendBadRequestError(fmt.Errorf("invalid start_time: %s", startTimeStr))
 			return
 		}
 		t := time.Unix(i, 0)
@@ -113,7 +114,7 @@ func (ra *RepJobAPI) List() {
 	if len(endTimeStr) != 0 {
 		i, err := strconv.ParseInt(endTimeStr, 10, 64)
 		if err != nil {
-			ra.HandleBadRequest(fmt.Sprintf("invalid end_time: %s", endTimeStr))
+			ra.SendBadRequestError(fmt.Errorf("invalid end_time: %s", endTimeStr))
 			return
 		}
 		t := time.Unix(i, 0)
@@ -124,12 +125,12 @@ func (ra *RepJobAPI) List() {
 
 	total, err := dao.GetTotalCountOfRepJobs(query)
 	if err != nil {
-		ra.HandleInternalServerError(fmt.Sprintf("failed to get total count of repository jobs of policy %d: %v", policyID, err))
+		ra.SendInternalServerError(fmt.Errorf("failed to get total count of repository jobs of policy %d: %v", policyID, err))
 		return
 	}
 	jobs, err := dao.GetRepJobs(query)
 	if err != nil {
-		ra.HandleInternalServerError(fmt.Sprintf("failed to get repository jobs, query: %v :%v", query, err))
+		ra.SendInternalServerError(fmt.Errorf("failed to get repository jobs, query: %v :%v", query, err))
 		return
 	}
 
@@ -142,79 +143,75 @@ func (ra *RepJobAPI) List() {
 // Delete ...
 func (ra *RepJobAPI) Delete() {
 	if ra.jobID == 0 {
-		ra.HandleBadRequest("ID is nil")
+		ra.SendBadRequestError(errors.New("ID is nil"))
 		return
 	}
 
 	job, err := dao.GetRepJob(ra.jobID)
 	if err != nil {
 		log.Errorf("failed to get job %d: %v", ra.jobID, err)
-		ra.CustomAbort(http.StatusInternalServerError, http.StatusText(http.StatusInternalServerError))
+		ra.SendInternalServerError(fmt.Errorf("failed to get job %d: %v", ra.jobID, err))
+		return
 	}
 
 	if job == nil {
-		ra.HandleNotFound(fmt.Sprintf("job %d not found", ra.jobID))
+		ra.SendNotFoundError(fmt.Errorf("job %d not found", ra.jobID))
 		return
 	}
 
 	if job.Status == models.JobPending || job.Status == models.JobRunning {
-		ra.HandleBadRequest(fmt.Sprintf("job is %s, can not be deleted", job.Status))
+		ra.SendBadRequestError(fmt.Errorf("job is %s, can not be deleted", job.Status))
 		return
 	}
 
 	if err = dao.DeleteRepJob(ra.jobID); err != nil {
 		log.Errorf("failed to deleted job %d: %v", ra.jobID, err)
-		ra.CustomAbort(http.StatusInternalServerError, http.StatusText(http.StatusInternalServerError))
+		ra.SendInternalServerError(fmt.Errorf("failed to deleted job %d: %v", ra.jobID, err))
+		return
 	}
 }
 
 // GetLog ...
 func (ra *RepJobAPI) GetLog() {
 	if ra.jobID == 0 {
-		ra.HandleBadRequest("ID is nil")
+		ra.SendBadRequestError(errors.New("ID is nil"))
 		return
 	}
 
 	job, err := dao.GetRepJob(ra.jobID)
 	if err != nil {
-		ra.HandleInternalServerError(fmt.Sprintf("failed to get replication job %d: %v", ra.jobID, err))
+		ra.SendInternalServerError(fmt.Errorf("failed to get replication job %d: %v", ra.jobID, err))
 		return
 	}
 
 	if job == nil {
-		ra.HandleNotFound(fmt.Sprintf("replication job %d not found", ra.jobID))
+		ra.SendNotFoundError(fmt.Errorf("replication job %d not found", ra.jobID))
 		return
 	}
 
 	policy, err := core.GlobalController.GetPolicy(job.PolicyID)
 	if err != nil {
-		ra.HandleInternalServerError(fmt.Sprintf("failed to get policy %d: %v", job.PolicyID, err))
+		ra.SendInternalServerError(fmt.Errorf("failed to get policy %d: %v", job.PolicyID, err))
 		return
 	}
 
 	resource := rbac.NewProjectNamespace(policy.ProjectIDs[0]).Resource(rbac.ResourceReplicationJob)
 	if !ra.SecurityCtx.Can(rbac.ActionRead, resource) {
-		ra.HandleForbidden(ra.SecurityCtx.GetUsername())
+		ra.SendForbiddenError(errors.New(ra.SecurityCtx.GetUsername()))
 		return
 	}
 
 	logBytes, err := utils.GetJobServiceClient().GetJobLog(job.UUID)
 	if err != nil {
-		if httpErr, ok := err.(*common_http.Error); ok {
-			ra.RenderError(httpErr.Code, "")
-			log.Errorf(fmt.Sprintf("failed to get log of job %d: %d %s",
-				ra.jobID, httpErr.Code, httpErr.Message))
-			return
-		}
-		ra.HandleInternalServerError(fmt.Sprintf("failed to get log of job %s: %v",
-			job.UUID, err))
+		ra.ParseAndHandleError(fmt.Sprintf("failed to get log of job %s",
+			job.UUID), err)
 		return
 	}
 	ra.Ctx.ResponseWriter.Header().Set(http.CanonicalHeaderKey("Content-Length"), strconv.Itoa(len(logBytes)))
 	ra.Ctx.ResponseWriter.Header().Set(http.CanonicalHeaderKey("Content-Type"), "text/plain")
 	_, err = ra.Ctx.ResponseWriter.Write(logBytes)
 	if err != nil {
-		ra.HandleInternalServerError(fmt.Sprintf("failed to write log of job %s: %v", job.UUID, err))
+		ra.SendInternalServerError(fmt.Errorf("failed to write log of job %s: %v", job.UUID, err))
 		return
 	}
 }
@@ -226,12 +223,12 @@ func (ra *RepJobAPI) StopJobs() {
 
 	policy, err := core.GlobalController.GetPolicy(req.PolicyID)
 	if err != nil {
-		ra.HandleInternalServerError(fmt.Sprintf("failed to get policy %d: %v", req.PolicyID, err))
+		ra.SendInternalServerError(fmt.Errorf("failed to get policy %d: %v", req.PolicyID, err))
 		return
 	}
 
 	if policy.ID == 0 {
-		ra.HandleNotFound(fmt.Sprintf("policy %d not found", req.PolicyID))
+		ra.SendNotFoundError(fmt.Errorf("policy %d not found", req.PolicyID))
 		return
 	}
 
@@ -240,7 +237,7 @@ func (ra *RepJobAPI) StopJobs() {
 		Operations: []string{models.RepOpTransfer, models.RepOpDelete},
 	})
 	if err != nil {
-		ra.HandleInternalServerError(fmt.Sprintf("failed to list jobs of policy %d: %v", policy.ID, err))
+		ra.SendInternalServerError(fmt.Errorf("failed to list jobs of policy %d: %v", policy.ID, err))
 		return
 	}
 	for _, job := range jobs {

--- a/src/core/api/repository.go
+++ b/src/core/api/repository.go
@@ -41,6 +41,7 @@ import (
 	coreutils "github.com/goharbor/harbor/src/core/utils"
 	"github.com/goharbor/harbor/src/replication/event/notification"
 	"github.com/goharbor/harbor/src/replication/event/topic"
+	"github.com/pkg/errors"
 )
 
 // RepositoryAPI handles request to /api/repositories /api/repositories/tags /api/repositories/manifests, the parm has to be put
@@ -110,13 +111,13 @@ type manifestResp struct {
 func (ra *RepositoryAPI) Get() {
 	projectID, err := ra.GetInt64("project_id")
 	if err != nil || projectID <= 0 {
-		ra.HandleBadRequest(fmt.Sprintf("invalid project_id %s", ra.GetString("project_id")))
+		ra.SendBadRequestError(fmt.Errorf("invalid project_id %s", ra.GetString("project_id")))
 		return
 	}
 
 	labelID, err := ra.GetInt64("label_id", 0)
 	if err != nil {
-		ra.HandleBadRequest(fmt.Sprintf("invalid label_id: %s", ra.GetString("label_id")))
+		ra.SendBadRequestError(fmt.Errorf("invalid label_id: %s", ra.GetString("label_id")))
 		return
 	}
 
@@ -128,17 +129,17 @@ func (ra *RepositoryAPI) Get() {
 	}
 
 	if !exist {
-		ra.HandleNotFound(fmt.Sprintf("project %d not found", projectID))
+		ra.SendNotFoundError(fmt.Errorf("project %d not found", projectID))
 		return
 	}
 
 	resource := rbac.NewProjectNamespace(projectID).Resource(rbac.ResourceRepository)
 	if !ra.SecurityCtx.Can(rbac.ActionList, resource) {
 		if !ra.SecurityCtx.IsAuthenticated() {
-			ra.HandleUnauthorized()
+			ra.SendUnAuthorizedError(errors.New("Unauthorized"))
 			return
 		}
-		ra.HandleForbidden(ra.SecurityCtx.GetUsername())
+		ra.SendForbiddenError(errors.New(ra.SecurityCtx.GetUsername()))
 		return
 	}
 
@@ -152,14 +153,14 @@ func (ra *RepositoryAPI) Get() {
 
 	total, err := dao.GetTotalOfRepositories(query)
 	if err != nil {
-		ra.HandleInternalServerError(fmt.Sprintf("failed to get total of repositories of project %d: %v",
+		ra.SendInternalServerError(fmt.Errorf("failed to get total of repositories of project %d: %v",
 			projectID, err))
 		return
 	}
 
 	repositories, err := getRepositories(query)
 	if err != nil {
-		ra.HandleInternalServerError(fmt.Sprintf("failed to get repository: %v", err))
+		ra.SendInternalServerError(fmt.Errorf("failed to get repository: %v", err))
 		return
 	}
 
@@ -240,25 +241,26 @@ func (ra *RepositoryAPI) Delete() {
 	}
 
 	if project == nil {
-		ra.HandleNotFound(fmt.Sprintf("project %s not found", projectName))
+		ra.SendNotFoundError(fmt.Errorf("project %s not found", projectName))
 		return
 	}
 
 	if !ra.SecurityCtx.IsAuthenticated() {
-		ra.HandleUnauthorized()
+		ra.SendUnAuthorizedError(errors.New("UnAuthorized"))
 		return
 	}
 
 	resource := rbac.NewProjectNamespace(project.ProjectID).Resource(rbac.ResourceRepository)
 	if !ra.SecurityCtx.Can(rbac.ActionDelete, resource) {
-		ra.HandleForbidden(ra.SecurityCtx.GetUsername())
+		ra.SendForbiddenError(errors.New(ra.SecurityCtx.GetUsername()))
 		return
 	}
 
 	rc, err := coreutils.NewRepositoryClientForUI(ra.SecurityCtx.GetUsername(), repoName)
 	if err != nil {
 		log.Errorf("error occurred while initializing repository client for %s: %v", repoName, err)
-		ra.CustomAbort(http.StatusInternalServerError, "internal error")
+		ra.SendInternalServerError(errors.New("internal error"))
+		return
 	}
 
 	tags := []string{}
@@ -266,18 +268,13 @@ func (ra *RepositoryAPI) Delete() {
 	if len(tag) == 0 {
 		tagList, err := rc.ListTag()
 		if err != nil {
-			log.Errorf("error occurred while listing tags of %s: %v", repoName, err)
-
-			if regErr, ok := err.(*commonhttp.Error); ok {
-				ra.CustomAbort(regErr.Code, regErr.Message)
-			}
-
-			ra.CustomAbort(http.StatusInternalServerError, "internal error")
+			ra.ParseAndHandleError(fmt.Sprintf("error occurred while listing tags of %s", repoName), err)
+			return
 		}
 
 		// TODO remove the logic if the bug of registry is fixed
 		if len(tagList) == 0 {
-			ra.HandleNotFound(fmt.Sprintf("no tags found for repository %s", repoName))
+			ra.SendNotFoundError(fmt.Errorf("no tags found for repository %s", repoName))
 			return
 		}
 
@@ -289,7 +286,7 @@ func (ra *RepositoryAPI) Delete() {
 	if config.WithNotary() {
 		signedTags, err := getSignatures(ra.SecurityCtx.GetUsername(), repoName)
 		if err != nil {
-			ra.HandleInternalServerError(fmt.Sprintf(
+			ra.SendInternalServerError(fmt.Errorf(
 				"failed to get signatures for repository %s: %v", repoName, err))
 			return
 		}
@@ -298,12 +295,14 @@ func (ra *RepositoryAPI) Delete() {
 			digest, _, err := rc.ManifestExist(t)
 			if err != nil {
 				log.Errorf("Failed to Check the digest of tag: %s, error: %v", t, err.Error())
-				ra.CustomAbort(http.StatusInternalServerError, err.Error())
+				ra.SendInternalServerError(err)
+				return
 			}
 			log.Debugf("Tag: %s, digest: %s", t, digest)
 			if _, ok := signedTags[digest]; ok {
 				log.Errorf("Found signed tag, repostory: %s, tag: %s, deletion will be canceled", repoName, t)
-				ra.CustomAbort(http.StatusPreconditionFailed, fmt.Sprintf("tag %s is signed", t))
+				ra.SendPreconditionFailedError(fmt.Errorf("tag %s is signed", t))
+				return
 			}
 		}
 	}
@@ -311,7 +310,7 @@ func (ra *RepositoryAPI) Delete() {
 	for _, t := range tags {
 		image := fmt.Sprintf("%s:%s", repoName, t)
 		if err = dao.DeleteLabelsOfResource(common.ResourceTypeImage, image); err != nil {
-			ra.HandleInternalServerError(fmt.Sprintf("failed to delete labels of image %s: %v", image, err))
+			ra.SendInternalServerError(fmt.Errorf("failed to delete labels of image %s: %v", image, err))
 			return
 		}
 		if err = rc.DeleteTag(t); err != nil {
@@ -319,11 +318,9 @@ func (ra *RepositoryAPI) Delete() {
 				if regErr.Code == http.StatusNotFound {
 					continue
 				}
-				log.Errorf("failed to delete tag %s: %v", t, err)
-				ra.CustomAbort(regErr.Code, regErr.Message)
 			}
-			log.Errorf("error occurred while deleting tag %s:%s: %v", repoName, t, err)
-			ra.CustomAbort(http.StatusInternalServerError, "internal error")
+			ra.ParseAndHandleError(fmt.Sprintf("failed to delete tag %s", t), err)
+			return
 		}
 		log.Infof("delete tag: %s:%s", repoName, t)
 
@@ -356,12 +353,13 @@ func (ra *RepositoryAPI) Delete() {
 	exist, err := repositoryExist(repoName, rc)
 	if err != nil {
 		log.Errorf("failed to check the existence of repository %s: %v", repoName, err)
-		ra.CustomAbort(http.StatusInternalServerError, "")
+		ra.SendInternalServerError(fmt.Errorf("failed to check the existence of repository %s: %v", repoName, err))
+		return
 	}
 	if !exist {
 		repository, err := dao.GetRepositoryByName(repoName)
 		if err != nil {
-			ra.HandleInternalServerError(fmt.Sprintf("failed to get repository %s: %v", repoName, err))
+			ra.SendInternalServerError(fmt.Errorf("failed to get repository %s: %v", repoName, err))
 			return
 		}
 		if repository == nil {
@@ -371,13 +369,14 @@ func (ra *RepositoryAPI) Delete() {
 
 		if err = dao.DeleteLabelsOfResource(common.ResourceTypeRepository,
 			strconv.FormatInt(repository.RepositoryID, 10)); err != nil {
-			ra.HandleInternalServerError(fmt.Sprintf("failed to delete labels of repository %s: %v",
+			ra.SendInternalServerError(fmt.Errorf("failed to delete labels of repository %s: %v",
 				repoName, err))
 			return
 		}
 		if err = dao.DeleteRepository(repoName); err != nil {
 			log.Errorf("failed to delete repository %s: %v", repoName, err)
-			ra.CustomAbort(http.StatusInternalServerError, "")
+			ra.SendInternalServerError(fmt.Errorf("failed to delete repository %s: %v", repoName, err))
+			return
 		}
 	}
 }
@@ -388,38 +387,38 @@ func (ra *RepositoryAPI) GetTag() {
 	tag := ra.GetString(":tag")
 	exist, _, err := ra.checkExistence(repository, tag)
 	if err != nil {
-		ra.HandleInternalServerError(fmt.Sprintf("failed to check the existence of resource, error: %v", err))
+		ra.SendInternalServerError(fmt.Errorf("failed to check the existence of resource, error: %v", err))
 		return
 	}
 	if !exist {
-		ra.HandleNotFound(fmt.Sprintf("resource: %s:%s not found", repository, tag))
+		ra.SendNotFoundError(fmt.Errorf("resource: %s:%s not found", repository, tag))
 		return
 	}
 	project, _ := utils.ParseRepository(repository)
 	resource := rbac.NewProjectNamespace(project).Resource(rbac.ResourceRepositoryTag)
 	if !ra.SecurityCtx.Can(rbac.ActionRead, resource) {
 		if !ra.SecurityCtx.IsAuthenticated() {
-			ra.HandleUnauthorized()
+			ra.SendUnAuthorizedError(errors.New("UnAuthorized"))
 			return
 		}
-		ra.HandleForbidden(ra.SecurityCtx.GetUsername())
+		ra.SendForbiddenError(errors.New(ra.SecurityCtx.GetUsername()))
 		return
 	}
 
 	client, err := coreutils.NewRepositoryClientForUI(ra.SecurityCtx.GetUsername(), repository)
 	if err != nil {
-		ra.HandleInternalServerError(fmt.Sprintf("failed to initialize the client for %s: %v",
+		ra.SendInternalServerError(fmt.Errorf("failed to initialize the client for %s: %v",
 			repository, err))
 		return
 	}
 
 	_, exist, err = client.ManifestExist(tag)
 	if err != nil {
-		ra.HandleInternalServerError(fmt.Sprintf("failed to check the existence of %s:%s: %v", repository, tag, err))
+		ra.SendInternalServerError(fmt.Errorf("failed to check the existence of %s:%s: %v", repository, tag, err))
 		return
 	}
 	if !exist {
-		ra.HandleNotFound(fmt.Sprintf("%s not found", tag))
+		ra.SendNotFoundError(fmt.Errorf("%s not found", tag))
 		return
 	}
 
@@ -432,14 +431,14 @@ func (ra *RepositoryAPI) GetTag() {
 // Retag tags an existing image to another tag in this repo, the source image is specified by request body.
 func (ra *RepositoryAPI) Retag() {
 	if !ra.SecurityCtx.IsAuthenticated() {
-		ra.HandleUnauthorized()
+		ra.SendUnAuthorizedError(errors.New("UnAuthorized"))
 		return
 	}
 
 	repoName := ra.GetString(":splat")
 	project, repo := utils.ParseRepository(repoName)
 	if !utils.ValidateRepo(repo) {
-		ra.HandleBadRequest(fmt.Sprintf("invalid repo '%s'", repo))
+		ra.SendBadRequestError(fmt.Errorf("invalid repo '%s'", repo))
 		return
 	}
 
@@ -447,23 +446,23 @@ func (ra *RepositoryAPI) Retag() {
 	ra.DecodeJSONReq(&request)
 	srcImage, err := models.ParseImage(request.SrcImage)
 	if err != nil {
-		ra.HandleBadRequest(fmt.Sprintf("invalid src image string '%s', should in format '<project>/<repo>:<tag>'", request.SrcImage))
+		ra.SendBadRequestError(fmt.Errorf("invalid src image string '%s', should in format '<project>/<repo>:<tag>'", request.SrcImage))
 		return
 	}
 
 	if !utils.ValidateTag(request.Tag) {
-		ra.HandleBadRequest(fmt.Sprintf("invalid tag '%s'", request.Tag))
+		ra.SendBadRequestError(fmt.Errorf("invalid tag '%s'", request.Tag))
 		return
 	}
 
 	// Check whether source image exists
 	exist, _, err := ra.checkExistence(fmt.Sprintf("%s/%s", srcImage.Project, srcImage.Repo), srcImage.Tag)
 	if err != nil {
-		ra.HandleInternalServerError(fmt.Sprintf("check existence of %s error: %v", request.SrcImage, err))
+		ra.SendInternalServerError(fmt.Errorf("check existence of %s error: %v", request.SrcImage, err))
 		return
 	}
 	if !exist {
-		ra.HandleNotFound(fmt.Sprintf("image %s not exist", request.SrcImage))
+		ra.SendNotFoundError(fmt.Errorf("image %s not exist", request.SrcImage))
 		return
 	}
 
@@ -474,7 +473,7 @@ func (ra *RepositoryAPI) Retag() {
 		return
 	}
 	if !exist {
-		ra.HandleNotFound(fmt.Sprintf("project %s not found", project))
+		ra.SendNotFoundError(fmt.Errorf("project %s not found", project))
 		return
 	}
 
@@ -482,11 +481,11 @@ func (ra *RepositoryAPI) Retag() {
 	if !request.Override {
 		exist, _, err := ra.checkExistence(repoName, request.Tag)
 		if err != nil {
-			ra.HandleInternalServerError(fmt.Sprintf("check existence of %s:%s error: %v", repoName, request.Tag, err))
+			ra.SendInternalServerError(fmt.Errorf("check existence of %s:%s error: %v", repoName, request.Tag, err))
 			return
 		}
 		if exist {
-			ra.HandleConflict(fmt.Sprintf("tag '%s' already existed for '%s'", request.Tag, repoName))
+			ra.SendConflictError(fmt.Errorf("tag '%s' already existed for '%s'", request.Tag, repoName))
 			return
 		}
 	}
@@ -495,7 +494,7 @@ func (ra *RepositoryAPI) Retag() {
 	srcResource := rbac.NewProjectNamespace(srcImage.Project).Resource(rbac.ResourceRepository)
 	if !ra.SecurityCtx.Can(rbac.ActionPull, srcResource) {
 		log.Errorf("user has no read permission to project '%s'", srcImage.Project)
-		ra.HandleForbidden(fmt.Sprintf("%s has no read permission to project %s", ra.SecurityCtx.GetUsername(), srcImage.Project))
+		ra.SendForbiddenError(fmt.Errorf("%s has no read permission to project %s", ra.SecurityCtx.GetUsername(), srcImage.Project))
 		return
 	}
 
@@ -503,7 +502,7 @@ func (ra *RepositoryAPI) Retag() {
 	destResource := rbac.NewProjectNamespace(project).Resource(rbac.ResourceRepository)
 	if !ra.SecurityCtx.Can(rbac.ActionPush, destResource) {
 		log.Errorf("user has no write permission to project '%s'", project)
-		ra.HandleForbidden(fmt.Sprintf("%s has no write permission to project %s", ra.SecurityCtx.GetUsername(), project))
+		ra.SendForbiddenError(fmt.Errorf("%s has no write permission to project %s", ra.SecurityCtx.GetUsername(), project))
 		return
 	}
 
@@ -513,7 +512,7 @@ func (ra *RepositoryAPI) Retag() {
 		Repo:    repo,
 		Tag:     request.Tag,
 	}); err != nil {
-		ra.HandleInternalServerError(fmt.Sprintf("%v", err))
+		ra.SendInternalServerError(fmt.Errorf("%v", err))
 	}
 }
 
@@ -522,7 +521,7 @@ func (ra *RepositoryAPI) GetTags() {
 	repoName := ra.GetString(":splat")
 	labelID, err := ra.GetInt64("label_id", 0)
 	if err != nil {
-		ra.HandleBadRequest(fmt.Sprintf("invalid label_id: %s", ra.GetString("label_id")))
+		ra.SendBadRequestError(fmt.Errorf("invalid label_id: %s", ra.GetString("label_id")))
 		return
 	}
 
@@ -535,29 +534,30 @@ func (ra *RepositoryAPI) GetTags() {
 	}
 
 	if !exist {
-		ra.HandleNotFound(fmt.Sprintf("project %s not found", projectName))
+		ra.SendNotFoundError(fmt.Errorf("project %s not found", projectName))
 		return
 	}
 
 	resource := rbac.NewProjectNamespace(projectName).Resource(rbac.ResourceRepositoryTag)
 	if !ra.SecurityCtx.Can(rbac.ActionList, resource) {
 		if !ra.SecurityCtx.IsAuthenticated() {
-			ra.HandleUnauthorized()
+			ra.SendUnAuthorizedError(errors.New("UnAuthorized"))
 			return
 		}
-		ra.HandleForbidden(ra.SecurityCtx.GetUsername())
+		ra.SendForbiddenError(errors.New(ra.SecurityCtx.GetUsername()))
 		return
 	}
 
 	client, err := coreutils.NewRepositoryClientForUI(ra.SecurityCtx.GetUsername(), repoName)
 	if err != nil {
 		log.Errorf("error occurred while initializing repository client for %s: %v", repoName, err)
-		ra.CustomAbort(http.StatusInternalServerError, "internal error")
+		ra.SendInternalServerError(errors.New("internal error"))
+		return
 	}
 
 	tags, err := client.ListTag()
 	if err != nil {
-		ra.HandleInternalServerError(fmt.Sprintf("failed to get tag of %s: %v", repoName, err))
+		ra.SendInternalServerError(fmt.Errorf("failed to get tag of %s: %v", repoName, err))
 		return
 	}
 
@@ -568,7 +568,7 @@ func (ra *RepositoryAPI) GetTags() {
 			ResourceType: common.ResourceTypeImage,
 		})
 		if err != nil {
-			ra.HandleInternalServerError(fmt.Sprintf("failed to list resource labels: %v", err))
+			ra.SendInternalServerError(fmt.Errorf("failed to list resource labels: %v", err))
 			return
 		}
 		labeledTags := map[string]struct{}{}
@@ -731,7 +731,7 @@ func (ra *RepositoryAPI) GetManifests() {
 	}
 
 	if version != "v1" && version != "v2" {
-		ra.HandleBadRequest("version should be v1 or v2")
+		ra.SendBadRequestError(errors.New("version should be v1 or v2"))
 		return
 	}
 
@@ -744,36 +744,32 @@ func (ra *RepositoryAPI) GetManifests() {
 	}
 
 	if !exist {
-		ra.HandleNotFound(fmt.Sprintf("project %s not found", projectName))
+		ra.SendNotFoundError(fmt.Errorf("project %s not found", projectName))
 		return
 	}
 
 	resource := rbac.NewProjectNamespace(projectName).Resource(rbac.ResourceRepositoryTagManifest)
 	if !ra.SecurityCtx.Can(rbac.ActionRead, resource) {
 		if !ra.SecurityCtx.IsAuthenticated() {
-			ra.HandleUnauthorized()
+			ra.SendUnAuthorizedError(errors.New("Unauthorized"))
 			return
 		}
 
-		ra.HandleForbidden(ra.SecurityCtx.GetUsername())
+		ra.SendForbiddenError(errors.New(ra.SecurityCtx.GetUsername()))
 		return
 	}
 
 	rc, err := coreutils.NewRepositoryClientForUI(ra.SecurityCtx.GetUsername(), repoName)
 	if err != nil {
 		log.Errorf("error occurred while initializing repository client for %s: %v", repoName, err)
-		ra.CustomAbort(http.StatusInternalServerError, "internal error")
+		ra.SendInternalServerError(errors.New("internal error"))
+		return
 	}
 
 	manifest, err := getManifest(rc, tag, version)
 	if err != nil {
-		log.Errorf("error occurred while getting manifest of %s:%s: %v", repoName, tag, err)
-
-		if regErr, ok := err.(*commonhttp.Error); ok {
-			ra.CustomAbort(regErr.Code, regErr.Message)
-		}
-
-		ra.CustomAbort(http.StatusInternalServerError, "internal error")
+		ra.ParseAndHandleError(fmt.Sprintf("error occurred while getting manifest of %s:%s", repoName, tag), err)
+		return
 	}
 
 	ra.Data["json"] = manifest
@@ -826,7 +822,7 @@ func getManifest(client *registry.Repository,
 func (ra *RepositoryAPI) GetTopRepos() {
 	count, err := ra.GetInt("count", 10)
 	if err != nil || count <= 0 {
-		ra.HandleBadRequest(fmt.Sprintf("invalid count: %s", ra.GetString("count")))
+		ra.SendBadRequestError(fmt.Errorf("invalid count: %s", ra.GetString("count")))
 		return
 	}
 
@@ -839,7 +835,7 @@ func (ra *RepositoryAPI) GetTopRepos() {
 	if ra.SecurityCtx.IsAuthenticated() {
 		list, err := ra.SecurityCtx.GetMyProjects()
 		if err != nil {
-			ra.HandleInternalServerError(fmt.Sprintf("failed to get projects which the user %s is a member of: %v",
+			ra.SendInternalServerError(fmt.Errorf("failed to get projects which the user %s is a member of: %v",
 				ra.SecurityCtx.GetUsername(), err))
 			return
 		}
@@ -853,7 +849,8 @@ func (ra *RepositoryAPI) GetTopRepos() {
 	repos, err := dao.GetTopRepos(projectIDs, count)
 	if err != nil {
 		log.Errorf("failed to get top repos: %v", err)
-		ra.CustomAbort(http.StatusInternalServerError, "internal server error")
+		ra.SendInternalServerError(errors.New("internal server error"))
+		return
 	}
 
 	ra.Data["json"] = assembleReposInParallel(repos)
@@ -865,24 +862,24 @@ func (ra *RepositoryAPI) Put() {
 	name := ra.GetString(":splat")
 	repository, err := dao.GetRepositoryByName(name)
 	if err != nil {
-		ra.HandleInternalServerError(fmt.Sprintf("failed to get repository %s: %v", name, err))
+		ra.SendInternalServerError(fmt.Errorf("failed to get repository %s: %v", name, err))
 		return
 	}
 
 	if repository == nil {
-		ra.HandleNotFound(fmt.Sprintf("repository %s not found", name))
+		ra.SendNotFoundError(fmt.Errorf("repository %s not found", name))
 		return
 	}
 
 	if !ra.SecurityCtx.IsAuthenticated() {
-		ra.HandleUnauthorized()
+		ra.SendUnAuthorizedError(errors.New("Unauthorized"))
 		return
 	}
 
 	project, _ := utils.ParseRepository(name)
 	resource := rbac.NewProjectNamespace(project).Resource(rbac.ResourceRepository)
 	if !ra.SecurityCtx.Can(rbac.ActionUpdate, resource) {
-		ra.HandleForbidden(ra.SecurityCtx.GetUsername())
+		ra.SendForbiddenError(errors.New(ra.SecurityCtx.GetUsername()))
 		return
 	}
 
@@ -893,7 +890,7 @@ func (ra *RepositoryAPI) Put() {
 
 	repository.Description = desc.Description
 	if err = dao.UpdateRepository(*repository); err != nil {
-		ra.HandleInternalServerError(fmt.Sprintf("failed to update repository %s: %v", name, err))
+		ra.SendInternalServerError(fmt.Errorf("failed to update repository %s: %v", name, err))
 		return
 	}
 }
@@ -911,17 +908,17 @@ func (ra *RepositoryAPI) GetSignatures() {
 	}
 
 	if !exist {
-		ra.HandleNotFound(fmt.Sprintf("project %s not found", projectName))
+		ra.SendNotFoundError(fmt.Errorf("project %s not found", projectName))
 		return
 	}
 
 	resource := rbac.NewProjectNamespace(projectName).Resource(rbac.ResourceRepository)
 	if !ra.SecurityCtx.Can(rbac.ActionRead, resource) {
 		if !ra.SecurityCtx.IsAuthenticated() {
-			ra.HandleUnauthorized()
+			ra.SendUnAuthorizedError(errors.New("Unauthorized"))
 			return
 		}
-		ra.HandleForbidden(ra.SecurityCtx.GetUsername())
+		ra.SendForbiddenError(errors.New(ra.SecurityCtx.GetUsername()))
 		return
 	}
 
@@ -929,7 +926,8 @@ func (ra *RepositoryAPI) GetSignatures() {
 		ra.SecurityCtx.GetUsername(), repoName)
 	if err != nil {
 		log.Errorf("Error while fetching signature from notary: %v", err)
-		ra.CustomAbort(http.StatusInternalServerError, "internal error")
+		ra.SendInternalServerError(errors.New("internal error"))
+		return
 	}
 	ra.Data["json"] = targets
 	ra.ServeJSON()
@@ -939,7 +937,7 @@ func (ra *RepositoryAPI) GetSignatures() {
 func (ra *RepositoryAPI) ScanImage() {
 	if !config.WithClair() {
 		log.Warningf("Harbor is not deployed with Clair, scan is disabled.")
-		ra.RenderError(http.StatusServiceUnavailable, "")
+		ra.SendInternalServerError(errors.New("Harbor is not deployed with Clair, scan is disabled."))
 		return
 	}
 	repoName := ra.GetString(":splat")
@@ -952,23 +950,23 @@ func (ra *RepositoryAPI) ScanImage() {
 		return
 	}
 	if !exist {
-		ra.HandleNotFound(fmt.Sprintf("project %s not found", projectName))
+		ra.SendNotFoundError(fmt.Errorf("project %s not found", projectName))
 		return
 	}
 	if !ra.SecurityCtx.IsAuthenticated() {
-		ra.HandleUnauthorized()
+		ra.SendUnAuthorizedError(errors.New("Unauthorized"))
 		return
 	}
 
 	resource := rbac.NewProjectNamespace(projectName).Resource(rbac.ResourceRepositoryTagScanJob)
 	if !ra.SecurityCtx.Can(rbac.ActionCreate, resource) {
-		ra.HandleForbidden(ra.SecurityCtx.GetUsername())
+		ra.SendForbiddenError(errors.New(ra.SecurityCtx.GetUsername()))
 		return
 	}
 	err = coreutils.TriggerImageScan(repoName, tag)
 	if err != nil {
 		log.Errorf("Error while calling job service to trigger image scan: %v", err)
-		ra.HandleInternalServerError("Failed to scan image, please check log for details")
+		ra.SendInternalServerError(errors.New("Failed to scan image, please check log for details"))
 		return
 	}
 }
@@ -977,18 +975,18 @@ func (ra *RepositoryAPI) ScanImage() {
 func (ra *RepositoryAPI) VulnerabilityDetails() {
 	if !config.WithClair() {
 		log.Warningf("Harbor is not deployed with Clair, it's not impossible to get vulnerability details.")
-		ra.RenderError(http.StatusServiceUnavailable, "")
+		ra.SendInternalServerError(errors.New("Harbor is not deployed with Clair, it's not impossible to get vulnerability details."))
 		return
 	}
 	repository := ra.GetString(":splat")
 	tag := ra.GetString(":tag")
 	exist, digest, err := ra.checkExistence(repository, tag)
 	if err != nil {
-		ra.HandleInternalServerError(fmt.Sprintf("failed to check the existence of resource, error: %v", err))
+		ra.SendInternalServerError(fmt.Errorf("failed to check the existence of resource, error: %v", err))
 		return
 	}
 	if !exist {
-		ra.HandleNotFound(fmt.Sprintf("resource: %s:%s not found", repository, tag))
+		ra.SendNotFoundError(fmt.Errorf("resource: %s:%s not found", repository, tag))
 		return
 	}
 	project, _ := utils.ParseRepository(repository)
@@ -996,16 +994,16 @@ func (ra *RepositoryAPI) VulnerabilityDetails() {
 	resource := rbac.NewProjectNamespace(project).Resource(rbac.ResourceRepositoryTagVulnerability)
 	if !ra.SecurityCtx.Can(rbac.ActionList, resource) {
 		if !ra.SecurityCtx.IsAuthenticated() {
-			ra.HandleUnauthorized()
+			ra.SendUnAuthorizedError(errors.New("Unauthorized"))
 			return
 		}
-		ra.HandleForbidden(ra.SecurityCtx.GetUsername())
+		ra.SendForbiddenError(errors.New(ra.SecurityCtx.GetUsername()))
 		return
 	}
 	res := []*models.VulnerabilityItem{}
 	overview, err := dao.GetImgScanOverview(digest)
 	if err != nil {
-		ra.HandleInternalServerError(fmt.Sprintf("failed to get the scan overview, error: %v", err))
+		ra.SendInternalServerError(fmt.Errorf("failed to get the scan overview, error: %v", err))
 		return
 	}
 	if overview != nil && len(overview.DetailsKey) > 0 {
@@ -1013,7 +1011,7 @@ func (ra *RepositoryAPI) VulnerabilityDetails() {
 		log.Debugf("The key for getting details: %s", overview.DetailsKey)
 		details, err := clairClient.GetResult(overview.DetailsKey)
 		if err != nil {
-			ra.HandleInternalServerError(fmt.Sprintf("Failed to get scan details from Clair, error: %v", err))
+			ra.SendInternalServerError(fmt.Errorf("Failed to get scan details from Clair, error: %v", err))
 			return
 		}
 		res = transformVulnerabilities(details)
@@ -1030,20 +1028,20 @@ func (ra *RepositoryAPI) ScanAll() {
 		return
 	}
 	if !ra.SecurityCtx.IsAuthenticated() {
-		ra.HandleUnauthorized()
+		ra.SendUnAuthorizedError(errors.New("Unauthorized"))
 		return
 	}
 	if !ra.SecurityCtx.IsSysAdmin() {
-		ra.HandleForbidden(ra.SecurityCtx.GetUsername())
+		ra.SendForbiddenError(errors.New(ra.SecurityCtx.GetUsername()))
 		return
 	}
 	if err := coreutils.ScanAllImages(); err != nil {
 		log.Errorf("Failed triggering scan all images, error: %v", err)
 		if httpErr, ok := err.(*commonhttp.Error); ok && httpErr.Code == http.StatusConflict {
-			ra.HandleConflict("Conflict when triggering scan all images, please try again later.")
+			ra.SendConflictError(errors.New("Conflict when triggering scan all images, please try again later."))
 			return
 		}
-		ra.HandleInternalServerError(fmt.Sprintf("Error: %v", err))
+		ra.SendInternalServerError(fmt.Errorf("Error: %v", err))
 		return
 	}
 	ra.Ctx.ResponseWriter.WriteHeader(http.StatusAccepted)

--- a/src/core/api/scan_job.go
+++ b/src/core/api/scan_job.go
@@ -16,7 +16,6 @@ package api
 
 import (
 	"github.com/goharbor/harbor/src/common/dao"
-	common_http "github.com/goharbor/harbor/src/common/http"
 	"github.com/goharbor/harbor/src/common/rbac"
 	"github.com/goharbor/harbor/src/common/utils/log"
 	"github.com/goharbor/harbor/src/core/utils"
@@ -25,6 +24,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"errors"
 )
 
 // ScanJobAPI handles request to /api/scanJobs/:id/log
@@ -39,12 +39,12 @@ type ScanJobAPI struct {
 func (sj *ScanJobAPI) Prepare() {
 	sj.BaseController.Prepare()
 	if !sj.SecurityCtx.IsAuthenticated() {
-		sj.HandleUnauthorized()
+		sj.SendUnAuthorizedError(errors.New("UnAuthorized"))
 		return
 	}
 	id, err := sj.GetInt64FromPath(":id")
 	if err != nil {
-		sj.HandleBadRequest("invalid ID")
+		sj.SendBadRequestError(errors.New("invalid ID"))
 		return
 	}
 	sj.jobID = id
@@ -52,14 +52,16 @@ func (sj *ScanJobAPI) Prepare() {
 	data, err := dao.GetScanJob(id)
 	if err != nil {
 		log.Errorf("Failed to load job data for job: %d, error: %v", id, err)
-		sj.CustomAbort(http.StatusInternalServerError, "Failed to get Job data")
+		sj.SendInternalServerError(errors.New("Failed to get Job data"))
+		return
 	}
 	projectName := strings.SplitN(data.Repository, "/", 2)[0]
 
 	resource := rbac.NewProjectNamespace(projectName).Resource(rbac.ResourceRepositoryTagScanJob)
 	if !sj.SecurityCtx.Can(rbac.ActionRead, resource) {
 		log.Errorf("User does not have read permission for project: %s", projectName)
-		sj.HandleForbidden(sj.SecurityCtx.GetUsername())
+		sj.SendForbiddenError(errors.New(sj.SecurityCtx.GetUsername()))
+		return
 	}
 	sj.projectName = projectName
 	sj.jobUUID = data.UUID
@@ -69,20 +71,14 @@ func (sj *ScanJobAPI) Prepare() {
 func (sj *ScanJobAPI) GetLog() {
 	logBytes, err := utils.GetJobServiceClient().GetJobLog(sj.jobUUID)
 	if err != nil {
-		if httpErr, ok := err.(*common_http.Error); ok {
-			sj.RenderError(httpErr.Code, "")
-			log.Errorf(fmt.Sprintf("failed to get log of job %d: %d %s",
-				sj.jobID, httpErr.Code, httpErr.Message))
-			return
-		}
-		sj.HandleInternalServerError(fmt.Sprintf("Failed to get job logs, uuid: %s, error: %v", sj.jobUUID, err))
+		sj.ParseAndHandleError(fmt.Sprintf("Failed to get job logs, uuid: %s, error: %v", sj.jobUUID), err)
 		return
 	}
 	sj.Ctx.ResponseWriter.Header().Set(http.CanonicalHeaderKey("Content-Length"), strconv.Itoa(len(logBytes)))
 	sj.Ctx.ResponseWriter.Header().Set(http.CanonicalHeaderKey("Content-Type"), "text/plain")
 	_, err = sj.Ctx.ResponseWriter.Write(logBytes)
 	if err != nil {
-		sj.HandleInternalServerError(fmt.Sprintf("Failed to write job logs, uuid: %s, error: %v", sj.jobUUID, err))
+		sj.SendInternalServerError(fmt.Errorf("Failed to write job logs, uuid: %s, error: %v", sj.jobUUID, err))
 	}
 
 }

--- a/src/core/api/search.go
+++ b/src/core/api/search.go
@@ -16,7 +16,6 @@ package api
 
 import (
 	"fmt"
-	"net/http"
 	"strings"
 
 	"github.com/goharbor/harbor/src/common"
@@ -69,7 +68,7 @@ func (s *SearchAPI) Get() {
 		if isAuthenticated {
 			mys, err := s.SecurityCtx.GetMyProjects()
 			if err != nil {
-				s.HandleInternalServerError(fmt.Sprintf(
+				s.SendInternalServerError(fmt.Errorf(
 					"failed to get projects: %v", err))
 				return
 			}
@@ -111,7 +110,8 @@ func (s *SearchAPI) Get() {
 		})
 		if err != nil {
 			log.Errorf("failed to get total of repositories of project %d: %v", p.ProjectID, err)
-			s.CustomAbort(http.StatusInternalServerError, "")
+			s.SendInternalServerError(fmt.Errorf("failed to get total of repositories of project %d: %v", p.ProjectID, err))
+			return
 		}
 
 		p.RepoCount = total
@@ -122,7 +122,8 @@ func (s *SearchAPI) Get() {
 	repositoryResult, err := filterRepositories(projects, keyword)
 	if err != nil {
 		log.Errorf("failed to filter repositories: %v", err)
-		s.CustomAbort(http.StatusInternalServerError, "")
+		s.SendInternalServerError(fmt.Errorf("failed to filter repositories: %v", err))
+		return
 	}
 
 	result := &searchResult{
@@ -139,7 +140,9 @@ func (s *SearchAPI) Get() {
 		chartResults, err := searchHandler(keyword, proNames)
 		if err != nil {
 			log.Errorf("failed to filter charts: %v", err)
-			s.CustomAbort(http.StatusInternalServerError, err.Error())
+			s.SendInternalServerError(err)
+			return
+
 		}
 
 		result.Chart = chartResults

--- a/src/core/api/statistic.go
+++ b/src/core/api/statistic.go
@@ -16,7 +16,7 @@ package api
 
 import (
 	"fmt"
-	"net/http"
+	"errors"
 
 	"github.com/goharbor/harbor/src/common/dao"
 	"github.com/goharbor/harbor/src/common/models"
@@ -48,7 +48,7 @@ type StatisticAPI struct {
 func (s *StatisticAPI) Prepare() {
 	s.BaseController.Prepare()
 	if !s.SecurityCtx.IsAuthenticated() {
-		s.HandleUnauthorized()
+		s.SendUnAuthorizedError(errors.New("UnAuthorized"))
 		return
 	}
 	s.username = s.SecurityCtx.GetUsername()
@@ -76,7 +76,8 @@ func (s *StatisticAPI) Get() {
 		})
 		if err != nil {
 			log.Errorf("failed to get total of public repositories: %v", err)
-			s.CustomAbort(http.StatusInternalServerError, "")
+			s.SendInternalServerError(fmt.Errorf("failed to get total of public repositories: %v", err))
+			return
 		}
 		statistic[PubRC] = n
 	}
@@ -85,7 +86,8 @@ func (s *StatisticAPI) Get() {
 		result, err := s.ProjectMgr.List(nil)
 		if err != nil {
 			log.Errorf("failed to get total of projects: %v", err)
-			s.CustomAbort(http.StatusInternalServerError, "")
+			s.SendInternalServerError(fmt.Errorf("failed to get total of projects: %v", err))
+			return
 		}
 		statistic[TPC] = result.Total
 		statistic[PriPC] = result.Total - statistic[PubPC]
@@ -93,7 +95,8 @@ func (s *StatisticAPI) Get() {
 		n, err := dao.GetTotalOfRepositories()
 		if err != nil {
 			log.Errorf("failed to get total of repositories: %v", err)
-			s.CustomAbort(http.StatusInternalServerError, "")
+			s.SendInternalServerError(fmt.Errorf("failed to get total of repositories: %v", err))
+			return
 		}
 		statistic[TRC] = n
 		statistic[PriRC] = n - statistic[PubRC]
@@ -124,7 +127,7 @@ func (s *StatisticAPI) Get() {
 				ProjectIDs: ids,
 			})
 			if err != nil {
-				s.HandleInternalServerError(fmt.Sprintf(
+				s.SendInternalServerError(fmt.Errorf(
 					"failed to get total of repositories for user %s: %v",
 					s.username, err))
 				return

--- a/src/core/api/user.go
+++ b/src/core/api/user.go
@@ -20,6 +20,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"errors"
 
 	"github.com/goharbor/harbor/src/common"
 	"github.com/goharbor/harbor/src/common/dao"
@@ -52,7 +53,8 @@ func (ua *UserAPI) Prepare() {
 	mode, err := config.AuthMode()
 	if err != nil {
 		log.Errorf("failed to get auth mode: %v", err)
-		ua.CustomAbort(http.StatusInternalServerError, http.StatusText(http.StatusInternalServerError))
+		ua.SendInternalServerError(errors.New(""))
+		return
 	}
 
 	ua.AuthMode = mode
@@ -60,7 +62,8 @@ func (ua *UserAPI) Prepare() {
 	self, err := config.SelfRegistration()
 	if err != nil {
 		log.Errorf("failed to get self registration: %v", err)
-		ua.CustomAbort(http.StatusInternalServerError, http.StatusText(http.StatusInternalServerError))
+		ua.SendInternalServerError(errors.New(""))
+		return
 	}
 
 	ua.SelfRegistration = self
@@ -69,7 +72,7 @@ func (ua *UserAPI) Prepare() {
 		if ua.Ctx.Input.IsPost() {
 			return
 		}
-		ua.HandleUnauthorized()
+		ua.SendUnAuthorizedError(errors.New("UnAuthorize"))
 		return
 	}
 
@@ -77,7 +80,7 @@ func (ua *UserAPI) Prepare() {
 		Username: ua.SecurityCtx.GetUsername(),
 	})
 	if err != nil {
-		ua.HandleInternalServerError(fmt.Sprintf("failed to get user %s: %v",
+		ua.SendInternalServerError(fmt.Errorf("failed to get user %s: %v",
 			ua.SecurityCtx.GetUsername(), err))
 		return
 	}
@@ -91,17 +94,20 @@ func (ua *UserAPI) Prepare() {
 		ua.userID, err = strconv.Atoi(id)
 		if err != nil {
 			log.Errorf("Invalid user id, error: %v", err)
-			ua.CustomAbort(http.StatusBadRequest, "Invalid user Id")
+			ua.SendBadRequestError(errors.New("invalid user Id"))
+			return
 		}
 		userQuery := models.User{UserID: ua.userID}
 		u, err := dao.GetUser(userQuery)
 		if err != nil {
 			log.Errorf("Error occurred in GetUser, error: %v", err)
-			ua.CustomAbort(http.StatusInternalServerError, "Internal error.")
+			ua.SendInternalServerError(errors.New("internal error"))
+			return
 		}
 		if u == nil {
 			log.Errorf("User with Id: %d does not exist", ua.userID)
-			ua.CustomAbort(http.StatusNotFound, "")
+			ua.SendNotFoundError(errors.New(""))
+			return
 		}
 	}
 
@@ -115,7 +121,8 @@ func (ua *UserAPI) Get() {
 		u, err := dao.GetUser(userQuery)
 		if err != nil {
 			log.Errorf("Error occurred in GetUser, error: %v", err)
-			ua.CustomAbort(http.StatusInternalServerError, "Internal error.")
+			ua.SendInternalServerError(errors.New("internal error"))
+			return
 		}
 		u.Password = ""
 		if ua.userID == ua.currentUserID {
@@ -127,7 +134,7 @@ func (ua *UserAPI) Get() {
 	}
 
 	log.Errorf("Current user, id: %d does not have admin role, can not view other user's detail", ua.currentUserID)
-	ua.RenderError(http.StatusForbidden, "User does not have admin role")
+	ua.SendForbiddenError(errors.New("user does not have admin role"))
 	return
 }
 
@@ -135,7 +142,7 @@ func (ua *UserAPI) Get() {
 func (ua *UserAPI) List() {
 	if !ua.IsAdmin {
 		log.Errorf("Current user, id: %d does not have admin role, can not list users", ua.currentUserID)
-		ua.RenderError(http.StatusForbidden, "User does not have admin role")
+		ua.SendForbiddenError(errors.New("user does not have admin role"))
 		return
 	}
 
@@ -151,13 +158,13 @@ func (ua *UserAPI) List() {
 
 	total, err := dao.GetTotalOfUsers(query)
 	if err != nil {
-		ua.HandleInternalServerError(fmt.Sprintf("failed to get total of users: %v", err))
+		ua.SendInternalServerError(fmt.Errorf("failed to get total of users: %v", err))
 		return
 	}
 
 	users, err := dao.ListUsers(query)
 	if err != nil {
-		ua.HandleInternalServerError(fmt.Sprintf("failed to get users: %v", err))
+		ua.SendInternalServerError(fmt.Errorf("failed to get users: %v", err))
 		return
 	}
 
@@ -169,7 +176,7 @@ func (ua *UserAPI) List() {
 // Put ...
 func (ua *UserAPI) Put() {
 	if !ua.modifiable() {
-		ua.RenderError(http.StatusForbidden, fmt.Sprintf("User with ID %d cannot be modified", ua.userID))
+		ua.SendForbiddenError(fmt.Errorf("User with ID %d cannot be modified", ua.userID))
 		return
 	}
 	user := models.User{UserID: ua.userID}
@@ -177,34 +184,38 @@ func (ua *UserAPI) Put() {
 	err := commonValidate(user)
 	if err != nil {
 		log.Warningf("Bad request in change user profile: %v", err)
-		ua.RenderError(http.StatusBadRequest, "change user profile error:"+err.Error())
+		ua.SendBadRequestError(fmt.Errorf("change user profile error:"+err.Error()))
 		return
 	}
 	userQuery := models.User{UserID: ua.userID}
 	u, err := dao.GetUser(userQuery)
 	if err != nil {
 		log.Errorf("Error occurred in GetUser, error: %v", err)
-		ua.CustomAbort(http.StatusInternalServerError, "Internal error.")
+		ua.SendInternalServerError(errors.New("internal error"))
+		return
 	}
 	if u == nil {
 		log.Errorf("User with Id: %d does not exist", ua.userID)
-		ua.CustomAbort(http.StatusNotFound, "")
+		ua.SendNotFoundError(errors.New(""))
+		return
 	}
 	if u.Email != user.Email {
 		emailExist, err := dao.UserExists(user, "email")
 		if err != nil {
 			log.Errorf("Error occurred in change user profile: %v", err)
-			ua.CustomAbort(http.StatusInternalServerError, "Internal error.")
+			ua.SendInternalServerError(errors.New("internal error"))
+			return
 		}
 		if emailExist {
 			log.Warning("email has already been used!")
-			ua.RenderError(http.StatusConflict, "email has already been used!")
+			ua.SendConflictError(errors.New("email has already been used"))
 			return
 		}
 	}
 	if err := dao.ChangeUserProfile(user); err != nil {
 		log.Errorf("Failed to update user profile, error: %v", err)
-		ua.CustomAbort(http.StatusInternalServerError, err.Error())
+		ua.SendInternalServerError(err)
+		return
 	}
 }
 
@@ -212,12 +223,14 @@ func (ua *UserAPI) Put() {
 func (ua *UserAPI) Post() {
 
 	if !(ua.AuthMode == common.DBAuth) {
-		ua.CustomAbort(http.StatusForbidden, "")
+		ua.SendForbiddenError(errors.New(""))
+		return
 	}
 
 	if !(ua.SelfRegistration || ua.IsAdmin) {
 		log.Warning("Registration can only be used by admin role user when self-registration is off.")
-		ua.CustomAbort(http.StatusForbidden, "")
+		ua.SendForbiddenError(errors.New(""))
+		return
 	}
 
 	user := models.User{}
@@ -231,27 +244,30 @@ func (ua *UserAPI) Post() {
 	userExist, err := dao.UserExists(user, "username")
 	if err != nil {
 		log.Errorf("Error occurred in Register: %v", err)
-		ua.CustomAbort(http.StatusInternalServerError, "Internal error.")
+		ua.SendInternalServerError(errors.New("internal error"))
+		return
 	}
 	if userExist {
 		log.Warning("username has already been used!")
-		ua.RenderError(http.StatusConflict, "username has already been used!")
+		ua.SendConflictError(errors.New("username has already been used"))
 		return
 	}
 	emailExist, err := dao.UserExists(user, "email")
 	if err != nil {
 		log.Errorf("Error occurred in change user profile: %v", err)
-		ua.CustomAbort(http.StatusInternalServerError, "Internal error.")
+		ua.SendInternalServerError(errors.New("internal error"))
+		return
 	}
 	if emailExist {
 		log.Warning("email has already been used!")
-		ua.RenderError(http.StatusConflict, "email has already been used!")
+		ua.SendConflictError(errors.New("email has already been used"))
 		return
 	}
 	userID, err := dao.Register(user)
 	if err != nil {
 		log.Errorf("Error occurred in Register: %v", err)
-		ua.CustomAbort(http.StatusInternalServerError, "Internal error.")
+		ua.SendInternalServerError(errors.New("internal error"))
+		return
 	}
 
 	ua.Redirect(http.StatusCreated, strconv.FormatInt(userID, 10))
@@ -260,7 +276,7 @@ func (ua *UserAPI) Post() {
 // Delete ...
 func (ua *UserAPI) Delete() {
 	if !ua.IsAdmin || ua.AuthMode != common.DBAuth || ua.userID == 1 || ua.currentUserID == ua.userID {
-		ua.RenderError(http.StatusForbidden, fmt.Sprintf("User with ID: %d cannot be removed, auth mode: %s, current user ID: %d", ua.userID, ua.AuthMode, ua.currentUserID))
+		ua.SendForbiddenError(fmt.Errorf("User with ID: %d cannot be removed, auth mode: %s, current user ID: %d", ua.userID, ua.AuthMode, ua.currentUserID))
 		return
 	}
 
@@ -268,7 +284,7 @@ func (ua *UserAPI) Delete() {
 	err = dao.DeleteUser(ua.userID)
 	if err != nil {
 		log.Errorf("Failed to delete data from database, error: %v", err)
-		ua.RenderError(http.StatusInternalServerError, "Failed to delete User")
+		ua.SendInternalServerError(errors.New("failed to delete User"))
 		return
 	}
 }
@@ -276,7 +292,7 @@ func (ua *UserAPI) Delete() {
 // ChangePassword handles PUT to /api/users/{}/password
 func (ua *UserAPI) ChangePassword() {
 	if !ua.modifiable() {
-		ua.RenderError(http.StatusForbidden, fmt.Sprintf("User with ID: %d is not modifiable", ua.userID))
+		ua.SendForbiddenError(fmt.Errorf("User with ID: %d is not modifiable", ua.userID))
 		return
 	}
 
@@ -286,33 +302,33 @@ func (ua *UserAPI) ChangePassword() {
 	ua.DecodeJSONReq(&req)
 
 	if changePwdOfOwn && len(req.OldPassword) == 0 {
-		ua.HandleBadRequest("empty old_password")
+		ua.SendBadRequestError(errors.New("empty old_password"))
 		return
 	}
 
 	if len(req.NewPassword) == 0 {
-		ua.HandleBadRequest("empty new_password")
+		ua.SendBadRequestError(errors.New("empty new_password"))
 		return
 	}
 
 	user, err := dao.GetUser(models.User{UserID: ua.userID})
 	if err != nil {
-		ua.HandleInternalServerError(fmt.Sprintf("failed to get user %d: %v", ua.userID, err))
+		ua.SendInternalServerError(fmt.Errorf("failed to get user %d: %v", ua.userID, err))
 		return
 	}
 	if user == nil {
-		ua.HandleNotFound(fmt.Sprintf("user %d not found", ua.userID))
+		ua.SendNotFoundError(fmt.Errorf("user %d not found", ua.userID))
 		return
 	}
 	if changePwdOfOwn {
 		if user.Password != utils.Encrypt(req.OldPassword, user.Salt) {
 			log.Info("incorrect old_password")
-			ua.RenderError(http.StatusForbidden, "incorrect old_password")
+			ua.SendForbiddenError(errors.New("incorrect old_password"))
 			return
 		}
 	}
 	if user.Password == utils.Encrypt(req.NewPassword, user.Salt) {
-		ua.HandleBadRequest("the new password can not be same with the old one")
+		ua.SendBadRequestError(errors.New("the new password can not be same with the old one"))
 		return
 	}
 
@@ -321,7 +337,7 @@ func (ua *UserAPI) ChangePassword() {
 		Password: req.NewPassword,
 	}
 	if err = dao.ChangeUserPassword(updatedUser); err != nil {
-		ua.HandleInternalServerError(fmt.Sprintf("failed to change password of user %d: %v", ua.userID, err))
+		ua.SendInternalServerError(fmt.Errorf("failed to change password of user %d: %v", ua.userID, err))
 		return
 	}
 }
@@ -337,7 +353,8 @@ func (ua *UserAPI) ToggleUserAdminRole() {
 	ua.DecodeJSONReq(&userQuery)
 	if err := dao.ToggleUserAdminRole(userQuery.UserID, userQuery.HasAdminRole); err != nil {
 		log.Errorf("Error occurred in ToggleUserAdminRole: %v", err)
-		ua.CustomAbort(http.StatusInternalServerError, "Internal error.")
+		ua.SendInternalServerError(errors.New("internal error"))
+		return
 	}
 }
 

--- a/src/core/api/usergroup.go
+++ b/src/core/api/usergroup.go
@@ -26,6 +26,7 @@ import (
 	"github.com/goharbor/harbor/src/common/utils/ldap"
 	"github.com/goharbor/harbor/src/common/utils/log"
 	"github.com/goharbor/harbor/src/core/auth"
+	"github.com/pkg/errors"
 )
 
 // UserGroupAPI ...
@@ -42,7 +43,7 @@ const (
 func (uga *UserGroupAPI) Prepare() {
 	uga.BaseController.Prepare()
 	if !uga.SecurityCtx.IsAuthenticated() {
-		uga.HandleUnauthorized()
+		uga.SendUnAuthorizedError(errors.New("Unauthorized"))
 		return
 	}
 
@@ -51,13 +52,13 @@ func (uga *UserGroupAPI) Prepare() {
 		log.Warningf("failed to parse user group id, error: %v", err)
 	}
 	if ugid <= 0 && (uga.Ctx.Input.IsPut() || uga.Ctx.Input.IsDelete()) {
-		uga.HandleBadRequest(fmt.Sprintf("invalid user group ID: %s", uga.GetStringFromPath(":ugid")))
+		uga.SendBadRequestError(fmt.Errorf("invalid user group ID: %s", uga.GetStringFromPath(":ugid")))
 		return
 	}
 	uga.id = int(ugid)
 	// Common user can create/update, only harbor admin can delete user group.
 	if uga.Ctx.Input.IsDelete() && !uga.SecurityCtx.IsSysAdmin() {
-		uga.HandleForbidden(uga.SecurityCtx.GetUsername())
+		uga.SendForbiddenError(errors.New(uga.SecurityCtx.GetUsername()))
 		return
 	}
 }
@@ -71,7 +72,7 @@ func (uga *UserGroupAPI) Get() {
 		query := models.UserGroup{GroupType: common.LdapGroupType} // Current query LDAP group only
 		userGroupList, err := group.QueryUserGroup(query)
 		if err != nil {
-			uga.HandleInternalServerError(fmt.Sprintf("Failed to query database for user group list, error: %v", err))
+			uga.SendInternalServerError(fmt.Errorf("Failed to query database for user group list, error: %v", err))
 			return
 		}
 		if len(userGroupList) > 0 {
@@ -81,11 +82,11 @@ func (uga *UserGroupAPI) Get() {
 		// return a specific user group
 		userGroup, err := group.GetUserGroup(ID)
 		if userGroup == nil {
-			uga.HandleNotFound("The user group does not exist.")
+			uga.SendNotFoundError(errors.New("The user group does not exist."))
 			return
 		}
 		if err != nil {
-			uga.HandleInternalServerError(fmt.Sprintf("Failed to query database for user group list, error: %v", err))
+			uga.SendInternalServerError(fmt.Errorf("Failed to query database for user group list, error: %v", err))
 			return
 		}
 		uga.Data["json"] = userGroup
@@ -102,37 +103,37 @@ func (uga *UserGroupAPI) Post() {
 	userGroup.LdapGroupDN = strings.TrimSpace(userGroup.LdapGroupDN)
 	userGroup.GroupName = strings.TrimSpace(userGroup.GroupName)
 	if len(userGroup.GroupName) == 0 {
-		uga.HandleBadRequest(userNameEmptyMsg)
+		uga.SendBadRequestError(errors.New(userNameEmptyMsg))
 		return
 	}
 	query := models.UserGroup{GroupType: userGroup.GroupType, LdapGroupDN: userGroup.LdapGroupDN}
 	result, err := group.QueryUserGroup(query)
 	if err != nil {
-		uga.HandleInternalServerError(fmt.Sprintf("Error occurred in add user group, error: %v", err))
+		uga.SendInternalServerError(fmt.Errorf("Error occurred in add user group, error: %v", err))
 		return
 	}
 	if len(result) > 0 {
-		uga.HandleConflict("Error occurred in add user group, duplicate user group exist.")
+		uga.SendConflictError(errors.New("Error occurred in add user group, duplicate user group exist."))
 		return
 	}
 	// User can not add ldap group when the ldap server is offline
 	ldapGroup, err := auth.SearchGroup(userGroup.LdapGroupDN)
 	if err == ldap.ErrNotFound || ldapGroup == nil {
-		uga.HandleNotFound(fmt.Sprintf("LDAP Group DN is not found: DN:%v", userGroup.LdapGroupDN))
+		uga.SendNotFoundError(fmt.Errorf("LDAP Group DN is not found: DN:%v", userGroup.LdapGroupDN))
 		return
 	}
 	if err == ldap.ErrDNSyntax {
-		uga.HandleBadRequest(fmt.Sprintf("Invalid DN syntax. DN: %v", userGroup.LdapGroupDN))
+		uga.SendBadRequestError(fmt.Errorf("Invalid DN syntax. DN: %v", userGroup.LdapGroupDN))
 		return
 	}
 	if err != nil {
-		uga.HandleInternalServerError(fmt.Sprintf("Error occurred in search user group. error: %v", err))
+		uga.SendInternalServerError(fmt.Errorf("Error occurred in search user group. error: %v", err))
 		return
 	}
 
 	groupID, err := group.AddUserGroup(userGroup)
 	if err != nil {
-		uga.HandleInternalServerError(fmt.Sprintf("Error occurred in add user group, error: %v", err))
+		uga.SendInternalServerError(fmt.Errorf("Error occurred in add user group, error: %v", err))
 		return
 	}
 	uga.Redirect(http.StatusCreated, strconv.FormatInt(int64(groupID), 10))
@@ -145,14 +146,14 @@ func (uga *UserGroupAPI) Put() {
 	ID := uga.id
 	userGroup.GroupName = strings.TrimSpace(userGroup.GroupName)
 	if len(userGroup.GroupName) == 0 {
-		uga.HandleBadRequest(userNameEmptyMsg)
+		uga.SendBadRequestError(errors.New(userNameEmptyMsg))
 		return
 	}
 	userGroup.GroupType = common.LdapGroupType
 	log.Debugf("Updated user group %v", userGroup)
 	err := group.UpdateUserGroupName(ID, userGroup.GroupName)
 	if err != nil {
-		uga.HandleInternalServerError(fmt.Sprintf("Error occurred in update user group, error: %v", err))
+		uga.SendInternalServerError(fmt.Errorf("Error occurred in update user group, error: %v", err))
 		return
 	}
 	return
@@ -162,7 +163,7 @@ func (uga *UserGroupAPI) Put() {
 func (uga *UserGroupAPI) Delete() {
 	err := group.DeleteUserGroup(uga.id)
 	if err != nil {
-		uga.HandleInternalServerError(fmt.Sprintf("Error occurred in update user group, error: %v", err))
+		uga.SendInternalServerError(fmt.Errorf("Error occurred in update user group, error: %v", err))
 		return
 	}
 	return

--- a/src/core/api/utils.go
+++ b/src/core/api/utils.go
@@ -150,6 +150,7 @@ func diffRepos(reposInRegistry []string, reposInDB []string,
 			}
 
 			// TODO remove the workaround when the bug of registry is fixed
+			// ISSUE: #1585 in docker distribution.
 			client, err := coreutils.NewRepositoryClientForUI("harbor-core", repoInR)
 			if err != nil {
 				return needsAdd, needsDel, err
@@ -170,6 +171,7 @@ func diffRepos(reposInRegistry []string, reposInDB []string,
 			j++
 		} else {
 			// TODO remove the workaround when the bug of registry is fixed
+			// ISSUE: #1585 in docker distribution.
 			client, err := coreutils.NewRepositoryClientForUI("harbor-core", repoInR)
 			if err != nil {
 				return needsAdd, needsDel, err

--- a/src/core/utils/error.go
+++ b/src/core/utils/error.go
@@ -5,23 +5,35 @@ import (
 	"errors"
 )
 
-// WrapErrorMessage wraps the error msg to the well formated error message `{ "error": "The error message" }`
-func WrapErrorMessage(msg string) string {
-	errBody := make(map[string]string, 1)
-	errBody["error"] = msg
-	data, err := json.Marshal(&errBody)
-	if err != nil {
-		return msg
-	}
+type Error struct {
+	Code    int    `json:"code,omitempty"`
+	Message string `json:"message,omitempty"`
+}
 
+// WrapErrorMessage wraps the error msg to the well formated error message
+// {
+//		"error": {
+//			"code": 404,
+//			"message": "Requested entity was not found."
+//		}
+//}
+func WrapErrorMessage(code int, message string) string {
+	error := &Error{
+		Code:    code,
+		Message: message,
+	}
+	data, err := json.Marshal(&error)
+	if err != nil {
+		return message
+	}
 	return string(data)
 }
 
 // WrapError wraps the error to the well formated error `{ "error": "The error message" }`
-func WrapError(err error) error {
+func WrapError(code int, err error) error {
 	if err == nil {
 		return nil
 	}
 
-	return errors.New(WrapErrorMessage(err.Error()))
+	return errors.New(WrapErrorMessage(code, err.Error()))
 }

--- a/src/jobservice/job/impl/gc/job.go
+++ b/src/jobservice/job/impl/gc/job.go
@@ -48,6 +48,7 @@ type GarbageCollector struct {
 	CoreURL           string
 	insecure          bool
 	redisURL          string
+	cacheClean        bool
 }
 
 // MaxFails implements the interface in job/Interface
@@ -90,8 +91,10 @@ func (gc *GarbageCollector) Run(ctx env.JobContext, params map[string]interface{
 		gc.logger.Errorf("failed to get gc result: %v", err)
 		return err
 	}
-	if err := gc.cleanCache(); err != nil {
-		return err
+	if gc.cacheClean {
+		if err := gc.cleanCache(); err != nil {
+			return err
+		}
 	}
 	gc.logger.Infof("GC results: status: %t, message: %s, start: %s, end: %s.", gcr.Status, gcr.Msg, gcr.StartTime, gcr.EndTime)
 	gc.logger.Infof("success to run gc in job.")
@@ -114,6 +117,7 @@ func (gc *GarbageCollector) init(ctx env.JobContext, params map[string]interface
 		return fmt.Errorf(errTpl, common.CoreURL)
 	}
 	gc.redisURL = params["redis_url_reg"].(string)
+	gc.cacheClean = params["cache_clean"].(bool)
 	return nil
 }
 


### PR DESCRIPTION
Add a flag to define whether do a cache clean for the registry, as the cache invalidation issue still in registry v2.7.1, it has been marked to be fixed in v2.7.2. So, let's wait for the v2.7.2.

Signed-off-by: wang yan <wangyan@vmware.com>