### PR TITLE
Remove DB migration from notary images

### DIFF
--- a/make/photon/Makefile
+++ b/make/photon/Makefile
@@ -172,8 +172,6 @@ _build_notary:
 		else \
 			cd $(DOCKERFILEPATH_NOTARY) && $(DOCKERFILEPATH_NOTARY)/builder $(NOTARYVERSION) && cd - ; \
 		fi ; \
-		$(call _get_binary, https://storage.googleapis.com/harbor-builds/bin/notary/release-$(NOTARYVERSION)/notary-migrate-postgresql.tgz, $(DOCKERFILEPATH_NOTARY)/binary/notary-migrate.tgz); \
-		cd $(DOCKERFILEPATH_NOTARY)/binary && tar -zvxf notary-migrate.tgz && cd - ; \
 		echo "building notary container for photon..."; \
 		chmod 655 $(DOCKERFILEPATH_NOTARY)/binary/notary-signer && $(DOCKERBUILD) -f $(DOCKERFILEPATH_NOTARY)/$(DOCKERFILENAME_NOTARYSIGNER) -t $(DOCKERIMAGENAME_NOTARYSIGNER):$(NOTARYVERSION)-$(VERSIONTAG) . ; \
 		chmod 655 $(DOCKERFILEPATH_NOTARY)/binary/notary-server && $(DOCKERBUILD) -f $(DOCKERFILEPATH_NOTARY)/$(DOCKERFILENAME_NOTARYSERVER) -t $(DOCKERIMAGENAME_NOTARYSERVER):$(NOTARYVERSION)-$(VERSIONTAG) . ; \

--- a/make/photon/notary/server-start.sh
+++ b/make/photon/notary/server-start.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-sudo -E -u \#10000 sh -c "/usr/bin/env /migrations/migrate.sh && /bin/notary-server -config=/etc/notary/server-config.postgres.json -logf=logfmt"
+sudo -E -u \#10000 sh -c "/bin/notary-server -config=/etc/notary/server-config.postgres.json -logf=logfmt"

--- a/make/photon/notary/server.Dockerfile
+++ b/make/photon/notary/server.Dockerfile
@@ -6,9 +6,7 @@ RUN tdnf install -y shadow sudo \
     && useradd --no-log-init -r -g 10000 -u 10000 notary
 
 COPY ./make/photon/notary/binary/notary-server /bin/notary-server
-COPY ./make/photon/notary/binary/migrate /bin/migrate
-COPY ./make/photon/notary/binary/migrations/ /migrations/
 COPY ./make/photon/notary/server-start.sh /bin/server-start.sh
-RUN chmod u+x /bin/notary-server /migrations/migrate.sh /bin/migrate /bin/server-start.sh
+RUN chmod u+x /bin/notary-server /bin/server-start.sh
 ENV SERVICE_NAME=notary_server
 ENTRYPOINT [ "/bin/server-start.sh" ]

--- a/make/photon/notary/signer-start.sh
+++ b/make/photon/notary/signer-start.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-sudo -E -u \#10000 sh -c "/usr/bin/env && /migrations/migrate.sh && /bin/notary-signer -config=/etc/notary/signer-config.postgres.json -logf=logfmt"
+sudo -E -u \#10000 sh -c "/bin/notary-signer -config=/etc/notary/signer-config.postgres.json -logf=logfmt"

--- a/make/photon/notary/signer.Dockerfile
+++ b/make/photon/notary/signer.Dockerfile
@@ -5,10 +5,8 @@ RUN tdnf install -y shadow sudo \
     && groupadd -r -g 10000 notary \
     && useradd --no-log-init -r -g 10000 -u 10000 notary
 COPY ./make/photon/notary/binary/notary-signer /bin/notary-signer
-COPY ./make/photon/notary/binary/migrate /bin/migrate
-COPY ./make/photon/notary/binary/migrations/ /migrations/
 COPY ./make/photon/notary/signer-start.sh /bin/signer-start.sh
 
-RUN chmod u+x /bin/notary-signer /migrations/migrate.sh /bin/migrate /bin/signer-start.sh
+RUN chmod u+x /bin/notary-signer /bin/signer-start.sh
 ENV SERVICE_NAME=notary_signer
 ENTRYPOINT [ "/bin/signer-start.sh" ]


### PR DESCRIPTION
There is a high risk vulnerabity in the migrate binary we've been using
in notary images.  I tried to bump up the binary but there was a
breaking change, more details see #5863.
To provide a fix to the vulnerability in 1.7.x and given the fact that
Notary has not updated the schema for 2 years.  We decided to remove the
migrate scripts from notary images.
This commit removes it, and a new issue #6952 is opened to track the
work to re-introduce the migration process.

Signed-off-by: Daniel Jiang <jiangd@vmware.com>