### PR TITLE
Enhhance: bump chartmuseum version to 0.8.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ MIGRATORVERSION=$(VERSIONTAG)
 REDISVERSION=$(VERSIONTAG)
 
 # version of chartmuseum
-CHARTMUSEUMVERSION=v0.7.1
+CHARTMUSEUMVERSION=v0.8.1
 
 # docker parameters
 DOCKERCMD=$(shell which docker)

--- a/make/photon/Makefile
+++ b/make/photon/Makefile
@@ -148,7 +148,7 @@ _build_chart_server:
 	@if [ "$(CHARTFLAG)" = "true" ] ; then \
 		if [ "$(BUILDBIN)" != "true" ] ; then \
 			rm -rf $(DOCKERFILEPATH_CHART_SERVER)/binary && mkdir -p $(DOCKERFILEPATH_CHART_SERVER)/binary && \
-			$(call _get_binary, https://storage.googleapis.com/harbor-builds/bin/chartm, $(DOCKERFILEPATH_CHART_SERVER)/binary/chartm); \
+			$(call _get_binary, https://storage.googleapis.com/harbor-builds/bin/chartmuseum/release-$(CHARTMUSEUMVERSION)/chartm, $(DOCKERFILEPATH_CHART_SERVER)/binary/chartm); \
 		else \
 			cd $(DOCKERFILEPATH_CHART_SERVER) && $(DOCKERFILEPATH_CHART_SERVER)/builder $(GOBUILDIMAGE) $(CHART_SERVER_CODE_BASE) $(CHARTMUSEUMVERSION) $(CHART_SERVER_MAIN_PATH) $(CHART_SERVER_BIN_NAME) && cd - ; \
 		fi ; \


### PR DESCRIPTION
bump the version of chartmuseum to 0.8.1

Signed-off-by: Qian Deng <dengq@vmware.com>