### PR TITLE
Disable validation for registry

### DIFF
--- a/make/common/templates/registry/config.yml
+++ b/make/common/templates/registry/config.yml
@@ -27,6 +27,8 @@ auth:
     realm: $public_url/service/token
     rootcertbundle: /etc/registry/root.crt
     service: harbor-registry
+validation:
+  disabled: true
 notifications:
   endpoints:
   - name: harbor


### PR DESCRIPTION
Disable validation for registry to fix Docker registry not working with Windows layers.

See [docker/distribution#2795](https://github.com/docker/distribution/issues/2795) for more details.

Signed-off-by: He Weiwei <hweiwei@vmware.com>