### PR TITLE
Install psycopg2 via photon's repo

### DIFF
--- a/tools/migration/Dockerfile
+++ b/tools/migration/Dockerfile
@@ -8,8 +8,8 @@ RUN tdnf distro-sync -y \
     && tdnf install -y sed shadow procps-ng gawk gzip sudo net-tools glibc-i18n >> /dev/null\
     && groupadd -r -g 10000 mysql && useradd --no-log-init -r -g 10000 -u 10000 mysql \
     && tdnf install -y mariadb-server mariadb mariadb-devel python2 python2-devel python-pip gcc \
-    linux-api-headers glibc-devel binutils zlib-devel openssl-devel postgresql >> /dev/null \
-    && pip install mysqlclient alembic psycopg2 \
+    linux-api-headers glibc-devel binutils zlib-devel openssl-devel postgresql python-psycopg2 >> /dev/null \
+    && pip install mysqlclient alembic \
     && mkdir /docker-entrypoint-initdb.d /docker-entrypoint-updatedb.d \
     && rm -fr /var/lib/mysql \
     && mkdir -p /var/lib/mysql /var/run/mysqld \


### PR DESCRIPTION
The psycopg2 installed by pip very old .so files.
This commit will mitigate such issue by using `tdnf` to install this package.

Signed-off-by: Daniel Jiang <jiangd@vmware.com>