### PR TITLE
Create dao folder in replication

### DIFF
--- a/src/replication/ng/dao/dao_test.go
+++ b/src/replication/ng/dao/dao_test.go
@@ -1,0 +1,27 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dao
+
+import (
+	"os"
+	"testing"
+
+	"github.com/goharbor/harbor/src/common/dao"
+)
+
+func TestMain(m *testing.M) {
+	dao.PrepareTestForPostgresSQL()
+	os.Exit(m.Run())
+}

--- a/src/replication/ng/dao/example.go
+++ b/src/replication/ng/dao/example.go
@@ -1,0 +1,27 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dao
+
+import (
+	"github.com/goharbor/harbor/src/common/dao"
+	"github.com/goharbor/harbor/src/common/models"
+)
+
+// TODO remove the file
+
+// CreateProject ...
+func CreateProject(project *models.Project) (int64, error) {
+	return dao.GetOrmer().Insert(project)
+}

--- a/src/replication/ng/dao/example_test.go
+++ b/src/replication/ng/dao/example_test.go
@@ -1,0 +1,33 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dao
+
+import (
+	"testing"
+
+	"github.com/goharbor/harbor/src/common/models"
+	"github.com/stretchr/testify/require"
+)
+
+// TODO remove the file
+
+func TestCreateProject(t *testing.T) {
+	project := &models.Project{
+		Name:    "example-project",
+		OwnerID: 1,
+	}
+	_, err := CreateProject(project)
+	require.Nil(t, err)
+}


### PR DESCRIPTION
This commit creates a new folder called dao under replication to hold dao codes

Signed-off-by: Wenkai Yin <yinw@vmware.com>