### PR TITLE
Configuration item verify_remote_cert is no longer useful, so it was …

### DIFF
--- a/tests/robot-cases/Group3-Upgrade/prepare.py
+++ b/tests/robot-cases/Group3-Upgrade/prepare.py
@@ -88,7 +88,6 @@ class HarborAPI:
             "read_only": False,
             "self_registration": selfreg,
             "token_expiration": token,
-            "verify_remote_cert": True,
             "scan_all_policy": {
                 "type": "none",
                 "parameter": {


### PR DESCRIPTION
Configuration item verify_remote_cert is no longer useful, so it was delete from data population script.

Signed-off-by: danfengliu <danfengl@vmware.com>

Fixed issue: #7038 #7036