### PR TITLE
Fix: global search not work when chart enabled

### DIFF
--- a/src/core/api/search.go
+++ b/src/core/api/search.go
@@ -41,7 +41,7 @@ type SearchAPI struct {
 type searchResult struct {
 	Project    []*models.Project        `json:"project"`
 	Repository []map[string]interface{} `json:"repository"`
-	Chart      []*search.Result         `json:"chart,omitempty"`
+	Chart      *[]*search.Result        `json:"chart,omitempty"`
 }
 
 // Get ...
@@ -141,8 +141,8 @@ func (s *SearchAPI) Get() {
 			log.Errorf("failed to filter charts: %v", err)
 			s.CustomAbort(http.StatusInternalServerError, err.Error())
 		}
+		result.Chart = &chartResults
 
-		result.Chart = chartResults
 	}
 
 	s.Data["json"] = result

--- a/src/core/api/search_test.go
+++ b/src/core/api/search_test.go
@@ -201,8 +201,8 @@ func TestSearch(t *testing.T) {
 		credential: sysAdmin,
 	}, result)
 	require.Nil(t, err)
-	require.Equal(t, 1, len(result.Chart))
-	require.Equal(t, "library/harbor", result.Chart[0].Name)
+	require.Equal(t, 1, len(*(result.Chart)))
+	require.Equal(t, "library/harbor", (*result.Chart)[0].Name)
 
 	// Restore chart search handler
 	searchHandler = nil

--- a/src/portal/src/app/base/global-search/search-result.component.html
+++ b/src/portal/src/app/base/global-search/search-result.component.html
@@ -16,7 +16,7 @@
         </div>
         <div *ngIf="withHelmChart" id="chart-results">
             <h2>{{'HELM_CHART.HELMCHARTS' | translate}}</h2>
-            <list-chart-version-ro [charts]="searchResults.Chart"></list-chart-version-ro>
+            <list-chart-version-ro [charts]="searchResults.chart"></list-chart-version-ro>
         </div>
     </div>
 </div>


### PR DESCRIPTION
Global search result data does not contain the chart info when chart is empty

Signed-off-by: Qian Deng <dengq@vmware.com>