### PR TITLE
add http auth proxy selection in system configuration

### DIFF
--- a/src/portal/lib/src/config/config.ts
+++ b/src/portal/lib/src/config/config.ts
@@ -87,6 +87,9 @@ export class Configuration {
     cfg_expiration: NumberValueItem;
     scan_all_policy: ComplexValueItem;
     read_only: BoolValueItem;
+    http_authproxy_endpoint?: StringValueItem;
+    http_authproxy_skip_cert_verify?: BoolValueItem;
+    http_authproxy_always_onboard?: BoolValueItem;
 
     public constructor() {
         this.auth_mode = new StringValueItem("db_auth", true);
@@ -128,5 +131,8 @@ export class Configuration {
             }
         }, true);
         this.read_only = new BoolValueItem(false, true);
+        this.http_authproxy_endpoint = new StringValueItem("", true);
+        this.http_authproxy_skip_cert_verify = new BoolValueItem(false, true);
+        this.http_authproxy_always_onboard = new BoolValueItem(false, true);
     }
 }

--- a/src/portal/src/app/config/auth/config-auth.component.html
+++ b/src/portal/src/app/config/auth/config-auth.component.html
@@ -3,14 +3,16 @@
         <div class="form-group">
             <label for="authMode">{{'CONFIG.AUTH_MODE' | translate }}</label>
             <div class="select">
-                <select id="authMode" name="authMode" (change)="handleOnChange($event)" [disabled]="disabled(currentConfig.auth_mode)"
-                    [(ngModel)]="currentConfig.auth_mode.value">
+                <select id="authMode" name="authMode" (change)="handleOnChange($event)"
+                    [disabled]="disabled(currentConfig.auth_mode)" [(ngModel)]="currentConfig.auth_mode.value">
                     <option value="db_auth">{{'CONFIG.AUTH_MODE_DB' | translate }}</option>
                     <option value="ldap_auth">{{'CONFIG.AUTH_MODE_LDAP' | translate }}</option>
                     <option value="uaa_auth">{{'CONFIG.AUTH_MODE_UAA' | translate }}</option>
+                    <option *ngIf="showHttpAuth" value="http_auth">{{'CONFIG.AUTH_MODE_HTTP' | translate }}</option>
                 </select>
             </div>
-            <a href="javascript:void(0)" role="tooltip" aria-haspopup="true" class="tooltip tooltip-lg tooltip-top-right top-1">
+            <a href="javascript:void(0)" role="tooltip" aria-haspopup="true"
+                class="tooltip tooltip-lg tooltip-top-right top-1">
                 <clr-icon shape="info-circle" size="24" class="info-tips-icon"></clr-icon>
                 <span class="tooltip-content">{{'CONFIG.TOOLTIP.AUTH_MODE' | translate}}</span>
             </a>
@@ -19,22 +21,24 @@
     <section class="form-block" *ngIf="showUAA">
         <div class="form-group">
             <label for="uaa-endpoint" class="required">{{'CONFIG.UAA.ENDPOINT' | translate}}</label>
-            <input type="text" id="uaa-endpoint" name="uaa-endpoint" size="35" [(ngModel)]="currentConfig.uaa_endpoint.value"
-                [disabled]="!currentConfig.uaa_verify_cert.editable">
+            <input type="text" id="uaa-endpoint" name="uaa-endpoint" size="35"
+                [(ngModel)]="currentConfig.uaa_endpoint.value" [disabled]="!currentConfig.uaa_verify_cert.editable">
         </div>
         <div class="form-group">
             <label for="uaa-id" class="required">{{'CONFIG.UAA.CLIENT_ID' | translate}}</label>
-            <input type="text" id="uaa-cid" name="uaa-client-id" size="35" [(ngModel)]="currentConfig.uaa_client_id.value"
-                [disabled]="!currentConfig.uaa_verify_cert.editable">
+            <input type="text" id="uaa-cid" name="uaa-client-id" size="35"
+                [(ngModel)]="currentConfig.uaa_client_id.value" [disabled]="!currentConfig.uaa_verify_cert.editable">
         </div>
         <div class="form-group">
             <label for="uaa-id" class="required">{{'CONFIG.UAA.CLIENT_SECRET' | translate}}</label>
-            <input type="text" id="uaa-secret" name="uaa-client-secret" type="password" size="35" [(ngModel)]="currentConfig.uaa_client_secret.value"
+            <input id="uaa-secret" name="uaa-client-secret" type="password" size="35"
+                [(ngModel)]="currentConfig.uaa_client_secret.value"
                 [disabled]="!currentConfig.uaa_verify_cert.editable">
         </div>
         <div class="form-group">
             <clr-checkbox-wrapper>
-                <input type="checkbox" clrCheckbox name="uaa-cert" id="uaa-cert" required [(ngModel)]="currentConfig.uaa_verify_cert.value"
+                <input type="checkbox" clrCheckbox name="uaa-cert" id="uaa-cert" required
+                    [(ngModel)]="currentConfig.uaa_verify_cert.value"
                     [disabled]="!currentConfig.uaa_verify_cert.editable" />
                 <label for="uaa-cert" class="required">{{'CONFIG.UAA.VERIFY_CERT' | translate}}</label>
             </clr-checkbox-wrapper>
@@ -44,7 +48,8 @@
     <section class="form-block" *ngIf="showLdap">
         <div class="form-group">
             <label for="ldapUrl" class="required">{{'CONFIG.LDAP.URL' | translate}}</label>
-            <label for="ldapUrl" aria-haspopup="true" role="tooltip" class="tooltip tooltip-validation tooltip-lg tooltip-top-right"
+            <label for="ldapUrl" aria-haspopup="true" role="tooltip"
+                class="tooltip tooltip-validation tooltip-lg tooltip-top-right"
                 [class.invalid]="ldapUrlInput.invalid && (ldapUrlInput.dirty || ldapUrlInput.touched)">
                 <input name="ldapUrl" type="text" #ldapUrlInput="ngModel" [(ngModel)]="currentConfig.ldap_url.value"
                     required id="ldapUrl" size="40" [disabled]="disabled(currentConfig.ldap_url)">
@@ -55,23 +60,28 @@
         </div>
         <div class="form-group">
             <label for="ldapSearchDN">{{'CONFIG.LDAP.SEARCH_DN' | translate}}</label>
-            <label for="ldapSearchDN" aria-haspopup="true" role="tooltip" class="tooltip tooltip-validation tooltip-lg tooltip-top-right">
-                <input name="ldapSearchDN" type="text" #ldapSearchDNInput="ngModel" [(ngModel)]="currentConfig.ldap_search_dn.value"
-                    id="ldapSearchDN" size="40" [disabled]="disabled(currentConfig.ldap_search_dn)">
+            <label for="ldapSearchDN" aria-haspopup="true" role="tooltip"
+                class="tooltip tooltip-validation tooltip-lg tooltip-top-right">
+                <input name="ldapSearchDN" type="text" #ldapSearchDNInput="ngModel"
+                    [(ngModel)]="currentConfig.ldap_search_dn.value" id="ldapSearchDN" size="40"
+                    [disabled]="disabled(currentConfig.ldap_search_dn)">
                 <span class="tooltip-content">
                     {{'TOOLTIP.ITEM_REQUIRED' | translate}}
                 </span>
             </label>
-            <a href="javascript:void(0)" role="tooltip" aria-haspopup="true" class="tooltip tooltip-lg tooltip-top-right top-1">
+            <a href="javascript:void(0)" role="tooltip" aria-haspopup="true"
+                class="tooltip tooltip-lg tooltip-top-right top-1">
                 <clr-icon shape="info-circle" class="info-tips-icon" size="24"></clr-icon>
                 <span class="tooltip-content">{{'CONFIG.TOOLTIP.LDAP_SEARCH_DN' | translate}}</span>
             </a>
         </div>
         <div class="form-group">
             <label for="ldapSearchPwd">{{'CONFIG.LDAP.SEARCH_PWD' | translate}}</label>
-            <label for="ldapSearchPwd" aria-haspopup="true" role="tooltip" class="tooltip tooltip-validation tooltip-lg tooltip-top-right">
-                <input name="ldapSearchPwd" type="password" #ldapSearchPwdInput="ngModel" [(ngModel)]="currentConfig.ldap_search_password.value"
-                    id="ldapSearchPwd" size="40" [disabled]="disabled(currentConfig.ldap_search_password)">
+            <label for="ldapSearchPwd" aria-haspopup="true" role="tooltip"
+                class="tooltip tooltip-validation tooltip-lg tooltip-top-right">
+                <input name="ldapSearchPwd" type="password" #ldapSearchPwdInput="ngModel"
+                    [(ngModel)]="currentConfig.ldap_search_password.value" id="ldapSearchPwd" size="40"
+                    [disabled]="disabled(currentConfig.ldap_search_password)">
                 <span class="tooltip-content">
                     {{'TOOLTIP.ITEM_REQUIRED' | translate}}
                 </span>
@@ -79,10 +89,12 @@
         </div>
         <div class="form-group">
             <label for="ldapBaseDN" class="required">{{'CONFIG.LDAP.BASE_DN' | translate}}</label>
-            <label for="ldapBaseDN" aria-haspopup="true" role="tooltip" class="tooltip tooltip-validation tooltip-lg tooltip-top-right"
+            <label for="ldapBaseDN" aria-haspopup="true" role="tooltip"
+                class="tooltip tooltip-validation tooltip-lg tooltip-top-right"
                 [class.invalid]="ldapBaseDNInput.invalid && (ldapBaseDNInput.dirty || ldapBaseDNInput.touched)">
-                <input name="ldapBaseDN" type="text" #ldapBaseDNInput="ngModel" [(ngModel)]="currentConfig.ldap_base_dn.value"
-                    required id="ldapBaseDN" size="40" [disabled]="disabled(currentConfig.ldap_base_dn)">
+                <input name="ldapBaseDN" type="text" #ldapBaseDNInput="ngModel"
+                    [(ngModel)]="currentConfig.ldap_base_dn.value" required id="ldapBaseDN" size="40"
+                    [disabled]="disabled(currentConfig.ldap_base_dn)">
                 <span class="tooltip-content">
                     {{'TOOLTIP.ITEM_REQUIRED' | translate}}
                 </span>
@@ -94,9 +106,11 @@
         </div>
         <div class="form-group">
             <label for="ldapFilter">{{'CONFIG.LDAP.FILTER' | translate}}</label>
-            <label for="ldapFilter" aria-haspopup="true" role="tooltip" class="tooltip tooltip-validation tooltip-lg tooltip-top-right">
-                <input name="ldapFilter" type="text" #ldapFilterInput="ngModel" [(ngModel)]="currentConfig.ldap_filter.value"
-                    id="ldapFilter" size="40" [disabled]="disabled(currentConfig.ldap_filter)">
+            <label for="ldapFilter" aria-haspopup="true" role="tooltip"
+                class="tooltip tooltip-validation tooltip-lg tooltip-top-right">
+                <input name="ldapFilter" type="text" #ldapFilterInput="ngModel"
+                    [(ngModel)]="currentConfig.ldap_filter.value" id="ldapFilter" size="40"
+                    [disabled]="disabled(currentConfig.ldap_filter)">
                 <span class="tooltip-content">
                     {{'TOOLTIP.ITEM_REQUIRED' | translate}}
                 </span>
@@ -104,7 +118,8 @@
         </div>
         <div class="form-group">
             <label for="ldapUid" class="required">{{'CONFIG.LDAP.UID' | translate}}</label>
-            <label for="ldapUid" aria-haspopup="true" role="tooltip" class="tooltip tooltip-validation tooltip-lg tooltip-top-right"
+            <label for="ldapUid" aria-haspopup="true" role="tooltip"
+                class="tooltip tooltip-validation tooltip-lg tooltip-top-right"
                 [class.invalid]="ldapUidInput.invalid && (ldapUidInput.dirty || ldapUidInput.touched)">
                 <input name="ldapUid" type="text" #ldapUidInput="ngModel" [(ngModel)]="currentConfig.ldap_uid.value"
                     required id="ldapUid" size="40" [disabled]="disabled(currentConfig.ldap_uid)">
@@ -112,7 +127,8 @@
                     {{'TOOLTIP.ITEM_REQUIRED' | translate}}
                 </span>
             </label>
-            <a href="javascript:void(0)" role="tooltip" aria-haspopup="true" class="tooltip tooltip-lg tooltip-top-right top-1">
+            <a href="javascript:void(0)" role="tooltip" aria-haspopup="true"
+                class="tooltip tooltip-lg tooltip-top-right top-1">
                 <clr-icon shape="info-circle" class="info-tips-icon" size="24"></clr-icon>
                 <span class="tooltip-content">{{'CONFIG.TOOLTIP.LDAP_UID' | translate}}</span>
             </a>
@@ -120,7 +136,8 @@
         <div class="form-group">
             <label for="ldapScope">{{'CONFIG.LDAP.SCOPE' | translate}}</label>
             <div class="select">
-                <select id="ldapScope" name="ldapScope" [(ngModel)]="currentConfig.ldap_scope.value" [disabled]="disabled(currentConfig.ldap_scope)">
+                <select id="ldapScope" name="ldapScope" [(ngModel)]="currentConfig.ldap_scope.value"
+                    [disabled]="disabled(currentConfig.ldap_scope)">
                     <option value="0">{{'CONFIG.SCOPE_BASE' | translate }}</option>
                     <option value="1">{{'CONFIG.SCOPE_ONE_LEVEL' | translate }}</option>
                     <option value="2">{{'CONFIG.SCOPE_SUBTREE' | translate }}</option>
@@ -133,8 +150,9 @@
         </div>
         <div class="form-group">
             <label for="ldapGroupBaseDN">{{'CONFIG.LDAP.LDAP_GROUP_BASE_DN' | translate}}</label>
-            <input name="ldapGroupBaseDN" class="padding-right-28" type="text" #ldapGroupDNInput="ngModel" [(ngModel)]="currentConfig.ldap_group_base_dn.value"
-                id="ldapGroupBaseDN" size="40" [disabled]="disabled(currentConfig.ldap_group_base_dn)">
+            <input name="ldapGroupBaseDN" class="padding-right-28" type="text" #ldapGroupDNInput="ngModel"
+                [(ngModel)]="currentConfig.ldap_group_base_dn.value" id="ldapGroupBaseDN" size="40"
+                [disabled]="disabled(currentConfig.ldap_group_base_dn)">
             <clr-tooltip>
                 <clr-icon clrTooltipTrigger shape="info-circle" size="24"></clr-icon>
                 <clr-tooltip-content clrPosition="top-right" clrSize="lg" *clrIfOpen>
@@ -145,7 +163,8 @@
         <div class="form-group">
             <label for="ldapGroupFilter">{{'CONFIG.LDAP.LDAP_GROUP_FILTER' | translate}}</label>
             <input name="ldapGroupFilter" type="text" class="padding-right-28" #ldapGroupFilterInput="ngModel"
-                [(ngModel)]="currentConfig.ldap_group_search_filter.value" id="ldapGroupFilter" size="40" [disabled]="disabled(currentConfig.ldap_group_search_filter)">
+                [(ngModel)]="currentConfig.ldap_group_search_filter.value" id="ldapGroupFilter" size="40"
+                [disabled]="disabled(currentConfig.ldap_group_search_filter)">
             <clr-tooltip>
                 <clr-icon clrTooltipTrigger shape="info-circle" size="24"></clr-icon>
                 <clr-tooltip-content clrPosition="top-right" clrSize="lg" *clrIfOpen>
@@ -155,8 +174,9 @@
         </div>
         <div class="form-group">
             <label for="ldapGroupGID">{{'CONFIG.LDAP.LDAP_GROUP_GID' | translate}}</label>
-            <input name="ldapGroupGID" class="padding-right-28" type="text" #ldapGroupDNInput="ngModel" [(ngModel)]="currentConfig.ldap_group_attribute_name.value"
-                id="ldapGroupGID" size="40" [disabled]="disabled(currentConfig.ldap_group_attribute_name)">
+            <input name="ldapGroupGID" class="padding-right-28" type="text" #ldapGroupDNInput="ngModel"
+                [(ngModel)]="currentConfig.ldap_group_attribute_name.value" id="ldapGroupGID" size="40"
+                [disabled]="disabled(currentConfig.ldap_group_attribute_name)">
             <clr-tooltip>
                 <clr-icon clrTooltipTrigger shape="info-circle" size="24"></clr-icon>
                 <clr-tooltip-content clrPosition="top-right" clrSize="lg" *clrIfOpen>
@@ -168,7 +188,8 @@
         <div class="form-group">
             <label>{{'CONFIG.LDAP.LDAP_GROUP_ADMIN_DN' | translate}}</label>
             <input name="ldapGroupAdminDN" class="padding-right-28" type="text" #ldapGroupFilterInput="ngModel"
-                [(ngModel)]="currentConfig.ldap_group_admin_dn.value" id="ldapGroupAdminDN" size="40" [disabled]="disabled(currentConfig.ldap_group_admin_dn)">
+                [(ngModel)]="currentConfig.ldap_group_admin_dn.value" id="ldapGroupAdminDN" size="40"
+                [disabled]="disabled(currentConfig.ldap_group_admin_dn)">
             <clr-tooltip>
                 <clr-icon clrTooltipTrigger shape="info-circle" size="24"></clr-icon>
                 <clr-tooltip-content clrPosition="top-right" clrSize="lg" *clrIfOpen>
@@ -180,7 +201,8 @@
         <div class="form-group">
             <label for="ldapGroupScope">{{'CONFIG.LDAP.GROUP_SCOPE' | translate}}</label>
             <div class="select">
-                <select id="ldapGroupScope" name="ldapGroupScope" [(ngModel)]="currentConfig.ldap_group_search_scope.value"
+                <select id="ldapGroupScope" name="ldapGroupScope"
+                    [(ngModel)]="currentConfig.ldap_group_search_scope.value"
                     [disabled]="disabled(currentConfig.ldap_group_search_scope)">
                     <option value="0">{{'CONFIG.SCOPE_BASE' | translate }}</option>
                     <option value="1">{{'CONFIG.SCOPE_ONE_LEVEL' | translate }}</option>
@@ -199,15 +221,18 @@
         <div class="form-group" *ngIf="showSelfReg">
             <label for="selfReg">{{'CONFIG.SELF_REGISTRATION' | translate}}</label>
             <clr-checkbox-wrapper>
-                <input type="checkbox" clrCheckbox name="selfReg" id="selfReg" [(ngModel)]="currentConfig.self_registration.value"
+                <input type="checkbox" clrCheckbox name="selfReg" id="selfReg"
+                    [(ngModel)]="currentConfig.self_registration.value"
                     [disabled]="disabled(currentConfig.self_registration)" />
                 <label>
-                    <a href="javascript:void(0)" role="tooltip" aria-haspopup="true" class="tooltip tooltip-top-right top-7">
+                    <a href="javascript:void(0)" role="tooltip" aria-haspopup="true"
+                        class="tooltip tooltip-top-right top-7">
                         <clr-icon shape="info-circle" class="info-tips-icon" size="24"></clr-icon>
                         <span *ngIf="checkable; else elseBlock" class="tooltip-content">{{'CONFIG.TOOLTIP.SELF_REGISTRATION_ENABLE'
                             | translate}}</span>
                         <ng-template #elseBlock>
-                            <span class="tooltip-content">{{'CONFIG.TOOLTIP.SELF_REGISTRATION_DISABLE' | translate}}</span>
+                            <span
+                                class="tooltip-content">{{'CONFIG.TOOLTIP.SELF_REGISTRATION_DISABLE' | translate}}</span>
                         </ng-template>
                     </a>
                 </label>
@@ -218,10 +243,12 @@
         <div class="form-group">
             <label for="ldapVerifyCert">{{'CONFIG.LDAP.VERIFY_CERT' | translate}}</label>
             <clr-checkbox-wrapper>
-                <input type="checkbox" clrCheckbox name="ldapVerifyCert" id="ldapVerifyCert" [ngModel]="currentConfig.ldap_verify_cert.value"
-                    [disabled]="disabled(currentConfig.ldap_scope)" (ngModelChange)="setVerifyCertValue($event)" />
+                <input type="checkbox" clrCheckbox name="ldapVerifyCert" id="ldapVerifyCert"
+                    [ngModel]="currentConfig.ldap_verify_cert.value" [disabled]="disabled(currentConfig.ldap_scope)"
+                    (ngModelChange)="setVerifyCertValue($event)" />
                 <label>
-                    <a href="javascript:void(0)" role="tooltip" aria-haspopup="true" class="tooltip tooltip-top-right top-7">
+                    <a href="javascript:void(0)" role="tooltip" aria-haspopup="true"
+                        class="tooltip tooltip-top-right top-7">
                         <clr-icon shape="info-circle" class="info-tips-icon" size="24"></clr-icon>
                         <span class="tooltip-content">{{'CONFIG.TOOLTIP.VERIFY_CERT' | translate}}</span>
                     </a>
@@ -229,13 +256,43 @@
             </clr-checkbox-wrapper>
         </div>
     </section>
+    <section class="form-block" *ngIf="showHttpAuth">
+        <div class="form-group">
+            <label for="http_authproxy_endpoint" class="required">{{'CONFIG.HTTP_AUTH.ENDPOINT' | translate}}</label>
+            <label for="http_authproxy_endpoint" aria-haspopup="true" role="tooltip" class="tooltip tooltip-validation tooltip-md tooltip-top-right"
+            [class.invalid]="httpAuthproxyEndpointInput.invalid && (httpAuthproxyEndpointInput.dirty || httpAuthproxyEndpointInput.touched)">
+            <input type="text" pattern="^([hH][tT]{2}[pP]:\/\/|[hH][tT]{2}[pP][sS]:\/\/)(.*?)*$"  #httpAuthproxyEndpointInput="ngModel" required id="http_authproxy_endpoint" name="http_authproxy_endpoint" size="35"
+                [(ngModel)]="currentConfig.http_authproxy_endpoint.value" [disabled]="!currentConfig.http_authproxy_endpoint.editable" >
+                <span class="tooltip-content">
+                        {{'TOOLTIP.ENDPOINT_FORMAT' | translate}}
+                    </span>
+            </label>
+        </div>
+        <div class="form-group">
+            <label for="http_authproxy_skip_cert_verify"
+                class="required">{{'CONFIG.HTTP_AUTH.VERIFY_CERT' | translate}}</label>
+            <clr-checkbox-wrapper>
+                <input type="checkbox" clrCheckbox name="http_authproxy_skip_cert_verify" id="http_authproxy_skip_cert_verify"
+                 [(ngModel)]="currentConfig.http_authproxy_skip_cert_verify.value"  [disabled]="!currentConfig.http_authproxy_skip_cert_verify.editable" />
+            </clr-checkbox-wrapper>
+        </div>
+        <div class="form-group">
+            <label for="http_authproxy_always_onboard"
+                class="required">{{'CONFIG.HTTP_AUTH.ALWAYS_ONBOARD' | translate}}</label>
+            <clr-checkbox-wrapper>
+                <input type="checkbox" clrCheckbox name="http_authproxy_always_onboard"
+                    id="http_authproxy_always_onboard" [disabled]="!currentConfig.http_authproxy_always_onboard.editable"
+                    [(ngModel)]="currentConfig.http_authproxy_always_onboard.value" />
+            </clr-checkbox-wrapper>
+        </div>
+    </section>
 </form>
 <div>
-    <button type="button" id="config_auth_save" class="btn btn-primary" (click)="save()" [disabled]="!isValid() || !hasChanges()">{{'BUTTON.SAVE'
-        | translate}}</button>
-    <button type="button" class="btn btn-outline" (click)="cancel()" [disabled]="!isValid() || !hasChanges()">{{'BUTTON.CANCEL'
-        | translate}}</button>
-    <button type="button" class="btn btn-outline" (click)="testLDAPServer()" *ngIf="showLdapServerBtn" [disabled]="!isLDAPConfigValid()">{{'BUTTON.TEST_LDAP'
-        | translate}}</button>
+    <button type="button" id="config_auth_save" class="btn btn-primary" (click)="save()"
+        [disabled]="!isValid() || !hasChanges()">{{'BUTTON.SAVE' | translate}}</button>
+    <button type="button" class="btn btn-outline" (click)="cancel()"
+        [disabled]="!isValid() || !hasChanges()">{{'BUTTON.CANCEL' | translate}}</button>
+    <button type="button" class="btn btn-outline" (click)="testLDAPServer()" *ngIf="showLdapServerBtn"
+        [disabled]="!isLDAPConfigValid()">{{'BUTTON.TEST_LDAP' | translate}}</button>
     <span id="forTestingLDAP" class="spinner spinner-inline" [hidden]="hideLDAPTestingSpinner"></span>
 </div>

--- a/src/portal/src/app/config/auth/config-auth.component.ts
+++ b/src/portal/src/app/config/auth/config-auth.component.ts
@@ -65,12 +65,15 @@ export class ConfigurationAuthComponent implements OnChanges {
     public get showUAA(): boolean {
         return this.currentConfig && this.currentConfig.auth_mode && this.currentConfig.auth_mode.value === 'uaa_auth';
     }
-
+    public get showHttpAuth(): boolean {
+        return this.currentConfig && this.currentConfig.auth_mode && this.currentConfig.auth_mode.value === 'http_auth';
+    }
     public get showSelfReg(): boolean {
         if (!this.currentConfig || !this.currentConfig.auth_mode) {
             return true;
         } else {
-            return this.currentConfig.auth_mode.value !== 'ldap_auth' && this.currentConfig.auth_mode.value !== 'uaa_auth';
+            return this.currentConfig.auth_mode.value !== 'ldap_auth' && this.currentConfig.auth_mode.value !== 'uaa_auth'
+            && this.currentConfig.auth_mode.value !== 'http_auth' ;
         }
     }
 
@@ -143,7 +146,11 @@ export class ConfigurationAuthComponent implements OnChanges {
             || prop.startsWith('uaa_')
             || prop === 'auth_mode'
             || prop === 'project_creattion_restriction'
-            || prop === 'self_registration') {
+            || prop === 'self_registration'
+            || prop === 'http_authproxy_endpoint'
+            || prop === 'http_authproxy_skip_cert_verify'
+            || prop === 'http_authproxy_always_onboard'
+            ) {
                 changes[prop] = allChanges[prop];
             }
         }
@@ -161,7 +168,7 @@ export class ConfigurationAuthComponent implements OnChanges {
     handleOnChange($event: any): void {
         if ($event && $event.target && $event.target["value"]) {
             let authMode = $event.target["value"];
-            if (authMode === 'ldap_auth' || authMode === 'uaa_auth') {
+            if (authMode === 'ldap_auth' || authMode === 'uaa_auth' || authMode === 'http_auth') {
                 if (this.currentConfig.self_registration.value) {
                     this.currentConfig.self_registration.value = false; // unselect
                 }

--- a/src/portal/src/i18n/lang/en-us-lang.json
+++ b/src/portal/src/i18n/lang/en-us-lang.json
@@ -70,7 +70,8 @@
         "RULE_USER_EXISTING": "Name is already in use.",
         "EMPTY": "Name is required",
         "NONEMPTY": "Can't be empty",
-        "REPO_TOOLTIP": "Users can not do any operations to the images in this mode."
+        "REPO_TOOLTIP": "Users can not do any operations to the images in this mode.",
+        "ENDPOINT_FORMAT": "Endpoint must start with HTTP or HTTPS."
     },
     "PLACEHOLDER": {
         "CURRENT_PWD": "Enter current password",
@@ -618,6 +619,7 @@
         "AUTH_MODE_DB": "Database",
         "AUTH_MODE_LDAP": "LDAP",
         "AUTH_MODE_UAA": "UAA",
+        "AUTH_MODE_HTTP": "http_auth",
         "SCOPE_BASE": "Base",
         "SCOPE_ONE_LEVEL": "OneLevel",
         "SCOPE_SUBTREE": "Subtree",
@@ -670,6 +672,11 @@
             "CLIENT_ID": "UAA Client ID",
             "CLIENT_SECRET": "UAA Client Secret",
             "VERIFY_CERT": "UAA Verify Cert"
+        },
+        "HTTP_AUTH": {
+            "ENDPOINT": "Server Endpoint",
+            "ALWAYS_ONBOARD": "Always Onboard",
+            "VERIFY_CERT": "Authentication Verify Cert"
         },
         "SCANNING": {
             "TRIGGER_SCAN_ALL_SUCCESS": "Trigger scan all successfully!",

--- a/src/portal/src/i18n/lang/es-es-lang.json
+++ b/src/portal/src/i18n/lang/es-es-lang.json
@@ -70,7 +70,8 @@
         "RULE_USER_EXISTING": "Name is already in use.",
         "EMPTY": "Name is required",
         "NONEMPTY": "Can't be empty",
-        "REPO_TOOLTIP": "Users can not do any operations to the images in this mode."
+        "REPO_TOOLTIP": "Users can not do any operations to the images in this mode.",
+        "ENDPOINT_FORMAT": "Endpoint must start with HTTP or HTTPS."
     },
     "PLACEHOLDER": {
         "CURRENT_PWD": "Introduzca la contraseña actual",
@@ -617,6 +618,7 @@
         "AUTH_MODE_DB": "Base de datos",
         "AUTH_MODE_LDAP": "LDAP",
         "AUTH_MODE_UAA": "UAA",
+        "AUTH_MODE_HTTP": "http_auth",
         "SCOPE_BASE": "Base",
         "SCOPE_ONE_LEVEL": "UnNivel",
         "SCOPE_SUBTREE": "Subárbol",
@@ -669,6 +671,11 @@
             "CLIENT_ID": "UAA Client ID",
             "CLIENT_SECRET": "UAA Client Secret",
             "VERIFY_CERT": "UAA Verify Cert"
+        },
+        "HTTP_AUTH": {
+            "ENDPOINT": "Server Endpoint",
+            "ALWAYS_ONBOARD": "Always Onboard",
+            "VERIFY_CERT": "Authentication Verify Cert"
         },
         "SCANNING": {
             "TRIGGER_SCAN_ALL_SUCCESS": "Trigger scan all successfully!",

--- a/src/portal/src/i18n/lang/fr-fr-lang.json
+++ b/src/portal/src/i18n/lang/fr-fr-lang.json
@@ -57,7 +57,8 @@
         "EMAIL_EXISTING": "L'adresse e-mail existe déjà.",
         "USER_EXISTING": "Le nom d'utilisateur est déjà utilisé.",
         "NONEMPTY": "Can't be empty",
-        "REPO_TOOLTIP": "Users can not do any operations to the images in this mode."
+        "REPO_TOOLTIP": "Users can not do any operations to the images in this mode.",
+        "ENDPOINT_FORMAT": "Endpoint must start with HTTP or HTTPS."
     },
     "PLACEHOLDER": {
         "CURRENT_PWD": "Entrez le mot de passe actuel",
@@ -589,6 +590,7 @@
         "SELF_REGISTRATION": "Autoriser l'Auto-Inscription",
         "AUTH_MODE_DB": "Base de données",
         "AUTH_MODE_LDAP": "LDAP",
+        "AUTH_MODE_HTTP": "http_auth",
         "SCOPE_BASE": "Base",
         "SCOPE_ONE_LEVEL": "Premier Niveau",
         "SCOPE_SUBTREE": "Sous-arbre",
@@ -634,6 +636,11 @@
             "LDAP_GROUP_ADMIN_DN_INFO": "Specify an LDAP group DN. all LDAP user in this group will have harbor admin privilege. Keep it blank if you do not want to.",
             "GROUP_SCOPE": "LDAP Group Scope",
             "GROUP_SCOPE_INFO": "The scope to search for groups, select Subtree by default."
+        },
+        "HTTP_AUTH": {
+            "ENDPOINT": "serveur paramètre",
+            "ALWAYS_ONBOARD": "Always Onboard",
+            "VERIFY_CERT": "authentification vérifier cert"
         },
         "SCANNING": {
             "TRIGGER_SCAN_ALL_SUCCESS": "Déclenchement d'analyse globale avec succès !",

--- a/src/portal/src/i18n/lang/pt-br-lang.json
+++ b/src/portal/src/i18n/lang/pt-br-lang.json
@@ -68,7 +68,8 @@
         "EMAIL_EXISTING": "Email já existe.",
         "USER_EXISTING": "Nome de usuário já está em uso.",
         "RULE_USER_EXISTING": "Nome já em uso.",
-        "EMPTY": "Nome é obrigatório"
+        "EMPTY": "Nome é obrigatório",
+        "ENDPOINT_FORMAT": "Avaliação deve começar por HTTP Ou HTTPS."
     },
     "PLACEHOLDER": {
         "CURRENT_PWD": "Insira a senha atual",
@@ -612,6 +613,7 @@
         "AUTH_MODE_DB": "Banco de Dados",
         "AUTH_MODE_LDAP": "LDAP",
         "AUTH_MODE_UAA": "UAA",
+        "AUTH_MODE_HTTP": "http_auth",
         "SCOPE_BASE": "Base",
         "SCOPE_ONE_LEVEL": "OneLevel",
         "SCOPE_SUBTREE": "Subtree",
@@ -663,6 +665,11 @@
             "CLIENT_ID": "ID de cliente UAA",
             "CLIENT_SECRET": "Secret de Cliente UAA",
             "VERIFY_CERT": "Verificar certificado UAA"
+        },
+        "HTTP_AUTH": {
+            "ENDPOINT": "server endpoint",
+            "ALWAYS_ONBOARD": "Sempre Onboard",
+            "VERIFY_CERT": "Verificar certificado de Authentication"
         },
         "SCANNING": {
             "TRIGGER_SCAN_ALL_SUCCESS": "Disparo de análise geral efetuado com sucesso!",

--- a/src/portal/src/i18n/lang/zh-cn-lang.json
+++ b/src/portal/src/i18n/lang/zh-cn-lang.json
@@ -69,7 +69,8 @@
         "USER_EXISTING": "用户名已经存在。",
         "RULE_USER_EXISTING": "名称已经存在。",
         "EMPTY": "名称为必填项",
-        "NONEMPTY": "不能为空"
+        "NONEMPTY": "不能为空",
+        "ENDPOINT_FORMAT": "Endpoint必须以http或https开头。"
     },
     "PLACEHOLDER": {
         "CURRENT_PWD": "输入当前密码",
@@ -617,6 +618,7 @@
         "AUTH_MODE_DB": "数据库",
         "AUTH_MODE_LDAP": "LDAP",
         "AUTH_MODE_UAA": "UAA",
+        "AUTH_MODE_HTTP": "http_auth",
         "SCOPE_BASE": "本层",
         "SCOPE_ONE_LEVEL": "下一层",
         "SCOPE_SUBTREE": "子树",
@@ -668,6 +670,11 @@
             "CLIENT_ID": "UAA Client ID",
             "CLIENT_SECRET": "UAA Client Secret",
             "VERIFY_CERT": "UAA 检查证书"
+        },
+        "HTTP_AUTH": {
+            "ENDPOINT": "Server Endpoint",
+            "ALWAYS_ONBOARD": "Always Onboard",
+            "VERIFY_CERT": "Authentication验证证书"
         },
         "SCANNING": {
             "TRIGGER_SCAN_ALL_SUCCESS": "启动扫描所有镜像任务成功!",


### PR DESCRIPTION

add http auth proxy selection in system configuration:
Under System Configuration Authentication AuthMode module selection, Add option'http auth', which is read-only. Under this option, there are modifiable parts such as Server Endpoint, Authentication Verify Cert, Always Onboard, etc.

Signed-off-by: Yogi_Wang <yawang@vmware.com>