### PR TITLE
Update OWNERS based on clouderati's request

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -15,8 +15,6 @@ describes governance guidelines and maintainer responsibilities.
 | Qian Deng | [ninjadq](https://github.com/ninjadq) | [VMware](https://www.github.com/vmware/) |
 | Mia Zhou | [zhoumeina](https://github.com/zhoumeina) | [VMware](https://www.github.com/vmware/) |
 | Steven Zou | [steven-zou](https://github.com/steven-zou) | [VMware](https://www.github.com/vmware/) |
-| James Zabala | [clouderati](https://github.com/clouderati) | [VMware](https://www.github.com/vmware/) |
-
 
 # Maintainers
 | Maintainer | GitHub ID | Affiliation |


### PR DESCRIPTION
Removal of James Zabala as core maintainer for Harbor based on his request to step down, found here:
https://github.com/goharbor/community/pull/61

Signed-off-by: <jrosland@vmware.com>