### PR TITLE
Update docker-healthcheck.sh

### DIFF
--- a/make/photon/db/docker-healthcheck.sh
+++ b/make/photon/db/docker-healthcheck.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eo pipefail
 
-host="$(hostname -i || echo '127.0.0.1')"
+host="$(cat /etc/hostname || echo '127.0.0.1')"
 user="${POSTGRES_USER:-postgres}"
 db="${POSTGRES_DB:-$POSTGRES_USER}"
 export PGPASSWORD="${POSTGRES_PASSWORD:-}"


### PR DESCRIPTION
the `hostname` command not found will cause the Pod readinessProbe fail.

