### PR TITLE
Enable docker registry to clean untagged revisions

### DIFF
--- a/src/registryctl/api/registry.go
+++ b/src/registryctl/api/registry.go
@@ -38,7 +38,7 @@ type GCResult struct {
 
 // StartGC ...
 func StartGC(w http.ResponseWriter, r *http.Request) {
-	cmd := exec.Command("/bin/bash", "-c", "registry garbage-collect "+regConf)
+	cmd := exec.Command("/bin/bash", "-c", "registry garbage-collect --delete-untagged=true "+regConf)
 	var outBuf, errBuf bytes.Buffer
 	cmd.Stdout = &outBuf
 	cmd.Stderr = &errBuf


### PR DESCRIPTION
As registry v2.7.1 has introduced the possibility to clean untagged manifests,
enable it in the registryctl api.

Signed-off-by: wang yan <wangyan@vmware.com>