### PR TITLE
Fix cannot get adapters

### DIFF
--- a/src/portal/lib/src/create-edit-endpoint/create-edit-endpoint.component.html
+++ b/src/portal/lib/src/create-edit-endpoint/create-edit-endpoint.component.html
@@ -17,7 +17,7 @@
           <div class="form-select">
             <div class="select providerSelect pull-left">
               <select name="adapter" id="adapter" [(ngModel)]="target.type" [disabled]="testOngoing || controlEnabled">
-                <option *ngFor="let adapter of adapterList" [ngValue]="adapter" value="{{adapter.type}}">{{adapter.type}}</option>
+                <option *ngFor="let adapter of adapterList" [ngValue]="adapter" value="{{adapter}}">{{adapter}}</option>
               </select>
             </div>
           </div>

--- a/src/portal/lib/src/list-replication-rule/list-replication-rule.component.ts
+++ b/src/portal/lib/src/list-replication-rule/list-replication-rule.component.ts
@@ -146,6 +146,7 @@ export class ListReplicationRuleComponent implements OnInit, OnChanges {
                 // job list hidden
                 this.hideJobs.emit();
                 this.changedRules = this.rules;
+                this.loading = false;
                 // get registry name
                 let targetLists: ReplicationRule[] = rules;
                 if (targetLists && targetLists.length) {
@@ -163,7 +164,6 @@ export class ListReplicationRuleComponent implements OnInit, OnChanges {
                     forkJoin(...registryList).subscribe((item) => {
                         this.selectedRow = null;
                         this.registryName = item.map(target => target.name);
-                        this.loading = false;
                     });
                 }
             }, error => {

--- a/src/portal/lib/src/service/replication.service.ts
+++ b/src/portal/lib/src/service/replication.service.ts
@@ -338,7 +338,7 @@ export class ReplicationDefaultService extends ReplicationService {
       return observableThrowError("Bad argument");
     }
 
-    let url: string = `${this._replicateUrl}`;
+    let url: string = `${this._replicateUrl}/executions`;
     return this.http
       .post(url, { policy_id: ruleId }, HTTP_JSON_OPTIONS)
       .pipe(map(response => response)


### PR DESCRIPTION
1、fix cannot get adapters
2、fix cannot execute replication operation ,execute replication api is changed from 'api/replication' to 'api/replication/execution'
Signed-off-by: FangyuanCheng <fangyuanc@vmware.com>