### PR TITLE
Add callback controller for OIDC

### DIFF
--- a/src/common/const.go
+++ b/src/common/const.go
@@ -135,5 +135,5 @@ const (
 	CoreConfigPath          = "/api/internal/configurations"
 	RobotTokenDuration      = "robot_token_duration"
 
-	OIDCCallbackPath = "/c/oidc_callback"
+	OIDCCallbackPath = "/c/oidc/callback"
 )

--- a/src/common/utils/oidc/helper_test.go
+++ b/src/common/utils/oidc/helper_test.go
@@ -44,24 +44,23 @@ func TestMain(m *testing.M) {
 		os.Exit(result)
 	}
 }
-
 func TestHelperLoadConf(t *testing.T) {
 	testP := &providerHelper{}
 	assert.Nil(t, testP.setting.Load())
-	err := testP.loadConf()
+	err := testP.reload()
 	assert.Nil(t, err)
 	assert.Equal(t, "test", testP.setting.Load().(models.OIDCSetting).Name)
-	assert.Nil(t, testP.ep.Load())
+	assert.Equal(t, endpoint{}, testP.ep)
 }
 
 func TestHelperCreate(t *testing.T) {
 	testP := &providerHelper{}
-	err := testP.loadConf()
+	err := testP.reload()
 	assert.Nil(t, err)
 	assert.Nil(t, testP.instance.Load())
 	err = testP.create()
 	assert.Nil(t, err)
-	assert.EqualValues(t, "https://accounts.google.com", testP.ep.Load().(string))
+	assert.EqualValues(t, "https://accounts.google.com", testP.ep.url)
 	assert.NotNil(t, testP.instance.Load())
 }
 

--- a/src/core/config/config_test.go
+++ b/src/core/config/config_test.go
@@ -260,6 +260,6 @@ func TestOIDCSetting(t *testing.T) {
 	assert.True(t, v.SkipCertVerify)
 	assert.Equal(t, "client", v.ClientID)
 	assert.Equal(t, "secret", v.ClientSecret)
-	assert.Equal(t, "https://harbor.test/c/oidc_callback", v.RedirectURL)
+	assert.Equal(t, "https://harbor.test/c/oidc/callback", v.RedirectURL)
 	assert.ElementsMatch(t, []string{"openid", "profile"}, v.Scope)
 }

--- a/src/core/controllers/oidc.go
+++ b/src/core/controllers/oidc.go
@@ -24,21 +24,75 @@ import (
 	"net/http"
 )
 
+const idTokenKey = "oidc_id_token"
+const stateKey = "oidc_state"
+
 // OIDCController handles requests for OIDC login, callback and user onboard
 type OIDCController struct {
 	api.BaseController
 }
 
+type oidcUserData struct {
+	Issuer   string `json:"iss"`
+	Subject  string `json:"sub"`
+	Username string `json:"name"`
+	Email    string `json:"email"`
+}
+
+// Prepare include public code path for call request handler of OIDCController
+func (oc *OIDCController) Prepare() {
+	if mode, _ := config.AuthMode(); mode != common.OIDCAuth {
+		oc.CustomAbort(http.StatusPreconditionFailed, fmt.Sprintf("Auth Mode: %s is not OIDC based.", mode))
+	}
+}
+
 // RedirectLogin redirect user's browser to OIDC provider's login page
 func (oc *OIDCController) RedirectLogin() {
-	if mode, _ := config.AuthMode(); mode != common.OIDCAuth {
-		oc.RenderError(http.StatusPreconditionFailed, fmt.Sprintf("Auth Mode: %s is not OIDC based.", mode))
-		return
-	}
-	url, err := oidc.AuthCodeURL(utils.GenerateRandomString())
+	state := utils.GenerateRandomString()
+	url, err := oidc.AuthCodeURL(state)
 	if err != nil {
 		oc.RenderFormatedError(http.StatusInternalServerError, err)
+		return
 	}
+	oc.SetSession(stateKey, state)
 	// Force to use the func 'Redirect' of beego.Controller
 	oc.Controller.Redirect(url, http.StatusFound)
+}
+
+// Callback handles redirection from OIDC provider.  It will exchange the token and
+// kick off onboard if needed.
+func (oc *OIDCController) Callback() {
+	if oc.Ctx.Request.URL.Query().Get("state") != oc.GetSession(stateKey) {
+		oc.RenderError(http.StatusBadRequest, "State mismatch.")
+		return
+	}
+	code := oc.Ctx.Request.URL.Query().Get("code")
+	ctx := oc.Ctx.Request.Context()
+	token, err := oidc.ExchangeToken(ctx, code)
+	if err != nil {
+		oc.RenderFormatedError(http.StatusInternalServerError, err)
+		return
+	}
+	idToken, err := oidc.VerifyToken(ctx, token.IDToken)
+	if err != nil {
+		oc.RenderFormatedError(http.StatusInternalServerError, err)
+		return
+	}
+	d := &oidcUserData{}
+	err = idToken.Claims(d)
+	if err != nil {
+		oc.RenderFormatedError(http.StatusInternalServerError, err)
+		return
+	}
+	oc.SetSession(idTokenKey, token.IDToken)
+	// TODO: check and trigger onboard popup or redirect user to project page
+	oc.Data["json"] = d
+	oc.ServeFormatted()
+}
+
+// Onboard handles the request to onboard an user authenticated via OIDC provider
+func (oc *OIDCController) Onboard() {
+	oc.RenderError(http.StatusNotImplemented, "")
+	return
+
 }

--- a/src/core/router.go
+++ b/src/core/router.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"github.com/goharbor/harbor/src/common"
 	"github.com/goharbor/harbor/src/core/api"
 	"github.com/goharbor/harbor/src/core/config"
 	"github.com/goharbor/harbor/src/core/controllers"
@@ -37,7 +38,9 @@ func initRouters() {
 		beego.Router("/c/reset", &controllers.CommonController{}, "post:ResetPassword")
 		beego.Router("/c/userExists", &controllers.CommonController{}, "post:UserExists")
 		beego.Router("/c/sendEmail", &controllers.CommonController{}, "get:SendResetEmail")
-		beego.Router("/c/oidc_login", &controllers.OIDCController{}, "get:RedirectLogin")
+		beego.Router("/c/oidc/login", &controllers.OIDCController{}, "get:RedirectLogin")
+		beego.Router("/c/oidc/onboard", &controllers.OIDCController{}, "post:Onboard")
+		beego.Router(common.OIDCCallbackPath, &controllers.OIDCController{}, "get:Callback")
 
 		// API:
 		beego.Router("/api/projects/:pid([0-9]+)/members/?:pmid([0-9]+)", &api.ProjectMemberAPI{})


### PR DESCRIPTION
This commit add callback controller to handler the redirection from
successful OIDC authentication.
For E2E case this requires callback controller to kick off onboard
process, which will be covered in subsequent commits.