### PR TITLE
Update the registry client to support pulling public images from docker hub without login

### DIFF
--- a/src/common/utils/registry/auth/credential.go
+++ b/src/common/utils/registry/auth/credential.go
@@ -38,7 +38,12 @@ func NewBasicAuthCredential(username, password string) Credential {
 }
 
 func (b *basicAuthCredential) AddAuthorization(req *http.Request) {
-	req.SetBasicAuth(b.username, b.password)
+	// only add the authentication info when the username isn't empty
+	// the logic is needed for requesting resources from docker hub's
+	// public repositories
+	if len(b.username) > 0 {
+		req.SetBasicAuth(b.username, b.password)
+	}
 }
 
 // implement github.com/goharbor/harbor/src/common/http/modifier.Modifier


### PR DESCRIPTION
Only add the authentication info when the username is provided to support pulling public images from docker hub without login

Signed-off-by: Wenkai Yin <yinw@vmware.com>