### PR TITLE
Call Harbor API to delete the images in Harbor adapter

### DIFF
--- a/src/replication/ng/adapter/harbor/image_registry.go
+++ b/src/replication/ng/adapter/harbor/image_registry.go
@@ -66,3 +66,10 @@ func (a *adapter) FetchImages(namespaces []string, filters []*model.Filter) ([]*
 
 	return resources, nil
 }
+
+// override the default implementation from the default image registry
+// by calling Harbor API directly
+func (a *adapter) DeleteManifest(repository, reference string) error {
+	url := fmt.Sprintf("%s/api/repositories/%s/tags/%s", a.coreServiceURL, repository, reference)
+	return a.client.Delete(url)
+}

--- a/src/replication/ng/adapter/image_registry_test.go
+++ b/src/replication/ng/adapter/image_registry_test.go
@@ -1,0 +1,46 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package adapter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TODO add UT
+
+func TestIsDigest(t *testing.T) {
+	cases := []struct {
+		str      string
+		isDigest bool
+	}{
+		{
+			str:      "",
+			isDigest: false,
+		},
+		{
+			str:      "latest",
+			isDigest: false,
+		},
+		{
+			str:      "sha256:fea8895f450959fa676bcc1df0611ea93823a735a01205fd8622846041d0c7cf",
+			isDigest: true,
+		},
+	}
+	for _, c := range cases {
+		assert.Equal(t, c.isDigest, isDigest(c.str))
+	}
+}

--- a/src/replication/ng/transfer/repository/transfer.go
+++ b/src/replication/ng/transfer/repository/transfer.go
@@ -278,10 +278,9 @@ func (t *transfer) delete(repo *repository) error {
 		return jobStoppedErr
 	}
 
-	digests := map[string]struct{}{}
 	repository := repo.repository
 	for _, tag := range repo.tags {
-		exist, digest, err := t.dst.ManifestExist(repository, tag)
+		exist, _, err := t.dst.ManifestExist(repository, tag)
 		if err != nil {
 			t.logger.Errorf("failed to check the existence of the manifest of image %s:%s on the destination registry: %v",
 				repository, tag, err)
@@ -292,18 +291,12 @@ func (t *transfer) delete(repo *repository) error {
 				repository, tag)
 			continue
 		}
-		t.logger.Infof("the digest of image %s:%s is %s", repository, tag, digest)
-		if _, exist := digests[digest]; !exist {
-			digests[digest] = struct{}{}
-		}
-	}
-	for digest := range digests {
-		if err := t.dst.DeleteManifest(repository, digest); err != nil {
+		if err := t.dst.DeleteManifest(repository, tag); err != nil {
 			t.logger.Errorf("failed to delete the manifest of image %s:%s on the destination registry: %v",
-				repository, digest, err)
+				repository, tag, err)
 			return err
 		}
-		t.logger.Infof("the manifest of image %s:%s is deleted", repository, digest)
+		t.logger.Infof("the manifest of image %s:%s is deleted", repository, tag)
 	}
 	return nil
 }


### PR DESCRIPTION
Call Harbor API to delete the images in Harbor adapter to avoid the inconsistent between the different versions of Harbor

Signed-off-by: Wenkai Yin <yinw@vmware.com>