### PR TITLE
Fix make prepare problem

### DIFF
--- a/make/photon/prepare/utils/docker_compose.py
+++ b/make/photon/prepare/utils/docker_compose.py
@@ -25,8 +25,6 @@ def prepare_docker_compose(configs, with_clair, with_notary, with_chartmuseum):
         'chartmuseum_version': '{}-{}'.format(CHARTMUSEUM_VERSION, VERSION_TAG),
         'data_volume': configs['data_volume'],
         'log_location': configs['log_location'],
-        'cert_key_path': configs['cert_key_path'],
-        'cert_path': configs['cert_path'],
         'protocol': configs['protocol'],
         'http_port': configs['http_port'],
         'registry_custom_ca_bundle_path': configs['registry_custom_ca_bundle_path'],
@@ -40,5 +38,9 @@ def prepare_docker_compose(configs, with_clair, with_notary, with_chartmuseum):
         rendering_variables['gcs_keyfile'] = storage_config['keyfile']
     if configs.get('https_port'):
         rendering_variables['https_port'] = configs['https_port']
+
+    if configs['protocol'] == 'https':
+        rendering_variables['cert_key_path'] = configs['cert_key_path']
+        rendering_variables['cert_path'] = configs['cert_path']
 
     render_jinja(docker_compose_template_path, docker_compose_yml_path, **rendering_variables)


### PR DESCRIPTION
Signed-off-by: cd1989 <chende@caicloud.io>

Fix problem for `make prepare` error:

```
preparing...
host make path is set to /Users/xfoolish/Work/src/github.com/goharbor/harbor/make
cp: /data/cert/server.crt: No such file or directory
cp: /data/cert/server.key: No such file or directory

...

loaded secret from file: /secret/keys/secretkey
Traceback (most recent call last):
  File "main.py", line 70, in <module>
    main()
  File "/usr/lib/python3.6/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/usr/lib/python3.6/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/usr/lib/python3.6/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/lib/python3.6/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "main.py", line 67, in main
    prepare_docker_compose(config_dict, with_clair, with_notary, with_chartmuseum)
  File "/usr/src/app/utils/docker_compose.py", line 28, in prepare_docker_compose
    'cert_key_path': configs['cert_key_path'],
KeyError: 'cert_key_path'
```