### PR TITLE
Fix issue of oidc configuration save button is always disabled.

### DIFF
--- a/src/portal/src/app/config/auth/config-auth.component.ts
+++ b/src/portal/src/app/config/auth/config-auth.component.ts
@@ -149,6 +149,7 @@ export class ConfigurationAuthComponent implements OnChanges {
         for (let prop in allChanges) {
             if (prop.startsWith('ldap_')
                 || prop.startsWith('uaa_')
+                || prop.startsWith('oidc_')
                 || prop === 'auth_mode'
                 || prop === 'project_creattion_restriction'
                 || prop === 'self_registration'

--- a/src/portal/src/i18n/lang/en-us-lang.json
+++ b/src/portal/src/i18n/lang/en-us-lang.json
@@ -692,12 +692,12 @@
             "VERIFY_CERT": "Authentication Verify Cert"
         },
         "OIDC": {
-            "OIDC_PROVIDER": "OIDC provider",
+            "OIDC_PROVIDER": "OIDC Provider",
             "ENDPOINT": "OIDC Endpoint",
             "CLIENT_ID": "OIDC Client ID",
             "CLIENTSECRET": "OIDC Client Secret",
             "SCOPE": "OIDC Scope",
-            "OIDCSKIPCERTVERIFY": "OIDC Verify Cert",
+            "OIDCSKIPCERTVERIFY": "OIDC Skip Verifying Certificate",
             "OIDC_SETNAME": "Set OIDC Username",
             "OIDC_SETNAMECONTENT": "You must create a Harbor username the first time when authenticating via a third party(OIDC).This will be used within Harbor to be associated with projects, roles, etc.",
             "OIDC_USERNAME": "Username"

--- a/src/portal/src/i18n/lang/es-es-lang.json
+++ b/src/portal/src/i18n/lang/es-es-lang.json
@@ -696,7 +696,7 @@
             "CLIENT_ID": "ID de cliente OIDC",
             "CLIENTSECRET": "OIDC Client Secret",
             "SCOPE": "OIDC Ámbito",
-            "OIDCSKIPCERTVERIFY": "OIDC Verify Cert",
+            "OIDCSKIPCERTVERIFY": "OIDC Skip Verificar certificado",
             "OIDC_SETNAME": "Set OIDC nombre de usuario",
             "OIDC_SETNAMECONTENT": "Usted debe crear un Harbor nombre de usuario la primera vez cuando la autenticación a través de un tercero (OIDC). Esta será usada en Harbor para ser asociados con proyectos, funciones, etc.",
             "OIDC_USERNAME": "Usuario"

--- a/src/portal/src/i18n/lang/fr-fr-lang.json
+++ b/src/portal/src/i18n/lang/fr-fr-lang.json
@@ -656,12 +656,12 @@
             "VERIFY_CERT": "authentification vérifier cert"
         },
         "OIDC": {
-            "OIDC_PROVIDER": "OIDC fournisseur",
-            "ENDPOINT": "OIDC paramètre",
+            "OIDC_PROVIDER": "OIDC Fournisseur",
+            "ENDPOINT": "OIDC Faramètre",
             "CLIENT_ID": "no d'identification du client OIDC",
             "CLIENTSECRET": "OIDC Client Secret",
             "SCOPE": "OIDC Scope",
-            "OIDCSKIPCERTVERIFY": "OIDC vérifier cert",
+            "OIDCSKIPCERTVERIFY": "Certificat OIDC skip vérifier",
             "OIDC_SETNAME": "Ensemble OIDC nom d'utilisateur",
             "OIDC_SETNAMECONTENT": "vous devez créer un Harbor identifiant la première fois lors de la vérification par une tierce partie (oidc). il sera utilisé au sein de port à être associés aux projets, des rôles, etc.",
             "OIDC_USERNAME": "d'utilisateur"

--- a/src/portal/src/i18n/lang/pt-br-lang.json
+++ b/src/portal/src/i18n/lang/pt-br-lang.json
@@ -690,7 +690,7 @@
             "CLIENT_ID": "ID de cliente OIDC",
             "CLIENTSECRET": "OIDC Client Secret",
             "SCOPE": "Escopo OIDC",
-            "OIDCSKIPCERTVERIFY": "Verificar certificado OIDC",
+            "OIDCSKIPCERTVERIFY": "OIDC Skip Verificar Certificado",
             "OIDC_SETNAME": "Definir o Utilizador OIDC",
             "OIDC_SETNAMECONTENT": "Você deve Criar um Nome de usuário do Porto a primeira vez que autenticar através de um terceiro (OIDC). Isto será usado Dentro de Harbor para ser associado a projetos, papéis, etc.",
             "OIDC_USERNAME": "Utilizador"

--- a/src/portal/src/i18n/lang/zh-cn-lang.json
+++ b/src/portal/src/i18n/lang/zh-cn-lang.json
@@ -694,7 +694,7 @@
             "ENDPOINT": "OIDC Endpoint",
             "CLIENT_ID": "OIDC 客户端标识",
             "CLIENTSECRET": "OIDC 客户端密码",
-            "SCOPE": "OIDC scope",
+            "SCOPE": "OIDC Scope",
             "OIDCSKIPCERTVERIFY": "OIDC 验证证书",
             "OIDC_SETNAME": "设置OIDC用户名",
             "OIDC_SETNAMECONTENT": "在通过第三方（OIDC）进行身份验证时，您必须第一次创建一个Harbor用户名。这将在端口中用于与项目、角色等关联。",


### PR DESCRIPTION
Fix issue of oidc configuration save button is always disabled and incorrect character.
when we login Harbor width OIDC ,we cannot click the save  button of oidc config page