### PR TITLE
Use policy controller in registry deletion

### DIFF
--- a/src/core/main.go
+++ b/src/core/main.go
@@ -38,6 +38,7 @@ import (
 	"github.com/goharbor/harbor/src/core/filter"
 	"github.com/goharbor/harbor/src/core/proxy"
 	"github.com/goharbor/harbor/src/core/service/token"
+	"github.com/goharbor/harbor/src/replication/ng"
 )
 
 const (
@@ -129,8 +130,9 @@ func main() {
 		}
 	}
 
-	closing := make(chan struct{})
-	go gracefulShutdown(closing)
+	if err := ng.Init(); err != nil {
+		log.Fatalf("failed to initialize replication: %v", err)
+	}
 
 	filter.Init()
 	beego.InsertFilter("/*", beego.BeforeRouter, filter.SecurityFilter)

--- a/src/replication/ng/dao/policy_test.go
+++ b/src/replication/ng/dao/policy_test.go
@@ -3,9 +3,12 @@ package dao
 import (
 	"testing"
 
-	"github.com/goharbor/harbor/src/replication/ng/dao/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	common_models "github.com/goharbor/harbor/src/common/models"
+	"github.com/goharbor/harbor/src/replication/ng/dao/models"
+	"github.com/goharbor/harbor/src/replication/ng/model"
 )
 
 var (
@@ -84,34 +87,6 @@ func TestAddRepPolicy(t *testing.T) {
 	}
 }
 
-func TestGetTotalOfRepPolicies(t *testing.T) {
-	type args struct {
-		name      string
-		namespace string
-	}
-	tests := []struct {
-		name    string
-		args    args
-		want    int64
-		wantErr bool
-	}{
-		{name: "GetTotalOfRepPolicies 1", args: args{name: "Test 1"}, want: 1},
-		{name: "GetTotalOfRepPolicies 2", args: args{name: "Test"}, want: 3},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := GetTotalOfRepPolicies(tt.args.name, tt.args.namespace)
-			if tt.wantErr {
-				require.NotNil(t, err, "wantErr: %s", err)
-				return
-			}
-
-			require.Nil(t, err)
-			assert.Equal(t, tt.want, got)
-		})
-	}
-}
-
 func TestGetPolicies(t *testing.T) {
 	type args struct {
 		name      string
@@ -131,7 +106,16 @@ func TestGetPolicies(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotPolicies, err := GetPolicies(tt.args.name, tt.args.namespace, tt.args.page, tt.args.pageSize)
+			_, gotPolicies, err := GetPolicies([]*model.PolicyQuery{
+				{
+					Name:      tt.args.name,
+					Namespace: tt.args.namespace,
+					Pagination: common_models.Pagination{
+						Page: tt.args.page,
+						Size: tt.args.pageSize,
+					},
+				},
+			}...)
 			if tt.wantErr {
 				require.NotNil(t, err, "wantErr: %s", err)
 				return

--- a/src/replication/ng/model/policy.go
+++ b/src/replication/ng/model/policy.go
@@ -152,6 +152,8 @@ type PolicyQuery struct {
 	Name string
 	// TODO: need to consider how to support listing the policies
 	// of one namespace in both pull and push modes
-	Namespace string
+	Namespace    string
+	SrcRegistry  int64
+	DestRegistry int64
 	models.Pagination
 }

--- a/src/replication/ng/policy/manager/manager.go
+++ b/src/replication/ng/policy/manager/manager.go
@@ -156,25 +156,8 @@ func (m *DefaultManager) Create(policy *model.Policy) (int64, error) {
 
 // List returns all the policies
 func (m *DefaultManager) List(queries ...*model.PolicyQuery) (total int64, policies []*model.Policy, err error) {
-	// default query parameters
-	var name = ""
-	var namespace = ""
-	var page int64 = 1
-	var pageSize int64 = 15
-
-	if len(queries) > 0 {
-		name = queries[0].Name
-		namespace = queries[0].Namespace
-		page = queries[0].Pagination.Page
-		pageSize = queries[0].Pagination.Size
-	}
-
 	var persistPolicies []*persist_models.RepPolicy
-	persistPolicies, err = dao.GetPolicies(name, namespace, page, pageSize)
-	if err != nil {
-		return
-	}
-	total, err = dao.GetTotalOfRepPolicies(name, namespace)
+	total, persistPolicies, err = dao.GetPolicies(queries...)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
Signed-off-by: cd1989 <chende@caicloud.io>

Use policy controller to get policies when delete registry.

And also refactor the GetPolicies method.