### PR TITLE
Add a checkpoint in the end of key word <Add Guest Member To Project>

### DIFF
--- a/tests/resources/Harbor-Pages/Project-Members.robot
+++ b/tests/resources/Harbor-Pages/Project-Members.robot
@@ -96,9 +96,7 @@ Add Guest Member To Project
     #select guest
     Mouse Down  xpath=${project_member_guest_radio_checkbox}
     Mouse Up  xpath=${project_member_guest_radio_checkbox}
-    Retry Button Click  xpath=${project_member_add_confirmation_ok_xpath}
-    Retry Wait Element  xpath=${project_member_xpath}
-    Sleep  1
+    Retry Double Keywords When Error  Retry Element Click  xpath=${project_member_add_confirmation_ok_xpath}  Retry Wait Until Page Not Contains Element  xpath=${project_member_add_confirmation_ok_xpath}
 
 Delete Project Member
     [arguments]  ${member}

--- a/tests/resources/Util.robot
+++ b/tests/resources/Util.robot
@@ -176,7 +176,7 @@ Retry Keyword When Error
 Retry Double Keywords When Error
     [Arguments]  ${keyword1}  ${element1}  ${keyword2}  ${element2}
     :For  ${n}  IN RANGE  1  6
-    \    Log To Console  Trying Delete Repo ${n} times ...
+    \    Log To Console  Trying ${keyword1} and ${keyword2} ${n} times ...
     \    ${out1}  Run Keyword And Ignore Error  ${keyword1}  ${element1}
     \    Capture Page Screenshot
     \    ${out2}  Run Keyword And Ignore Error  ${keyword2}  ${element2}


### PR DESCRIPTION
Add a checkpoint in the end of key word <Add Guest Member To Project>, to make sure that the confirm button was click successfully, to see if this confirm button was dissappered after clicked.

Signed-off-by: danfengliu <danfengl@vmware.com>