### PR TITLE
Add wait and retry in keywords of ToolKit.robot

### DIFF
--- a/tests/resources/Harbor-Pages/Public_Elements.robot
+++ b/tests/resources/Harbor-Pages/Public_Elements.robot
@@ -1,0 +1,21 @@
+# Copyright Project Harbor Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+*** Settings ***
+Documentation  This resource provides any keywords related to public
+
+*** Variables ***
+${delete_btn}  //clr-modal//button[contains(.,'DELETE')]
+${delete_btn_2}  //button[contains(.,'Delete')]
+

--- a/tests/resources/Harbor-Pages/ToolKit.robot
+++ b/tests/resources/Harbor-Pages/ToolKit.robot
@@ -67,34 +67,27 @@ Multi-delete Object
 Multi-delete User
     [Arguments]    @{obj}
     :For  ${obj}  in  @{obj}
-    \    Click Element  //clr-dg-row[contains(.,'${obj}')]//label
-    Sleep  1
-    Click Element  ${member_action_xpath}
-    Sleep  1
-    Click Element  //clr-dropdown/clr-dropdown-menu/button[2]
-    Sleep  2
-    Click Element  //clr-modal//button[contains(.,'DELETE')]
-    Sleep  3
+    \    Retry Element Click  //clr-dg-row[contains(.,'${obj}')]//label
+    Retry Element Click  ${member_action_xpath}
+    Retry Element Click  //clr-dropdown/clr-dropdown-menu/button[2]
+    Retry Double Keywords When Error  Retry Element Click  ${delete_btn}  Retry Wait Until Page Not Contains Element  ${delete_btn}
+
 
 Multi-delete Member
     [Arguments]    @{obj}
     :For  ${obj}  in  @{obj}
-    \    Click Element  //clr-dg-row[contains(.,'${obj}')]//label
-    Sleep  1
-    Click Element  ${member_action_xpath}
-    Sleep  1
-    Click Element  ${delete_action_xpath}
-    Sleep  2
-    Click Element  //clr-modal//button[contains(.,'DELETE')]
-    Sleep  3
+    \    Retry Element Click  //clr-dg-row[contains(.,'${obj}')]//label
+    Retry Element Click  ${member_action_xpath}
+    Retry Element Click  ${delete_action_xpath}
+    Retry Double Keywords When Error  Retry Element Click  ${delete_btn}  Retry Wait Until Page Not Contains Element  ${delete_btn}
+
 
 Multi-delete Object Without Confirmation
     [Arguments]    @{obj}
     :For  ${obj}  in  @{obj}
-    \    Click Element  //clr-dg-row[contains(.,'${obj}')]//label
-    Sleep  1
-    Click Element  //button[contains(.,'Delete')]
-    Sleep  3
+    \    Retry Element Click  //clr-dg-row[contains(.,'${obj}')]//label
+    Retry Double Keywords When Error  Retry Element Click  ${delete_btn_2}  Retry Wait Until Page Not Contains Element  ${delete_btn_2}
+
 
 Select All On Current Page Object
-    Click Element  //div[@class='datagrid-head']//label
+    Retry Element Click  //div[@class='datagrid-head']//label

--- a/tests/resources/Util.robot
+++ b/tests/resources/Util.robot
@@ -28,6 +28,7 @@ Resource  VCH-Util.robot
 Resource  Drone-Util.robot
 Resource  Github-Util.robot
 Resource  Harbor-Util.robot
+Resource  Harbor-Pages/Public_Elements.robot
 Resource  Harbor-Pages/HomePage.robot
 Resource  Harbor-Pages/HomePage_Elements.robot
 Resource  Harbor-Pages/Project.robot


### PR DESCRIPTION
Many keywords in ToolKit.robot miss wait or retry when operating elements, and it has cause test case failure one time, so I modify all keywords in ToolKit.robot.

Signed-off-by: danfengliu <danfengl@vmware.com>