### PR TITLE
Add Cli secret in Harbor user profile

### DIFF
--- a/src/portal/src/app/account/account-settings/account-settings-modal.component.html
+++ b/src/portal/src/app/account/account-settings/account-settings-modal.component.html
@@ -51,6 +51,19 @@
                     </span>
                     </label>
                 </div>
+                <div class="form-group form-group-override" *ngIf="account.oidc_user_meta">
+                    <label for="cli_password" aria-haspopup="true" class="form-group-label-override"><span class="label-inner-text">{{'PROFILE.CLI_PASSWORD' | translate}}</span>
+                        <clr-tooltip>
+                            <clr-icon clrTooltipTrigger shape="info-circle" size="20"></clr-icon>
+                            <clr-tooltip-content clrPosition="top-right" clrSize="md" *clrIfOpen>
+                                <span> {{'PROFILE.CLI_PASSWORD_TIP' | translate}}</span>
+                            </clr-tooltip-content>
+                        </clr-tooltip></label>
+                    <input type="password" name="cli_password" disabled [ngModel]="'account.oidc_user_meta.secret'" size="33">
+                    <div class="rename-tool">
+                        <hbr-copy-input #copyInput (onCopySuccess)="onSuccess($event)" (onCopyError)="onCpError($event)"  iconMode="true" defaultValue="{{account.oidc_user_meta.secret}}"></hbr-copy-input>
+                    </div>
+                </div>
             </section>
         </form>
     </div>

--- a/src/portal/src/app/account/account-settings/account-settings-modal.component.scss
+++ b/src/portal/src/app/account/account-settings/account-settings-modal.component.scss
@@ -11,4 +11,7 @@ clr-modal {
     position: relative;
     bottom: 9px;
     }
+    .label-inner-text{
+        margin: 0;
+    }
 }

--- a/src/portal/src/app/account/account-settings/account-settings-modal.component.ts
+++ b/src/portal/src/app/account/account-settings/account-settings-modal.component.ts
@@ -22,7 +22,7 @@ import { InlineAlertComponent } from "../../shared/inline-alert/inline-alert.com
 import { MessageHandlerService } from "../../shared/message-handler/message-handler.service";
 import { SearchTriggerService } from "../../base/global-search/search-trigger.service";
 import { CommonRoutes } from "../../shared/shared.const";
-
+import { CopyInputComponent } from "@harbor/ui";
 @Component({
   selector: "account-settings-modal",
   templateUrl: "account-settings-modal.component.html",
@@ -48,6 +48,7 @@ export class AccountSettingsModalComponent implements OnInit, AfterViewChecked {
   accountFormRef: NgForm;
   @ViewChild("accountSettingsFrom") accountForm: NgForm;
   @ViewChild(InlineAlertComponent) inlineAlert: InlineAlertComponent;
+  @ViewChild("copyInput") copyInput: CopyInputComponent;
 
   constructor(
     private session: SessionService,
@@ -319,5 +320,11 @@ export class AccountSettingsModalComponent implements OnInit, AfterViewChecked {
     }
     this.inlineAlert.close();
     this.opened = false;
+  }
+  onSuccess(event) {
+    this.inlineAlert.showInlineSuccess({message: 'PROFILE.COPY_SUCCESS'});
+  }
+  onError(event) {
+    this.inlineAlert.showInlineError({message: 'PROFILE.COPY_ERROR'});
   }
 }

--- a/src/portal/src/app/shared/session-user.ts
+++ b/src/portal/src/app/shared/session-user.ts
@@ -21,4 +21,13 @@ export class SessionUser {
     role_id?: number;
     has_admin_role?: boolean;
     comment: string;
+    oidc_user_meta?: OidcUserMeta;
+}
+export class OidcUserMeta {
+    id: number;
+    user_id: number;
+    secret: string;
+    subiss: string;
+    creation_time: Date;
+    update_time: Date;
 }

--- a/src/portal/src/i18n/lang/en-us-lang.json
+++ b/src/portal/src/i18n/lang/en-us-lang.json
@@ -101,7 +101,11 @@
         "ADMIN_RENAME_BUTTON": "Change username",
         "ADMIN_RENAME_TIP": "Select the button in order to change the username to \"admin@harbor.local\". This operation can not be undone.",
         "RENAME_SUCCESS": "Rename success!",
-        "RENAME_CONFIRM_INFO": "Warning, changing the name to admin@harbor.local can not be undone."
+        "RENAME_CONFIRM_INFO": "Warning, changing the name to admin@harbor.local can not be undone.",
+        "CLI_PASSWORD": "CLI secret",
+        "CLI_PASSWORD_TIP": "You can use this cli secret as password when using docker/helm cli to access Harbor.",
+        "COPY_SUCCESS": "copy success",
+        "COPY_ERROR": "copy failed"
     },
     "CHANGE_PWD": {
         "TITLE": "Change Password",

--- a/src/portal/src/i18n/lang/es-es-lang.json
+++ b/src/portal/src/i18n/lang/es-es-lang.json
@@ -101,7 +101,11 @@
         "ADMIN_RENAME_BUTTON": "Change username",
         "ADMIN_RENAME_TIP": "Select the button in order to change the username to \"admin@harbor.local\". This operation can not be undone.",
         "RENAME_SUCCESS": "Rename success!",
-        "RENAME_CONFIRM_INFO": "Warning, changing the name to admin@harbor.local can not be undone."
+        "RENAME_CONFIRM_INFO": "Warning, changing the name to admin@harbor.local can not be undone.",
+        "CLI_PASSWORD": "CLI secreto",
+        "CLI_PASSWORD_TIP": "Puede utilizar este generador CLI secreto como utilizando Docker / Helm CLI para acceder a puerto.",
+        "COPY_SUCCESS": "Copiar el éxito",
+        "COPY_ERROR": "Copia no"
     },
     "CHANGE_PWD": {
         "TITLE": "Cambiar contraseña",

--- a/src/portal/src/i18n/lang/fr-fr-lang.json
+++ b/src/portal/src/i18n/lang/fr-fr-lang.json
@@ -88,7 +88,11 @@
         "ADMIN_RENAME_BUTTON": "Change username",
         "ADMIN_RENAME_TIP": "Select the button in order to change the username to \"admin@harbor.local\". This operation can not be undone.",
         "RENAME_SUCCESS": "Rename success!",
-        "RENAME_CONFIRM_INFO": "Warning, changing the name to admin@harbor.local can not be undone."
+        "RENAME_CONFIRM_INFO": "Warning, changing the name to admin@harbor.local can not be undone.",
+        "CLI_PASSWORD": "CLI secret",
+        "CLI_PASSWORD_TIP": "vous pouvez utiliser ce cli secret comme mot de passe quand utiliser docker / barre l'accès à harbor.",
+        "COPY_SUCCESS": "copie de succès",
+        "COPY_ERROR": "copie a échoué"
     },
     "CHANGE_PWD": {
         "TITLE": "Modifier le mot de passe",

--- a/src/portal/src/i18n/lang/pt-br-lang.json
+++ b/src/portal/src/i18n/lang/pt-br-lang.json
@@ -99,7 +99,11 @@
         "ADMIN_RENAME_BUTTON": "Alterar nome de usuário",
         "ADMIN_RENAME_TIP": "Selecione o botão para alterar o nome de usuário para \"admin@harbor.local\". Essa operação não pode ser desfeita.",
         "RENAME_SUCCESS": "Renomeado com sucesso!",
-        "RENAME_CONFIRM_INFO": "Atenção, alterar o nome para admin@harbor.local não pode ser desfeito."
+        "RENAME_CONFIRM_INFO": "Atenção, alterar o nome para admin@harbor.local não pode ser desfeito.",
+        "CLI_PASSWORD": "Segredo CLI",
+        "CLI_PASSWORD_TIP": "Você Pode USAR este Segredo de clitóris Como senha Ao USAR clitóris de estivador /leme para acessar Harbor.",
+        "COPY_SUCCESS": "SUCESSO de cópia",
+        "COPY_ERROR": "Cópia falhou"
     },
     "CHANGE_PWD": {
         "TITLE": "Alterar Senha",

--- a/src/portal/src/i18n/lang/zh-cn-lang.json
+++ b/src/portal/src/i18n/lang/zh-cn-lang.json
@@ -100,7 +100,11 @@
         "ADMIN_RENAME_TIP": "单击将用户名改为 \"admin@harbor.local\", 注意这个操作是无法撤销的",
         "RENAME_SUCCESS": "用户名更改成功！",
         "ADMIN_RENAME_BUTTON": "更改用户名",
-        "RENAME_CONFIRM_INFO": "更改用户名为admin@harbor.local是无法撤销的, 你确定更改吗?"
+        "RENAME_CONFIRM_INFO": "更改用户名为admin@harbor.local是无法撤销的, 你确定更改吗?",
+        "CLI_PASSWORD": "CLI密码",
+        "CLI_PASSWORD_TIP": "使用docker/helm cli访问Harbor时，可以使用此cli密码作为密码。",
+        "COPY_SUCCESS": "复制成功",
+        "COPY_ERROR": "复制失败"
     },
     "CHANGE_PWD": {
         "TITLE": "修改密码",


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/29826789/55931656-fb081880-5c58-11e9-87dc-b9d3411a6543.png)

user could copy the CLI secret when login through oidc, and using this cli secret as password when using docker/helm cli to access Harbor.
Signed-off-by: Yogi_Wang <yawang@vmware.com>