### PR TITLE
Add Token Review Endpoint in configuration page

### DIFF
--- a/src/portal/lib/src/config/config.ts
+++ b/src/portal/lib/src/config/config.ts
@@ -89,6 +89,7 @@ export class Configuration {
     scan_all_policy: ComplexValueItem;
     read_only: BoolValueItem;
     http_authproxy_endpoint?: StringValueItem;
+    http_authproxy_tokenreview_endpoint?: StringValueItem;
     http_authproxy_skip_cert_verify?: BoolValueItem;
     http_authproxy_always_onboard?: BoolValueItem;
     oidc_name?: StringValueItem;
@@ -139,6 +140,7 @@ export class Configuration {
         }, true);
         this.read_only = new BoolValueItem(false, true);
         this.http_authproxy_endpoint = new StringValueItem("", true);
+        this.http_authproxy_tokenreview_endpoint = new StringValueItem("", true);
         this.http_authproxy_skip_cert_verify = new BoolValueItem(false, true);
         this.http_authproxy_always_onboard = new BoolValueItem(false, true);
         this.oidc_name = new StringValueItem('', true);

--- a/src/portal/src/app/config/auth/config-auth.component.html
+++ b/src/portal/src/app/config/auth/config-auth.component.html
@@ -287,6 +287,19 @@
             </label>
         </div>
         <div class="form-group">
+            <label for="http_authproxy_tokenreview_endpoint" class="required">{{'CONFIG.HTTP_AUTH.TOKEN_REVIEW' | translate}}</label>
+            <label for="http_authproxy_tokenreview_endpoint" aria-haspopup="true" role="tooltip"
+                class="tooltip tooltip-validation tooltip-md tooltip-top-right"
+                [class.invalid]="httpAuthproxyTokenReviewInput.invalid && (httpAuthproxyTokenReviewInput.dirty || httpAuthproxyTokenReviewInput.touched)">
+                <input type="text" #httpAuthproxyTokenReviewInput="ngModel" pattern="^([hH][tT]{2}[pP]:\/\/|[hH][tT]{2}[pP][sS]:\/\/)(.*?)*$"
+                 required id="http_authproxy_tokenreview_endpoint" name="http_authproxy_tokenreview_endpoint" size="35"
+                 [(ngModel)]="currentConfig.http_authproxy_tokenreview_endpoint.value" [disabled]="!currentConfig.http_authproxy_tokenreview_endpoint.editable">
+                <span class="tooltip-content">
+                    {{'TOOLTIP.ENDPOINT_FORMAT' | translate}}
+                </span>
+            </label>
+        </div>
+        <div class="form-group">
             <label for="http_authproxy_skip_cert_verify"
                 class="required">{{'CONFIG.HTTP_AUTH.VERIFY_CERT' | translate}}</label>
             <clr-checkbox-wrapper>

--- a/src/portal/src/app/config/auth/config-auth.component.ts
+++ b/src/portal/src/app/config/auth/config-auth.component.ts
@@ -53,7 +53,6 @@ export class ConfigurationAuthComponent implements OnChanges {
 
     ngOnChanges(changes: SimpleChanges): void {
         if (changes && changes["currentConfig"]) {
-
             this.originalConfig = clone(this.currentConfig);
 
         }
@@ -153,9 +152,7 @@ export class ConfigurationAuthComponent implements OnChanges {
                 || prop === 'auth_mode'
                 || prop === 'project_creattion_restriction'
                 || prop === 'self_registration'
-                || prop === 'http_authproxy_endpoint'
-                || prop === 'http_authproxy_skip_cert_verify'
-                || prop === 'http_authproxy_always_onboard'
+                || prop.startsWith('http_')
             ) {
                 changes[prop] = allChanges[prop];
             }

--- a/src/portal/src/i18n/lang/en-us-lang.json
+++ b/src/portal/src/i18n/lang/en-us-lang.json
@@ -73,8 +73,8 @@
         "EMPTY": "Name is required",
         "NONEMPTY": "Can't be empty",
         "REPO_TOOLTIP": "Users can not do any operations to the images in this mode.",
-        "ENDPOINT_FORMAT": "Endpoint must start with HTTP or HTTPS.",
-        "OIDC_ENDPOIT_FORMAT": "Endpoint must start with HTTPS.",
+        "ENDPOINT_FORMAT": "Endpoint must start with HTTP:// or HTTPS://.",
+        "OIDC_ENDPOIT_FORMAT": "Endpoint must start with HTTPS://.",
         "OIDC_NAME": "The name of the OIDC provider.",
         "OIDC_ENDPOINT": "The URL of an OIDC-complaint server.",
         "OIDC_SCOPE": "The scope sent to OIDC server during authentication.  It has to contain “openid”, and “offline_access”.  If you are using google, please remove “offline_access” from this field.",
@@ -696,6 +696,7 @@
         },
         "HTTP_AUTH": {
             "ENDPOINT": "Server Endpoint",
+            "TOKEN_REVIEW": "Token Review Endpoint",
             "ALWAYS_ONBOARD": "Always Onboard",
             "VERIFY_CERT": "Authentication Verify Cert"
         },

--- a/src/portal/src/i18n/lang/es-es-lang.json
+++ b/src/portal/src/i18n/lang/es-es-lang.json
@@ -73,8 +73,8 @@
         "EMPTY": "Name is required",
         "NONEMPTY": "Can't be empty",
         "REPO_TOOLTIP": "Users can not do any operations to the images in this mode.",
-        "ENDPOINT_FORMAT": "Endpoint must start with HTTP or HTTPS.",
-        "OIDC_ENDPOIT_FORMAT": "Endpoint must start with HTTPS.",
+        "ENDPOINT_FORMAT": "Endpoint must start with HTTP:// or HTTPS://.",
+        "OIDC_ENDPOIT_FORMAT": "Endpoint must start with HTTPS://.",
         "OIDC_NAME": "El nombre de la OIDC proveedor.",
         "OIDC_ENDPOINT": "La dirección URL de un servidor OIDC denuncia.",
         "OIDC_SCOPE": "El ámbito de aplicación enviada a OIDC Server durante la autenticación.Tiene que contener 'Openid', y 'offline_access'.Si usted esta usando Google, por favor quitar 'offline_access' de este campo",
@@ -694,6 +694,7 @@
         },
         "HTTP_AUTH": {
             "ENDPOINT": "Server Endpoint",
+            "TOKEN_REVIEW": "Review Endpoint De Token",
             "ALWAYS_ONBOARD": "Always Onboard",
             "VERIFY_CERT": "Authentication Verify Cert"
         },

--- a/src/portal/src/i18n/lang/fr-fr-lang.json
+++ b/src/portal/src/i18n/lang/fr-fr-lang.json
@@ -60,8 +60,8 @@
         "USER_EXISTING": "Le nom d'utilisateur est déjà utilisé.",
         "NONEMPTY": "Can't be empty",
         "REPO_TOOLTIP": "Users can not do any operations to the images in this mode.",
-        "ENDPOINT_FORMAT": "Endpoint must start with HTTP or HTTPS.",
-        "OIDC_ENDPOIT_FORMAT": "Endpoint must start with HTTPS.",
+        "ENDPOINT_FORMAT": "Endpoint must start with HTTP:// or HTTPS://.",
+        "OIDC_ENDPOIT_FORMAT": "Endpoint must start with HTTPS://.",
         "OIDC_NAME": "le nom du fournisseur de oidc.",
         "OIDC_ENDPOINT": "l'url d'un serveur oidc plainte.",
         "OIDC_SCOPE": "le champ envoyés au serveur au cours oidc l'authentification.il doit contenir 'openid', et 'offline_access'.si vous utilisez google, veuillez supprimer 'offline_access' dans ce domaine",
@@ -659,7 +659,8 @@
         },
         "HTTP_AUTH": {
             "ENDPOINT": "serveur paramètre",
-            "ALWAYS_ONBOARD": "Always Onboard",
+            "TOKEN_REVIEW": "examen symbolique paramètre",
+            "ALWAYS_ONBOARD": "always onboard",
             "VERIFY_CERT": "authentification vérifier cert"
         },
         "OIDC": {

--- a/src/portal/src/i18n/lang/pt-br-lang.json
+++ b/src/portal/src/i18n/lang/pt-br-lang.json
@@ -71,8 +71,8 @@
         "USER_EXISTING": "Nome de usuário já está em uso.",
         "RULE_USER_EXISTING": "Nome já em uso.",
         "EMPTY": "Nome é obrigatório",
-        "ENDPOINT_FORMAT": "Avaliação deve começar por HTTP Ou HTTPS.",
-        "OIDC_ENDPOIT_FORMAT": "Avaliação deve começar por HTTPS.",
+        "ENDPOINT_FORMAT": "Avaliação deve começar por HTTP:// Ou HTTPS://.",
+        "OIDC_ENDPOIT_FORMAT": "Avaliação deve começar por HTTPS://.",
         "OIDC_NAME": "O Nome do prestador de oidc.",
         "OIDC_ENDPOINT": "A URL de um servidor oidc denúncia.",
         "OIDC_SCOPE": "O âmbito de aplicação enviada Ao servidor oidc Durante a autenticação.TEM que conter 'openid' e 'offline_access'.Se você está usando o Google, por favor remova 'offline_access' desse Campo.",
@@ -687,7 +687,8 @@
             "VERIFY_CERT": "Verificar certificado UAA"
         },
         "HTTP_AUTH": {
-            "ENDPOINT": "server endpoint",
+            "ENDPOINT": "Server endpoint",
+            "TOKEN_REVIEW": "Ponto final do Token Review",
             "ALWAYS_ONBOARD": "Sempre Onboard",
             "VERIFY_CERT": "Verificar certificado de Authentication"
         },

--- a/src/portal/src/i18n/lang/zh-cn-lang.json
+++ b/src/portal/src/i18n/lang/zh-cn-lang.json
@@ -72,8 +72,8 @@
         "RULE_USER_EXISTING": "名称已经存在。",
         "EMPTY": "名称为必填项",
         "NONEMPTY": "不能为空",
-        "ENDPOINT_FORMAT": "Endpoint必须以http或https开头。",
-        "OIDC_ENDPOIT_FORMAT": "Endpoint必须以https开头。",
+        "ENDPOINT_FORMAT": "Endpoint必须以http://或https://开头。",
+        "OIDC_ENDPOIT_FORMAT": "Endpoint必须以https://开头。",
         "OIDC_NAME": "OIDC提供商的名称.",
         "OIDC_ENDPOINT": "OIDC服务器的地址.",
         "OIDC_SCOPE": "在身份验证期间发送到OIDC服务器的scope。它必须包含“openid”和“offline_access”。如果您使用Google，请从此字段中删除“脱机访问”。",
@@ -693,6 +693,7 @@
         },
         "HTTP_AUTH": {
             "ENDPOINT": "Server Endpoint",
+            "TOKEN_REVIEW": "Token Review Endpoint",
             "ALWAYS_ONBOARD": "Always Onboard",
             "VERIFY_CERT": "Authentication验证证书"
         },


### PR DESCRIPTION
adding token review endpoint to the configuration page allows users to edit token review endpoint when logging in through http auth.
![image](https://user-images.githubusercontent.com/29826789/56017250-48f04f80-5d31-11e9-869a-8a45fbd154af.png)

Signed-off-by: Yogi_Wang <yawang@vmware.com>