### PR TITLE
Fix: grep https not work

### DIFF
--- a/make/install.sh
+++ b/make/install.sh
@@ -192,7 +192,7 @@ docker-compose up -d
 protocol=http
 hostname=reg.mydomain.com
 
-if [ -n "$(grep '^[^#]*https:' ./harbor.yml)"]
+if [ -n "$(grep '^[^#]*https:' ./harbor.yml)" ]
 then
 protocol=https
 fi


### PR DESCRIPTION
Add space before right braket

Signed-off-by: Qian Deng <dengq@vmware.com>