### PR TITLE
Handle OIDC user invalidation from OIDC provider.

### DIFF
--- a/src/common/utils/oidc/helper.go
+++ b/src/common/utils/oidc/helper.go
@@ -113,7 +113,7 @@ var insecureTransport = &http.Transport{
 
 // Token wraps the attributes of a oauth2 token plus the attribute of ID token
 type Token struct {
-	*oauth2.Token
+	oauth2.Token
 	IDToken string `json:"id_token"`
 }
 
@@ -167,7 +167,7 @@ func ExchangeToken(ctx context.Context, code string) (*Token, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Token{Token: oauthToken, IDToken: oauthToken.Extra("id_token").(string)}, nil
+	return &Token{Token: *oauthToken, IDToken: oauthToken.Extra("id_token").(string)}, nil
 }
 
 // VerifyToken verifies the ID token based on the OIDC settings
@@ -203,10 +203,10 @@ func RefreshToken(ctx context.Context, token *Token) (*Token, error) {
 	}
 	setting := provider.setting.Load().(models.OIDCSetting)
 	ctx = clientCtx(ctx, setting.VerifyCert)
-	ts := oauth.TokenSource(ctx, token.Token)
+	ts := oauth.TokenSource(ctx, &token.Token)
 	t, err := ts.Token()
 	if err != nil {
 		return nil, err
 	}
-	return &Token{Token: t, IDToken: t.Extra("id_token").(string)}, nil
+	return &Token{Token: *t, IDToken: t.Extra("id_token").(string)}, nil
 }

--- a/src/common/utils/oidc/testutils.go
+++ b/src/common/utils/oidc/testutils.go
@@ -1,6 +1,9 @@
 package oidc
 
-import "context"
+import (
+	"context"
+	"github.com/goharbor/harbor/src/common/models"
+)
 import "errors"
 
 // This is for testing only
@@ -8,14 +11,14 @@ type fakeVerifier struct {
 	secret string
 }
 
-func (fv *fakeVerifier) SetSecret(uid int, s string, t *Token) error {
-	return nil
-}
-
 func (fv *fakeVerifier) VerifySecret(ctx context.Context, userID int, secret string) error {
 	if secret != fv.secret {
 		return verifyError(errors.New("mismatch"))
 	}
+	return nil
+}
+
+func (fv *fakeVerifier) VerifyToken(ctx context.Context, u *models.OIDCUser) error {
 	return nil
 }
 


### PR DESCRIPTION
Ths commmit ensures that when user's token is invalidated OIDC provider, he
cannot access protected resource in Harbor with the user info in his session.
We share the code path with secret verification b/c the refresh token
can be used only once, so it has to be stored in one place.

Signed-off-by: Daniel Jiang <jiangd@vmware.com>