### PR TITLE
Update the PrepareForPush method

### DIFF
--- a/src/replication/adapter/adapter.go
+++ b/src/replication/adapter/adapter.go
@@ -30,9 +30,9 @@ type Factory func(*model.Registry) (Adapter, error)
 type Adapter interface {
 	// Info return the information of this adapter
 	Info() (*model.RegistryInfo, error)
-	// PrepareForPush does the prepare work that needed for pushing/uploading the resource
+	// PrepareForPush does the prepare work that needed for pushing/uploading the resources
 	// eg: create the namespace or repository
-	PrepareForPush(*model.Resource) error
+	PrepareForPush([]*model.Resource) error
 	// HealthCheck checks health status of registry
 	HealthCheck() (model.HealthStatus, error)
 }

--- a/src/replication/adapter/harbor/adapter_test.go
+++ b/src/replication/adapter/harbor/adapter_test.go
@@ -87,31 +87,42 @@ func TestPrepareForPush(t *testing.T) {
 	adapter, err := newAdapter(registry)
 	require.Nil(t, err)
 	// nil resource
-	err = adapter.PrepareForPush(nil)
+	err = adapter.PrepareForPush([]*model.Resource{nil})
 	require.NotNil(t, err)
 	// nil metadata
-	err = adapter.PrepareForPush(&model.Resource{})
+	err = adapter.PrepareForPush([]*model.Resource{
+		{},
+	})
 	require.NotNil(t, err)
 	// nil repository
-	err = adapter.PrepareForPush(&model.Resource{
-		Metadata: &model.ResourceMetadata{},
-	})
+	err = adapter.PrepareForPush(
+		[]*model.Resource{
+			{
+				Metadata: &model.ResourceMetadata{},
+			},
+		})
 	require.NotNil(t, err)
 	// nil repository name
-	err = adapter.PrepareForPush(&model.Resource{
-		Metadata: &model.ResourceMetadata{
-			Repository: &model.Repository{},
-		},
-	})
+	err = adapter.PrepareForPush(
+		[]*model.Resource{
+			{
+				Metadata: &model.ResourceMetadata{
+					Repository: &model.Repository{},
+				},
+			},
+		})
 	require.NotNil(t, err)
 	// project doesn't exist
-	err = adapter.PrepareForPush(&model.Resource{
-		Metadata: &model.ResourceMetadata{
-			Repository: &model.Repository{
-				Name: "library/hello-world",
+	err = adapter.PrepareForPush(
+		[]*model.Resource{
+			{
+				Metadata: &model.ResourceMetadata{
+					Repository: &model.Repository{
+						Name: "library/hello-world",
+					},
+				},
 			},
-		},
-	})
+		})
 	require.Nil(t, err)
 
 	server.Close()
@@ -129,12 +140,15 @@ func TestPrepareForPush(t *testing.T) {
 	}
 	adapter, err = newAdapter(registry)
 	require.Nil(t, err)
-	err = adapter.PrepareForPush(&model.Resource{
-		Metadata: &model.ResourceMetadata{
-			Repository: &model.Repository{
-				Name: "library/hello-world",
+	err = adapter.PrepareForPush(
+		[]*model.Resource{
+			{
+				Metadata: &model.ResourceMetadata{
+					Repository: &model.Repository{
+						Name: "library/hello-world",
+					},
+				},
 			},
-		},
-	})
+		})
 	require.Nil(t, err)
 }

--- a/src/replication/adapter/huawei/huawei_adapter_test.go
+++ b/src/replication/adapter/huawei/huawei_adapter_test.go
@@ -49,7 +49,7 @@ func TestAdapter_PrepareForPush(t *testing.T) {
 		Repository: repository,
 	}
 	resource.Metadata = metadata
-	err := hwAdapter.PrepareForPush(resource)
+	err := hwAdapter.PrepareForPush([]*model.Resource{resource})
 	if err != nil {
 		if strings.HasPrefix(err.Error(), "[401]") {
 			t.Log("huawei ak/sk is not available", err.Error())

--- a/src/replication/adapter/native/adapter.go
+++ b/src/replication/adapter/native/adapter.go
@@ -74,4 +74,4 @@ func (native) Info() (info *model.RegistryInfo, err error) {
 }
 
 // PrepareForPush nothing need to do.
-func (native) PrepareForPush(*model.Resource) error { return nil }
+func (native) PrepareForPush([]*model.Resource) error { return nil }

--- a/src/replication/operation/controller_test.go
+++ b/src/replication/operation/controller_test.go
@@ -130,7 +130,7 @@ func (f *fakedAdapter) Info() (*model.RegistryInfo, error) {
 	}, nil
 }
 
-func (f *fakedAdapter) PrepareForPush(*model.Resource) error {
+func (f *fakedAdapter) PrepareForPush([]*model.Resource) error {
 	return nil
 }
 func (f *fakedAdapter) HealthCheck() (model.HealthStatus, error) {

--- a/src/replication/operation/flow/stage.go
+++ b/src/replication/operation/flow/stage.go
@@ -209,14 +209,10 @@ func assembleDestinationResources(resources []*model.Resource,
 
 // do the prepare work for pushing/uploading the resources: create the namespace or repository
 func prepareForPush(adapter adp.Adapter, resources []*model.Resource) error {
-	// TODO need to consider how to handle that both contains public/private namespace
-	for _, resource := range resources {
-		name := resource.Metadata.Repository.Name
-		if err := adapter.PrepareForPush(resource); err != nil {
-			return fmt.Errorf("failed to do the prepare work for pushing/uploading %s: %v", name, err)
-		}
-		log.Debugf("the prepare work for pushing/uploading %s completed", name)
+	if err := adapter.PrepareForPush(resources); err != nil {
+		return fmt.Errorf("failed to do the prepare work for pushing/uploading resources: %v", err)
 	}
+	log.Debug("the prepare work for pushing/uploading resources completed")
 	return nil
 }
 

--- a/src/replication/operation/flow/stage_test.go
+++ b/src/replication/operation/flow/stage_test.go
@@ -46,7 +46,7 @@ func (f *fakedAdapter) Info() (*model.RegistryInfo, error) {
 	}, nil
 }
 
-func (f *fakedAdapter) PrepareForPush(*model.Resource) error {
+func (f *fakedAdapter) PrepareForPush([]*model.Resource) error {
 	return nil
 }
 func (f *fakedAdapter) HealthCheck() (model.HealthStatus, error) {


### PR DESCRIPTION
Update the PrepareForPush method to avoid the useless API callings to create namespaces

Signed-off-by: Wenkai Yin <yinw@vmware.com>