### PR TITLE
Fix cron input box and select box not in one line

### DIFF
--- a/src/portal/lib/src/cron-schedule/cron-schedule.component.html
+++ b/src/portal/lib/src/cron-schedule/cron-schedule.component.html
@@ -33,7 +33,7 @@
     </select>
   </div>
   <span [hidden]="scheduleType!==SCHEDULE_TYPE.CUSTOM">{{ "SCHEDULE.CRON" | translate }} :</span>
-  <div [hidden]="scheduleType!==SCHEDULE_TYPE.CUSTOM">
+  <div [hidden]="scheduleType!==SCHEDULE_TYPE.CUSTOM" class="cron-input">
     <label for="targetCron" aria-haspopup="true" role="tooltip" [class.invalid]="dateInvalid" class="tooltip tooltip-validation tooltip-md tooltip-top-right cron-label">
       <input type="text"  (blur)="blurInvalid()" (input)="inputInvalid()" name=targetCron id="targetCron" #cronStringInput="ngModel" required class="form-control"
         [(ngModel)]="cronString">

--- a/src/portal/lib/src/cron-schedule/cron-schedule.component.scss
+++ b/src/portal/lib/src/cron-schedule/cron-schedule.component.scss
@@ -37,6 +37,12 @@
       width: 100px;
     }
 
+    .cron-input {
+      position: absolute;
+      display: inline-block;
+      width: 270px;
+    }
+
     .cron-label {
       width: 195px;
     }


### PR DESCRIPTION
When select custom, input will automatically go to the second line.
![image](https://user-images.githubusercontent.com/40712758/56222949-745f9b00-609f-11e9-8c70-9d3084047ce5.png)
The modified page is
![image](https://user-images.githubusercontent.com/40712758/56223049-9bb66800-609f-11e9-84a9-dc4f51f14733.png)

Signed-off-by: FangyuanCheng <fangyuanc@vmware.com>