### PR TITLE
Hide vulnrability if clair is not installed

### DIFF
--- a/src/portal/src/app/base/harbor-shell/harbor-shell.component.html
+++ b/src/portal/src/app/base/harbor-shell/harbor-shell.component.html
@@ -46,15 +46,15 @@
                     </a>
                 </clr-vertical-nav-group-children>
             </clr-vertical-nav-group>
-            <clr-vertical-nav-group *ngIf="isSystemAdmin" routerLinkActive="active">
+            <clr-vertical-nav-group *ngIf="isSystemAdmin && (withClair || hasAdminRole)" routerLinkActive="active">
                 <clr-icon shape="event" clrVerticalNavIcon></clr-icon>
                 {{'SIDE_NAV.TASKS' | translate}}
                 <a routerLink="#" hidden aria-hidden="true"></a>
                 <clr-vertical-nav-group-children *clrIfExpanded="true">
-                    <a clrVerticalNavLink routerLink="/harbor/vulnerability" routerLinkActive="active">
+                    <a clrVerticalNavLink *ngIf="withClair" routerLink="/harbor/vulnerability" routerLinkActive="active">
                         {{'SIDE_NAV.SYSTEM_MGMT.VULNERABILITY' | translate}}
                     </a>
-                    <a clrVerticalNavLink routerLink="/harbor/gc" routerLinkActive="active">
+                    <a clrVerticalNavLink *ngIf="hasAdminRole" routerLink="/harbor/gc" routerLinkActive="active">
                         {{'SIDE_NAV.SYSTEM_MGMT.GARBAGE_COLLECTION' | translate}}
                     </a>
                 </clr-vertical-nav-group-children>

--- a/src/portal/src/app/base/harbor-shell/harbor-shell.component.ts
+++ b/src/portal/src/app/base/harbor-shell/harbor-shell.component.ts
@@ -107,6 +107,15 @@ export class HarborShellComponent implements OnInit, OnDestroy {
         return account != null;
     }
 
+    public get withClair(): boolean {
+        return this.appConfigService.getConfig().with_clair;
+    }
+
+    public get hasAdminRole(): boolean {
+        return this.session.getCurrentUser() &&
+            this.session.getCurrentUser().has_admin_role;
+    }
+
     // Open modal dialog
     openModal(event: ModalEvent): void {
         switch (event.modalName) {


### PR DESCRIPTION
fix #7431 
1、Hide vulnrability if clair is not installed
2、Hide gc if is not has adminRole
3、If there is no gc and vulneravility at the same time, hide the task
Signed-off-by: FangyuanCheng <fangyuanc@vmware.com>