### PR TITLE
Add UI test case Pro-Replication-Rules-Add

### DIFF
--- a/tests/resources/Harbor-Pages/Replication.robot
+++ b/tests/resources/Harbor-Pages/Replication.robot
@@ -21,11 +21,11 @@ ${HARBOR_VERSION}  v1.1.1
 
 *** Keywords ***
 Check New Rule UI Without Endpoint
-    Click Element  ${new_replication-rule_button}
-    Page Should Contain  Please add an endpoint first
-    Mouse Down  ${link_to_registries}
-    Mouse Up  ${link_to_registries}
-    Page Should Contain  Endpoint Name
+    Retry Element Click    ${new_replication-rule_button}
+    Page Should Contain    Please add an endpoint first
+    Retry Element Click    ${link_to_registries}
+    Retry Wait Until Page Contains    Endpoint URL
+    Retry Wait Element  ${new_endpoint_button}
 
 Create A New Endpoint
     [Arguments]  ${name}  ${url}  ${username}  ${pwd}  ${save}=Y
@@ -42,7 +42,7 @@ Create A New Endpoint
     Run Keyword If  '${save}' == 'N'  No Operation
 
 Create A Rule With Existing Endpoint
-# day 1=Monday..7=Sunday timeformat 12hour+am/pm    
+# day 1=Monday..7=Sunday timeformat 12hour+am/pm
     [Arguments]  ${name}  ${project_name}  ${endpoint}  ${mode}  ${plan}=Daily  ${weekday}=1  ${time}=0800a
     #click new
     Click Element  ${new_name_xpath}

--- a/tests/resources/Harbor-Pages/Replication_Elements.robot
+++ b/tests/resources/Harbor-Pages/Replication_Elements.robot
@@ -31,7 +31,7 @@ ${destination_insecure_xpath}  //label[@id='destination_insecure_checkbox']
 
 ${new_replication-rule_button}  //button[contains(.,'New Replication Rule')]
 ${link_to_registries}  //clr-modal//span[contains(.,'Endpoint')]
-${new_endpoint_button}  //hbr-endpoint//button[contains(.,'New')]
+${new_endpoint_button}  //hbr-endpoint//button[contains(.,'New Endpoint')]
 ${rule_name}  //input[@id='ruleName']
 ${source_project}    //input[@value='name']
 ${source_image_filter_add}  //hbr-create-edit-rule/clr-modal//clr-icon[@id='add-label-list']

--- a/tests/robot-cases/Group1-Nightly/Replication.robot
+++ b/tests/robot-cases/Group1-Nightly/Replication.robot
@@ -34,3 +34,10 @@ ${REMOTE_SERVER_API_ENDPOINT}  ${REMOTE_SERVER_URL}/api
 Test Case - Get Harbor Version
 #Just get harbor version and log it
     Get Harbor Version
+
+Test Case - Pro Replication Rules Add
+    Init Chrome Driver
+    Sign In Harbor    ${HARBOR_URL}    ${HARBOR_ADMIN}    ${HARBOR_PASSWORD}
+    Switch To Replication Manage
+    Check New Rule UI Without Endpoint
+    Close Browser


### PR DESCRIPTION
Due to replication NG feature already in master branch, old replication UI test cases have been moved out of Jenkins pipeline, and here test case Pro-Replication-Rules-Add has been finished and ready for duty.

Signed-off-by: danfengliu <danfengl@vmware.com>