### PR TITLE
List simple tags when detail set to false

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1263,11 +1263,16 @@ paths:
           type: string
           required: true
           description: Relevant repository name.
-        - name: label_ids
+        - name: label_id
           in: query
           type: string
           required: false
-          description: A list of comma separated label IDs.
+          description: A label ID.
+        - name: detail
+          in: query
+          type: boolean
+          required: false
+          description: Bool value indicating whether return detailed information of the tag, such as vulnerability scan info, if set to false, only tag name is returned.
       tags:
         - Products
       responses:

--- a/src/core/api/repository.go
+++ b/src/core/api/repository.go
@@ -576,9 +576,29 @@ func (ra *RepositoryAPI) GetTags() {
 		tags = ts
 	}
 
+	detail, err := ra.GetBool("detail", true)
+	if !detail && err == nil {
+		ra.Data["json"] = simpleTags(tags)
+		ra.ServeJSON()
+		return
+	}
+
 	ra.Data["json"] = assembleTagsInParallel(client, repoName, tags,
 		ra.SecurityCtx.GetUsername())
 	ra.ServeJSON()
+}
+
+func simpleTags(tags []string) []*models.TagResp {
+	var tagsResp []*models.TagResp
+	for _, tag := range tags {
+		tagsResp = append(tagsResp, &models.TagResp{
+			TagDetail: models.TagDetail{
+				Name: tag,
+			},
+		})
+	}
+
+	return tagsResp
 }
 
 // get config, signature and scan overview and assemble them into one

--- a/src/portal/lib/src/service/tag.service.ts
+++ b/src/portal/lib/src/service/tag.service.ts
@@ -140,7 +140,7 @@ export class TagDefaultService extends TagService {
       queryParams = queryParams = new RequestQueryParams();
     }
 
-    queryParams = queryParams.set("detail", "1");
+    queryParams = queryParams.set("detail", "true");
     let url: string = `${this._baseUrl}/${repositoryName}/tags`;
 
     return this.http


### PR DESCRIPTION
Signed-off-by: cd1989 <chende@caicloud.io>

Enable the `detail` parameter when list tags. In some cases, only tag name is cared, no need to spend long time to fetch detail, vulnerability scanning result, notary sign results.

Related issues: https://github.com/goharbor/harbor/issues/6876