### PR TITLE
Fix scan task never ends in UI

### DIFF
--- a/src/portal/lib/src/tag/tag.component.html
+++ b/src/portal/lib/src/tag/tag.component.html
@@ -95,7 +95,7 @@
                     <hbr-copy-input #copyInput (onCopyError)="onCpError($event)" iconMode="true" defaultValue="docker pull {{registryUrl}}/{{repoName}}:{{t.name}}"></hbr-copy-input>
                 </clr-dg-cell>
                 <clr-dg-cell *ngIf="withClair">
-                    <hbr-vulnerability-bar [repoName]="repoName" [tagId]="t.name" [summary]="t.scan_overview"></hbr-vulnerability-bar>
+                    <hbr-vulnerability-bar [tagStatus]="t.scan_overview.scan_status" [repoName]="repoName" [tagId]="t.name" [summary]="t.scan_overview"></hbr-vulnerability-bar>
                 </clr-dg-cell>
                 <clr-dg-cell *ngIf="withNotary" [ngSwitch]="t.signature !== null">
                     <clr-icon shape="check-circle" *ngSwitchCase="true" size="20" class="color-green"></clr-icon>

--- a/src/portal/lib/src/vulnerability-scanning/result-bar-chart.component.ts
+++ b/src/portal/lib/src/vulnerability-scanning/result-bar-chart.component.ts
@@ -29,6 +29,7 @@ const RETRY_TIMES: number = 3;
 })
 export class ResultBarChartComponent implements OnInit, OnDestroy {
     @Input() repoName: string = "";
+    @Input() tagStatus: string = "";
     @Input() tagId: string = "";
     @Input() summary: VulnerabilitySummary;
     onSubmitting: boolean = false;
@@ -47,6 +48,9 @@ export class ResultBarChartComponent implements OnInit, OnDestroy {
     ) { }
 
     ngOnInit(): void {
+        if (this.tagStatus === "running") {
+            this.scanNow();
+        }
         this.scanSubscription = this.channel.scanCommand$.subscribe((tagId: string) => {
             let myFullTag: string = this.repoName + "/" + this.tagId;
             if (myFullTag === tagId) {

--- a/src/portal/lib/src/vulnerability-scanning/result-grid.component.html
+++ b/src/portal/lib/src/vulnerability-scanning/result-grid.component.html
@@ -18,7 +18,7 @@
               <clr-dg-column [clrDgField]="'version'">{{'VULNERABILITY.GRID.COLUMN_VERSION' | translate}}</clr-dg-column>
               <clr-dg-column [clrDgField]="'fixedVersion'">{{'VULNERABILITY.GRID.COLUMN_FIXED' | translate}}</clr-dg-column>
       
-              <clr-dg-placeholder>{{'VULNERABILITY.GRID.PLACEHOLDER' | translate}}</clr-dg-placeholder>
+              <clr-dg-placeholder>{{'VULNERABILITY.CHART.TOOLTIPS_TITLE_ZERO' | translate}}</clr-dg-placeholder>
               <clr-dg-row *clrDgItems="let res of scanningResults">
                   <clr-dg-cell><a href="{{res.link}}" target="_blank">{{res.id}}</a></clr-dg-cell>
                   <clr-dg-cell [ngSwitch]="res.severity">


### PR DESCRIPTION
fix #7402 
If set to automatically scan images on push,Entering the tag page image will always scan,So need to keep getting the status until the end
Signed-off-by: FangyuanCheng <fangyuanc@vmware.com>