### PR TITLE
Add UI test case endpoint add/edit/delete

### DIFF
--- a/tests/resources/Harbor-Pages/Replication.robot
+++ b/tests/resources/Harbor-Pages/Replication.robot
@@ -40,6 +40,7 @@ Create A New Endpoint
     #cancel verify cert since we use a selfsigned cert
     Retry Element Click  ${destination_insecure_xpath}
     Run Keyword If  '${save}' == 'Y'  Run keyword  Retry Double Keywords When Error  Retry Element Click  ${replication_save_xpath}  Retry Wait Until Page Not Contains Element  ${replication_save_xpath}
+    Run Keyword If  '${save}' == 'Y'  Run keyword  Retry Wait Until Page Contains  ${name}
     Run Keyword If  '${save}' == 'N'  No Operation
 
 Create A Rule With Existing Endpoint

--- a/tests/robot-cases/Group1-Nightly/Replication.robot
+++ b/tests/robot-cases/Group1-Nightly/Replication.robot
@@ -54,11 +54,38 @@ Test Case - Harbor Endpoint Verification
     Endpoint Is Unpingable
     Close Browser
 
-Test Case - DockerHub Endpoint Verification
+Test Case - DockerHub Endpoint Add
     #This case need vailid info and selfsign cert
     Init Chrome Driver
     ${d}=    Get Current Date    result_format=%M%S
     Sign In Harbor    ${HARBOR_URL}    ${HARBOR_ADMIN}    ${HARBOR_PASSWORD}
     Switch To Registries
     Create A New Endpoint    dockerHub    edp1${d}    https://hub.docker.com/    danfengliu    Aa123456    Y
+    Close Browser
+
+Test Case - Harbor Endpoint Add
+    #This case need vailid info and selfsign cert
+    Init Chrome Driver
+    ${d}=    Get Current Date    result_format=%M%S
+    Sign In Harbor    ${HARBOR_URL}    ${HARBOR_ADMIN}    ${HARBOR_PASSWORD}
+    Switch To Registries
+    Create A New Endpoint    harbor    testabc    https://${ip}    ${HARBOR_ADMIN}    ${HARBOR_PASSWORD}    Y
+    Close Browser
+
+Test Case - Harbor Endpoint Edit
+    Init Chrome Driver
+    ${d}=  Get Current Date  result_format=%m%s
+    Sign In Harbor  ${HARBOR_URL}  ${HARBOR_ADMIN}  ${HARBOR_PASSWORD}
+    Switch To Registries
+    Rename Endpoint  testabc  deletea
+    Retry Wait Until Page Contains  deletea
+    Close Browser
+
+Test Case - Harbor Endpoint Delete
+    Init Chrome Driver
+    ${d}=  Get Current Date  result_format=%m%s
+    Sign In Harbor  ${HARBOR_URL}  ${HARBOR_ADMIN}  ${HARBOR_PASSWORD}
+    Switch To Registries
+    Delete Endpoint  deletea
+    Delete Success  deletea
     Close Browser


### PR DESCRIPTION
Due to replication NG feature already in master branch, old replication UI test cases have been moved out of Jenkins pipeline, and here is that test case endpoint add/edit/delete  have been finished and ready for duty.

Signed-off-by: danfengliu <danfengl@vmware.com>