### PR TITLE
refine chart clint http response

### DIFF
--- a/src/chartserver/utils.go
+++ b/src/chartserver/utils.go
@@ -16,22 +16,22 @@ const (
 
 // Extract error object '{"error": "****---***"}' from the content if existing
 // nil error will be returned if it does exist
-func extractError(content []byte) error {
+func extractError(content []byte) (text string, err error) {
 	if len(content) == 0 {
-		return nil
+		return "", nil
 	}
 
 	errorObj := make(map[string]string)
-	err := json.Unmarshal(content, &errorObj)
+	err = json.Unmarshal(content, &errorObj)
 	if err != nil {
-		return nil
+		return "", err
 	}
 
 	if errText, ok := errorObj["error"]; ok {
-		return errors.New(errText)
+		return errText, nil
 	}
 
-	return nil
+	return "", nil
 }
 
 // Parse the redis configuration to the beego cache pattern

--- a/src/core/api/chart_repository.go
+++ b/src/core/api/chart_repository.go
@@ -186,7 +186,7 @@ func (cra *ChartRepositoryAPI) ListCharts() {
 
 	charts, err := chartController.ListCharts(cra.namespace)
 	if err != nil {
-		cra.SendInternalServerError(err)
+		cra.ParseAndHandleError("fail to list charts", err)
 		return
 	}
 
@@ -204,7 +204,7 @@ func (cra *ChartRepositoryAPI) ListChartVersions() {
 
 	versions, err := chartController.GetChart(cra.namespace, chartName)
 	if err != nil {
-		cra.SendInternalServerError(err)
+		cra.ParseAndHandleError("fail to get chart", err)
 		return
 	}
 
@@ -234,7 +234,7 @@ func (cra *ChartRepositoryAPI) GetChartVersion() {
 
 	chartVersion, err := chartController.GetChartVersionDetails(cra.namespace, chartName, version)
 	if err != nil {
-		cra.SendInternalServerError(err)
+		cra.ParseAndHandleError("fail to get chart version", err)
 		return
 	}
 
@@ -267,7 +267,7 @@ func (cra *ChartRepositoryAPI) DeleteChartVersion() {
 	}
 
 	if err := chartController.DeleteChartVersion(cra.namespace, chartName, version); err != nil {
-		cra.SendInternalServerError(err)
+		cra.ParseAndHandleError("fail to delete chart version", err)
 		return
 	}
 }
@@ -360,7 +360,7 @@ func (cra *ChartRepositoryAPI) DeleteChart() {
 	// Remove labels from all the deleting chart versions under the chart
 	chartVersions, err := chartController.GetChart(cra.namespace, chartName)
 	if err != nil {
-		cra.SendInternalServerError(err)
+		cra.ParseAndHandleError("fail to get chart", err)
 		return
 	}
 


### PR DESCRIPTION
Chart client eats the http error if not status ok, after refactor, the
real http response will be catched in core api.

Signed-off-by: wang yan <wangyan@vmware.com>