### PR TITLE
use endpoint in api config to load gc logs

### DIFF
--- a/src/portal/lib/package.json
+++ b/src/portal/lib/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@harbor/ui",
-    "version": "1.7.1-rc1",
+    "version": "1.7.4-rc2",
     "description": "Harbor shared UI components based on Clarity and Angular6",
     "author": "CNCF",
     "module": "index.js",

--- a/src/portal/lib/src/config/gc/gc.api.repository.ts
+++ b/src/portal/lib/src/config/gc/gc.api.repository.ts
@@ -17,6 +17,8 @@ export abstract class GcApiRepository {
     abstract getStatus(id): Observable<any>;
 
     abstract getJobs(): Observable<any>;
+
+    abstract getLogLink(id): string;
 }
 
 @Injectable()
@@ -59,6 +61,10 @@ export class GcApiDefaultRepository extends GcApiRepository {
         return this.http.get(`${this.config.gcEndpoint}`)
             .pipe(catchError(error => observableThrowError(error)))
             .pipe(map(response => response.json()));
+    }
+
+    public getLogLink(id) {
+        return `${this.config.gcEndpoint}/${id}/log`;
     }
 
 }

--- a/src/portal/lib/src/config/gc/gc.component.html
+++ b/src/portal/lib/src/config/gc/gc.component.html
@@ -45,7 +45,7 @@
     <clr-dg-cell>{{job.createTime | date:'medium'}}</clr-dg-cell>
     <clr-dg-cell>{{job.updateTime | date:'medium'}}</clr-dg-cell>
     <clr-dg-cell>
-      <a *ngIf="job.status.toLowerCase() === 'finished' || job.status.toLowerCase() === 'error'" target="_blank" href="/api/system/gc/{{job.id}}/log"><clr-icon shape="list"></clr-icon></a>
+      <a *ngIf="job.status.toLowerCase() === 'finished' || job.status.toLowerCase() === 'error'" target="_blank" [href]="logLink(job.id)"><clr-icon shape="list"></clr-icon></a>
     </clr-dg-cell>
   </clr-dg-row>
   <clr-dg-footer>{{'GC.LATEST_JOBS' | translate :{param: jobs.length} }}</clr-dg-footer>

--- a/src/portal/lib/src/config/gc/gc.component.ts
+++ b/src/portal/lib/src/config/gc/gc.component.ts
@@ -115,6 +115,10 @@ export class GcComponent implements OnInit {
     this.getJobs();
   }
 
+  logLink(id) {
+    return this.gcRepoService.getLogLink(id);
+  }
+
   scheduleGc(): void {
     let offTime = this.gcUtility.getOffTime(this.dailyTime);
     let schedule = this.schedule;

--- a/src/portal/lib/src/config/gc/gc.service.ts
+++ b/src/portal/lib/src/config/gc/gc.service.ts
@@ -61,4 +61,8 @@ export class GcRepoService {
         }
         return this.gcApiRepository.putSchedule(param);
     }
+
+    public getLogLink(id): string  {
+        return this.gcApiRepository.getLogLink(id);
+    }
 }


### PR DESCRIPTION
Before just hardcoded the log url in the gc html. That caused admiral will get log fail because different endpoint. 
Therefore, we need to make gc log endpoint also use api config in config files. 