### PR TITLE
Persist the new token in DB after login

### DIFF
--- a/src/common/utils/oidc/helper.go
+++ b/src/common/utils/oidc/helper.go
@@ -148,8 +148,8 @@ func AuthCodeURL(state string) (string, error) {
 		log.Errorf("Failed to get OAuth configuration, error: %v", err)
 		return "", err
 	}
-	if strings.HasPrefix(conf.Endpoint.AuthURL, googleEndpoint) {
-		return conf.AuthCodeURL(state, oauth2.AccessTypeOffline), nil
+	if strings.HasPrefix(conf.Endpoint.AuthURL, googleEndpoint) { // make sure the refresh token will be returned
+		return conf.AuthCodeURL(state, oauth2.AccessTypeOffline, oauth2.SetAuthURLParam("prompt", "consent")), nil
 	}
 	return conf.AuthCodeURL(state), nil
 }

--- a/src/common/utils/oidc/secret.go
+++ b/src/common/utils/oidc/secret.go
@@ -102,6 +102,7 @@ func (dm *defaultManager) VerifyToken(ctx context.Context, user *models.OIDCUser
 	if err != nil {
 		return verifyError(err)
 	}
+	log.Debugf("Token string for verify: %s", tokenStr)
 	_, err = VerifyToken(ctx, token.IDToken)
 	if err == nil {
 		return nil


### PR DESCRIPTION
This commit make sure the token is persist to DB after every time after
a user logs in via OIDC provider, to make sure the secret is usable for
the OIDC providers that don't provide refresh token.

It also updates the authorize URL for google to make sure the refresh
token will be returned.

Also some misc refinement included, including add comment to the
OIDC onboarded user, preset the username in onboard dialog.

Signed-off-by: Daniel Jiang <jiangd@vmware.com>