### PR TITLE
add get jobs API to provide powerful job stats management

### DIFF
--- a/src/jobservice/api/handler_test.go
+++ b/src/jobservice/api/handler_test.go
@@ -277,7 +277,7 @@ func (suite *APIHandlerTestSuite) TestGetPeriodicExecutionsWithQuery() {
 }
 
 // TestScheduledJobs ...
-func (suite *APIHandlerTestSuite) TestScheduledJobs() {
+func (suite *APIHandlerTestSuite) TestGetJobs() {
 	q := &query.Parameter{
 		PageNumber: 2,
 		PageSize:   50,
@@ -285,11 +285,20 @@ func (suite *APIHandlerTestSuite) TestScheduledJobs() {
 	}
 
 	fc := &fakeController{}
-	fc.On("ScheduledJobs", q).
-		Return([]*job.Stats{createJobStats("sample", "Generic", "")}, int64(1), nil)
+	fc.On("GetJobs", q).
+		Return([]*job.Stats{createJobStats("sample", job.KindGeneric, "")}, int64(1), nil)
 	suite.controller = fc
 
-	_, code := suite.getReq(fmt.Sprintf("%s/%s", suite.APIAddr, "jobs/scheduled?page_number=2&page_size=50"))
+	_, code := suite.getReq(fmt.Sprintf("%s/%s", suite.APIAddr, "jobs?page_number=2&page_size=50"))
+	assert.Equal(suite.T(), 200, code, "expected 200 ok but got %d", code)
+
+	q.Extras.Set(query.ExtraParamKeyKind, job.KindScheduled)
+	fc = &fakeController{}
+	fc.On("GetJobs", q).
+		Return([]*job.Stats{createJobStats("sample", job.KindScheduled, "")}, int64(1), nil)
+	suite.controller = fc
+
+	_, code = suite.getReq(fmt.Sprintf("%s/%s", suite.APIAddr, "jobs?page_number=2&page_size=50&kind=Scheduled"))
 	assert.Equal(suite.T(), 200, code, "expected 200 ok but got %d", code)
 }
 
@@ -397,8 +406,8 @@ func (suite *APIHandlerTestSuite) GetPeriodicExecutions(periodicJobID string, qu
 	return suite.controller.GetPeriodicExecutions(periodicJobID, query)
 }
 
-func (suite *APIHandlerTestSuite) ScheduledJobs(query *query.Parameter) ([]*job.Stats, int64, error) {
-	return suite.controller.ScheduledJobs(query)
+func (suite *APIHandlerTestSuite) GetJobs(query *query.Parameter) ([]*job.Stats, int64, error) {
+	return suite.controller.GetJobs(query)
 }
 
 type fakeController struct {
@@ -460,7 +469,7 @@ func (fc *fakeController) GetPeriodicExecutions(periodicJobID string, query *que
 	return args.Get(0).([]*job.Stats), args.Get(1).(int64), nil
 }
 
-func (fc *fakeController) ScheduledJobs(query *query.Parameter) ([]*job.Stats, int64, error) {
+func (fc *fakeController) GetJobs(query *query.Parameter) ([]*job.Stats, int64, error) {
 	args := fc.Called(query)
 	if args.Error(2) != nil {
 		return nil, args.Get(1).(int64), args.Error(2)

--- a/src/jobservice/api/router.go
+++ b/src/jobservice/api/router.go
@@ -88,7 +88,7 @@ func (br *BaseRouter) registerRoutes() {
 	subRouter := br.router.PathPrefix(fmt.Sprintf("%s/%s", baseRoute, apiVersion)).Subrouter()
 
 	subRouter.HandleFunc("/jobs", br.handler.HandleLaunchJobReq).Methods(http.MethodPost)
-	subRouter.HandleFunc("/jobs/scheduled", br.handler.HandleScheduledJobs).Methods(http.MethodGet)
+	subRouter.HandleFunc("/jobs", br.handler.HandleGetJobsReq).Methods(http.MethodGet)
 	subRouter.HandleFunc("/jobs/{job_id}", br.handler.HandleGetJobReq).Methods(http.MethodGet)
 	subRouter.HandleFunc("/jobs/{job_id}", br.handler.HandleJobActionReq).Methods(http.MethodPost)
 	subRouter.HandleFunc("/jobs/{job_id}/log", br.handler.HandleJobLogReq).Methods(http.MethodGet)

--- a/src/jobservice/common/query/q.go
+++ b/src/jobservice/common/query/q.go
@@ -14,6 +14,8 @@
 
 package query
 
+import "encoding/json"
+
 const (
 	// DefaultPageSize defines the default page size
 	DefaultPageSize uint = 25
@@ -23,8 +25,16 @@ const (
 	ParamKeyPageSize = "page_size"
 	// ParamKeyNonStoppedOnly defines query param key of querying non stopped periodic executions
 	ParamKeyNonStoppedOnly = "non_dead_only"
+	// ParamKeyCursor defines query param of cursor for fetching job stats with batches
+	ParamKeyCursor = "cursor"
+	// ParamKeyJobKind defines query param of job kind
+	ParamKeyJobKind = "kind"
 	// ExtraParamKeyNonStoppedOnly defines extra parameter key for querying non stopped periodic executions
 	ExtraParamKeyNonStoppedOnly = "NonDeadOnly"
+	// ExtraParamKeyCursor defines extra parameter key for the cursor of fetching job stats with batches
+	ExtraParamKeyCursor = "Cursor"
+	// ExtraParamKeyKind defines extra parameter key for the job kind
+	ExtraParamKeyKind = "Kind"
 )
 
 // ExtraParameters to keep non pagination query parameters
@@ -42,6 +52,16 @@ func (ep ExtraParameters) Get(key string) (interface{}, bool) {
 	v, ok := ep[key]
 
 	return v, ok
+}
+
+// String returns the json string of ExtraParameters
+func (ep ExtraParameters) String() string {
+	bytes, err := json.Marshal(&ep)
+	if err != nil {
+		return ""
+	}
+
+	return string(bytes)
 }
 
 // Parameter for getting executions

--- a/src/jobservice/common/query/q_test.go
+++ b/src/jobservice/common/query/q_test.go
@@ -1,6 +1,8 @@
 package query
 
 import (
+	"encoding/json"
+	"github.com/stretchr/testify/require"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -26,4 +28,13 @@ func (suite *QueryTestSuite) TestExtraParams() {
 
 	assert.Equal(suite.T(), true, ok)
 	assert.Equal(suite.T(), 100, v.(int))
+
+	str := extras.String()
+	copy := make(ExtraParameters)
+	err := json.Unmarshal([]byte(str), &copy)
+	require.NoError(suite.T(), err)
+
+	v, ok = copy.Get("a")
+	assert.Equal(suite.T(), true, ok)
+	assert.Equal(suite.T(), 100, int(v.(float64)))
 }

--- a/src/jobservice/common/rds/keys.go
+++ b/src/jobservice/common/rds/keys.go
@@ -37,8 +37,6 @@ func RedisKeyLastPeriodicEnqueue(namespace string) string {
 	return RedisNamespacePrefix(namespace) + "last_periodic_enqueue"
 }
 
-// ----------------------------------------------------------
-
 // KeyNamespacePrefix returns the based key based on the namespace.
 func KeyNamespacePrefix(namespace string) string {
 	ns := strings.TrimSpace(namespace)

--- a/src/jobservice/core/controller.go
+++ b/src/jobservice/core/controller.go
@@ -16,6 +16,7 @@ package core
 
 import (
 	"fmt"
+	"github.com/goharbor/harbor/src/jobservice/mgt"
 	"github.com/pkg/errors"
 
 	"github.com/goharbor/harbor/src/jobservice/logger"
@@ -24,7 +25,6 @@ import (
 	"github.com/goharbor/harbor/src/jobservice/common/utils"
 	"github.com/goharbor/harbor/src/jobservice/errs"
 	"github.com/goharbor/harbor/src/jobservice/job"
-	"github.com/goharbor/harbor/src/jobservice/lcm"
 	"github.com/goharbor/harbor/src/jobservice/worker"
 	"github.com/robfig/cron"
 )
@@ -34,15 +34,15 @@ import (
 type basicController struct {
 	// Refer the backend worker
 	backendWorker worker.Interface
-	// Refer the job life cycle management controller
-	ctl lcm.Controller
+	// Refer the job stats manager
+	manager mgt.Manager
 }
 
 // NewController is constructor of basicController.
-func NewController(backendWorker worker.Interface, ctl lcm.Controller) Interface {
+func NewController(backendWorker worker.Interface, mgr mgt.Manager) Interface {
 	return &basicController{
 		backendWorker: backendWorker,
-		ctl:           ctl,
+		manager:       mgr,
 	}
 }
 
@@ -92,7 +92,7 @@ func (bc *basicController) LaunchJob(req *job.Request) (res *job.Stats, err erro
 
 	// Save job stats
 	if err == nil {
-		if _, err := bc.ctl.New(res); err != nil {
+		if err := bc.manager.SaveJob(res); err != nil {
 			return nil, err
 		}
 	}
@@ -106,12 +106,7 @@ func (bc *basicController) GetJob(jobID string) (*job.Stats, error) {
 		return nil, errs.BadRequestError(errors.New("empty job ID"))
 	}
 
-	t, err := bc.ctl.Track(jobID)
-	if err != nil {
-		return nil, err
-	}
-
-	return t.Job(), nil
+	return bc.manager.GetJob(jobID)
 }
 
 // StopJob is implementation of same method in core interface.
@@ -157,32 +152,25 @@ func (bc *basicController) GetPeriodicExecutions(periodicJobID string, query *qu
 		return nil, 0, errs.BadRequestError(errors.New("nil periodic job ID"))
 	}
 
-	t, err := bc.ctl.Track(periodicJobID)
-	if err != nil {
-		return nil, 0, err
-	}
-
-	eIDs, total, err := t.Executions(query)
-	if err != nil {
-		return nil, 0, err
-	}
-
-	res := make([]*job.Stats, 0)
-	for _, eID := range eIDs {
-		et, err := bc.ctl.Track(eID)
-		if err != nil {
-			return nil, 0, err
-		}
-
-		res = append(res, et.Job())
-	}
-
-	return res, total, nil
+	return bc.manager.GetPeriodicExecution(periodicJobID, query)
 }
 
-// ScheduledJobs returns the scheduled jobs by page
-func (bc *basicController) ScheduledJobs(query *query.Parameter) ([]*job.Stats, int64, error) {
-	return bc.backendWorker.ScheduledJobs(query)
+// GetJobs returns the jobs by specified
+func (bc *basicController) GetJobs(q *query.Parameter) ([]*job.Stats, int64, error) {
+	onlyScheduledJobs := false
+	if q != nil && q.Extras != nil {
+		if v, ok := q.Extras.Get(query.ExtraParamKeyKind); ok {
+			if job.KindScheduled == v.(string) {
+				onlyScheduledJobs = true
+			}
+		}
+	}
+
+	if onlyScheduledJobs {
+		return bc.manager.GetScheduledJobs(q)
+	}
+
+	return bc.manager.GetJobs(q)
 }
 
 func validJobReq(req *job.Request) error {

--- a/src/jobservice/core/interface.go
+++ b/src/jobservice/core/interface.go
@@ -68,8 +68,11 @@ type Interface interface {
 	// The total number is also returned.
 	GetPeriodicExecutions(periodicJobID string, query *query.Parameter) ([]*job.Stats, int64, error)
 
-	// Get the scheduled jobs by page
-	// The page number in the query will be ignored, default 20 is used. This is the limitation of backend lib.
+	// Get the jobs with queries.
+	//
+	// For scheduled jobs, the page number in the query will be ignored, default 20 is used.
+	// This is the limitation of backend lib. The int64 is total number.
+	// For other cases, query the jobs with cursor, not standard pagination. The int64 is next cursor.
 	// The total number is also returned.
-	ScheduledJobs(query *query.Parameter) ([]*job.Stats, int64, error)
+	GetJobs(query *query.Parameter) ([]*job.Stats, int64, error)
 }

--- a/src/jobservice/errs/errors.go
+++ b/src/jobservice/errs/errors.go
@@ -18,6 +18,7 @@ package errs
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/goharbor/harbor/src/jobservice/common/query"
 )
 
 const (
@@ -49,8 +50,8 @@ const (
 	ResourceConflictsErrorCode
 	// BadRequestErrorCode is code for the error of bad request
 	BadRequestErrorCode
-	// GetScheduledJobsErrorCode is code for the error of getting scheduled jobs
-	GetScheduledJobsErrorCode
+	// GetJobsErrorCode is code for the error of getting scheduled jobs
+	GetJobsErrorCode
 	// GetPeriodicExecutionErrorCode is code for the error of getting periodic executions
 	GetPeriodicExecutionErrorCode
 	// StatusMismatchErrorCode is code for the error of mismatching status
@@ -137,9 +138,13 @@ func UnauthorizedError(err error) error {
 	return New(UnAuthorizedErrorCode, "unauthorized", err.Error())
 }
 
-// GetScheduledJobsError is error for the case of getting scheduled jobs failed
-func GetScheduledJobsError(err error) error {
-	return New(GetScheduledJobsErrorCode, "failed to get scheduled jobs", err.Error())
+// GetJobsError is error for the case of getting jobs failed
+func GetJobsError(q *query.Parameter, err error) error {
+	qStr := ""
+	if q != nil {
+		qStr = q.Extras.String()
+	}
+	return New(GetJobsErrorCode, fmt.Sprintf("failed to get scheduled jobs, q=%s", qStr), err.Error())
 }
 
 // GetPeriodicExecutionError is error for the case of getting periodic jobs failed

--- a/src/jobservice/job/tracker_test.go
+++ b/src/jobservice/job/tracker_test.go
@@ -19,8 +19,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/goharbor/harbor/src/jobservice/common/query"
-
 	"github.com/goharbor/harbor/src/jobservice/common/utils"
 	"github.com/goharbor/harbor/src/jobservice/tests"
 	"github.com/gomodule/redigo/redis"
@@ -175,14 +173,6 @@ func (suite *TrackerTestSuite) TestPeriodicTracker() {
 	id, err := t.NumericID()
 	require.NoError(suite.T(), err)
 	assert.Equal(suite.T(), nID, id)
-
-	_, total, err := t.Executions(&query.Parameter{
-		PageNumber: 1,
-		PageSize:   10,
-		Extras:     make(query.ExtraParameters),
-	})
-	require.NoError(suite.T(), err)
-	assert.Equal(suite.T(), int64(1), total)
 
 	err = t2.PeriodicExecutionDone()
 	require.NoError(suite.T(), err)

--- a/src/jobservice/main.go
+++ b/src/jobservice/main.go
@@ -16,10 +16,17 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
+	"os"
+
+	"github.com/goharbor/harbor/src/common"
+	comcfg "github.com/goharbor/harbor/src/common/config"
 	"github.com/goharbor/harbor/src/jobservice/common/utils"
 	"github.com/goharbor/harbor/src/jobservice/config"
+	"github.com/goharbor/harbor/src/jobservice/job"
+	"github.com/goharbor/harbor/src/jobservice/job/impl"
 	"github.com/goharbor/harbor/src/jobservice/logger"
 	"github.com/goharbor/harbor/src/jobservice/runtime"
 )
@@ -52,7 +59,7 @@ func main() {
 	}
 
 	// Set job context initializer
-	/*runtime.JobService.SetJobContextInitializer(func(ctx context.Context) (job.Context, error) {
+	runtime.JobService.SetJobContextInitializer(func(ctx context.Context) (job.Context, error) {
 		secret := config.GetAuthSecret()
 		if utils.IsEmptyStr(secret) {
 			return nil, errors.New("empty auth secret")
@@ -67,7 +74,7 @@ func main() {
 		}
 
 		return jobCtx, nil
-	})*/
+	})
 
 	// Start
 	if err := runtime.JobService.LoadAndRun(ctx, cancel); err != nil {

--- a/src/jobservice/main.go
+++ b/src/jobservice/main.go
@@ -18,13 +18,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"github.com/goharbor/harbor/src/common"
-	comcfg "github.com/goharbor/harbor/src/common/config"
-	"github.com/goharbor/harbor/src/jobservice/job"
-	"github.com/goharbor/harbor/src/jobservice/job/impl"
-	"github.com/pkg/errors"
-	"os"
-
 	"github.com/goharbor/harbor/src/jobservice/common/utils"
 	"github.com/goharbor/harbor/src/jobservice/config"
 	"github.com/goharbor/harbor/src/jobservice/logger"
@@ -59,7 +52,7 @@ func main() {
 	}
 
 	// Set job context initializer
-	runtime.JobService.SetJobContextInitializer(func(ctx context.Context) (job.Context, error) {
+	/*runtime.JobService.SetJobContextInitializer(func(ctx context.Context) (job.Context, error) {
 		secret := config.GetAuthSecret()
 		if utils.IsEmptyStr(secret) {
 			return nil, errors.New("empty auth secret")
@@ -74,7 +67,7 @@ func main() {
 		}
 
 		return jobCtx, nil
-	})
+	})*/
 
 	// Start
 	if err := runtime.JobService.LoadAndRun(ctx, cancel); err != nil {

--- a/src/jobservice/mgt/manager.go
+++ b/src/jobservice/mgt/manager.go
@@ -1,0 +1,349 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mgt
+
+import (
+	"context"
+	"fmt"
+	"github.com/gocraft/work"
+	"github.com/goharbor/harbor/src/jobservice/common/query"
+	"github.com/goharbor/harbor/src/jobservice/common/rds"
+	"github.com/goharbor/harbor/src/jobservice/common/utils"
+	"github.com/goharbor/harbor/src/jobservice/errs"
+	"github.com/goharbor/harbor/src/jobservice/job"
+	"github.com/goharbor/harbor/src/jobservice/logger"
+	"github.com/goharbor/harbor/src/jobservice/period"
+	"github.com/gomodule/redigo/redis"
+	"github.com/pkg/errors"
+	"strconv"
+	"strings"
+)
+
+// Manager defies the related operations to handle the management of job stats.
+type Manager interface {
+	// Get the stats data of all kinds of jobs.
+	// Data returned by pagination.
+	//
+	// Arguments:
+	//   q *query.Parameter : the query parameters
+	//
+	// Returns:
+	//   The matched job stats list
+	//   The total number of the jobs
+	//   Non nil error if any issues meet
+	GetJobs(q *query.Parameter) ([]*job.Stats, int64, error)
+
+	// Get the executions of the specified periodic job by pagination
+	//
+	// Arguments:
+	//   pID: ID of the periodic job
+	//   q *query.Parameter: query parameters
+	//
+	// Returns:
+	//   The matched job stats list,
+	//   The total number of the executions,
+	//   Non nil error if any issues meet.
+	GetPeriodicExecution(pID string, q *query.Parameter) ([]*job.Stats, int64, error)
+
+	// Get the scheduled jobs
+	//
+	// Arguments:
+	//   q *query.Parameter: query parameters
+	//
+	// Returns:
+	//   The matched job stats list,
+	//   The total number of the executions,
+	//   Non nil error if any issues meet.
+	GetScheduledJobs(q *query.Parameter) ([]*job.Stats, int64, error)
+
+	// Get the stats of the specified job
+	//
+	// Arguments:
+	//   jobID string: ID of the job
+	//
+	// Returns:
+	//   The job stats
+	//   Non nil error if any issues meet
+	GetJob(jobID string) (*job.Stats, error)
+
+	// Save the job stats
+	//
+	// Arguments:
+	//   job *job.Stats: the saving job stats
+	//
+	// Returns:
+	//   Non nil error if any issues meet
+	SaveJob(job *job.Stats) error
+}
+
+// basicManager is the default implementation of @manager,
+// based on redis.
+type basicManager struct {
+	// system context
+	ctx context.Context
+	// db namespace
+	namespace string
+	// redis conn pool
+	pool *redis.Pool
+	// go work client
+	client *work.Client
+}
+
+// NewManager news a basic manager
+func NewManager(ctx context.Context, ns string, pool *redis.Pool) Manager {
+	return &basicManager{
+		ctx:       ctx,
+		namespace: ns,
+		pool:      pool,
+		client:    work.NewClient(ns, pool),
+	}
+}
+
+// GetJobs is implementation of Manager.GetJobs
+// Because of the hash set used to keep the job stats, we can not support a standard pagination.
+// A cursor is used to fetch the jobs with several batches.
+func (bm *basicManager) GetJobs(q *query.Parameter) ([]*job.Stats, int64, error) {
+	cursor, count := int64(0), query.DefaultPageSize
+	if q != nil {
+		if q.PageSize > 0 {
+			count = q.PageSize
+		}
+
+		if cur, ok := q.Extras.Get(query.ExtraParamKeyCursor); ok {
+			cursor = cur.(int64)
+		}
+	}
+
+	pattern := rds.KeyJobStats(bm.namespace, "*")
+	args := []interface{}{cursor, "MATCH", pattern, "COUNT", count}
+
+	conn := bm.pool.Get()
+	defer func() {
+		_ = conn.Close()
+	}()
+
+	values, err := redis.Values(conn.Do("SCAN", args...))
+	if err != nil {
+		return nil, 0, err
+	}
+	if len(values) != 2 {
+		return nil, 0, errors.New("malform scan results")
+	}
+
+	nextCur, err := strconv.ParseUint(string(values[0].([]byte)), 10, 8)
+	if err != nil {
+		return nil, 0, err
+	}
+	list := values[1].([]interface{})
+
+	results := make([]*job.Stats, 0)
+	for _, v := range list {
+		if bytes, ok := v.([]byte); ok {
+			statsKey := string(bytes)
+			if i := strings.LastIndex(statsKey, ":"); i != -1 {
+				jID := statsKey[i+1:]
+				t := job.NewBasicTrackerWithID(bm.ctx, jID, bm.namespace, bm.pool, nil)
+				if err := t.Load(); err != nil {
+					logger.Errorf("retrieve stats data of job %s error: %s", jID, err)
+					continue
+				}
+
+				results = append(results, t.Job())
+			}
+		}
+	}
+
+	return results, int64(nextCur), nil
+}
+
+// GetPeriodicExecution is implementation of Manager.GetPeriodicExecution
+func (bm *basicManager) GetPeriodicExecution(pID string, q *query.Parameter) (results []*job.Stats, total int64, err error) {
+	if utils.IsEmptyStr(pID) {
+		return nil, 0, errors.New("nil periodic job ID")
+	}
+
+	tracker := job.NewBasicTrackerWithID(bm.ctx, pID, bm.namespace, bm.pool, nil)
+	err = tracker.Load()
+	if err != nil {
+		return nil, 0, err
+	}
+
+	if tracker.Job().Info.JobKind != job.KindPeriodic {
+		return nil, 0, errors.Errorf("only periodic job has executions: %s kind is received", tracker.Job().Info.JobKind)
+	}
+
+	conn := bm.pool.Get()
+	defer func() {
+		_ = conn.Close()
+	}()
+
+	key := rds.KeyUpstreamJobAndExecutions(bm.namespace, pID)
+
+	executionIDs := make([]string, 0)
+	// Query executions by "non stopped"
+	if nonStoppedOnly, ok := q.Extras.Get(query.ExtraParamKeyNonStoppedOnly); ok {
+		if v, yes := nonStoppedOnly.(bool); yes && v {
+			executionIDs, total, err = queryExecutions(conn, key, q)
+			if err != nil {
+				return nil, 0, err
+			}
+		}
+	} else {
+		// Query all
+		// Pagination
+		var pageNumber, pageSize uint = 1, query.DefaultPageSize
+		if q != nil {
+			if q.PageNumber > 0 {
+				pageNumber = q.PageNumber
+			}
+			if q.PageSize > 0 {
+				pageSize = q.PageSize
+			}
+		}
+
+		// Get total first
+		total, err = redis.Int64(conn.Do("ZCARD", key))
+		if err != nil {
+			return nil, 0, err
+		}
+
+		// No items
+		if total == 0 || (int64)((pageNumber-1)*pageSize) >= total {
+			return results, total, nil
+		}
+
+		min, max := (pageNumber-1)*pageSize, pageNumber*pageSize-1
+		args := []interface{}{key, min, max}
+		list, err := redis.Values(conn.Do("ZREVRANGE", args...))
+		if err != nil {
+			return nil, 0, err
+		}
+
+		for _, item := range list {
+			if eID, ok := item.([]byte); ok {
+				executionIDs = append(executionIDs, string(eID))
+			}
+		}
+	}
+
+	for _, eID := range executionIDs {
+		t := job.NewBasicTrackerWithID(bm.ctx, eID, bm.namespace, bm.pool, nil)
+		if er := t.Load(); er != nil {
+			logger.Errorf("track job %s error: %s", eID, err)
+			continue
+		}
+
+		results = append(results, t.Job())
+	}
+
+	return
+}
+
+// GetScheduledJobs is implementation of Manager.GetScheduledJobs
+func (bm *basicManager) GetScheduledJobs(q *query.Parameter) ([]*job.Stats, int64, error) {
+	// PageSize is not supported here
+	var page uint = 1
+	if q != nil && q.PageNumber > 1 {
+		page = q.PageNumber
+	}
+
+	sJobs, total, err := bm.client.ScheduledJobs(page)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	res := make([]*job.Stats, 0)
+	for _, sJob := range sJobs {
+		jID := sJob.ID
+		if len(sJob.Args) > 0 {
+			if _, ok := sJob.Args[period.PeriodicExecutionMark]; ok {
+				// Periodic scheduled job
+				jID = fmt.Sprintf("%s@%d", sJob.ID, sJob.RunAt)
+			}
+		}
+		t := job.NewBasicTrackerWithID(bm.ctx, jID, bm.namespace, bm.pool, nil)
+		err = t.Load()
+		if err != nil {
+			// Just log it
+			logger.Errorf("mgt.basicManager: query scheduled jobs error: %s", err)
+			continue
+		}
+
+		res = append(res, t.Job())
+	}
+
+	return res, total, nil
+}
+
+// GetJob is implementation of Manager.GetJob
+func (bm *basicManager) GetJob(jobID string) (*job.Stats, error) {
+	if utils.IsEmptyStr(jobID) {
+		return nil, errs.BadRequestError("empty job ID")
+	}
+
+	t := job.NewBasicTrackerWithID(bm.ctx, jobID, bm.namespace, bm.pool, nil)
+	if err := t.Load(); err != nil {
+		return nil, err
+	}
+
+	return t.Job(), nil
+}
+
+// SaveJob is implementation of Manager.SaveJob
+func (bm *basicManager) SaveJob(j *job.Stats) error {
+	if j == nil {
+		return errs.BadRequestError("nil saving job stats")
+	}
+
+	t := job.NewBasicTrackerWithStats(bm.ctx, j, bm.namespace, bm.pool, nil)
+	return t.Save()
+}
+
+// queryExecutions queries periodic executions by status
+func queryExecutions(conn redis.Conn, dataKey string, q *query.Parameter) ([]string, int64, error) {
+	total, err := redis.Int64(conn.Do("ZCOUNT", dataKey, 0, "+inf"))
+	if err != nil {
+		return nil, 0, err
+	}
+
+	var pageNumber, pageSize uint = 1, query.DefaultPageSize
+	if q.PageNumber > 0 {
+		pageNumber = q.PageNumber
+	}
+	if q.PageSize > 0 {
+		pageSize = q.PageSize
+	}
+
+	results := make([]string, 0)
+	if total == 0 || (int64)((pageNumber-1)*pageSize) >= total {
+		return results, total, nil
+	}
+
+	offset := (pageNumber - 1) * pageSize
+	args := []interface{}{dataKey, "+inf", 0, "LIMIT", offset, pageSize}
+
+	eIDs, err := redis.Values(conn.Do("ZREVRANGEBYSCORE", args...))
+	if err != nil {
+		return nil, 0, err
+	}
+
+	for _, eID := range eIDs {
+		if eIDBytes, ok := eID.([]byte); ok {
+			results = append(results, string(eIDBytes))
+		}
+	}
+
+	return results, total, nil
+}

--- a/src/jobservice/mgt/manager_test.go
+++ b/src/jobservice/mgt/manager_test.go
@@ -1,0 +1,184 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mgt
+
+import (
+	"context"
+	"github.com/gocraft/work"
+	"github.com/goharbor/harbor/src/jobservice/common/query"
+	"github.com/goharbor/harbor/src/jobservice/job"
+	"github.com/goharbor/harbor/src/jobservice/tests"
+	"github.com/gomodule/redigo/redis"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"testing"
+	"time"
+)
+
+// BasicManagerTestSuite tests the function of basic manager
+type BasicManagerTestSuite struct {
+	suite.Suite
+
+	namespace string
+	pool      *redis.Pool
+
+	manager Manager
+}
+
+// SetupSuite prepares the test suite
+func (suite *BasicManagerTestSuite) SetupSuite() {
+	suite.namespace = tests.GiveMeTestNamespace()
+	suite.pool = tests.GiveMeRedisPool()
+	suite.manager = NewManager(context.TODO(), suite.namespace, suite.pool)
+
+	// Mock data
+	periodicJob := &job.Stats{
+		Info: &job.StatsInfo{
+			JobID:    "1000",
+			JobName:  job.SampleJob,
+			JobKind:  job.KindPeriodic,
+			Status:   job.ScheduledStatus.String(),
+			IsUnique: false,
+			CronSpec: "* */10 * * * *",
+		},
+	}
+
+	t := job.NewBasicTrackerWithStats(context.TODO(), periodicJob, suite.namespace, suite.pool, nil)
+	err := t.Save()
+	require.NoError(suite.T(), err)
+
+	execution := &job.Stats{
+		Info: &job.StatsInfo{
+			JobID:         "1001",
+			JobKind:       job.KindScheduled,
+			JobName:       job.SampleJob,
+			Status:        job.PendingStatus.String(),
+			IsUnique:      false,
+			RunAt:         time.Now().Add(5 * time.Minute).Unix(),
+			UpstreamJobID: "1000",
+		},
+	}
+	t = job.NewBasicTrackerWithStats(context.TODO(), execution, suite.namespace, suite.pool, nil)
+	err = t.Save()
+	require.NoError(suite.T(), err)
+}
+
+// TearDownSuite clears the test suite
+func (suite *BasicManagerTestSuite) TearDownSuite() {
+	conn := suite.pool.Get()
+	defer func() {
+		_ = conn.Close()
+	}()
+
+	_ = tests.ClearAll(suite.namespace, conn)
+}
+
+// TestBasicManagerTestSuite is entry of go test
+func TestBasicManagerTestSuite(t *testing.T) {
+	suite.Run(t, new(BasicManagerTestSuite))
+}
+
+// TestBasicManagerGetJobs tests get jobs
+func (suite *BasicManagerTestSuite) TestBasicManagerGetJobs() {
+	jobs, _, err := suite.manager.GetJobs(&query.Parameter{
+		PageSize:   25,
+		PageNumber: 1,
+	})
+	require.NoError(suite.T(), err)
+	assert.Condition(suite.T(), func() bool {
+		return len(jobs) > 0
+	})
+}
+
+// TestGetPeriodicExecutions tests get periodic executions
+func (suite *BasicManagerTestSuite) TestGetPeriodicExecutions() {
+	extras := make(query.ExtraParameters)
+	extras.Set(query.ExtraParamKeyNonStoppedOnly, true)
+
+	jobs, total, err := suite.manager.GetPeriodicExecution("1000", &query.Parameter{
+		PageSize:   20,
+		PageNumber: 1,
+		Extras:     extras,
+	})
+	require.NoError(suite.T(), err)
+	assert.Equal(suite.T(), int64(1), total)
+	assert.Equal(suite.T(), int64(1), int64(len(jobs)))
+
+	t := job.NewBasicTrackerWithID(context.TODO(), "1001", suite.namespace, suite.pool, nil)
+	err = t.Load()
+	require.NoError(suite.T(), err)
+	err = t.PeriodicExecutionDone()
+	require.NoError(suite.T(), err)
+
+	jobs, total, err = suite.manager.GetPeriodicExecution("1000", &query.Parameter{
+		PageSize:   20,
+		PageNumber: 1,
+	})
+	require.NoError(suite.T(), err)
+	assert.Equal(suite.T(), int64(1), total)
+	assert.Equal(suite.T(), int64(1), int64(len(jobs)))
+}
+
+// TestGetScheduledJobs tests get scheduled jobs
+func (suite *BasicManagerTestSuite) TestGetScheduledJobs() {
+	enqueuer := work.NewEnqueuer(suite.namespace, suite.pool)
+	scheduledJob, err := enqueuer.EnqueueIn(job.SampleJob, 1000, make(map[string]interface{}))
+	require.NoError(suite.T(), err)
+	stats := &job.Stats{
+		Info: &job.StatsInfo{
+			JobID:   scheduledJob.ID,
+			JobName: job.SampleJob,
+			JobKind: job.KindScheduled,
+			Status:  job.ScheduledStatus.String(),
+			RunAt:   scheduledJob.RunAt,
+		},
+	}
+
+	t := job.NewBasicTrackerWithStats(context.TODO(), stats, suite.namespace, suite.pool, nil)
+	err = t.Save()
+	require.NoError(suite.T(), err)
+
+	list, total, err := suite.manager.GetScheduledJobs(&query.Parameter{
+		PageNumber: 1,
+		PageSize:   10,
+	})
+	require.NoError(suite.T(), err)
+	assert.Equal(suite.T(), int64(1), total)
+	assert.Equal(suite.T(), int64(1), int64(len(list)))
+}
+
+// TestGetJob tests get job
+func (suite *BasicManagerTestSuite) TestGetJob() {
+	j, err := suite.manager.GetJob("1001")
+	require.NoError(suite.T(), err)
+	assert.Equal(suite.T(), j.Info.JobID, "1001")
+}
+
+// TestSaveJob tests saving job
+func (suite *BasicManagerTestSuite) TestSaveJob() {
+	newJob := &job.Stats{
+		Info: &job.StatsInfo{
+			JobID:    "1002",
+			JobKind:  job.KindPeriodic,
+			JobName:  job.SampleJob,
+			Status:   job.PendingStatus.String(),
+			IsUnique: false,
+		},
+	}
+
+	err := suite.manager.SaveJob(newJob)
+	require.NoError(suite.T(), err)
+}

--- a/src/jobservice/worker/cworker/c_worker.go
+++ b/src/jobservice/worker/cworker/c_worker.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	"github.com/gocraft/work"
-	"github.com/goharbor/harbor/src/jobservice/common/query"
 	"github.com/goharbor/harbor/src/jobservice/common/utils"
 	"github.com/goharbor/harbor/src/jobservice/env"
 	"github.com/goharbor/harbor/src/jobservice/job"
@@ -360,40 +359,6 @@ func (w *basicWorker) ValidateJobParameters(jobType interface{}, params job.Para
 
 	theJ := runner.Wrap(jobType)
 	return theJ.Validate(params)
-}
-
-// ScheduledJobs returns the scheduled jobs by page
-func (w *basicWorker) ScheduledJobs(query *query.Parameter) ([]*job.Stats, int64, error) {
-	var page uint = 1
-	if query != nil && query.PageNumber > 1 {
-		page = query.PageNumber
-	}
-
-	sJobs, total, err := w.client.ScheduledJobs(page)
-	if err != nil {
-		return nil, 0, err
-	}
-
-	res := make([]*job.Stats, 0)
-	for _, sJob := range sJobs {
-		jID := sJob.ID
-		if len(sJob.Args) > 0 {
-			if _, ok := sJob.Args[period.PeriodicExecutionMark]; ok {
-				// Periodic scheduled job
-				jID = fmt.Sprintf("%s@%d", sJob.ID, sJob.RunAt)
-			}
-		}
-		t, err := w.ctl.Track(jID)
-		if err != nil {
-			// Just log it
-			logger.Errorf("cworker: query scheduled jobs error: %s", err)
-			continue
-		}
-
-		res = append(res, t.Job())
-	}
-
-	return res, total, nil
 }
 
 // RegisterJob is used to register the job to the worker.

--- a/src/jobservice/worker/cworker/c_worker_test.go
+++ b/src/jobservice/worker/cworker/c_worker_test.go
@@ -156,6 +156,9 @@ func (suite *CWorkerTestSuite) TestEnqueuePeriodicJob() {
 	params["name"] = "testing:v1"
 
 	m := time.Now().Minute()
+	if m+2 >= 60 {
+		m = m - 2
+	}
 	_, err := suite.cWorker.PeriodicallyEnqueue(
 		"fake_job",
 		params,
@@ -202,16 +205,6 @@ func (suite *CWorkerTestSuite) TestStopJob() {
 
 	err = suite.cWorker.StopJob(scheduledJob.Info.JobID)
 	require.NoError(suite.T(), err, "stop job: nil error expected but got %s", err)
-}
-
-// TestScheduledJobs tests get scheduled job
-func (suite *CWorkerTestSuite) TestScheduledJobs() {
-	params := make(map[string]interface{})
-	params["name"] = "testing:v1"
-
-	_, total, err := suite.cWorker.ScheduledJobs(nil)
-	require.NoError(suite.T(), err, "get scheduled job: nil error expected but got %s", err)
-	assert.EqualValues(suite.T(), int64(2), total, "expect 1 item but got 0")
 }
 
 type fakeJob struct{}

--- a/src/jobservice/worker/interface.go
+++ b/src/jobservice/worker/interface.go
@@ -15,7 +15,6 @@
 package worker
 
 import (
-	"github.com/goharbor/harbor/src/jobservice/common/query"
 	"github.com/goharbor/harbor/src/jobservice/job"
 )
 
@@ -112,16 +111,4 @@ type Interface interface {
 	// Return:
 	//  error           : error returned if meet any problems
 	RetryJob(jobID string) error
-
-	// Get the scheduled jobs by page
-	// The page number in the query will be ignored, default 20 is used. This is the limitation of backend lib.
-	// The total number is also returned.
-	//
-	// query *query.Parameter : query parameters
-	//
-	// Return:
-	//   []*job.Stats : list of scheduled jobs
-	//   int          : the total number of scheduled jobs
-	//   error        : non nil error if meet any issues
-	ScheduledJobs(query *query.Parameter) ([]*job.Stats, int64, error)
 }

--- a/tests/robot-cases/Group0-BAT/API_DB.robot
+++ b/tests/robot-cases/Group0-BAT/API_DB.robot
@@ -17,6 +17,8 @@ ${SERVER_API_ENDPOINT}  ${SERVER_URL}/api
 &{SERVER_CONFIG}  endpoint=${SERVER_API_ENDPOINT}  verify_ssl=False
 
 *** Test Cases ***
+Test Case - Garbage Collection
+    Harbor API Test  ./tests/apitests/python/test_garbage_collection.py
 Test Case - Add Private Project Member and Check User Can See It
     Harbor API Test  ./tests/apitests/python/test_add_member_to_private_project.py
 Test Case - Delete a Repository of a Certain Project Created by Normal User
@@ -33,8 +35,6 @@ Test Case - Manage Project Member
     Harbor API Test  ./tests/apitests/python/test_manage_project_member.py
 Test Case - Project Level Policy Content Trust
     Harbor API Test  ./tests/apitests/python/test_project_level_policy_content_trust.py
-Test Case - Garbage Collection
-    Harbor API Test  ./tests/apitests/python/test_garbage_collection.py
 Test Case - User View Logs
     Harbor API Test  ./tests/apitests/python/test_user_view_logs.py
 Test Case - Scan All Images


### PR DESCRIPTION
Signed-off-by: Steven Zou <szou@vmware.com>

Support API  **GET** `/api/v1/jobs` to get job list
Following query parameters supported:
* `kind=Scheduled` : only query the jobs which are in the scheduled queue (not executed yet)
* `page_number` : only valid for `kind=Scheduled` case
* `page_size`:  for `kind=Scheduled` case, this is fixed to 20; for other cases, this is used to set the query scope (not the real page_size, so the items in the returned list are not guaranteed to be totally equal with `page_size`. Check [documemt](https://redis.io/commands/scan) to learn more details)
* for case without param `kind`, param `cursor` is used to query the 'next page'

For the response header,
  * For `kind=Scheduled`, header `Total-Count` is returned, which includes the total number of the requesting resurces
  * For othere cases, header `Next-Cursor` is returned, which contains the next slot used to get the "next page"

