### PR TITLE
Return more details for error in exchange token

### DIFF
--- a/src/common/api/base.go
+++ b/src/common/api/base.go
@@ -222,6 +222,9 @@ func (b *BaseAPI) SendBadRequestError(err error) {
 }
 
 // SendInternalServerError sends internal server error to the client.
+// Note the detail info of err will not include in the response body.
+// When you send an internal server error  to the client, you expect user to check the log
+// to find out the root cause.
 func (b *BaseAPI) SendInternalServerError(err error) {
 	log.Error(err.Error())
 	b.RenderFormattedError(http.StatusInternalServerError, http.StatusText(http.StatusInternalServerError))
@@ -232,12 +235,12 @@ func (b *BaseAPI) SendForbiddenError(err error) {
 	b.RenderFormattedError(http.StatusForbidden, err.Error())
 }
 
-// SendPreconditionFailedError sends forbidden error to the client.
+// SendPreconditionFailedError sends conflict error to the client.
 func (b *BaseAPI) SendPreconditionFailedError(err error) {
 	b.RenderFormattedError(http.StatusPreconditionFailed, err.Error())
 }
 
-// SendStatusServiceUnavailableError sends forbidden error to the client.
+// SendStatusServiceUnavailableError sends service unavailable error to the client.
 func (b *BaseAPI) SendStatusServiceUnavailableError(err error) {
 	b.RenderFormattedError(http.StatusServiceUnavailable, err.Error())
 }

--- a/src/core/controllers/oidc.go
+++ b/src/core/controllers/oidc.go
@@ -82,7 +82,9 @@ func (oc *OIDCController) Callback() {
 	ctx := oc.Ctx.Request.Context()
 	token, err := oidc.ExchangeToken(ctx, code)
 	if err != nil {
-		oc.SendInternalServerError(err)
+		log.Errorf("Failed to exchange token, error: %v", err)
+		// Return a 4xx error so user can see the details in case it's due to misconfiguration.
+		oc.SendBadRequestError(err)
 		return
 	}
 	idToken, err := oidc.VerifyToken(ctx, token.IDToken)


### PR DESCRIPTION
This commit update the response off OIDC callback when there's error in exchange token.
Additionally add comments to clarify that by default 500 error will not
contain any details.

Signed-off-by: Daniel Jiang <jiangd@vmware.com>