### PR TITLE
Display '-' if the end_time does not exist

### DIFF
--- a/src/portal/lib/src/replication/replication-tasks/replication-tasks.component.html
+++ b/src/portal/lib/src/replication/replication-tasks/replication-tasks.component.html
@@ -110,7 +110,7 @@
         <clr-dg-cell>{{t.operation}}</clr-dg-cell>
         <clr-dg-cell>{{t.status}}</clr-dg-cell>
         <clr-dg-cell>{{t.start_time | date: 'short'}}</clr-dg-cell>
-        <clr-dg-cell>{{t.end_time | date: 'short'}}</clr-dg-cell>
+        <clr-dg-cell>{{t.end_time ? (t.end_time | date: 'short') : "-"}}</clr-dg-cell>
         <clr-dg-cell>
           <a target="_blank" [href]="viewLog(t.id)">
             <clr-icon shape="list"></clr-icon>

--- a/src/portal/lib/src/replication/replication-tasks/replication-tasks.component.ts
+++ b/src/portal/lib/src/replication/replication-tasks/replication-tasks.component.ts
@@ -8,11 +8,7 @@ import { ErrorHandler } from "../../error-handler/error-handler";
 import { ReplicationJob, ReplicationTasks, Comparator, ReplicationJobItem, State } from "../../service/interface";
 import { CustomComparator, DEFAULT_PAGE_SIZE, calculatePage, doFiltering, doSorting } from "../../utils";
 import { RequestQueryParams } from "../../service/RequestQueryParams";
-const taskStatus: any = {
-  PENDING: "pending",
-  RUNNING: "running",
-  SCHEDULED: "scheduled"
-};
+const executionStatus = 'InProgress';
 @Component({
   selector: 'replication-tasks',
   templateUrl: './replication-tasks.component.html',
@@ -73,7 +69,7 @@ export class ReplicationTasksComponent implements OnInit, OnDestroy {
     if (!this.timerDelay) {
       this.timerDelay = timer(10000, 10000).subscribe(() => {
         let count: number = 0;
-          if (this.executions['in_progress'] > 0) {
+          if (this.executions['status'] === executionStatus) {
             count++;
           }
         if (count > 0) {
@@ -180,9 +176,6 @@ export class ReplicationTasksComponent implements OnInit, OnDestroy {
   }
 
   public doSearch(value: string): void {
-    if (!value) {
-      return;
-    }
     this.searchTask = value.trim();
     this.loading = true;
     this.clrLoadTasks();

--- a/src/portal/lib/src/replication/replication.component.ts
+++ b/src/portal/lib/src/replication/replication.component.ts
@@ -246,9 +246,6 @@ export class ReplicationComponent implements OnInit, OnDestroy {
     );
   }
   public doSearchExecutions(terms: string): void {
-    if (!terms) {
-      return;
-    }
     this.currentTerm = terms.trim();
     // Trigger data loading and start from first page
     this.jobsLoading = true;


### PR DESCRIPTION
fix #7551 
1、If the task is in progress, the api should not return end_time. The frontend check that if there is no end_time field, it will display ‘-’ by default.
2、Refresh the list if the search field is empty

![image](https://user-images.githubusercontent.com/40712758/56891209-4e2df800-6aae-11e9-9b6e-61a07005f35c.png)
Signed-off-by: FangyuanCheng <fangyuanc@vmware.com>