### PR TITLE
Return 400 status code for validation failed

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -515,8 +515,6 @@ paths:
           description: User need to log in first.
         '403':
           description: User in session does not have permission to the project.
-        '404':
-          description: 'Project does not exist, or the username does not found, or the user group does not found.'
         '409':
           description: An LDAP user group with same DN already exist.
         '500':
@@ -1846,8 +1844,6 @@ paths:
           $ref: '#/responses/Unauthorized'
         '403':
           $ref: '#/responses/Forbidden'
-        '404':
-          $ref: '#/responses/NotFound'
         '409':
           $ref: '#/responses/Conflict'
         '415':
@@ -2578,8 +2574,6 @@ paths:
           description: User need to log in first.
         '403':
           description: User in session does not have permission to the user group.
-        '404':
-          description: The LDAP group is not found.
         '409':
           description: An LDAP user group with same DN already exist.
         '500':

--- a/src/core/api/label.go
+++ b/src/core/api/label.go
@@ -116,7 +116,7 @@ func (l *LabelAPI) Post() {
 			return
 		}
 		if !exist {
-			l.SendNotFoundError(fmt.Errorf("project %d not found", label.ProjectID))
+			l.SendBadRequestError(fmt.Errorf("project %d not found", label.ProjectID))
 			return
 		}
 	}

--- a/src/core/api/label_test.go
+++ b/src/core/api/label_test.go
@@ -106,7 +106,7 @@ func TestLabelAPIPost(t *testing.T) {
 			code: http.StatusForbidden,
 		},
 
-		// 404 non-exist project
+		// 400 non-exist project
 		{
 			request: &testingRequest{
 				method: http.MethodPost,
@@ -118,7 +118,7 @@ func TestLabelAPIPost(t *testing.T) {
 				},
 				credential: projAdmin,
 			},
-			code: http.StatusNotFound,
+			code: http.StatusBadRequest,
 		},
 
 		// 200

--- a/src/core/api/projectmember.go
+++ b/src/core/api/projectmember.go
@@ -158,7 +158,7 @@ func (pma *ProjectMemberAPI) Post() {
 
 	pmid, err := AddProjectMember(projectID, request)
 	if err == auth.ErrorGroupNotExist || err == auth.ErrorUserNotExist {
-		pma.SendNotFoundError(fmt.Errorf("Failed to add project member, error: %v", err))
+		pma.SendBadRequestError(fmt.Errorf("Failed to add project member, error: %v", err))
 		return
 	} else if err == auth.ErrDuplicateLDAPGroup {
 		pma.SendConflictError(fmt.Errorf("Failed to add project member, already exist LDAP group or project member, groupDN:%v", request.MemberGroup.LdapGroupDN))

--- a/src/core/api/projectmember_test.go
+++ b/src/core/api/projectmember_test.go
@@ -126,7 +126,7 @@ func TestProjectMemberAPI_Post(t *testing.T) {
 				},
 				credential: admin,
 			},
-			code: http.StatusNotFound,
+			code: http.StatusBadRequest,
 		},
 		{
 			request: &testingRequest{

--- a/src/core/api/replication_policy.go
+++ b/src/core/api/replication_policy.go
@@ -131,7 +131,7 @@ func (r *ReplicationPolicyAPI) validateRegistry(policy *model.Policy) bool {
 		return false
 	}
 	if registry == nil {
-		r.SendNotFoundError(fmt.Errorf("registry %d not found", registryID))
+		r.SendBadRequestError(fmt.Errorf("registry %d not found", registryID))
 		return false
 	}
 	return true

--- a/src/core/api/replication_policy_test.go
+++ b/src/core/api/replication_policy_test.go
@@ -159,7 +159,7 @@ func TestReplicationPolicyAPICreate(t *testing.T) {
 			},
 			code: http.StatusConflict,
 		},
-		// 404, registry not found
+		// 400, registry not found
 		{
 			request: &testingRequest{
 				method:     http.MethodPost,
@@ -172,7 +172,7 @@ func TestReplicationPolicyAPICreate(t *testing.T) {
 					},
 				},
 			},
-			code: http.StatusNotFound,
+			code: http.StatusBadRequest,
 		},
 		// 201
 		{
@@ -310,7 +310,7 @@ func TestReplicationPolicyAPIUpdate(t *testing.T) {
 			},
 			code: http.StatusConflict,
 		},
-		// 404, registry not found
+		// 400, registry not found
 		{
 			request: &testingRequest{
 				method:     http.MethodPut,
@@ -323,7 +323,7 @@ func TestReplicationPolicyAPIUpdate(t *testing.T) {
 					},
 				},
 			},
-			code: http.StatusNotFound,
+			code: http.StatusBadRequest,
 		},
 		// 200
 		{

--- a/src/core/api/usergroup.go
+++ b/src/core/api/usergroup.go
@@ -15,12 +15,12 @@
 package api
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
 
-	"errors"
 	"github.com/goharbor/harbor/src/common"
 	"github.com/goharbor/harbor/src/common/dao/group"
 	"github.com/goharbor/harbor/src/common/models"
@@ -123,7 +123,7 @@ func (uga *UserGroupAPI) Post() {
 	// User can not add ldap group when the ldap server is offline
 	ldapGroup, err := auth.SearchGroup(userGroup.LdapGroupDN)
 	if err == ldap.ErrNotFound || ldapGroup == nil {
-		uga.SendNotFoundError(fmt.Errorf("LDAP Group DN is not found: DN:%v", userGroup.LdapGroupDN))
+		uga.SendBadRequestError(fmt.Errorf("LDAP Group DN is not found: DN:%v", userGroup.LdapGroupDN))
 		return
 	}
 	if err == ldap.ErrDNSyntax {


### PR DESCRIPTION
Return 400 status code for validation failed which fix #6880 and this match the responses of `/api/labels` in swagger.yaml 

Signed-off-by: He Weiwei <hweiwei@vmware.com>