### PR TITLE
Update API test script - "Robot Account"

### DIFF
--- a/tests/apitests/python/library/docker_api.py
+++ b/tests/apitests/python/library/docker_api.py
@@ -13,11 +13,18 @@ class DockerAPI(object):
     def __init__(self):
         self.DCLIENT = docker.APIClient(base_url='unix://var/run/docker.sock',version='auto',timeout=10)
 
-    def docker_login(self, registry, username, password):
+    def docker_login(self, registry, username, password, expected_error_message = None):
+        if expected_error_message is "":
+            expected_error_message = None
         try:
             self.DCLIENT.login(registry = registry, username=username, password=password)
-        except docker.errors.APIError, e:
-            raise Exception(r" Docker login failed, error is [{}]".format (e.message))
+        except docker.errors.APIError, err:
+            if expected_error_message is not None:
+                print "docker login error:", str(err)
+                if str(err).lower().find(expected_error_message.lower()) < 0:
+                    raise Exception(r"Docker login: Return message {} is not as expected {}".format(str(err), expected_error_message))
+            else:
+                raise Exception(r" Docker login {} failed, error is [{}]".format (image, err.message))
 
     def docker_image_pull(self, image, tag = None, expected_error_message = None):
         if tag is not None:

--- a/tests/apitests/python/library/repository.py
+++ b/tests/apitests/python/library/repository.py
@@ -6,17 +6,20 @@ import swagger_client
 from docker_api import DockerAPI
 from swagger_client.rest import ApiException
 
-def pull_harbor_image(registry, username, password, image, tag, expected_error_message = None):
+def pull_harbor_image(registry, username, password, image, tag, expected_login_error_message = None, expected_error_message = None):
     _docker_api = DockerAPI()
-    _docker_api.docker_login(registry, username, password)
+    _docker_api.docker_login(registry, username, password, expected_error_message = expected_login_error_message)
+    if expected_login_error_message != None:
+        return
     time.sleep(2)
     _docker_api.docker_image_pull(r'{}/{}'.format(registry, image), tag = tag, expected_error_message = expected_error_message)
 
-def push_image_to_project(project_name, registry, username, password, image, tag, expected_error_message = None):
+def push_image_to_project(project_name, registry, username, password, image, tag, expected_login_error_message = None, expected_error_message = None):
     _docker_api = DockerAPI()
-    _docker_api.docker_login(registry, username, password)
+    _docker_api.docker_login(registry, username, password, expected_error_message = expected_login_error_message)
     time.sleep(2)
-
+    if expected_login_error_message != None:
+        return
     _docker_api.docker_image_pull(image, tag = tag)
     time.sleep(2)
 

--- a/tests/apitests/python/test_robot_account.py
+++ b/tests/apitests/python/test_robot_account.py
@@ -120,15 +120,15 @@ class TestProjects(unittest.TestCase):
         push_image_to_project(project_ra_name_c, harbor_server, robot_account.name, robot_account.token, image_robot_account, tag, expected_error_message = "denied: requested access to the resource is denied")
 
         print "#12. Update action property of robot account(RA);"
-        #self.project.disable_project_robot_account(TestProjects.project_ra_id_a, robot_id, True, **TestProjects.USER_RA_CLIENT)
+        self.project.disable_project_robot_account(TestProjects.project_ra_id_a, robot_id, True, **TestProjects.USER_RA_CLIENT)
 
         print "#13. Pull image(ImagePA) from project(PA) by robot account(RA), it must be not successful;"
-        #pull_harbor_image(harbor_server, robot_account.name, robot_account.token, TestProjects.repo_name_in_project_a, tag_a, expected_error_message = "")
+        pull_harbor_image(harbor_server, robot_account.name, robot_account.token, TestProjects.repo_name_in_project_a, tag_a, expected_login_error_message = "401 Client Error: Unauthorized")
 
         print "#14. Push image(ImageRA) to project(PA) by robot account(RA), it must be not successful;"
-        #push_image_to_project(project_ra_name_a, harbor_server, robot_account.name, robot_account.token, image_robot_account, tag, expected_error_message = "")
+        push_image_to_project(project_ra_name_a, harbor_server, robot_account.name, robot_account.token, image_robot_account, tag, expected_login_error_message = "401 Client Error: Unauthorized")
 
-        print "#15. Push image(ImageRA) to project(PA) by robot account(RA), it must be not successful;"
+        print "#15. Delete robot account(RA), it must be not successful;"
         self.project.delete_project_robot_account(TestProjects.project_ra_id_a, robot_id, **TestProjects.USER_RA_CLIENT)
 
 if __name__ == '__main__':

--- a/tests/apitests/python/testutils.py
+++ b/tests/apitests/python/testutils.py
@@ -17,7 +17,7 @@ USER_ROLE=dict(admin=0,normal=1)
 TEARDOWN = True
 
 def GetProductApi(username, password, harbor_server= os.environ["HARBOR_HOST"]):
-    
+
     cfg = swagger_client.Configuration()
     cfg.host = "https://"+harbor_server+"/api"
     cfg.username = username

--- a/tests/robot-cases/Group0-BAT/API_DB.robot
+++ b/tests/robot-cases/Group0-BAT/API_DB.robot
@@ -45,3 +45,5 @@ Test Case - Assign Sys Admin
     Harbor API Test  ./tests/apitests/python/test_assign_sys_admin.py
 Test Case - Retag Image
     Harbor API Test  ./tests/apitests/python/test_retag.py
+Test Case - Robot Account
+    Harbor API Test  ./tests/apitests/python/test_robot_account.py


### PR DESCRIPTION
This API test script was blocked by a swagger error, now this error was fixed, so robot account script can be finished now. In swagger.yaml, robot account can be updated in "disabled" status, it's added into script.

Signed-off-by: danfengliu <danfengl@vmware.com>