### PR TITLE
Fix failed to get filter data when switching replication mode

### DIFF
--- a/src/portal/lib/src/create-edit-rule/create-edit-rule.component.html
+++ b/src/portal/lib/src/create-edit-rule/create-edit-rule.component.html
@@ -21,8 +21,8 @@
         <!-- replication mode -->
         <div class="form-group form-group-override">
           <label class="form-group-label-override">{{'REPLICATION.REPLI_MODE' | translate}}</label>
-          <div class="radio-inline" [class.disabled]="policyId >= 0">
-            <input type="radio" id="push_base" name="replicationMode" [value]=true  [disabled]="policyId >= 0" [(ngModel)]="isPushMode" (change)="modeChange()" [ngModelOptions]="{standalone: true}">
+          <div class="radio-inline" [class.disabled]="policyId >= 0 || onGoing">
+            <input type="radio" id="push_base" name="replicationMode" [value]=true  [disabled]="policyId >= 0 || onGoing" [(ngModel)]="isPushMode" (change)="modeChange()" [ngModelOptions]="{standalone: true}">
             <label for="push_base">Push-based</label>
             <clr-tooltip class="mode-tooltip">
               <clr-icon clrTooltipTrigger shape="info-circle" size="24"></clr-icon>
@@ -31,8 +31,8 @@
               </clr-tooltip-content>
             </clr-tooltip>
           </div>
-          <div class="radio-inline" [class.disabled]="policyId >= 0">          
-            <input type="radio" id="pull_base" name="replicationMode" [value]=false [disabled]="policyId >= 0" [(ngModel)]="isPushMode" [ngModelOptions]="{standalone: true}">
+          <div class="radio-inline" [class.disabled]="policyId >= 0 || onGoing">          
+            <input type="radio" id="pull_base" name="replicationMode" [value]=false [disabled]="policyId >= 0 || onGoing" [(ngModel)]="isPushMode" [ngModelOptions]="{standalone: true}">
             <label for="pull_base">Pull-based</label>
             <clr-tooltip class="mode-tooltip">
               <clr-icon clrTooltipTrigger shape="info-circle" size="24"></clr-icon>

--- a/src/portal/lib/src/replication/replication.component.ts
+++ b/src/portal/lib/src/replication/replication.component.ts
@@ -505,6 +505,8 @@ export class ReplicationComponent implements OnInit, OnDestroy {
 
     if (seconds <= 0 && timesDiff > 0) {
       return timesDiff + 'ms';
+    } else {
+      return '-';
     }
   }
 }


### PR DESCRIPTION
Steps in issue
1、Create a new replication rule
2、Click pull mode
3、Choose a source repository
4、Quickly click on the push mode before the filter does not get the data.
5、Dialog display
![image](https://user-images.githubusercontent.com/40712758/56957547-1d1af980-6b7a-11e9-86f7-7b5b090ab737.png)


solution：
Disable replication mode before the filter is loaded.

![image](https://user-images.githubusercontent.com/40712758/57207841-a0b56a00-7002-11e9-80dc-96db8454a09b.png)

Signed-off-by: FangyuanCheng <fangyuanc@vmware.com>