### PR TITLE
Modify auth mode icon to jump to a new page only in OIDC mode

### DIFF
--- a/src/portal/src/app/config/auth/config-auth.component.html
+++ b/src/portal/src/app/config/auth/config-auth.component.html
@@ -12,8 +12,8 @@
                     <option value="oidc_auth">{{'CONFIG.AUTH_MODE_OIDC' | translate }}</option>
                 </select>
             </div>
-            <a href="{{currentConfig?.auth_mode?.value==='oidc_auth'?'https://openid.net/connect/':'javascript:void(0)'}}"
-                target="{{currentConfig?.auth_mode?.value==='oidc_auth'?'_blank':''}}" role="tooltip"
+            <a href="{{currentConfig?.auth_mode?.value==='oidc_auth'?'https://openid.net/connect/':'/'}}"
+                target="{{currentConfig?.auth_mode?.value==='oidc_auth'?'_blank':''}}" role="tooltip" (click)="allowGoOidc($event)"
                 aria-haspopup="true" class="tooltip tooltip-lg tooltip-top-right top-1">
                 <clr-icon shape="info-circle" size="24" class="info-tips-icon"></clr-icon>
                 <span class="tooltip-content">{{'CONFIG.TOOLTIP.AUTH_MODE' | translate}}</span>

--- a/src/portal/src/app/config/auth/config-auth.component.ts
+++ b/src/portal/src/app/config/auth/config-auth.component.ts
@@ -251,5 +251,8 @@ export class ConfigurationAuthComponent implements OnChanges, OnInit {
             console.error('Nothing changed');
         }
     }
+    public allowGoOidc(event) {
+        return this.currentConfig.auth_mode && this.currentConfig.auth_mode.value === 'oidc_auth';
+    }
 
 }


### PR DESCRIPTION
for 7622: click the icon of auth mode when value is database in configuration page will go to a wrong pagee

Signed-off-by: Yogi_Wang <yawang@vmware.com>