### PR TITLE
expose the chartmuseum metrics endpoint in harbor

### DIFF
--- a/src/core/api/chart_repository.go
+++ b/src/core/api/chart_repository.go
@@ -124,6 +124,23 @@ func (cra *ChartRepositoryAPI) GetHealthStatus() {
 	chartController.ProxyTraffic(cra.Ctx.ResponseWriter, cra.Ctx.Request)
 }
 
+// GetMetrics handles GET /api/chartrepo/metrics
+func (cra *ChartRepositoryAPI) GetMetrics() {
+	// Check access
+	if !cra.SecurityCtx.IsAuthenticated() {
+		cra.SendUnAuthorizedError(errors.New("Unauthorized"))
+		return
+	}
+
+	if !cra.SecurityCtx.IsSysAdmin() {
+		cra.SendForbiddenError(errors.New(cra.SecurityCtx.GetUsername()))
+		return
+	}
+
+	// Directly proxy to the backend
+	chartController.ProxyTraffic(cra.Ctx.ResponseWriter, cra.Ctx.Request)
+}
+
 // GetIndexByRepo handles GET /:repo/index.yaml
 func (cra *ChartRepositoryAPI) GetIndexByRepo() {
 	// Check access

--- a/src/core/router.go
+++ b/src/core/router.go
@@ -145,6 +145,7 @@ func initRouters() {
 		// Charts are controlled under projects
 		chartRepositoryAPIType := &api.ChartRepositoryAPI{}
 		beego.Router("/api/chartrepo/health", chartRepositoryAPIType, "get:GetHealthStatus")
+		beego.Router("/api/chartrepo/metrics", chartRepositoryAPIType, "get:GetMetrics")
 		beego.Router("/api/chartrepo/:repo/charts", chartRepositoryAPIType, "get:ListCharts")
 		beego.Router("/api/chartrepo/:repo/charts/:name", chartRepositoryAPIType, "get:ListChartVersions")
 		beego.Router("/api/chartrepo/:repo/charts/:name", chartRepositoryAPIType, "delete:DeleteChart")


### PR DESCRIPTION
The chartmuseum server exposes a metrics endpoint. It would be useful for harbor to provide a reverse proxy to it.