### PR TITLE
Fix will not get filter and trigger when switching from push to pull

### DIFF
--- a/src/portal/lib/src/create-edit-rule/create-edit-rule.component.html
+++ b/src/portal/lib/src/create-edit-rule/create-edit-rule.component.html
@@ -22,7 +22,7 @@
         <div class="form-group form-group-override">
           <label class="form-group-label-override">{{'REPLICATION.REPLI_MODE' | translate}}</label>
           <div class="radio-inline" [class.disabled]="policyId >= 0 || onGoing">
-            <input type="radio" id="push_base" name="replicationMode" [value]=true  [disabled]="policyId >= 0 || onGoing" [(ngModel)]="isPushMode" (change)="modeChange()" [ngModelOptions]="{standalone: true}">
+            <input type="radio" id="push_base" name="replicationMode" [value]=true  [disabled]="policyId >= 0 || onGoing" [(ngModel)]="isPushMode" (change)="pushModeChange()" [ngModelOptions]="{standalone: true}">
             <label for="push_base">Push-based</label>
             <clr-tooltip class="mode-tooltip">
               <clr-icon clrTooltipTrigger shape="info-circle" size="24"></clr-icon>
@@ -32,7 +32,7 @@
             </clr-tooltip>
           </div>
           <div class="radio-inline" [class.disabled]="policyId >= 0 || onGoing">          
-            <input type="radio" id="pull_base" name="replicationMode" [value]=false [disabled]="policyId >= 0 || onGoing" [(ngModel)]="isPushMode" [ngModelOptions]="{standalone: true}">
+            <input type="radio" id="pull_base" name="replicationMode" [value]=false [disabled]="policyId >= 0 || onGoing" [(ngModel)]="isPushMode" (change)="pullModeChange()" [ngModelOptions]="{standalone: true}">
             <label for="pull_base">Pull-based</label>
             <clr-tooltip class="mode-tooltip">
               <clr-icon clrTooltipTrigger shape="info-circle" size="24"></clr-icon>

--- a/src/portal/lib/src/create-edit-rule/create-edit-rule.component.ts
+++ b/src/portal/lib/src/create-edit-rule/create-edit-rule.component.ts
@@ -133,9 +133,17 @@ export class CreateEditRuleComponent implements OnInit, OnDestroy {
   equals(c1: any, c2: any): boolean {
     return c1 && c2 ? c1.id === c2.id : c1 === c2;
   }
-  modeChange(): void {
+  pushModeChange(): void {
     this.setFilter([]);
     this.initRegistryInfo(0);
+  }
+
+  pullModeChange(): void {
+    let selectId = this.ruleForm.get('src_registry').value;
+    if (selectId) {
+      this.setFilter([]);
+      this.initRegistryInfo(selectId.id);
+    }
   }
 
   sourceChange($event): void {


### PR DESCRIPTION
fix #7662 
Switch from push mode to pull mode. If the source registry has been selected, it will not get filter and trigger according to the id of the selected registry, resulting in incorrect page data.

![image](https://user-images.githubusercontent.com/40712758/57271053-8346d580-70c0-11e9-9956-332376c488b4.png)

solution:
Switch from push to pull. If the source registry is selected, re-acquire the filter and trigger according to the selected id.

![image](https://user-images.githubusercontent.com/40712758/57271518-5abfdb00-70c2-11e9-89c9-b7fae10a1ecd.png)

Signed-off-by: FangyuanCheng <fangyuanc@vmware.com>