### PR TITLE
Rename the adapter name of docker registry

### DIFF
--- a/src/replication/adapter/native/adapter.go
+++ b/src/replication/adapter/native/adapter.go
@@ -20,16 +20,14 @@ import (
 	"github.com/goharbor/harbor/src/replication/model"
 )
 
-const registryTypeNative model.RegistryType = "native"
-
 func init() {
-	if err := adp.RegisterFactory(registryTypeNative, func(registry *model.Registry) (adp.Adapter, error) {
+	if err := adp.RegisterFactory(model.RegistryTypeDockerRegistry, func(registry *model.Registry) (adp.Adapter, error) {
 		return newAdapter(registry)
 	}); err != nil {
-		log.Errorf("failed to register factory for %s: %v", registryTypeNative, err)
+		log.Errorf("failed to register factory for %s: %v", model.RegistryTypeDockerRegistry, err)
 		return
 	}
-	log.Infof("the factory for adapter %s registered", registryTypeNative)
+	log.Infof("the factory for adapter %s registered", model.RegistryTypeDockerRegistry)
 }
 
 func newAdapter(registry *model.Registry) (*native, error) {
@@ -52,7 +50,7 @@ var _ adp.Adapter = native{}
 
 func (native) Info() (info *model.RegistryInfo, err error) {
 	return &model.RegistryInfo{
-		Type: registryTypeNative,
+		Type: model.RegistryTypeDockerRegistry,
 		SupportedResourceTypes: []model.ResourceType{
 			model.ResourceTypeImage,
 		},

--- a/src/replication/adapter/native/adapter_test.go
+++ b/src/replication/adapter/native/adapter_test.go
@@ -57,7 +57,7 @@ func Test_native_Info(t *testing.T) {
 	var info, err = adapter.Info()
 	assert.Nil(t, err)
 	assert.NotNil(t, info)
-	assert.Equal(t, registryTypeNative, info.Type)
+	assert.Equal(t, model.RegistryTypeDockerRegistry, info.Type)
 	assert.Equal(t, 1, len(info.SupportedResourceTypes))
 	assert.Equal(t, 2, len(info.SupportedResourceFilters))
 	assert.Equal(t, 2, len(info.SupportedTriggers))

--- a/src/replication/adapter/native/image_registry_test.go
+++ b/src/replication/adapter/native/image_registry_test.go
@@ -65,7 +65,7 @@ func Test_native_FetchImages(t *testing.T) {
 	fmt.Println("mockNativeRegistry URL: ", mock.URL)
 
 	var registry = &model.Registry{
-		Type:     registryTypeNative,
+		Type:     model.RegistryTypeDockerRegistry,
 		URL:      mock.URL,
 		Insecure: true,
 	}

--- a/src/replication/model/registry.go
+++ b/src/replication/model/registry.go
@@ -22,10 +22,10 @@ import (
 
 // const definition
 const (
-	// RegistryTypeHarbor indicates registry type harbor
-	RegistryTypeHarbor    RegistryType = "harbor"
-	RegistryTypeDockerHub RegistryType = "dockerHub"
-	RegistryTypeHuawei    RegistryType = "Huawei"
+	RegistryTypeHarbor         RegistryType = "harbor"
+	RegistryTypeDockerHub      RegistryType = "docker-hub"
+	RegistryTypeDockerRegistry RegistryType = "docker-registry"
+	RegistryTypeHuawei         RegistryType = "huawei"
 
 	FilterStyleTypeText  = "input"
 	FilterStyleTypeRadio = "radio"


### PR DESCRIPTION
Rename the adapter name of docker registry to "docker-registry"

Signed-off-by: Wenkai Yin <yinw@vmware.com>