### PR TITLE
Make sure panic is not thrown when refresh token

### DIFF
--- a/src/common/utils/oidc/helper.go
+++ b/src/common/utils/oidc/helper.go
@@ -208,5 +208,9 @@ func RefreshToken(ctx context.Context, token *Token) (*Token, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Token{Token: *t, IDToken: t.Extra("id_token").(string)}, nil
+	it, ok := t.Extra("id_token").(string)
+	if !ok {
+		return nil, fmt.Errorf("failed to get id_token from refresh response")
+	}
+	return &Token{Token: *t, IDToken: it}, nil
 }


### PR DESCRIPTION
Some OIDC providers will not return error when refreshing the token

Fixes #7695

Signed-off-by: Daniel Jiang <jiangd@vmware.com>