### PR TITLE
Fix unable to save after entering invalid cron and then switching back to other schedules

### DIFF
--- a/src/portal/lib/src/cron-schedule/cron-schedule.component.ts
+++ b/src/portal/lib/src/cron-schedule/cron-schedule.component.ts
@@ -73,12 +73,15 @@ export class CronScheduleComponent implements OnChanges {
   }
 
   save(): void {
-    if (this.scheduleType === SCHEDULE_TYPE.CUSTOM && this.cronString === '') {
-      this.dateInvalid = true;
+    if (this.scheduleType === SCHEDULE_TYPE.CUSTOM ) {
+      if (this.cronString === '') {
+        this.dateInvalid = true;
+      }
+      if (this.dateInvalid) {
+        return;
+      }
     }
-    if (this.dateInvalid) {
-      return;
-    }
+
     let scheduleTerm: string = "";
     if (this.scheduleType && this.scheduleType === SCHEDULE_TYPE.NONE) {
       scheduleTerm = "";


### PR DESCRIPTION
fix #7668
Should only verify that the invalid cron is entered under the custom, can not be saved
Signed-off-by: FangyuanCheng <fangyuanc@vmware.com>