### PR TITLE
Redirect regular user to OIDC login page

### DIFF
--- a/src/common/const.go
+++ b/src/common/const.go
@@ -139,6 +139,7 @@ const (
 	RobotTokenDuration      = "robot_token_duration"
 
 	OIDCCallbackPath = "/c/oidc/callback"
+	OIDCLoginPath    = "/c/oidc/login"
 
 	ChartUploadCtxKey = contextKey("chart_upload_event")
 )

--- a/src/core/controllers/controllers_test.go
+++ b/src/core/controllers/controllers_test.go
@@ -14,6 +14,8 @@
 package controllers
 
 import (
+	"context"
+	"github.com/goharbor/harbor/src/core/filter"
 	"net/http"
 	"net/http/httptest"
 	// "net/url"
@@ -88,6 +90,15 @@ func TestUserResettable(t *testing.T) {
 	assert.True(isUserResetable(u2))
 	config.InitWithSettings(DBAuthConfig)
 	assert.True(isUserResetable(u1))
+}
+
+func TestRedirectForOIDC(t *testing.T) {
+	ctx := context.WithValue(context.Background(), filter.AuthModeKey, common.DBAuth)
+	assert.False(t, redirectForOIDC(ctx, "nonexist"))
+	ctx = context.WithValue(context.Background(), filter.AuthModeKey, common.OIDCAuth)
+	assert.True(t, redirectForOIDC(ctx, "nonexist"))
+	assert.False(t, redirectForOIDC(ctx, "admin"))
+
 }
 
 // TestMain is a sample to run an endpoint test

--- a/src/core/router.go
+++ b/src/core/router.go
@@ -38,7 +38,7 @@ func initRouters() {
 		beego.Router("/c/reset", &controllers.CommonController{}, "post:ResetPassword")
 		beego.Router("/c/userExists", &controllers.CommonController{}, "post:UserExists")
 		beego.Router("/c/sendEmail", &controllers.CommonController{}, "get:SendResetEmail")
-		beego.Router("/c/oidc/login", &controllers.OIDCController{}, "get:RedirectLogin")
+		beego.Router(common.OIDCLoginPath, &controllers.OIDCController{}, "get:RedirectLogin")
 		beego.Router("/c/oidc/onboard", &controllers.OIDCController{}, "post:Onboard")
 		beego.Router(common.OIDCCallbackPath, &controllers.OIDCController{}, "get:Callback")
 


### PR DESCRIPTION
When the auth mode is OIDC, when a user login via Harbor's login form.
If the user does not exist or the user is onboarded via OIDC, he will be
redirected to the OIDC login page.

Signed-off-by: Daniel Jiang <jiangd@vmware.com>