### PR TITLE
Fix issue: replication cannot work when Harbor is deployed on Kubernetes whose hairpin mode is disabled

### DIFF
--- a/src/replication/adapter/harbor/chart_registry.go
+++ b/src/replication/adapter/harbor/chart_registry.go
@@ -80,7 +80,7 @@ func (a *adapter) FetchCharts(filters []*model.Filter) ([]*model.Resource, error
 	}
 	resources := []*model.Resource{}
 	for _, project := range projects {
-		url := fmt.Sprintf("%s/api/chartrepo/%s/charts", a.coreServiceURL, project.Name)
+		url := fmt.Sprintf("%s/api/chartrepo/%s/charts", a.getURL(), project.Name)
 		charts := []*chart{}
 		if err := a.client.Get(url, &charts); err != nil {
 			return nil, err
@@ -93,7 +93,7 @@ func (a *adapter) FetchCharts(filters []*model.Filter) ([]*model.Resource, error
 			return nil, err
 		}
 		for _, chart := range charts {
-			url := fmt.Sprintf("%s/api/chartrepo/%s/charts/%s", a.coreServiceURL, project.Name, chart.Name)
+			url := fmt.Sprintf("%s/api/chartrepo/%s/charts/%s", a.getURL(), project.Name, chart.Name)
 			chartVersions := []*chartVersion{}
 			if err := a.client.Get(url, &chartVersions); err != nil {
 				return nil, err
@@ -136,7 +136,7 @@ func (a *adapter) getChartInfo(name, version string) (*chartVersionDetail, error
 	if err != nil {
 		return nil, err
 	}
-	url := fmt.Sprintf("%s/api/chartrepo/%s/charts/%s/%s", a.coreServiceURL, project, name, version)
+	url := fmt.Sprintf("%s/api/chartrepo/%s/charts/%s/%s", a.getURL(), project, name, version)
 	info := &chartVersionDetail{}
 	if err = a.client.Get(url, info); err != nil {
 		return nil, err
@@ -159,7 +159,7 @@ func (a *adapter) DownloadChart(name, version string) (io.ReadCloser, error) {
 		if err != nil {
 			return nil, err
 		}
-		url = fmt.Sprintf("%s/chartrepo/%s/%s", a.coreServiceURL, project, url)
+		url = fmt.Sprintf("%s/chartrepo/%s/%s", a.getURL(), project, url)
 	}
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
@@ -189,7 +189,7 @@ func (a *adapter) UploadChart(name, version string, chart io.Reader) error {
 	}
 	w.Close()
 
-	url := fmt.Sprintf("%s/api/chartrepo/%s/charts", a.coreServiceURL, project)
+	url := fmt.Sprintf("%s/api/chartrepo/%s/charts", a.getURL(), project)
 
 	req, err := http.NewRequest(http.MethodPost, url, buf)
 	if err != nil {
@@ -220,7 +220,7 @@ func (a *adapter) DeleteChart(name, version string) error {
 	if err != nil {
 		return err
 	}
-	url := fmt.Sprintf("%s/api/chartrepo/%s/charts/%s/%s", a.coreServiceURL, project, name, version)
+	url := fmt.Sprintf("%s/api/chartrepo/%s/charts/%s/%s", a.getURL(), project, name, version)
 	return a.client.Delete(url)
 }
 

--- a/src/replication/adapter/harbor/image_registry.go
+++ b/src/replication/adapter/harbor/image_registry.go
@@ -73,7 +73,7 @@ func (a *adapter) FetchImages(filters []*model.Filter) ([]*model.Resource, error
 			return nil, err
 		}
 		for _, repository := range repositories {
-			url := fmt.Sprintf("%s/api/repositories/%s/tags", a.coreServiceURL, repository.Name)
+			url := fmt.Sprintf("%s/api/repositories/%s/tags", a.getURL(), repository.Name)
 			tags := []*tag{}
 			if err = a.client.Get(url, &tags); err != nil {
 				return nil, err
@@ -146,7 +146,7 @@ func (a *adapter) listCandidateProjects(filters []*model.Filter) ([]*project, er
 // override the default implementation from the default image registry
 // by calling Harbor API directly
 func (a *adapter) DeleteManifest(repository, reference string) error {
-	url := fmt.Sprintf("%s/api/repositories/%s/tags/%s", a.coreServiceURL, repository, reference)
+	url := fmt.Sprintf("%s/api/repositories/%s/tags/%s", a.getURL(), repository, reference)
 	return a.client.Delete(url)
 }
 

--- a/src/replication/transfer/image/transfer.go
+++ b/src/replication/transfer/image/transfer.go
@@ -139,7 +139,7 @@ func (t *transfer) copy(src *repository, dst *repository, override bool) error {
 		srcRepo, strings.Join(src.tags, ","), dstRepo, strings.Join(dst.tags, ","))
 	var err error
 	for i := range src.tags {
-		if e := t.copyImage(srcRepo, src.tags[i], dstRepo, dst.tags[i], override); err != nil {
+		if e := t.copyImage(srcRepo, src.tags[i], dstRepo, dst.tags[i], override); e != nil {
 			t.logger.Errorf(e.Error())
 			err = e
 		}


### PR DESCRIPTION
Fix issue https://github.com/goharbor/harbor-helm/issues/222: replication cannot work when Harbor is deployed on Kubernetes whose hairpin mode is disabled

Signed-off-by: Wenkai Yin <yinw@vmware.com>