### PR TITLE
Rename the adapter name of huawei to huawei-SWR

### DIFF
--- a/src/replication/adapter/huawei/huawei_adapter.go
+++ b/src/replication/adapter/huawei/huawei_adapter.go
@@ -16,10 +16,6 @@ import (
 	"github.com/goharbor/harbor/src/replication/util"
 )
 
-const (
-	huawei model.RegistryType = "Huawei"
-)
-
 func init() {
 	err := adp.RegisterFactory(model.RegistryTypeHuawei, AdapterFactory)
 	if err != nil {
@@ -38,7 +34,7 @@ type adapter struct {
 // Info gets info about Huawei SWR
 func (a *adapter) Info() (*model.RegistryInfo, error) {
 	registryInfo := model.RegistryInfo{
-		Type:                     huawei,
+		Type:                     model.RegistryTypeHuawei,
 		Description:              "Adapter for SWR -- The image registry of Huawei Cloud",
 		SupportedResourceTypes:   []model.ResourceType{model.ResourceTypeImage},
 		SupportedResourceFilters: []*model.FilterStyle{},

--- a/src/replication/model/registry.go
+++ b/src/replication/model/registry.go
@@ -25,7 +25,7 @@ const (
 	RegistryTypeHarbor         RegistryType = "harbor"
 	RegistryTypeDockerHub      RegistryType = "docker-hub"
 	RegistryTypeDockerRegistry RegistryType = "docker-registry"
-	RegistryTypeHuawei         RegistryType = "huawei"
+	RegistryTypeHuawei         RegistryType = "huawei-SWR"
 
 	FilterStyleTypeText  = "input"
 	FilterStyleTypeRadio = "radio"


### PR DESCRIPTION
Rename the adapter name of huawei to huawei-SWR. Fixes #7732

Signed-off-by: Wenkai Yin <yinw@vmware.com>