### PR TITLE
Modify the prompt for deleting resources when creating a replication rule.

### DIFF
--- a/src/portal/src/i18n/lang/en-us-lang.json
+++ b/src/portal/src/i18n/lang/en-us-lang.json
@@ -491,7 +491,7 @@
         "TRIGGER_MODE": "Trigger Mode",
         "SOURCE_PROJECT": "Source project",
         "REPLICATE": "Replicate",
-        "DELETE_REMOTE_IMAGES": "Delete remote images when locally deleted",
+        "DELETE_REMOTE_IMAGES": "Delete remote resources when locally deleted",
         "DELETE_ENABLED": "Enabled this policy",
         "REPLICATE_IMMEDIATE": "Replicate existing images immediately",
         "NEW": "New",

--- a/src/portal/src/i18n/lang/es-es-lang.json
+++ b/src/portal/src/i18n/lang/es-es-lang.json
@@ -493,7 +493,7 @@
         "TRIGGER_MODE": "Trigger Mode",
         "SOURCE_PROJECT": "Source project",
         "REPLICATE": "Replicate",
-        "DELETE_REMOTE_IMAGES": "Delete remote images when locally deleted",
+        "DELETE_REMOTE_IMAGES": "Delete remote resources when locally deleted",
         "DELETE_ENABLED": "Enabled this policy",
         "REPLICATE_IMMEDIATE": "Replicate existing images immediately",
         "NEW": "New",

--- a/src/portal/src/i18n/lang/fr-fr-lang.json
+++ b/src/portal/src/i18n/lang/fr-fr-lang.json
@@ -481,7 +481,7 @@
         "TRIGGER_MODE": "Trigger Mode",
         "SOURCE_PROJECT": "Source project",
         "REPLICATE": "Replicate",
-        "DELETE_REMOTE_IMAGES": "Delete remote images when locally deleted",
+        "DELETE_REMOTE_IMAGES": "Delete remote resources when locally deleted",
         "DELETE_ENABLED": "Enabled this policy",
         "REPLICATE_IMMEDIATE": "Replicate existing images immediately",
         "NEW": "New",

--- a/src/portal/src/i18n/lang/pt-br-lang.json
+++ b/src/portal/src/i18n/lang/pt-br-lang.json
@@ -491,7 +491,7 @@
         "TRIGGER_MODE": "Modo de disparo",
         "SOURCE_PROJECT": "Projeto de origem",
         "REPLICATE": "Replicar",
-        "DELETE_REMOTE_IMAGES":"Remover imagens remotas quando removido localmente",
+        "DELETE_REMOTE_IMAGES":"Remover resources remotas quando removido localmente",
         "DELETE_ENABLED": "Enabled this policy",
         "REPLICATE_IMMEDIATE":"Replicar imagens existentes imediatamente",
         "NEW": "Novo",

--- a/src/portal/src/i18n/lang/zh-cn-lang.json
+++ b/src/portal/src/i18n/lang/zh-cn-lang.json
@@ -492,7 +492,7 @@
         "TRIGGER_MODE": "触发模式",
         "SOURCE_PROJECT": "源项目",
         "REPLICATE": "同步",
-        "DELETE_REMOTE_IMAGES": "删除本地镜像时同时也删除远程的镜像。",
+        "DELETE_REMOTE_IMAGES": "删除本地资源时同时也删除远程的资源。",
         "DELETE_ENABLED": "默认启用该规则",
         "REPLICATE_IMMEDIATE": "立即同步现有的镜像。",
         "NEW": "新增",


### PR DESCRIPTION
Change the images in ‘Delete remote images when locally deleted’ to resources
![image](https://user-images.githubusercontent.com/40712758/57435132-25a4bb80-726f-11e9-8b82-84949ba18ebd.png)

Signed-off-by: FangyuanCheng <fangyuanc@vmware.com>