### PR TITLE
Fix travis failure: read the content of env instead of config_env as the config_env has been removed

### DIFF
--- a/tests/testprepare.sh
+++ b/tests/testprepare.sh
@@ -16,6 +16,6 @@ echo "server ip is "$IP
 
 echo "Current path is"
 pwd
-cat make/common/config/core/config_env
+cat make/common/config/core/env
 
 chmod 777 /data/


### PR DESCRIPTION
Read the content of env instead of config_env as the config_env has been removed

Signed-off-by: Wenkai Yin <yinw@vmware.com>