### PR TITLE
Fix issue: harbor 1.7.4 aliyun oss chartmuseum 500

### DIFF
--- a/make/photon/prepare/utils/chart.py
+++ b/make/photon/prepare/utils/chart.py
@@ -77,9 +77,13 @@ def prepare_chartmuseum(config_dict):
     elif storage_provider_name == 'oss':
         # aliyun OSS
         storage_driver = "alibaba"
-        storage_provider_config_options.append("STORAGE_ALIBABA_BUCKET=%s" % ( storage_provider_config_map.get("bucket") or '') )
+        bucket = storage_provider_config_map.get("bucket") or ''
+        endpoint = storage_provider_config_map.get("endpoint") or ''
+        if endpoint.startswith(bucket + "."):
+            endpoint = endpoint.replace(bucket + ".", "")
+        storage_provider_config_options.append("STORAGE_ALIBABA_BUCKET=%s" % bucket )
+        storage_provider_config_options.append("STORAGE_ALIBABA_ENDPOINT=%s" % endpoint )
         storage_provider_config_options.append("STORAGE_ALIBABA_PREFIX=%s" % ( storage_provider_config_map.get("rootdirectory") or '') )
-        storage_provider_config_options.append("STORAGE_ALIBABA_ENDPOINT=%s" % ( storage_provider_config_map.get("endpoint") or '') )
         storage_provider_config_options.append("ALIBABA_CLOUD_ACCESS_KEY_ID=%s" % ( storage_provider_config_map.get("accesskeyid") or '') )
         storage_provider_config_options.append("ALIBABA_CLOUD_ACCESS_KEY_SECRET=%s" % ( storage_provider_config_map.get("accesskeysecret") or '') )
     else:


### PR DESCRIPTION
Signed-off-by: liqiang-fit2cloud <liqiang@fit2cloud.com>

Fix https://github.com/goharbor/harbor/issues/7288

The issue occurs when using Alibaba OSS for both docker registry and helm chart repository, the endpoint must be specified in the registry_storage_provider_config of harbor.cfg file as the endpoint is mandatory for helm chart, although it's optional for docker registry .
For docker registry the endpoint must contain the bucket name like bucket-name.oss-cn-qingdao-internal.aliyuncs.com, But for helm chart the endpoint must be in the format oss-cn-qingdao-internal.aliyuncs.com which should not contains bucket name.
So if set the endpoint with bucket name docker registry works well but helm chart is not working, if set the endpoint without bucket name docker registry is not working but helm chart works well, it's awkward...

With this PR, the bucket name will be removed from the endpoint for helm chart, both docker registry and helm chart work well.