### PR TITLE
Fixes bug in replication

### DIFF
--- a/src/replication/adapter/harbor/chart_registry.go
+++ b/src/replication/adapter/harbor/chart_registry.go
@@ -136,7 +136,7 @@ func (a *adapter) getChartInfo(name, version string) (*chartVersionDetail, error
 	if err != nil {
 		return nil, err
 	}
-	url := fmt.Sprintf("%s/api/chartrepo/%s/charts/%s/%s", a.getURL(), project, name, version)
+	url := fmt.Sprintf("%s/api/chartrepo/%s/charts/%s/%s", a.url, project, name, version)
 	info := &chartVersionDetail{}
 	if err = a.client.Get(url, info); err != nil {
 		return nil, err
@@ -159,7 +159,7 @@ func (a *adapter) DownloadChart(name, version string) (io.ReadCloser, error) {
 		if err != nil {
 			return nil, err
 		}
-		url = fmt.Sprintf("%s/chartrepo/%s/%s", a.getURL(), project, url)
+		url = fmt.Sprintf("%s/chartrepo/%s/%s", a.url, project, url)
 	}
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
@@ -189,7 +189,7 @@ func (a *adapter) UploadChart(name, version string, chart io.Reader) error {
 	}
 	w.Close()
 
-	url := fmt.Sprintf("%s/api/chartrepo/%s/charts", a.getURL(), project)
+	url := fmt.Sprintf("%s/api/chartrepo/%s/charts", a.url, project)
 
 	req, err := http.NewRequest(http.MethodPost, url, buf)
 	if err != nil {
@@ -220,7 +220,7 @@ func (a *adapter) DeleteChart(name, version string) error {
 	if err != nil {
 		return err
 	}
-	url := fmt.Sprintf("%s/api/chartrepo/%s/charts/%s/%s", a.getURL(), project, name, version)
+	url := fmt.Sprintf("%s/api/chartrepo/%s/charts/%s/%s", a.url, project, name, version)
 	return a.client.Delete(url)
 }
 

--- a/src/replication/adapter/harbor/image_registry.go
+++ b/src/replication/adapter/harbor/image_registry.go
@@ -146,7 +146,7 @@ func (a *adapter) listCandidateProjects(filters []*model.Filter) ([]*project, er
 // override the default implementation from the default image registry
 // by calling Harbor API directly
 func (a *adapter) DeleteManifest(repository, reference string) error {
-	url := fmt.Sprintf("%s/api/repositories/%s/tags/%s", a.getURL(), repository, reference)
+	url := fmt.Sprintf("%s/api/repositories/%s/tags/%s", a.url, repository, reference)
 	return a.client.Delete(url)
 }
 


### PR DESCRIPTION
Use internal service name rather than 127.0.0.1 when calling APIs of core in jobservice jobs

Signed-off-by: Wenkai Yin <yinw@vmware.com>