### PR TITLE
Add filter to handle request with ID token

### DIFF
--- a/src/core/controllers/oidc.go
+++ b/src/core/controllers/oidc.go
@@ -91,6 +91,8 @@ func (oc *OIDCController) Callback() {
 		oc.SendBadRequestError(err)
 		return
 	}
+	log.Debugf("ID token from provider: %s", token.IDToken)
+
 	idToken, err := oidc.VerifyToken(ctx, token.IDToken)
 	if err != nil {
 		oc.SendInternalServerError(err)
@@ -118,7 +120,6 @@ func (oc *OIDCController) Callback() {
 		oc.SendInternalServerError(err)
 		return
 	}
-	log.Debugf("Exchanged token string: %s", string(tokenBytes))
 	oc.SetSession(tokenKey, tokenBytes)
 
 	if u == nil {

--- a/src/core/filter/security_test.go
+++ b/src/core/filter/security_test.go
@@ -192,6 +192,31 @@ func TestOIDCCliReqCtxModifier(t *testing.T) {
 	assert.Nil(t, err)
 }
 
+func TestIdTokenReqCtxModifier(t *testing.T) {
+	bc := context.Background()
+	it := &idTokenReqCtxModifier{}
+	r1, err := http.NewRequest(http.MethodGet,
+		"http://127.0.0.1/chartrepo/", nil)
+	require.Nil(t, err)
+	req1 := r1.WithContext(context.WithValue(bc, AuthModeKey, common.DBAuth))
+	ctx1, err := newContext(req1)
+	require.Nil(t, err)
+	assert.False(t, it.Modify(ctx1))
+
+	req2 := r1.WithContext(context.WithValue(bc, AuthModeKey, common.OIDCAuth))
+	ctx2, err := newContext(req2)
+	require.Nil(t, err)
+	assert.False(t, it.Modify(ctx2))
+
+	r2, err := http.NewRequest(http.MethodGet,
+		"http://127.0.0.1/api/projects/", nil)
+	require.Nil(t, err)
+	req3 := r2.WithContext(context.WithValue(bc, AuthModeKey, common.OIDCAuth))
+	ctx3, err := newContext(req3)
+	require.Nil(t, err)
+	assert.False(t, it.Modify(ctx3))
+}
+
 func TestRobotReqCtxModifier(t *testing.T) {
 	req, err := http.NewRequest(http.MethodGet,
 		"http://127.0.0.1/api/projects/", nil)


### PR DESCRIPTION
This commit allows request with a valid ID token to access the API.

Signed-off-by: Daniel Jiang <jiangd@vmware.com>