### PR TITLE
Add "MaxMessageSize" to the config of rsyslogd

### DIFF
--- a/make/photon/log/rsyslog.conf
+++ b/make/photon/log/rsyslog.conf
@@ -5,6 +5,9 @@
 #
 #  Default logging rules can be found in /etc/rsyslog.d/50-default.conf
 
+# The default value is 8k. When the size of one log line > 8k, the line
+# is truncated and causes mess in log file directory
+$MaxMessageSize 32k
 
 #################
 #### MODULES ####


### PR DESCRIPTION
Add "MaxMessageSize" to the config of rsyslogd to avoid the mess of log file when the size of one log line > 8k

Signed-off-by: Wenkai Yin <yinw@vmware.com>