### PR TITLE
Add dockerignore file to prevent local node_modules to be copied into the portal image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+src/portal/node_modules/


### PR DESCRIPTION
Add dockerignore file to prevent local node_modules to be copied into the portal image.

Otherwise the portal linux image could contain node_modules built for darwin when the image is built on a Mac, which makes the angular build fail.