### PR TITLE
Add ensure settings when to search user in auth proxy

### DIFF
--- a/src/core/auth/authproxy/auth.go
+++ b/src/core/auth/authproxy/auth.go
@@ -104,6 +104,10 @@ func (a *Auth) PostAuthenticate(u *models.User) error {
 // SearchUser returns nil as authproxy does not have such capability.
 // When AlwaysOnboard is set it always return the default model.
 func (a *Auth) SearchUser(username string) (*models.User, error) {
+	err := a.ensure()
+	if err != nil {
+		log.Warningf("Failed to refresh configuration for HTTP Auth Proxy Authenticator, error: %v, the default settings will be used", err)
+	}
 	var u *models.User
 	if a.AlwaysOnboard {
 		u = &models.User{Username: username}


### PR DESCRIPTION
This issue is regresssion that introduced by https://github.com/goharbor/harbor/commit/f92bc8076dda5b62f3afac8e179268626f899ae1#diff-42381e6df5f17ebd3d9165a325d5d8f4, the a.ensure() was removed from SearchUser(), which leads to the alwaysonboard cannot be updated.

Signed-off-by: wang yan <wangyan@vmware.com>