### PR TITLE
Set Event.Type value to event.EventTypeImageDelete instead of event.EventTypeImagePush when deleting

### DIFF
--- a/src/core/api/repository.go
+++ b/src/core/api/repository.go
@@ -332,7 +332,7 @@ func (ra *RepositoryAPI) Delete() {
 
 		go func(tag string) {
 			e := &event.Event{
-				Type: event.EventTypeImagePush,
+				Type: event.EventTypeImageDelete,
 				Resource: &model.Resource{
 					Type: model.ResourceTypeImage,
 					Metadata: &model.ResourceMetadata{


### PR DESCRIPTION

Signed-off-by: Ted Guan <guanxiatao@corp.netease.com>