### PR TITLE
fix bug: Save button not enabled when all the required fields are filled on Safari, Edge , Internet Explorer

### DIFF
--- a/src/portal/lib/src/create-edit-rule/create-edit-rule.component.html
+++ b/src/portal/lib/src/create-edit-rule/create-edit-rule.component.html
@@ -48,6 +48,7 @@
           <div class="form-select">
             <div class="select endpointSelect pull-left">
               <select id="src_registry_id" (change)="sourceChange($event)"  formControlName="src_registry" [compareWith]="equals">
+                <option class="display-none"></option>
                 <option *ngFor="let source of sourceList" [ngValue]="source">{{source.name}}-{{source.url}}</option>
               </select>
             </div>
@@ -97,6 +98,7 @@
           <div class="form-select">
             <div class="select endpointSelect pull-left">
                 <select id="dest_registry" (change)="targetChange($event)" formControlName="dest_registry"  [compareWith]="equals">
+                    <option class="display-none"></option>
                     <option *ngFor="let target of targetList" [ngValue]="target">{{target.name}}-{{target.url}}</option>
                   </select>
             </div>

--- a/src/portal/lib/src/create-edit-rule/create-edit-rule.component.scss
+++ b/src/portal/lib/src/create-edit-rule/create-edit-rule.component.scss
@@ -265,3 +265,7 @@ clr-modal {
         width: 20rem;
     }
 }
+
+.display-none{
+    display: none;
+}


### PR DESCRIPTION
fix bug: Save button not enabled when all the required fields are filled on Safari, Edge , Internet Explorer
fix issue   https://github.com/goharbor/harbor/issues/7829
Signed-off-by: sshijun <sshijun@vmware.com>