### PR TITLE
Add button click confirmation in test case Disable-Scan-Schedule 

### DIFF
--- a/tests/resources/Harbor-Pages/Vulnerability.robot
+++ b/tests/resources/Harbor-Pages/Vulnerability.robot
@@ -8,10 +8,10 @@ Resource  ../../resources/Util.robot
  ${vulnerability_page}  //clr-vertical-nav-group-children/a[contains(.,'Vulnerability')]
 *** Keywords ***
 Disable Scan Schedule
-     Retry Element Click  //vulnerability-config//cron-selection//button[contains(.,'EDIT')]
-     Retry Element Click  //vulnerability-config//cron-selection//select[@id='selectPolicy']
-     Retry Element Click  //vulnerability-config//cron-selection//select[@id='selectPolicy']//option[contains(.,'None')]
-     Retry Element Click  //cron-selection//button[contains(.,'SAVE')]
+    Retry Double Keywords When Error  Retry Element Click  ${vulnerability_edit_btn}  Retry Wait Until Page Not Contains Element  ${vulnerability_edit_btn}
+    Retry Element Click  ${vulnerability_dropdown_list}
+    Retry Element Click  ${vulnerability_dropdown_list_item_none}
+    Retry Double Keywords When Error  Retry Element Click  ${vulnerability_save_btn}  Retry Wait Until Page Not Contains Element  ${vulnerability_save_btn}
 
 Trigger Scan Now
     Retry Element Click  xpath=${scan_now_button}

--- a/tests/resources/Harbor-Pages/Vulnerability_Elements.robot
+++ b/tests/resources/Harbor-Pages/Vulnerability_Elements.robot
@@ -1,0 +1,25 @@
+# Copyright Project Harbor Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+*** Settings ***
+Documentation  This resource provides any keywords related to the Harbor private registry appliance
+
+*** Variables ***
+${vulnerability_edit_btn}  xpath=//vulnerability-config//cron-selection//button[contains(.,'EDIT')]
+${vulnerability_dropdown_list}  xpath=//vulnerability-config//cron-selection//select[@id='selectPolicy']
+${vulnerability_dropdown_list_item_none}  xpath=//vulnerability-config//cron-selection//select[@id='selectPolicy']//option[contains(.,'None')]
+${vulnerability_save_btn}  xpath=//cron-selection//button[contains(.,'SAVE')]
+
+
+

--- a/tests/resources/Util.robot
+++ b/tests/resources/Util.robot
@@ -1,4 +1,4 @@
-# Copyright Project Harbor Authors
+f# Copyright Project Harbor Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -53,6 +53,7 @@ Resource  Harbor-Pages/Configuration_Elements.robot
 Resource  Harbor-Pages/ToolKit.robot
 Resource  Harbor-Pages/ToolKit_Elements.robot
 Resource  Harbor-Pages/Vulnerability.robot
+Resource  Harbor-Pages/Vulnerability_Elements.robot
 Resource  Harbor-Pages/LDAP-Mode.robot
 Resource  Harbor-Pages/OIDC_Auth.robot
 Resource  Harbor-Pages/OIDC_Auth_Elements.robot
@@ -221,6 +222,7 @@ Retry Keyword When Error
 
 Retry Double Keywords When Error
     [Arguments]  ${keyword1}  ${element1}  ${keyword2}  ${element2}
+    Retry Wait Element  ${element1}
     :For  ${n}  IN RANGE  1  6
     \    Log To Console  Trying ${keyword1} and ${keyword2} ${n} times ...
     \    ${out1}  Run Keyword And Ignore Error  ${keyword1}  ${element1}


### PR DESCRIPTION
In nightly test, case Disable-Scan-Schedule always failed at action of edit button click, so we should add a confirmation to make sure that this button will be disappeared after click action.

Signed-off-by: danfengliu <danfengl@vmware.com>