### PR TITLE
Switch registry health check to a 200 response url

### DIFF
--- a/src/core/api/health.go
+++ b/src/core/api/health.go
@@ -212,10 +212,10 @@ func jobserviceHealthChecker() health.Checker {
 }
 
 func registryHealthChecker() health.Checker {
-	url := getRegistryURL() + "/v2"
+	url := getRegistryURL() + "/"
 	timeout := 60 * time.Second
 	period := 10 * time.Second
-	checker := HTTPStatusCodeHealthChecker(http.MethodGet, url, nil, timeout, http.StatusUnauthorized)
+	checker := HTTPStatusCodeHealthChecker(http.MethodGet, url, nil, timeout, http.StatusOK)
 	return PeriodicHealthChecker(checker, period)
 }
 


### PR DESCRIPTION
The health check for the registry was using "/v2" which returned an
unauthorized response and put additional errors in the logs. Switch
to using "/" which returns an OK response with reduced logging.

Signed-off-by: Mark Peek <markpeek@vmware.com>