### PR TITLE
fix  filter ui bug : half filter is covered when there is one or two records in a datagrid

### DIFF
--- a/src/portal/src/styles.css
+++ b/src/portal/src/styles.css
@@ -87,3 +87,7 @@ body {
 .color-red {
     color: red;
 }
+
+.datagrid-table,.datagrid-header{
+    position: inherit !important;
+}


### PR DESCRIPTION
refer to #7700

Signed-off-by: sshijun <sshijun@vmware.com>