### PR TITLE
refactor the processor interface

### DIFF
--- a/src/pkg/retention/policy/alg/index.go
+++ b/src/pkg/retention/policy/alg/index.go
@@ -1,0 +1,49 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package alg
+
+import (
+	"github.com/pkg/errors"
+	"sync"
+)
+
+const (
+	// AlgorithmOR for || algorithm
+	AlgorithmOR = "or"
+)
+
+// index for keeping the mapping between algorithm and its processor
+var index sync.Map
+
+// Register processor with the algorithm
+func Register(algorithm string, processor Factory) {
+	if len(algorithm) > 0 && processor != nil {
+		index.Store(algorithm, processor)
+	}
+}
+
+// Get Processor
+func Get(algorithm string, params []*Parameter) (Processor, error) {
+	v, ok := index.Load(algorithm)
+	if !ok {
+		return nil, errors.Errorf("no processor registered with algorithm: %s", algorithm)
+	}
+
+	if fac, ok := v.(Factory); ok {
+		return fac(params), nil
+	}
+
+	return nil, errors.Errorf("no valid processor registered for algorithm: %s", algorithm)
+}

--- a/src/pkg/retention/policy/alg/or/processor_test.go
+++ b/src/pkg/retention/policy/alg/or/processor_test.go
@@ -64,21 +64,33 @@ func (suite *ProcessorTestSuite) SetupSuite() {
 		},
 	}
 
-	p := New()
-	p.AddActionPerformer(action.Retain, action.NewRetainAction(suite.all))
+	params := make([]*alg.Parameter, 0)
+
+	perf := action.NewRetainAction(suite.all)
 
 	lastxParams := make(map[string]rule.Parameter)
 	lastxParams[lastx.ParameterX] = 10
-	p.AddEvaluator(lastx.New(lastxParams), []res.Selector{
-		regexp.New(regexp.Matches, "*dev*"),
-		label.New(label.With, "L1,L2"),
+	params = append(params, &alg.Parameter{
+		Evaluator: lastx.New(lastxParams),
+		Selectors: []res.Selector{
+			regexp.New(regexp.Matches, "*dev*"),
+			label.New(label.With, "L1,L2"),
+		},
+		Performer: perf,
 	})
 
 	latestKParams := make(map[string]rule.Parameter)
 	latestKParams[latestk.ParameterK] = 10
-	p.AddEvaluator(latestk.New(latestKParams), []res.Selector{
-		label.New(label.With, "L3"),
+	params = append(params, &alg.Parameter{
+		Evaluator: latestk.New(latestKParams),
+		Selectors: []res.Selector{
+			label.New(label.With, "L3"),
+		},
+		Performer: perf,
 	})
+
+	p, err := alg.Get(alg.AlgorithmOR, params)
+	require.NoError(suite.T(), err)
 
 	suite.p = p
 }

--- a/src/pkg/retention/policy/alg/processor.go
+++ b/src/pkg/retention/policy/alg/processor.go
@@ -33,18 +33,20 @@ type Processor interface {
 	//    []*res.Result : the processed results
 	//    error         : common error object if any errors occurred
 	Process(artifacts []*res.Candidate) ([]*res.Result, error)
-
-	// Add a rule evaluator for the processor
-	//
-	//  Arguments:
-	//    evaluator rule.Evaluator    : a rule evaluator
-	//    selectors []res.Selector    : selectors to narrow down the scope (&& adopted), optional
-	AddEvaluator(evaluator rule.Evaluator, selectors []res.Selector)
-
-	// Add performer for the related action to the processor
-	//
-	//  Arguments:
-	//    action string              : action name
-	//    performer action.Performer : a performer implementation
-	AddActionPerformer(action string, performer action.Performer)
 }
+
+// Parameter for constructing a processor
+// Represents one rule
+type Parameter struct {
+	// Evaluator for the rule
+	Evaluator rule.Evaluator
+
+	// Selectors for the rule
+	Selectors []res.Selector
+
+	// Performer for the rule evaluator
+	Performer action.Performer
+}
+
+// Factory for creating processor
+type Factory func([]*Parameter) Processor


### PR DESCRIPTION
Signed-off-by: Steven Zou <szou@vmware.com>

Roll back the Processor interface and add an index for processors.

```go
// Processor processing the whole policy targeting a repository.
// Methods are defined to reflect the standard structure of the policy:
// list of rules with corresponding selectors plus an action performer.
type Processor interface {
	// Process the artifact candidates
	//
	//  Arguments:
	//    artifacts []*res.Candidate : process the retention candidates
	//
	//  Returns:
	//    []*res.Result : the processed results
	//    error         : common error object if any errors occurred
	Process(artifacts []*res.Candidate) ([]*res.Result, error)
}
```