### PR TITLE
Move the pkg manager/controller declaration to the api package

### DIFF
--- a/src/core/api/repository_label_test.go
+++ b/src/core/api/repository_label_test.go
@@ -28,7 +28,7 @@ import (
 
 var (
 	resourceLabelAPIBasePath = "/api/repositories"
-	repository               = "library/hello-world"
+	repo                     = "library/hello-world"
 	tag                      = "latest"
 	proLibraryLabelID        int64
 )
@@ -63,7 +63,7 @@ func TestAddToImage(t *testing.T) {
 		{
 			request: &testingRequest{
 				url: fmt.Sprintf("%s/%s/tags/%s/labels", resourceLabelAPIBasePath,
-					repository, tag),
+					repo, tag),
 				method: http.MethodPost,
 			},
 			code: http.StatusUnauthorized,
@@ -72,13 +72,13 @@ func TestAddToImage(t *testing.T) {
 		{
 			request: &testingRequest{
 				url: fmt.Sprintf("%s/%s/tags/%s/labels", resourceLabelAPIBasePath,
-					repository, tag),
+					repo, tag),
 				method:     http.MethodPost,
 				credential: projGuest,
 			},
 			code: http.StatusForbidden,
 		},
-		// 404 repository doesn't exist
+		// 404 repo doesn't exist
 		{
 			request: &testingRequest{
 				url:        fmt.Sprintf("%s/library/non-exist-repo/tags/%s/labels", resourceLabelAPIBasePath, tag),
@@ -90,7 +90,7 @@ func TestAddToImage(t *testing.T) {
 		// 404 image doesn't exist
 		{
 			request: &testingRequest{
-				url:        fmt.Sprintf("%s/%s/tags/non-exist-tag/labels", resourceLabelAPIBasePath, repository),
+				url:        fmt.Sprintf("%s/%s/tags/non-exist-tag/labels", resourceLabelAPIBasePath, repo),
 				method:     http.MethodPost,
 				credential: projDeveloper,
 			},
@@ -99,7 +99,7 @@ func TestAddToImage(t *testing.T) {
 		// 400
 		{
 			request: &testingRequest{
-				url:        fmt.Sprintf("%s/%s/tags/%s/labels", resourceLabelAPIBasePath, repository, tag),
+				url:        fmt.Sprintf("%s/%s/tags/%s/labels", resourceLabelAPIBasePath, repo, tag),
 				method:     http.MethodPost,
 				credential: projDeveloper,
 			},
@@ -109,7 +109,7 @@ func TestAddToImage(t *testing.T) {
 		{
 			request: &testingRequest{
 				url: fmt.Sprintf("%s/%s/tags/%s/labels", resourceLabelAPIBasePath,
-					repository, tag),
+					repo, tag),
 				method:     http.MethodPost,
 				credential: projDeveloper,
 				bodyJSON: struct {
@@ -124,7 +124,7 @@ func TestAddToImage(t *testing.T) {
 		{
 			request: &testingRequest{
 				url: fmt.Sprintf("%s/%s/tags/%s/labels", resourceLabelAPIBasePath,
-					repository, tag),
+					repo, tag),
 				method:     http.MethodPost,
 				credential: projDeveloper,
 				bodyJSON: struct {
@@ -139,7 +139,7 @@ func TestAddToImage(t *testing.T) {
 		{
 			request: &testingRequest{
 				url: fmt.Sprintf("%s/%s/tags/%s/labels", resourceLabelAPIBasePath,
-					repository, tag),
+					repo, tag),
 				method:     http.MethodPost,
 				credential: projDeveloper,
 				bodyJSON: struct {
@@ -154,7 +154,7 @@ func TestAddToImage(t *testing.T) {
 		{
 			request: &testingRequest{
 				url: fmt.Sprintf("%s/%s/tags/%s/labels", resourceLabelAPIBasePath,
-					repository, tag),
+					repo, tag),
 				method:     http.MethodPost,
 				credential: projDeveloper,
 				bodyJSON: struct {
@@ -172,7 +172,7 @@ func TestAddToImage(t *testing.T) {
 func TestGetOfImage(t *testing.T) {
 	labels := []*models.Label{}
 	err := handleAndParse(&testingRequest{
-		url:        fmt.Sprintf("%s/%s/tags/%s/labels", resourceLabelAPIBasePath, repository, tag),
+		url:        fmt.Sprintf("%s/%s/tags/%s/labels", resourceLabelAPIBasePath, repo, tag),
 		method:     http.MethodGet,
 		credential: projDeveloper,
 	}, &labels)
@@ -185,7 +185,7 @@ func TestRemoveFromImage(t *testing.T) {
 	runCodeCheckingCases(t, &codeCheckingCase{
 		request: &testingRequest{
 			url: fmt.Sprintf("%s/%s/tags/%s/labels/%d", resourceLabelAPIBasePath,
-				repository, tag, proLibraryLabelID),
+				repo, tag, proLibraryLabelID),
 			method:     http.MethodDelete,
 			credential: projDeveloper,
 		},
@@ -195,7 +195,7 @@ func TestRemoveFromImage(t *testing.T) {
 	labels := []*models.Label{}
 	err := handleAndParse(&testingRequest{
 		url: fmt.Sprintf("%s/%s/tags/%s/labels", resourceLabelAPIBasePath,
-			repository, tag),
+			repo, tag),
 		method:     http.MethodGet,
 		credential: projDeveloper,
 	}, &labels)
@@ -206,7 +206,7 @@ func TestRemoveFromImage(t *testing.T) {
 func TestAddToRepository(t *testing.T) {
 	runCodeCheckingCases(t, &codeCheckingCase{
 		request: &testingRequest{
-			url:    fmt.Sprintf("%s/%s/labels", resourceLabelAPIBasePath, repository),
+			url:    fmt.Sprintf("%s/%s/labels", resourceLabelAPIBasePath, repo),
 			method: http.MethodPost,
 			bodyJSON: struct {
 				ID int64
@@ -222,7 +222,7 @@ func TestAddToRepository(t *testing.T) {
 func TestGetOfRepository(t *testing.T) {
 	labels := []*models.Label{}
 	err := handleAndParse(&testingRequest{
-		url:        fmt.Sprintf("%s/%s/labels", resourceLabelAPIBasePath, repository),
+		url:        fmt.Sprintf("%s/%s/labels", resourceLabelAPIBasePath, repo),
 		method:     http.MethodGet,
 		credential: projDeveloper,
 	}, &labels)
@@ -235,7 +235,7 @@ func TestRemoveFromRepository(t *testing.T) {
 	runCodeCheckingCases(t, &codeCheckingCase{
 		request: &testingRequest{
 			url: fmt.Sprintf("%s/%s/labels/%d", resourceLabelAPIBasePath,
-				repository, proLibraryLabelID),
+				repo, proLibraryLabelID),
 			method:     http.MethodDelete,
 			credential: projDeveloper,
 		},
@@ -244,7 +244,7 @@ func TestRemoveFromRepository(t *testing.T) {
 
 	labels := []*models.Label{}
 	err := handleAndParse(&testingRequest{
-		url:        fmt.Sprintf("%s/%s/labels", resourceLabelAPIBasePath, repository),
+		url:        fmt.Sprintf("%s/%s/labels", resourceLabelAPIBasePath, repo),
 		method:     http.MethodGet,
 		credential: projDeveloper,
 	}, &labels)

--- a/src/pkg/project/manager.go
+++ b/src/pkg/project/manager.go
@@ -21,11 +21,6 @@ import (
 	"github.com/goharbor/harbor/src/common/models"
 )
 
-var (
-	// Mgr is an instance of the default project Manager
-	Mgr = New()
-)
-
 // Manager is used for project management
 // currently, the interface only defines the methods needed for tag retention
 // will expand it when doing refactor

--- a/src/pkg/repository/manager.go
+++ b/src/pkg/repository/manager.go
@@ -18,13 +18,7 @@ import (
 	"github.com/goharbor/harbor/src/chartserver"
 	"github.com/goharbor/harbor/src/common/dao"
 	"github.com/goharbor/harbor/src/common/models"
-	"github.com/goharbor/harbor/src/core/api"
 	"github.com/goharbor/harbor/src/pkg/project"
-)
-
-var (
-	// Mgr is an instance of the default repository Manager
-	Mgr = New()
 )
 
 // Manager is used for repository management
@@ -38,11 +32,17 @@ type Manager interface {
 }
 
 // New returns a default implementation of Manager
-func New() Manager {
-	return &manager{}
+func New(projectMgr project.Manager, chartCtl *chartserver.Controller) Manager {
+	return &manager{
+		projectMgr: projectMgr,
+		chartCtl:   chartCtl,
+	}
 }
 
-type manager struct{}
+type manager struct {
+	projectMgr project.Manager
+	chartCtl   *chartserver.Controller
+}
 
 // List image repositories under the project specified by the ID
 func (m *manager) ListImageRepositories(projectID int64) ([]*models.RepoRecord, error) {
@@ -53,9 +53,9 @@ func (m *manager) ListImageRepositories(projectID int64) ([]*models.RepoRecord, 
 
 // List chart repositories under the project specified by the ID
 func (m *manager) ListChartRepositories(projectID int64) ([]*chartserver.ChartInfo, error) {
-	project, err := project.Mgr.Get(projectID)
+	project, err := m.projectMgr.Get(projectID)
 	if err != nil {
 		return nil, err
 	}
-	return api.GetChartController().ListCharts(project.Name)
+	return m.chartCtl.ListCharts(project.Name)
 }


### PR DESCRIPTION
Move the pkg manager/controller declaration to the api package to avoid the dependency cycle

Signed-off-by: Wenkai Yin <yinw@vmware.com>