### PR TITLE
Fix logger line() call if built outside of the repo root

### DIFF
--- a/src/common/utils/log/logger.go
+++ b/src/common/utils/log/logger.go
@@ -278,7 +278,7 @@ func line(callDepth int) string {
 		line = 0
 	}
 	l := strings.SplitN(file, srcSeparator, 2)
-	if len(l) > 0 {
+	if len(l) > 1 {
 		file = l[1]
 	}
 	return fmt.Sprintf("[%s:%d]:", file, line)


### PR DESCRIPTION
If harbor is built (or `go test`'d) in a different folder than the repo
root, the call to `common/utils/log/line(...)` will panic with an index
out of range runtime error because the `strings.SplitN(...)` can't find `harbor/src`
in the path.

Since `SplitN` always returns at least one element for `n != 0`, the check should probably have originally been `if len(l) > 1` anyways.

I found this while writing #8357, not sure how I didn't hit this with previous PRs, perhaps the integration branch was missing 411876908807c966e627402ba87187c40981386a before now.

Signed-off-by: Nathan Lowe <public@nlowe.me>