### PR TITLE
Replace image from haproxy to postgres for vulnerability scanning

### DIFF
--- a/tests/resources/Docker-Util.robot
+++ b/tests/resources/Docker-Util.robot
@@ -32,12 +32,14 @@ Pull image
     Should Not Contain  ${output}  No such image:
 
 Push image
-    [Arguments]  ${ip}  ${user}  ${pwd}  ${project}  ${image}
-    Log To Console  \nRunning docker push ${image}...
-    Wait Unitl Command Success  docker pull ${image}
+    [Arguments]  ${ip}  ${user}  ${pwd}  ${project}  ${image}  ${sha256}=${null}  ${tag}=${null}
+    ${full_image}=  Set Variable If  '${sha256}'=='${null}'  ${image}  ${image}@sha256:${sha256}
+    ${image_with_tag}=  Set Variable If  '${tag}'=='${null}'  ${image}  ${image}:${sha256}
+    Log To Console  \nRunning docker push ${full_image}...
+    Wait Unitl Command Success  docker pull ${full_image}
     Wait Unitl Command Success  docker login -u ${user} -p ${pwd} ${ip}
-    Wait Unitl Command Success  docker tag ${image} ${ip}/${project}/${image}
-    Wait Unitl Command Success  docker push ${ip}/${project}/${image}
+    Wait Unitl Command Success  docker tag ${full_image} ${ip}/${project}/${image_with_tag}
+    Wait Unitl Command Success  docker push ${ip}/${project}/${image_with_tag}
     Wait Unitl Command Success  docker logout ${ip}
 
 Push Image With Tag
@@ -55,9 +57,10 @@ Cannot Docker Login Harbor
     Command Should be Failed  docker login -u ${user} -p ${pwd} ${ip}
 
 Cannot Pull image
-    [Arguments]  ${ip}  ${user}  ${pwd}  ${project}  ${image}
+    [Arguments]  ${ip}  ${user}  ${pwd}  ${project}  ${image}  ${tag}=${null}
+    ${image_with_tag}=  Set Variable If  '${tag}'=='${null}'  ${image}  ${image}:${tag}
     Wait Unitl Command Success  docker login -u ${user} -p ${pwd} ${ip}
-    Command Should be Failed  docker pull ${ip}/${project}/${image}
+    Command Should be Failed  docker pull ${ip}/${project}/${image_with_tag}
 
 Cannot Pull Unsigned Image
     [Arguments]  ${ip}  ${user}  ${pass}  ${proj}  ${imagewithtag}

--- a/tests/robot-cases/Group1-Nightly/Common.robot
+++ b/tests/robot-cases/Group1-Nightly/Common.robot
@@ -581,6 +581,7 @@ Test Case - Retag A Image Tag
 Test Case - Scan Image On Push
     Wait Unitl Vul Data Ready  ${HARBOR_URL}  7200  30
     Init Chrome Driver
+    Push Image  ${ip}  ${HARBOR_ADMIN}  ${HARBOR_PASSWORD}  library  hello-world
     Sign In Harbor  ${HARBOR_URL}  ${HARBOR_ADMIN}  ${HARBOR_PASSWORD}
     Go Into Project  library
     Goto Project Config
@@ -610,14 +611,16 @@ Test Case - Project Level Image Serverity Policy
     Init Chrome Driver
     Sign In Harbor  ${HARBOR_URL}  ${HARBOR_ADMIN}  ${HARBOR_PASSWORD}
     ${d}=  get current date  result_format=%m%s
+    ${sha256}=  Set Variable  68b49a280d2fbe9330c0031970ebb72015e1272dfa25f0ed7557514f9e5ad7b7
+    ${image}=  Set Variable  postgres
     Create An New Project  project${d}
-    Push Image  ${ip}  ${HARBOR_ADMIN}  ${HARBOR_PASSWORD}  project${d}  haproxy
+    Push Image  ${ip}  ${HARBOR_ADMIN}  ${HARBOR_PASSWORD}  project${d}  ${image}  sha256=${sha256}  tag=${sha256}
     Go Into Project  project${d}
-    Go Into Repo  haproxy
-    Scan Repo  latest  Succeed
+    Go Into Repo  ${image}
+    Scan Repo  ${sha256}  Succeed
     Navigate To Projects
     Go Into Project  project${d}
     Set Vulnerabilty Serverity  0
-    Cannot pull image  ${ip}  ${HARBOR_ADMIN}  ${HARBOR_PASSWORD}  project${d}  haproxy
+    Cannot pull image  ${ip}  ${HARBOR_ADMIN}  ${HARBOR_PASSWORD}  project${d}  ${image}  tag=${sha256}
     Close Browser
 


### PR DESCRIPTION
In nighly test case <Project Level Image Serverity Policy>, scan result of haproxy image is nolonger high but medium, it should be a bug of clair, so we replace haproxy by postgres, and also we pull postgres with sha256 to make sure the image under test is alway the specific one.

Signed-off-by: danfengliu <danfengl@vmware.com>