### PR TITLE
Create retention client with the configurations got from jobservice config

### DIFF
--- a/src/jobservice/config/config.go
+++ b/src/jobservice/config/config.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 
 	"github.com/goharbor/harbor/src/jobservice/common/utils"
-	"gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v2"
 )
 
 const (
@@ -37,6 +37,7 @@ const (
 	jobServiceRedisURL          = "JOB_SERVICE_POOL_REDIS_URL"
 	jobServiceRedisNamespace    = "JOB_SERVICE_POOL_REDIS_NAMESPACE"
 	jobServiceAuthSecret        = "JOBSERVICE_SECRET"
+	coreURL                     = "CORE_URL"
 
 	// JobServiceProtocolHTTPS points to the 'https' protocol
 	JobServiceProtocolHTTPS = "https"
@@ -161,6 +162,11 @@ func (c *Configuration) Load(yamlFilePath string, detectEnv bool) error {
 // GetAuthSecret get the auth secret from the env
 func GetAuthSecret() string {
 	return utils.ReadEnv(jobServiceAuthSecret)
+}
+
+// GetCoreURL get the core url from the env
+func GetCoreURL() string {
+	return utils.ReadEnv(coreURL)
 }
 
 // GetUIAuthSecret get the auth secret of UI side

--- a/src/jobservice/config/config_test.go
+++ b/src/jobservice/config/config_test.go
@@ -14,11 +14,12 @@
 package config
 
 import (
+	"os"
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"os"
-	"testing"
 )
 
 // ConfigurationTestSuite tests the configuration loading
@@ -84,6 +85,7 @@ func (suite *ConfigurationTestSuite) TestConfigLoadingWithEnv() {
 	)
 	assert.Equal(suite.T(), "js_secret", GetAuthSecret(), "expect auth secret 'js_secret' but got '%s'", GetAuthSecret())
 	assert.Equal(suite.T(), "core_secret", GetUIAuthSecret(), "expect auth secret 'core_secret' but got '%s'", GetUIAuthSecret())
+	assert.Equal(suite.T(), "core_url", GetCoreURL(), "expect core url 'core_url' but got '%s'", GetCoreURL())
 }
 
 // TestDefaultConfig ...
@@ -134,6 +136,7 @@ func setENV() error {
 	err = os.Setenv("JOB_SERVICE_POOL_REDIS_NAMESPACE", "ut_namespace")
 	err = os.Setenv("JOBSERVICE_SECRET", "js_secret")
 	err = os.Setenv("CORE_SECRET", "core_secret")
+	err = os.Setenv("CORE_URL", "core_url")
 
 	return err
 }

--- a/src/jobservice/main.go
+++ b/src/jobservice/main.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"os"
 
 	"github.com/goharbor/harbor/src/common"
 	comcfg "github.com/goharbor/harbor/src/common/config"
@@ -64,7 +63,7 @@ func main() {
 		if utils.IsEmptyStr(secret) {
 			return nil, errors.New("empty auth secret")
 		}
-		coreURL := os.Getenv("CORE_URL")
+		coreURL := config.GetCoreURL()
 		configURL := coreURL + common.CoreConfigPath
 		cfgMgr := comcfg.NewRESTCfgManager(configURL, secret)
 		jobCtx := impl.NewContext(ctx, cfgMgr)

--- a/src/pkg/retention/boot.go
+++ b/src/pkg/retention/boot.go
@@ -14,14 +14,10 @@
 
 package retention
 
-import "github.com/goharbor/harbor/src/pkg/retention/dep"
-
 // TODO: Move to api.Init()
 
 // Init the retention components
 func Init() error {
-	// New default retention client
-	dep.DefaultClient = dep.NewClient()
 
 	return nil
 }

--- a/src/pkg/retention/dep/client_test.go
+++ b/src/pkg/retention/dep/client_test.go
@@ -129,14 +129,6 @@ func (c *clientTestSuite) TestDelete() {
 	require.NotNil(c.T(), err)
 }
 
-func (c *clientTestSuite) TestSubmitTask() {
-	client := &basicClient{}
-	client.jobserviceClient = &fakeJobserviceClient{}
-	jobID, err := client.SubmitTask(1, nil, nil)
-	require.Nil(c.T(), err)
-	assert.Equal(c.T(), "1", jobID)
-}
-
 func TestClientTestSuite(t *testing.T) {
 	suite.Run(t, new(clientTestSuite))
 }

--- a/src/pkg/retention/job.go
+++ b/src/pkg/retention/job.go
@@ -205,28 +205,28 @@ func logError(logger logger.Interface, err error) error {
 }
 
 func getParamRepo(params job.Parameters) (*res.Repository, error) {
-	v, ok := params[dep.ParamRepo]
+	v, ok := params[ParamRepo]
 	if !ok {
-		return nil, errors.Errorf("missing parameter: %s", dep.ParamRepo)
+		return nil, errors.Errorf("missing parameter: %s", ParamRepo)
 	}
 
 	repo, ok := v.(*res.Repository)
 	if !ok {
-		return nil, errors.Errorf("invalid parameter: %s", dep.ParamRepo)
+		return nil, errors.Errorf("invalid parameter: %s", ParamRepo)
 	}
 
 	return repo, nil
 }
 
 func getParamMeta(params job.Parameters) (*lwp.Metadata, error) {
-	v, ok := params[dep.ParamMeta]
+	v, ok := params[ParamMeta]
 	if !ok {
-		return nil, errors.Errorf("missing parameter: %s", dep.ParamMeta)
+		return nil, errors.Errorf("missing parameter: %s", ParamMeta)
 	}
 
 	meta, ok := v.(*lwp.Metadata)
 	if !ok {
-		return nil, errors.Errorf("invalid parameter: %s", dep.ParamMeta)
+		return nil, errors.Errorf("invalid parameter: %s", ParamMeta)
 	}
 
 	return meta, nil

--- a/src/pkg/retention/job_test.go
+++ b/src/pkg/retention/job_test.go
@@ -21,32 +21,21 @@ import (
 	"testing"
 	"time"
 
+	"github.com/goharbor/harbor/src/jobservice/job"
+	"github.com/goharbor/harbor/src/jobservice/logger"
+	"github.com/goharbor/harbor/src/pkg/retention/dep"
+	"github.com/goharbor/harbor/src/pkg/retention/policy"
+	"github.com/goharbor/harbor/src/pkg/retention/policy/action"
 	"github.com/goharbor/harbor/src/pkg/retention/policy/alg"
 	"github.com/goharbor/harbor/src/pkg/retention/policy/alg/or"
-	"github.com/goharbor/harbor/src/pkg/retention/res/selectors"
-
-	"github.com/stretchr/testify/require"
-
-	"github.com/goharbor/harbor/src/pkg/retention/res/selectors/doublestar"
-
-	"github.com/goharbor/harbor/src/pkg/retention/res/selectors/label"
-
-	"github.com/goharbor/harbor/src/pkg/retention/policy/action"
-	"github.com/goharbor/harbor/src/pkg/retention/policy/rule/latestk"
-
-	"github.com/goharbor/harbor/src/pkg/retention/policy"
-	"github.com/goharbor/harbor/src/pkg/retention/policy/rule"
-
-	"github.com/goharbor/harbor/src/jobservice/logger"
-
-	"github.com/goharbor/harbor/src/jobservice/job"
-
 	"github.com/goharbor/harbor/src/pkg/retention/policy/lwp"
-
+	"github.com/goharbor/harbor/src/pkg/retention/policy/rule"
+	"github.com/goharbor/harbor/src/pkg/retention/policy/rule/latestk"
 	"github.com/goharbor/harbor/src/pkg/retention/res"
-
-	"github.com/goharbor/harbor/src/pkg/retention/dep"
-
+	"github.com/goharbor/harbor/src/pkg/retention/res/selectors"
+	"github.com/goharbor/harbor/src/pkg/retention/res/selectors/doublestar"
+	"github.com/goharbor/harbor/src/pkg/retention/res/selectors/label"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -87,7 +76,7 @@ func (suite *JobTestSuite) TearDownSuite() {
 
 func (suite *JobTestSuite) TestRunSuccess() {
 	params := make(job.Parameters)
-	params[dep.ParamRepo] = &res.Repository{
+	params[ParamRepo] = &res.Repository{
 		Namespace: "library",
 		Name:      "harbor",
 		Kind:      res.Image,
@@ -103,7 +92,7 @@ func (suite *JobTestSuite) TestRunSuccess() {
 	ruleParams := make(rule.Parameters)
 	ruleParams[latestk.ParameterK] = 10
 
-	params[dep.ParamMeta] = &lwp.Metadata{
+	params[ParamMeta] = &lwp.Metadata{
 		Algorithm: policy.AlgorithmOR,
 		Rules: []*rule.Metadata{
 			{


### PR DESCRIPTION
As the retention client is only used in job which running in jobservice, the configurations that needed to init the client should be read from jobservice

Signed-off-by: Wenkai Yin <yinw@vmware.com>