### PR TITLE
add internal reg request handler chain

### DIFF
--- a/make/photon/prepare/templates/core/env.jinja
+++ b/make/photon/prepare/templates/core/env.jinja
@@ -31,6 +31,7 @@ CLAIR_DB_USERNAME={{clair_db_username}}
 CLAIR_DB={{clair_db_name}}
 CLAIR_DB_SSLMODE={{clair_db_sslmode}}
 CORE_URL={{core_url}}
+CORE_LOCAL_URL={{core_local_url}}
 JOBSERVICE_URL={{jobservice_url}}
 CLAIR_URL={{clair_url}}
 NOTARY_URL={{notary_url}}

--- a/make/photon/prepare/utils/configs.py
+++ b/make/photon/prepare/utils/configs.py
@@ -67,6 +67,7 @@ def parse_yaml_config(config_file_path):
         'registry_url': "http://registry:5000",
         'registry_controller_url': "http://registryctl:8080",
         'core_url': "http://core:8080",
+        'core_local_url': "http://127.0.0.1:8080",
         'token_service_url': "http://core:8080/service/token",
         'jobservice_url': 'http://jobservice:8080',
         'clair_url': 'http://clair:6060',

--- a/src/common/config/metadata/metadatalist.go
+++ b/src/common/config/metadata/metadatalist.go
@@ -75,6 +75,7 @@ var (
 		{Name: common.ClairURL, Scope: SystemScope, Group: ClairGroup, EnvKey: "CLAIR_URL", DefaultValue: "http://clair:6060", ItemType: &StringType{}, Editable: false},
 
 		{Name: common.CoreURL, Scope: SystemScope, Group: BasicGroup, EnvKey: "CORE_URL", DefaultValue: "http://core:8080", ItemType: &StringType{}, Editable: false},
+		{Name: common.CoreLocalURL, Scope: SystemScope, Group: BasicGroup, EnvKey: "CORE_LOCAL_URL", DefaultValue: "http://127.0.0.1:8080", ItemType: &StringType{}, Editable: false},
 		{Name: common.DatabaseType, Scope: SystemScope, Group: BasicGroup, EnvKey: "DATABASE_TYPE", DefaultValue: "postgresql", ItemType: &StringType{}, Editable: false},
 
 		{Name: common.EmailFrom, Scope: UserScope, Group: EmailGroup, EnvKey: "EMAIL_FROM", DefaultValue: "admin <sample_admin@mydomain.com>", ItemType: &StringType{}, Editable: false},

--- a/src/common/const.go
+++ b/src/common/const.go
@@ -55,6 +55,7 @@ const (
 	PostGreSQLSSLMode                = "postgresql_sslmode"
 	SelfRegistration                 = "self_registration"
 	CoreURL                          = "core_url"
+	CoreLocalURL                     = "core_local_url"
 	JobServiceURL                    = "jobservice_url"
 	LDAPURL                          = "ldap_url"
 	LDAPSearchDN                     = "ldap_search_dn"

--- a/src/core/api/repository.go
+++ b/src/core/api/repository.go
@@ -238,7 +238,7 @@ func (ra *RepositoryAPI) Delete() {
 		return
 	}
 
-	rc, err := coreutils.NewRepositoryClientForUI(ra.SecurityCtx.GetUsername(), repoName)
+	rc, err := coreutils.NewRepositoryClientForLocal(ra.SecurityCtx.GetUsername(), repoName)
 	if err != nil {
 		log.Errorf("error occurred while initializing repository client for %s: %v", repoName, err)
 		ra.SendInternalServerError(errors.New("internal error"))

--- a/src/core/config/config.go
+++ b/src/core/config/config.go
@@ -280,7 +280,11 @@ func InternalJobServiceURL() string {
 // InternalCoreURL returns the local harbor core url
 func InternalCoreURL() string {
 	return strings.TrimSuffix(cfgMgr.Get(common.CoreURL).GetString(), "/")
+}
 
+// LocalCoreURL returns the local harbor core url
+func LocalCoreURL() string {
+	return cfgMgr.Get(common.CoreLocalURL).GetString()
 }
 
 // InternalTokenServiceEndpoint returns token service endpoint for internal communication between Harbor containers

--- a/src/core/config/config_test.go
+++ b/src/core/config/config_test.go
@@ -208,6 +208,9 @@ func TestConfig(t *testing.T) {
 	assert.Equal("http://myjob:8888", InternalJobServiceURL())
 	assert.Equal("http://myui:8888/service/token", InternalTokenServiceEndpoint())
 
+	localCoreURL := LocalCoreURL()
+	assert.Equal("http://127.0.0.1:8080", localCoreURL)
+
 }
 
 func currPath() string {

--- a/src/core/middlewares/config.go
+++ b/src/core/middlewares/config.go
@@ -28,3 +28,6 @@ const (
 
 // Middlewares with sequential organization
 var Middlewares = []string{READONLY, URL, MUITIPLEMANIFEST, LISTREPO, CONTENTTRUST, VULNERABLE, SIZEQUOTA, COUNTQUOTA}
+
+// MiddlewaresLocal ...
+var MiddlewaresLocal = []string{SIZEQUOTA, COUNTQUOTA}

--- a/src/core/middlewares/util/util.go
+++ b/src/core/middlewares/util/util.go
@@ -31,6 +31,7 @@ import (
 	"github.com/goharbor/harbor/src/pkg/scan/whitelist"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -368,6 +369,16 @@ func GetProjectID(name string) (int64, error) {
 
 // GetRegRedisCon ...
 func GetRegRedisCon() (redis.Conn, error) {
+	// FOR UT
+	if os.Getenv("UTTEST") == "true" {
+		return redis.Dial(
+			"tcp",
+			fmt.Sprintf("%s:%d", os.Getenv("REDIS_HOST"), 6379),
+			redis.DialConnectTimeout(DialConnectionTimeout),
+			redis.DialReadTimeout(DialReadTimeout),
+			redis.DialWriteTimeout(DialWriteTimeout),
+		)
+	}
 	return redis.DialURL(
 		config.GetRedisOfRegURL(),
 		redis.DialConnectTimeout(DialConnectionTimeout),

--- a/src/core/utils/retag.go
+++ b/src/core/utils/retag.go
@@ -28,13 +28,13 @@ import (
 // Retag tags an image to another
 func Retag(srcImage, destImage *models.Image) error {
 	isSameRepo := getRepoName(srcImage) == getRepoName(destImage)
-	srcClient, err := NewRepositoryClientForUI("harbor-ui", getRepoName(srcImage))
+	srcClient, err := NewRepositoryClientForLocal("harbor-ui", getRepoName(srcImage))
 	if err != nil {
 		return err
 	}
 	destClient := srcClient
 	if !isSameRepo {
-		destClient, err = NewRepositoryClientForUI("harbor-ui", getRepoName(destImage))
+		destClient, err = NewRepositoryClientForLocal("harbor-ui", getRepoName(destImage))
 		if err != nil {
 			return err
 		}

--- a/src/core/utils/utils.go
+++ b/src/core/utils/utils.go
@@ -17,6 +17,7 @@ package utils
 
 import (
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/goharbor/harbor/src/common/utils/log"
@@ -33,7 +34,20 @@ func NewRepositoryClientForUI(username, repository string) (*registry.Repository
 	if err != nil {
 		return nil, err
 	}
+	return newRepositoryClient(endpoint, username, repository)
+}
 
+// NewRepositoryClientForLocal creates a repository client that can only be used to
+// access the internal registry with 127.0.0.1
+func NewRepositoryClientForLocal(username, repository string) (*registry.Repository, error) {
+	// The 127.0.0.1:8080 is not reachable as we do not enable core in UT env.
+	if os.Getenv("UTTEST") == "true" {
+		return NewRepositoryClientForUI(username, repository)
+	}
+	return newRepositoryClient(config.LocalCoreURL(), username, repository)
+}
+
+func newRepositoryClient(endpoint, username, repository string) (*registry.Repository, error) {
 	uam := &auth.UserAgentModifier{
 		UserAgent: "harbor-registry-client",
 	}


### PR DESCRIPTION
this is for internal registry api call, the request should be intercepted by quota middlerwares, like retag and delete.
Note: The api developer has to know that if the internal registry call in your api, please consider to use
NewRepositoryClientForLocal() to init the repository client, which can handle quota change.

Signed-off-by: wang yan <wangyan@vmware.com>