### PR TITLE
fix bug #8499: redis connection pool is run out

### DIFF
--- a/src/jobservice/migration/manager_test.go
+++ b/src/jobservice/migration/manager_test.go
@@ -17,6 +17,10 @@ package migration
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
+	"testing"
+	"time"
+
 	"github.com/goharbor/harbor/src/jobservice/common/rds"
 	"github.com/goharbor/harbor/src/jobservice/common/utils"
 	"github.com/goharbor/harbor/src/jobservice/job"
@@ -25,9 +29,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"strings"
-	"testing"
-	"time"
 )
 
 // ManagerTestSuite tests functions of manager
@@ -168,7 +169,8 @@ func (suite *ManagerTestSuite) TestManager() {
 	assert.NoError(suite.T(), err, "get count of policies error")
 	assert.Equal(suite.T(), 1, count)
 
-	p, err := getPeriodicPolicy(suite.numbericID, conn, suite.namespace)
+	innerConn := suite.pool.Get()
+	p, err := getPeriodicPolicy(suite.numbericID, innerConn, suite.namespace)
 	assert.NoError(suite.T(), err, "get migrated policy error")
 	assert.NotEmpty(suite.T(), p.ID, "ID of policy")
 	assert.NotEmpty(suite.T(), p.WebHookURL, "Web hook URL of policy")

--- a/src/jobservice/runtime/bootstrap.go
+++ b/src/jobservice/runtime/bootstrap.go
@@ -264,9 +264,8 @@ func (bs *Bootstrap) loadAndRunRedisWorkerPool(
 // Get a redis connection pool
 func (bs *Bootstrap) getRedisPool(redisURL string) *redis.Pool {
 	return &redis.Pool{
-		MaxActive: 6,
-		MaxIdle:   6,
-		Wait:      true,
+		MaxIdle: 6,
+		Wait:    true,
 		Dial: func() (redis.Conn, error) {
 			return redis.DialURL(
 				redisURL,


### PR DESCRIPTION
Signed-off-by: Steven Zou <szou@vmware.com>

The cause is the Redis connection pool used in the job service for the data migration is run out. That is caused by a bug in the migration process, the connection should be returned to the pool instantly, not with `defer` way.

We’ll build a patch soon and check if we resolve this issue.