### PR TITLE
[cherry-pick]fix bug #8499: redis connection pool is run out

### DIFF
--- a/src/jobservice/migration/manager_test.go
+++ b/src/jobservice/migration/manager_test.go
@@ -17,6 +17,10 @@ package migration
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
+	"testing"
+	"time"
+
 	"github.com/goharbor/harbor/src/jobservice/common/rds"
 	"github.com/goharbor/harbor/src/jobservice/common/utils"
 	"github.com/goharbor/harbor/src/jobservice/job"
@@ -25,9 +29,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"strings"
-	"testing"
-	"time"
 )
 
 // ManagerTestSuite tests functions of manager
@@ -168,7 +169,8 @@ func (suite *ManagerTestSuite) TestManager() {
 	assert.NoError(suite.T(), err, "get count of policies error")
 	assert.Equal(suite.T(), 1, count)
 
-	p, err := getPeriodicPolicy(suite.numbericID, conn, suite.namespace)
+	innerConn := suite.pool.Get()
+	p, err := getPeriodicPolicy(suite.numbericID, innerConn, suite.namespace)
 	assert.NoError(suite.T(), err, "get migrated policy error")
 	assert.NotEmpty(suite.T(), p.ID, "ID of policy")
 	assert.NotEmpty(suite.T(), p.WebHookURL, "Web hook URL of policy")

--- a/src/jobservice/migration/migrator_v180.go
+++ b/src/jobservice/migration/migrator_v180.go
@@ -18,6 +18,8 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"strconv"
+
 	"github.com/goharbor/harbor/src/jobservice/common/rds"
 	"github.com/goharbor/harbor/src/jobservice/common/utils"
 	"github.com/goharbor/harbor/src/jobservice/job"
@@ -25,7 +27,6 @@ import (
 	"github.com/goharbor/harbor/src/jobservice/period"
 	"github.com/gomodule/redigo/redis"
 	"github.com/pkg/errors"
-	"strconv"
 )
 
 // PolicyMigrator migrate the cron job policy to new schema
@@ -137,10 +138,9 @@ func (pm *PolicyMigrator) Migrate() error {
 
 				// Update periodic policy model
 				// conn is working, we need new conn
+				// this inner connection will be closed by the calling method
 				innerConn := pm.pool.Get()
-				defer func() {
-					_ = innerConn.Close()
-				}()
+
 				policy, er := getPeriodicPolicy(numbericPolicyID, innerConn, pm.namespace)
 				if er == nil {
 					policy.ID = pID
@@ -250,6 +250,11 @@ func getScoreByID(id string, conn redis.Conn, ns string) (int64, error) {
 
 // Get periodic policy object by the numeric ID
 func getPeriodicPolicy(numericID int64, conn redis.Conn, ns string) (*period.Policy, error) {
+	// close this inner connection here
+	defer func() {
+		_ = conn.Close()
+	}()
+
 	bytes, err := redis.Values(conn.Do("ZRANGEBYSCORE", rds.KeyPeriodicPolicy(ns), numericID, numericID))
 	if err != nil {
 		return nil, err

--- a/src/jobservice/runtime/bootstrap.go
+++ b/src/jobservice/runtime/bootstrap.go
@@ -258,9 +258,8 @@ func (bs *Bootstrap) loadAndRunRedisWorkerPool(
 // Get a redis connection pool
 func (bs *Bootstrap) getRedisPool(redisURL string) *redis.Pool {
 	return &redis.Pool{
-		MaxActive: 6,
-		MaxIdle:   6,
-		Wait:      true,
+		MaxIdle: 6,
+		Wait:    true,
 		Dial: func() (redis.Conn, error) {
 			return redis.DialURL(
 				redisURL,


### PR DESCRIPTION
The casue is the redis connection pool used in the job service for the data migration is run out. That is caused by a bug in the migration process, the connection should be returned to the pool instantly, not with defer way.

