### PR TITLE
fix bug: dry run is missing when deleting ropo

### DIFF
--- a/src/pkg/retention/job_del_repo.go
+++ b/src/pkg/retention/job_del_repo.go
@@ -74,8 +74,10 @@ func (drj *DelRepoJob) Run(ctx job.Context, params job.Parameters) error {
 	}
 
 	// Delete the repository
-	if err := dep.DefaultClient.DeleteRepository(repo); err != nil {
-		return err
+	if !isDryRun {
+		if err := dep.DefaultClient.DeleteRepository(repo); err != nil {
+			return err
+		}
 	}
 
 	// Log deletions


### PR DESCRIPTION
Signed-off-by: Steven Zou <szou@vmware.com>

dry run is missing when deleting ropo