### PR TITLE
Adding retry for wait element visibility in nightly test case Developer-Operate-Labels

### DIFF
--- a/tests/resources/Harbor-Pages/Project-Members.robot
+++ b/tests/resources/Harbor-Pages/Project-Members.robot
@@ -142,7 +142,7 @@ Change User Role In Project
     [Arguments]  ${admin}  ${pwd}  ${project}  ${user}  ${role}  ${is_oidc_mode}=${false}
     Run Keyword If  ${is_oidc_mode} == ${false}  Sign In Harbor   ${HARBOR_URL}  ${admin}  ${pwd}
     ...    ELSE  Sign In Harbor With OIDC User  ${HARBOR_URL}  username=${admin}
-    Wait Until Element Is Visible  //clr-dg-cell//a[contains(.,'${project}')]
+    Retry Wait Element Visible  //clr-dg-cell//a[contains(.,'${project}')]
     Change Project Member Role  ${project}  ${user}  ${role}
     Logout Harbor
 

--- a/tests/resources/Harbor-Pages/Project.robot
+++ b/tests/resources/Harbor-Pages/Project.robot
@@ -170,8 +170,7 @@ Go Into Repo
     Retry Element Click  ${repo_search_icon}
     Retry Text Input  ${repo_search_input}  ${repoName}
     Retry Double Keywords When Error  Retry Element Click  ${repo_name_element}  Page Should Not Contain Element  ${repo_name_element}
-    Retry Wait Element  ${tag_table_column_signed}
-    Retry Wait Element  ${tag_table_column_vulnerability}
+    Retry Wait Element  ${tag_table_column_pull_command}
     Retry Wait Element  ${tag_images_btn}
     Capture Page Screenshot  gointo_${repoName}.png
 

--- a/tests/resources/Harbor-Pages/Project_Elements.robot
+++ b/tests/resources/Harbor-Pages/Project_Elements.robot
@@ -42,7 +42,9 @@ ${user_delete_btn}  xpath=/clr-dropdown-menu//button[contains(.,'Delete')]
 ${repo_search_icon}  xpath=//hbr-filter//clr-icon
 ${repo_search_input}  xpath=//hbr-filter//input
 ${repo_tag_1st_checkbox}  xpath=//clr-datagrid//clr-dg-row//clr-checkbox-wrapper
-${tag_table_column_signed}  xpath=//clr-dg-column//span[contains(.,'Signed')]
+${tag_table_column_pull_command}  xpath=//clr-dg-column//span[contains(.,'Pull Command')]
+${tag_table_column_tag}  xpath=//clr-dg-column//span[contains(.,'Tag')]
+${tag_table_column_size}  xpath=//clr-dg-column//span[contains(.,'Size')]
 ${tag_table_column_vulnerability}  xpath=//clr-dg-column//span[contains(.,'Vulnerability')]
 ${tag_images_btn}  xpath=//hbr-repository//button[contains(.,'Images')]
 ${project_member_action_xpath}  xpath=//*[@id='member-action']

--- a/tests/resources/Util.robot
+++ b/tests/resources/Util.robot
@@ -83,6 +83,11 @@ Retry Wait Element
     @{param}  Create List  ${element_xpath}
     Retry Action Keyword  Wait Until Element Is Visible And Enabled  @{param}
 
+Retry Wait Element Visible
+    [Arguments]  ${element_xpath}
+    @{param}  Create List  ${element_xpath}
+    Retry Action Keyword  Wait Until Element Is Visible  @{param}
+
 Retry Wait Element Not Visible
     [Arguments]  ${element_xpath}
     @{param}  Create List  ${element_xpath}


### PR DESCRIPTION
Adding retry for wait element visibility, in nightly test case Developer-Operate-Labels, project didn't show up when checking its visiblity, so add some wait for this check.

Signed-off-by: danfengliu <danfengl@vmware.com>