### PR TITLE
Update the swagger doc for GC API

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -5090,7 +5090,9 @@ definitions:
     properties:
       type:
         type: string
-        description: The schedule type. The valid values are hourly, daily， weekly, custom and None. 'None' means to cancel the schedule.
+        description: |
+          The schedule type. The valid values are 'Hourly', 'Daily', 'Weekly', 'Custom', 'Manually' and 'None'.
+          'Manually' means to trigger it right away and 'None' means to cancel the schedule.
       cron:
         type: string
         description: A cron expression, a time-based job scheduler.


### PR DESCRIPTION
This commit update the swagger doc to document how to trigger an "admin
job" such as "GC" to make it execute right away.

Signed-off-by: Daniel Jiang <jiangd@vmware.com>