### PR TITLE
nginx: Remove TLSv1.1 support

### DIFF
--- a/make/photon/prepare/templates/nginx/nginx.https.conf.jinja
+++ b/make/photon/prepare/templates/nginx/nginx.https.conf.jinja
@@ -39,7 +39,7 @@ http {
     ssl_certificate_key {{ssl_cert_key}};
   
     # Recommendations from https://raymii.org/s/tutorials/Strong_SSL_Security_On_nginx.html
-    ssl_protocols TLSv1.1 TLSv1.2;
+    ssl_protocols TLSv1.2;
     ssl_ciphers '!aNULL:kECDH+AESGCM:ECDH+AESGCM:RSA+AESGCM:kECDH+AES:ECDH+AES:RSA+AES:';
     ssl_prefer_server_ciphers on;
     ssl_session_cache shared:SSL:10m;


### PR DESCRIPTION
According to [linked article](https://raymii.org/s/tutorials/Strong_SSL_Security_On_nginx.html) from comment, TLSv1.1 is not recommended anymore and should be disabled. 

And for example, [GitLab 12 has TLSv1.1 disabled by default](https://docs.gitlab.com/omnibus/update/gitlab_11_changes.html#tls-v11-deprecation).