### PR TITLE
Only replicate "public" metadata when creating project in Harbor

### DIFF
--- a/src/replication/adapter/harbor/adapter.go
+++ b/src/replication/adapter/harbor/adapter.go
@@ -156,7 +156,7 @@ func (a *adapter) PrepareForPush(resources []*model.Resource) error {
 		paths := strings.Split(resource.Metadata.Repository.Name, "/")
 		projectName := paths[0]
 		// handle the public properties
-		metadata := resource.Metadata.Repository.Metadata
+		metadata := abstractPublicMetadata(resource.Metadata.Repository.Metadata)
 		pro, exist := projects[projectName]
 		if exist {
 			metadata = mergeMetadata(pro.Metadata, metadata)
@@ -185,6 +185,19 @@ func (a *adapter) PrepareForPush(resources []*model.Resource) error {
 		log.Debugf("project %s created", project.Name)
 	}
 	return nil
+}
+
+func abstractPublicMetadata(metadata map[string]interface{}) map[string]interface{} {
+	if metadata == nil {
+		return nil
+	}
+	public, exist := metadata["public"]
+	if !exist {
+		return nil
+	}
+	return map[string]interface{}{
+		"public": public,
+	}
 }
 
 // currently, mergeMetadata only handles the public metadata

--- a/src/replication/adapter/harbor/adapter_test.go
+++ b/src/replication/adapter/harbor/adapter_test.go
@@ -210,3 +210,26 @@ func TestMergeMetadata(t *testing.T) {
 		assert.Equal(t, strconv.FormatBool(c.public), m["public"].(string))
 	}
 }
+
+func TestAbstractPublicMetadata(t *testing.T) {
+	// nil input metadata
+	meta := abstractPublicMetadata(nil)
+	assert.Nil(t, meta)
+
+	// contains no public metadata
+	metadata := map[string]interface{}{
+		"other": "test",
+	}
+	meta = abstractPublicMetadata(metadata)
+	assert.Nil(t, meta)
+
+	// contains public metadata
+	metadata = map[string]interface{}{
+		"other":  "test",
+		"public": "true",
+	}
+	meta = abstractPublicMetadata(metadata)
+	require.NotNil(t, meta)
+	require.Equal(t, 1, len(meta))
+	require.Equal(t, "true", meta["public"].(string))
+}


### PR DESCRIPTION
This commit filters the metadata when creating project in replication to avoid replicate unnecessary properties, such as retention policy

Signed-off-by: Wenkai Yin <yinw@vmware.com>