### PR TITLE
Fix the swagger API definition

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -333,10 +333,10 @@ paths:
           description: Illegal format of provided ID value.
         '401':
           description: User need to log in first.
-        '404':
-          description: Project ID does not exist.
         '403':
           description: User does not have permission to get summary of the project.
+        '404':
+          description: Project ID does not exist.
         '500':
           description: Unexpected internal errors.
   '/projects/{project_id}/metadatas':
@@ -2380,10 +2380,10 @@ paths:
               $ref: '#/definitions/Namespace'
         '401':
           description: User need to login first.
-        '404':
-          description: No registry found.
         '403':
           description: User has no privilege for the operation.
+        '404':
+          description: No registry found.
         '500':
           description: Unexpected internal errors.
   /internal/syncregistry:
@@ -3684,7 +3684,7 @@ paths:
           description: Unexpected internal errors.
   '/projects/{project_id}/webhook/policies':
     get:
-      sumary: List project webhook policies.
+      summary: List project webhook policies.
       description: |
         This endpoint returns webhook policies of a project.
       parameters:
@@ -3712,7 +3712,7 @@ paths:
         '500':
           description: Unexpected internal errors.
     post:
-      sumary: Create project webhook policy.
+      summary: Create project webhook policy.
       description: |
         This endpoint create a webhook policy if the project does not have one.
       parameters:
@@ -3757,7 +3757,7 @@ paths:
           in: path
           description: The id of webhook policy.
           required: true
-          type: int64
+          type: integer
           format: int64
       tags:
         - Products
@@ -3791,7 +3791,7 @@ paths:
           in: path
           description: The id of webhook policy.
           required: true
-          type: int64
+          type: integer
           format: int64
         - name: policy
           in: body
@@ -3829,7 +3829,7 @@ paths:
           in: path
           description: The id of webhook policy.
           required: true
-          type: int64
+          type: integer
           format: int64
       tags:
         - Products
@@ -3908,7 +3908,7 @@ paths:
           description: Internal server errors.
   '/projects/{project_id}/webhook/jobs':
     get:
-      sumary: List project webhook jobs
+      summary: List project webhook jobs
       description: |
         This endpoint returns webhook jobs of a project.
       parameters:
@@ -5724,7 +5724,7 @@ definitions:
         description: The webhook job ID.
       policy_id:
         type: integer
-        fromat: int64
+        format: int64
         description: The webhook policy ID.
       event_type:
         type: string


### PR DESCRIPTION
This PR fixes all the errors in the swagger API definition. It does not remove all the warnings though.

Before: (using the [`go-swagger`](https://github.com/go-swagger/go-swagger/) tool)
```
> swagger validate docs/swagger.yaml
2019/08/11 23:14:13
The swagger spec at "docs/swagger.yaml" showed up some valid but possibly unwanted constructs.
2019/08/11 23:14:13 See warnings below:
2019/08/11 23:14:13 - WARNING: definition "#/definitions/ChartInfoList" is not used anywhere
2019/08/11 23:14:13 - WARNING: definition "#/definitions/InternalChartAPIError" is not used anywhere
2019/08/11 23:14:13 - WARNING: definition "#/definitions/PingRegistry" is not used anywhere
2019/08/11 23:14:13 - WARNING: definition "#/definitions/Role" is not used anywhere
2019/08/11 23:14:13 - WARNING: definition "#/definitions/ForbiddenChartAPIError" is not used anywhere
2019/08/11 23:14:13 - WARNING: definition "#/definitions/InsufficientStorageChartAPIError" is not used anywhere
2019/08/11 23:14:13 - WARNING: definition "#/definitions/JobStatus" is not used anywhere
2019/08/11 23:14:13 - WARNING: definition "#/definitions/BadRequestFormatedError" is not used anywhere
2019/08/11 23:14:13 - WARNING: definition "#/definitions/RoleParam" is not used anywhere
2019/08/11 23:14:13 - WARNING: definition "#/definitions/ConflictFormatedError" is not used anywhere
2019/08/11 23:14:13 - WARNING: definition "#/definitions/UnauthorizedChartAPIError" is not used anywhere
2019/08/11 23:14:13 - WARNING: definition "#/definitions/NotFoundChartAPIError" is not used anywhere

The swagger spec at "docs/swagger.yaml" is invalid against swagger specification 2.0.
See errors below:
- "paths./projects/{project_id}/webhook/policies/{policy_id}.get.parameters" must validate one and only one schema (oneOf). Found none valid
- paths./projects/{project_id}/webhook/policies/{policy_id}.get.parameters.in in body should be one of [header]
- paths./projects/{project_id}/webhook/policies/{policy_id}.get.parameters.type in body should be one of [string number boolean integer array]
- "paths./projects/{project_id}/webhook/policies/{policy_id}.put.parameters" must validate one and only one schema (oneOf). Found none valid
- paths./projects/{project_id}/webhook/policies/{policy_id}.put.parameters.type in body should be one of [string number boolean integer array]
- paths./projects/{project_id}/webhook/policies/{policy_id}.put.parameters.in in body should be one of [header]
- "paths./projects/{project_id}/webhook/policies/{policy_id}.delete.parameters" must validate one and only one schema (oneOf). Found none valid
- paths./projects/{project_id}/webhook/policies/{policy_id}.delete.parameters.in in body should be one of [header]
- paths./projects/{project_id}/webhook/policies/{policy_id}.delete.parameters.type in body should be one of [string number boolean integer array]
- paths./projects/{project_id}/webhook/jobs.get.sumary in body is a forbidden property
- paths./projects/{project_id}/webhook/policies.post.sumary in body is a forbidden property
- paths./projects/{project_id}/webhook/policies.get.sumary in body is a forbidden property
- definitions.WebhookJob.properties.policy_id.fromat in body is a forbidden property
```

After:

```
> swagger validate docs/swagger.yaml
2019/08/11 23:12:33
The swagger spec at "docs/swagger.yaml" is valid against swagger specification 2.0
2019/08/11 23:12:33
The swagger spec at "docs/swagger.yaml" showed up some valid but possibly unwanted constructs.
2019/08/11 23:12:33 See warnings below:
2019/08/11 23:12:33 - WARNING: definition "#/definitions/JobStatus" is not used anywhere
2019/08/11 23:12:33 - WARNING: definition "#/definitions/ChartInfoList" is not used anywhere
2019/08/11 23:12:33 - WARNING: definition "#/definitions/Role" is not used anywhere
2019/08/11 23:12:33 - WARNING: definition "#/definitions/UnauthorizedChartAPIError" is not used anywhere
2019/08/11 23:12:33 - WARNING: definition "#/definitions/InternalChartAPIError" is not used anywhere
2019/08/11 23:12:33 - WARNING: definition "#/definitions/PingRegistry" is not used anywhere
2019/08/11 23:12:33 - WARNING: definition "#/definitions/ForbiddenChartAPIError" is not used anywhere
2019/08/11 23:12:33 - WARNING: definition "#/definitions/RoleParam" is not used anywhere
2019/08/11 23:12:33 - WARNING: definition "#/definitions/BadRequestFormatedError" is not used anywhere
2019/08/11 23:12:33 - WARNING: definition "#/definitions/NotFoundChartAPIError" is not used anywhere
2019/08/11 23:12:33 - WARNING: definition "#/definitions/InsufficientStorageChartAPIError" is not used anywhere
2019/08/11 23:12:33 - WARNING: definition "#/definitions/ConflictFormatedError" is not used anywhere
```