### PR TITLE
feat: Expand password length to unlimited

### DIFF
--- a/src/portal/src/app/account/password-setting/password-setting.component.html
+++ b/src/portal/src/app/account/password-setting/password-setting.component.html
@@ -13,7 +13,7 @@
             </clr-input-container>
             <clr-input-container>
                 <label class="required">{{'CHANGE_PWD.NEW_PWD' | translate}}</label>
-                <input clrInput type="password" id="newPassword" required pattern="^(?=.*\d)(?=.*[a-z])(?=.*[A-Z])(?!.*\s).{8,20}$" name="newPassword"
+                <input clrInput type="password" id="newPassword" required pattern="^(?=.*\d)(?=.*[a-z])(?=.*[A-Z])(?!.*\s).{8,128}$" name="newPassword"
                     [(ngModel)]="newPwd" #newPassInput="ngModel" size="40" (input)='handleValidation("newPassword", false)' (blur)='handleValidation("newPassword", true)'>
                 <clr-control-helper>{{'CHANGE_PWD.PASS_TIPS' | translate}}</clr-control-helper>
                 <clr-control-error *ngIf="!getValidationState('newPassword')">
@@ -22,7 +22,7 @@
             </clr-input-container>
             <clr-input-container>
                 <label class="required">{{'CHANGE_PWD.CONFIRM_PWD' | translate}}</label>
-                <input clrInput type="password" id="reNewPassword" required pattern="^(?=.*\d)(?=.*[a-z])(?=.*[A-Z])(?!.*\s).{8,20}$" name="reNewPassword"
+                <input clrInput type="password" id="reNewPassword" required pattern="^(?=.*\d)(?=.*[a-z])(?=.*[A-Z])(?!.*\s).{8,128}$" name="reNewPassword"
                     [(ngModel)]="reNewPwd" #reNewPassInput="ngModel" size="40" (input)='handleValidation("reNewPassword", false)'
                     (blur)='handleValidation("reNewPassword", true)'>
                 <clr-control-error *ngIf='!getValidationState("reNewPassword")'>

--- a/src/portal/src/app/account/password-setting/reset-password/reset-password.component.html
+++ b/src/portal/src/app/account/password-setting/reset-password/reset-password.component.html
@@ -10,7 +10,7 @@
                     <label for="newPassword" aria-haspopup="true" role="tooltip" class="tooltip tooltip-validation tooltip-md tooltip-bottom-left"
                         [class.invalid]='!getValidationState("newPassword")'>
                         <input [disabled]="resetOk" type="password" id="newPassword" placeholder='{{"PLACEHOLDER.NEW_PWD" | translate}}' required
-                            pattern="^(?=.*\d)(?=.*[a-z])(?=.*[A-Z])(?!.*\s).{8,20}$" name="newPassword" [(ngModel)]="password"
+                            pattern="^(?=.*\d)(?=.*[a-z])(?=.*[A-Z])(?!.*\s).{8,128}$" name="newPassword" [(ngModel)]="password"
                             #newPassInput="ngModel" size="25" (input)='handleValidation("newPassword", false)' (blur)='handleValidation("newPassword", true)'>
                         <span class="tooltip-content">
                             {{'TOOLTIP.PASSWORD' | translate}}
@@ -22,7 +22,7 @@
                     <label for="reNewPassword" aria-haspopup="true" role="tooltip" class="tooltip tooltip-validation tooltip-md tooltip-top-left"
                         [class.invalid]='!getValidationState("reNewPassword")'>
                         <input [disabled]="resetOk" type="password" id="reNewPassword" placeholder='{{"PLACEHOLDER.CONFIRM_PWD" | translate}}' required
-                            pattern="^(?=.*\d)(?=.*[a-z])(?=.*[A-Z])(?!.*\s).{8,20}$" name="reNewPassword" [(ngModel)]="confirmPwd"
+                            pattern="^(?=.*\d)(?=.*[a-z])(?=.*[A-Z])(?!.*\s).{8,128}$" name="reNewPassword" [(ngModel)]="confirmPwd"
                             #reNewPassInput size="25" (input)='handleValidation("reNewPassword", false)' (blur)='handleValidation("reNewPassword", true)'>
                         <span class="tooltip-content">
                             {{'TOOLTIP.CONFIRM_PWD' | translate}}

--- a/src/portal/src/app/shared/new-user-form/new-user-form.component.html
+++ b/src/portal/src/app/shared/new-user-form/new-user-form.component.html
@@ -40,7 +40,7 @@
         </clr-input-container>
         <clr-input-container>
             <label class="required">{{'PROFILE.PASSWORD' | translate}}</label>
-            <input clrInput type="password" id="newPassword" required pattern="^(?=.*\d)(?=.*[a-z])(?=.*[A-Z])(?!.*\s).{8,20}$" name="newPassword"
+            <input clrInput type="password" id="newPassword" required pattern="^(?=.*\d)(?=.*[a-z])(?=.*[A-Z])(?!.*\s).{8,128}$" name="newPassword"
                 [(ngModel)]="newUser.password" #newPassInput="ngModel" size="30" (input)='handleValidation("newPassword", false)'
                 (blur)='handleValidation("newPassword", true)'>
             <clr-control-helper *ngIf="isSelfRegistration">{{'CHANGE_PWD.PASS_TIPS' | translate}}</clr-control-helper>
@@ -50,7 +50,7 @@
         </clr-input-container>
         <clr-input-container>
             <label class="required">{{'CHANGE_PWD.CONFIRM_PWD' | translate}}</label>
-            <input clrInput type="password" id="confirmPassword" required pattern="^(?=.*\d)(?=.*[a-z])(?=.*[A-Z])(?!.*\s).{8,20}$" name="confirmPassword"
+            <input clrInput type="password" id="confirmPassword" required pattern="^(?=.*\d)(?=.*[a-z])(?=.*[A-Z])(?!.*\s).{8,128}$" name="confirmPassword"
                 [(ngModel)]="confirmedPwd" #confirmPassInput="ngModel" size="30" (input)='handleValidation("confirmPassword", false)'
                 (blur)='handleValidation("confirmPassword", true)'>
             <clr-control-error *ngIf='getValidationState("confirmPassword")'>

--- a/src/portal/src/app/user/change-password/change-password.component.html
+++ b/src/portal/src/app/user/change-password/change-password.component.html
@@ -5,7 +5,7 @@
         <form #resetPwdForm="ngForm" clrForm>
             <clr-input-container>
                 <label>{{'CHANGE_PWD.NEW_PWD' | translate}}</label>
-                <input clrInput type="password" id="newPassword" placeholder='{{"PLACEHOLDER.NEW_PWD" | translate}}' required pattern="^(?=.*\d)(?=.*[a-z])(?=.*[A-Z])(?!.*\s).{8,20}$"
+                <input clrInput type="password" id="newPassword" placeholder='{{"PLACEHOLDER.NEW_PWD" | translate}}' required pattern="^(?=.*\d)(?=.*[a-z])(?=.*[A-Z])(?!.*\s).{8,128}$"
                     name="newPassword" [(ngModel)]="password" #newPassInput="ngModel" size="25" (input)='handleValidation("newPassword", false)'
                     (blur)='handleValidation("newPassword", true)'>
                 <clr-control-error *ngIf="!getValidationState('newPassword')">
@@ -14,7 +14,7 @@
             </clr-input-container>
             <clr-input-container>
                 <label>{{'CHANGE_PWD.CONFIRM_PWD' | translate}}</label>
-                <input clrInput type="password" id="reNewPassword" placeholder='{{"PLACEHOLDER.CONFIRM_PWD" | translate}}' required pattern="^(?=.*\d)(?=.*[a-z])(?=.*[A-Z])(?!.*\s).{8,20}$"
+                <input clrInput type="password" id="reNewPassword" placeholder='{{"PLACEHOLDER.CONFIRM_PWD" | translate}}' required pattern="^(?=.*\d)(?=.*[a-z])(?=.*[A-Z])(?!.*\s).{8,128}$"
                     name="reNewPassword" [(ngModel)]="confirmPwd" #reNewPassInput size="25" (input)='handleValidation("reNewPassword", false)'
                     (blur)='handleValidation("reNewPassword", true)'>
                 <clr-control-error *ngIf="!getValidationState('reNewPassword')">

--- a/src/portal/src/i18n/lang/en-us-lang.json
+++ b/src/portal/src/i18n/lang/en-us-lang.json
@@ -143,7 +143,7 @@
         "NEW_PWD": "New Password",
         "CONFIRM_PWD": "Confirm Password",
         "SAVE_SUCCESS": "User password changed successfully.",
-        "PASS_TIPS": "8-20 characters long with 1 uppercase, 1 lowercase and 1 number"
+        "PASS_TIPS": "8-128 characters long with 1 uppercase, 1 lowercase and 1 number"
     },
     "ACCOUNT_SETTINGS": {
         "PROFILE": "User Profile",

--- a/src/portal/src/i18n/lang/es-es-lang.json
+++ b/src/portal/src/i18n/lang/es-es-lang.json
@@ -143,7 +143,7 @@
         "NEW_PWD": "Nueva contraseña",
         "CONFIRM_PWD": "Confirmar contraseña",
         "SAVE_SUCCESS": "Contraseña de usuario guardada satisfactoriamente.",
-        "PASS_TIPS": "8-20 caracteres con 1 letra mayúscula, 1 minúscula y 1 número"
+        "PASS_TIPS": "8-128 caracteres con 1 letra mayúscula, 1 minúscula y 1 número"
     },
     "ACCOUNT_SETTINGS": {
         "PROFILE": "Perfil de usuario",

--- a/src/portal/src/i18n/lang/fr-fr-lang.json
+++ b/src/portal/src/i18n/lang/fr-fr-lang.json
@@ -138,7 +138,7 @@
         "NEW_PWD": "Nouveau Mot de Passe",
         "CONFIRM_PWD": "Confirmer le Mot de Passe",
         "SAVE_SUCCESS": "Mot de passe utilisateur modifié avec succès.",
-        "PASS_TIPS": "8-20 caractères long avec 1 majuscule, 1 minuscule et 1 chiffre"
+        "PASS_TIPS": "8-128 caractères long avec 1 majuscule, 1 minuscule et 1 chiffre"
     },
     "ACCOUNT_SETTINGS": {
         "PROFILE": "Profil Utilisateur",

--- a/src/portal/src/i18n/lang/pt-br-lang.json
+++ b/src/portal/src/i18n/lang/pt-br-lang.json
@@ -141,7 +141,7 @@
         "NEW_PWD": "Nova senha",
         "CONFIRM_PWD": "Confirmar senha",
         "SAVE_SUCCESS": "Senha do usuário alterada com sucesso.",
-        "PASS_TIPS": "8-20 caracteres com 1 maiuscula, 1 minuscula e 1 número"
+        "PASS_TIPS": "8-128 caracteres com 1 maiuscula, 1 minuscula e 1 número"
     },
     "ACCOUNT_SETTINGS": {
         "PROFILE": "Perfil do usuário",

--- a/src/portal/src/i18n/lang/zh-cn-lang.json
+++ b/src/portal/src/i18n/lang/zh-cn-lang.json
@@ -142,7 +142,7 @@
         "NEW_PWD": "新密码",
         "CONFIRM_PWD": "确认密码",
         "SAVE_SUCCESS": "成功更改用户密码。",
-        "PASS_TIPS": "8到20个字符且需包含至少一个大写字符、小写字符或者数字"
+        "PASS_TIPS": "8到128个字符且需包含至少一个大写字符、小写字符或者数字"
     },
     "ACCOUNT_SETTINGS": {
         "PROFILE": "用户设置",


### PR DESCRIPTION
Addresses: #234 

Extends the password length to unlimited characters.

This should be possible since:
* In [`src/common/dao/user.go`](https://github.com/goharbor/harbor/blob/master/src/common/dao/user.go#L159) the Salt never exceeds 32 characters since the [`utils.GenerateRandomString()`](https://github.com/goharbor/harbor/tree/master/src/common/utils/utils.go#L67) always return 32.
* [`utils.Encrypt(u.Password, u.Salt)`](https://github.com/goharbor/harbor/blob/master/src/common/utils/encrypt.go#L42) also always returns 32. that can be test here:
https://play.golang.org/p/NeBuv9eHm91

The database table for the password and the salt both have a `character varying(40)` type.

I updated the translations as best as I could, I trusted Google translate for most of them.