### PR TITLE
[Do not merge] fix(quota,replication): get blob size from body for replication

### DIFF
--- a/src/common/utils/registry/repository.go
+++ b/src/common/utils/registry/repository.go
@@ -25,7 +25,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	//	"time"
 
 	"github.com/docker/distribution/manifest/schema1"
 	"github.com/docker/distribution/manifest/schema2"
@@ -407,6 +406,9 @@ func (r *Repository) monolithicBlobUpload(location, digest string, size int64, d
 	if err != nil {
 		return err
 	}
+
+	// set the Content-Length for the request
+	req.ContentLength = size
 
 	resp, err := r.client.Do(req)
 	if err != nil {


### PR DESCRIPTION
1. Contains Content-Length when push blob for replication.
2. Get blob size from body for replication of harbor 1.8 and below.

Signed-off-by: He Weiwei <hweiwei@vmware.com>