### PR TITLE
API test for project level CVE whitelist

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -4023,6 +4023,9 @@ definitions:
       metadata:
         description: The metadata of the project.
         $ref: '#/definitions/ProjectMetadata'
+      cve_whitelist:
+        description: The CVE whitelist of the project.
+        $ref: '#/definitions/CVEWhitelist'
       count_limit:
         type: integer
         format: int64

--- a/tests/apitests/python/library/project.py
+++ b/tests/apitests/python/library/project.py
@@ -77,29 +77,20 @@ class Project(base.Base):
         base._assert_status_code(200, status_code)
         return data
 
-    def update_project(self, project_id, metadata, **kwargs):
+    def update_project(self, project_id, expect_status_code=200, metadata=None, cve_whitelist=None, **kwargs):
         client = self._get_client(**kwargs)
-        project = swagger_client.Project(project_id, None, None, None, None, None, None, None, None, None, None, metadata)
-        _, status_code, _ = client.projects_project_id_put_with_http_info(project_id, project)
-        base._assert_status_code(200, status_code)
+        project = swagger_client.ProjectReq(metadata=metadata, cve_whitelist=cve_whitelist)
+        try:
+            _, sc, _ = client.projects_project_id_put_with_http_info(project_id, project)
+        except ApiException as e:
+            base._assert_status_code(expect_status_code, e.status)
+        else:
+            base._assert_status_code(expect_status_code, sc)
 
     def delete_project(self, project_id, expect_status_code = 200, **kwargs):
         client = self._get_client(**kwargs)
         _, status_code, _ = client.projects_project_id_delete_with_http_info(project_id)
         base._assert_status_code(expect_status_code, status_code)
-
-    def get_project_metadata_by_name(self, project_id, meta_name, expect_status_code = 200, **kwargs):
-        client = self._get_client(**kwargs)
-        ProjectMetadata = swagger_client.ProjectMetadata()
-        ProjectMetadata, status_code, _ = client.projects_project_id_metadatas_meta_name_get_with_http_info(project_id, meta_name)
-        base._assert_status_code(expect_status_code, status_code)
-        return {
-            'public': ProjectMetadata.public,
-            'enable_content_trust': ProjectMetadata.enable_content_trust,
-            'prevent_vul': ProjectMetadata.prevent_vul,
-            'auto_scan': ProjectMetadata.auto_scan,
-            'severity': ProjectMetadata.severity,
-        }.get(meta_name,'error')
 
     def get_project_log(self, project_id, expect_status_code = 200, **kwargs):
         client = self._get_client(**kwargs)
@@ -160,7 +151,6 @@ class Project(base.Base):
     def update_project_member_role(self, project_id, member_id, member_role_id, expect_status_code = 200, **kwargs):
         client = self._get_client(**kwargs)
         role = swagger_client.Role(role_id = member_role_id)
-        data = []
         data, status_code, _ = client.projects_project_id_members_mid_put_with_http_info(project_id, member_id, role = role)
         base._assert_status_code(expect_status_code, status_code)
         base._assert_status_code(200, status_code)

--- a/tests/apitests/python/test_project_level_cve_whitelist.py
+++ b/tests/apitests/python/test_project_level_cve_whitelist.py
@@ -1,0 +1,95 @@
+from __future__ import absolute_import
+
+import unittest
+import swagger_client
+import time
+
+from testutils import ADMIN_CLIENT
+from library.project import Project
+from library.user import User
+
+
+class TestProjectCVEWhitelist(unittest.TestCase):
+    """
+    Test case:
+        Project Level CVE Whitelist
+    Setup:
+        1.Admin creates project(PA)
+        2.Create user(RA)
+        3.Add user(RA) as a guest of project(PA)
+    Test Steps:
+        1. User(RA) reads the project(PA), verify the "reuse_sys_cve_whitelist" is empty in the metadata, and the CVE whitelist is empty
+        2. User(RA) updates the project CVE whitelist, verify it fails with Forbidden error.
+        3. Admin user updates User(RA) as project admin.
+        4. User(RA) updates the project CVE whitelist with expiration date and one item in the items list.
+        5. User(RA) reads the project(PA), verify the CVE whitelist is updated as step 4
+        6. User(RA) updates the project CVE whitelist removes expiration date and clean the items.
+        7. User(RA) reads the project(PA), verify the CVE whitelist is updated as step 6
+        8. User(RA) updates the project metadata to set "reuse_sys_cve_whitelist" to true.
+        9. User(RA) reads the project(PA) verify the project metadata is updated.
+    Tear Down:
+        1. Remove User(RA) from project(PA) as member
+        2. Delete project(PA)
+        3. Delete User(RA)
+    """
+
+    def setUp(self):
+        self.user = User()
+        self.project = Project()
+        user_ra_password = "Aa123456"
+        print("Setup: Creating user for test")
+        user_ra_id, user_ra_name = self.user.create_user(user_password=user_ra_password, **ADMIN_CLIENT)
+        print("Created user: %s, id: %s" % (user_ra_name, user_ra_id))
+        self.USER_RA_CLIENT = dict(endpoint=ADMIN_CLIENT["endpoint"],
+                                   username=user_ra_name,
+                                   password=user_ra_password)
+        self.user_ra_id = int(user_ra_id)
+        p_id, _ = self.project.create_project(metadata = {"public": "false"}, **ADMIN_CLIENT)
+        self.project_pa_id = int(p_id)
+        m_id = self.project.add_project_members(self.project_pa_id, self.user_ra_id, member_role_id=3, **ADMIN_CLIENT)
+        self.member_id = int(m_id)
+
+    def tearDown(self):
+        print("Tearing down...")
+        self.project.delete_project_member(self.project_pa_id, self.member_id, **ADMIN_CLIENT)
+        self.project.delete_project(self.project_pa_id,**ADMIN_CLIENT)
+        self.user.delete_user(self.user_ra_id, **ADMIN_CLIENT)
+
+    def testProjectLevelCVEWhitelist(self):
+        # User(RA) reads the project(PA), verify the "reuse_sys_cve_whitelist" is empty in the metadata,
+        # and the CVE whitelist is empty
+        p = self.project.get_project(self.project_pa_id, **self.USER_RA_CLIENT)
+        self.assertIsNone(p.metadata.reuse_sys_cve_whitelist)
+        self.assertEqual(0, len(p.cve_whitelist.items))
+
+        # User(RA) updates the project CVE whitelist, verify it fails with Forbidden error.
+        item_list = [swagger_client.CVEWhitelistItem(cve_id="CVE-2019-12310")]
+        exp = int(time.time()) + 1000
+        wl = swagger_client.CVEWhitelist(expires_at=exp, items=item_list)
+        self.project.update_project(self.project_pa_id, cve_whitelist=wl, expect_status_code=403, **self.USER_RA_CLIENT)
+
+        # Admin user updates User(RA) as project admin.
+        self.project.update_project_member_role(self.project_pa_id,self.member_id, 1, **ADMIN_CLIENT)
+
+        # User(RA) updates the project CVE whitelist with expiration date and one item in the items list.
+        self.project.update_project(self.project_pa_id, cve_whitelist=wl, **self.USER_RA_CLIENT)
+        p = self.project.get_project(self.project_pa_id, **self.USER_RA_CLIENT)
+        self.assertEqual("CVE-2019-12310", p.cve_whitelist.items[0].cve_id)
+        self.assertEqual(exp, p.cve_whitelist.expires_at)
+
+        # User(RA) updates the project CVE whitelist with empty items list
+        wl2 = swagger_client.CVEWhitelist(items=[])
+        self.project.update_project(self.project_pa_id, cve_whitelist=wl2, **self.USER_RA_CLIENT)
+        p = self.project.get_project(self.project_pa_id, **self.USER_RA_CLIENT)
+        self.assertEqual(0, len(p.cve_whitelist.items))
+        self.assertIsNone(p.cve_whitelist.expires_at)
+
+        # User(RA) updates the project metadata to set "reuse_sys_cve_whitelist" to true.
+        meta = swagger_client.ProjectMetadata(reuse_sys_cve_whitelist="true")
+        self.project.update_project(self.project_pa_id, metadata=meta, **self.USER_RA_CLIENT)
+        p = self.project.get_project(self.project_pa_id, **self.USER_RA_CLIENT)
+        self.assertEqual("true", p.metadata.reuse_sys_cve_whitelist)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This commit update test case to cover project level CVE whitelist.
It also fixes the swagger doc to add missing attributes

Signed-off-by: Daniel Jiang <jiangd@vmware.com>