### PR TITLE
Handle the retention task status updating in concurrency

### DIFF
--- a/make/migrations/postgresql/0010_1.9.0_schema.up.sql
+++ b/make/migrations/postgresql/0010_1.9.0_schema.up.sql
@@ -131,6 +131,7 @@ create table retention_task
   repository   varchar(255),
   job_id       varchar(64),
   status       varchar(32),
+  status_code  integer,
   start_time   timestamp default CURRENT_TIMESTAMP,
   end_time     timestamp default CURRENT_TIMESTAMP,
   total        integer,

--- a/src/pkg/retention/dao/models/retention.go
+++ b/src/pkg/retention/dao/models/retention.go
@@ -54,6 +54,7 @@ type RetentionTask struct {
 	Repository  string    `orm:"column(repository)"`
 	JobID       string    `orm:"column(job_id)"`
 	Status      string    `orm:"column(status)"`
+	StatusCode  int       `orm:"column(status_code)"`
 	StartTime   time.Time `orm:"column(start_time)"`
 	EndTime     time.Time `orm:"column(end_time)"`
 	Total       int       `orm:"column(total)"`

--- a/src/pkg/retention/dao/retention.go
+++ b/src/pkg/retention/dao/retention.go
@@ -3,12 +3,13 @@ package dao
 import (
 	"errors"
 	"fmt"
+	"strconv"
+
 	"github.com/astaxie/beego/orm"
 	"github.com/goharbor/harbor/src/common/dao"
 	jobmodels "github.com/goharbor/harbor/src/common/models"
 	"github.com/goharbor/harbor/src/pkg/retention/dao/models"
 	"github.com/goharbor/harbor/src/pkg/retention/q"
-	"strconv"
 )
 
 // CreatePolicy Create Policy
@@ -225,6 +226,18 @@ func UpdateTask(task *models.RetentionTask, cols ...string) error {
 		return fmt.Errorf("invalid task ID: %d", task.ID)
 	}
 	_, err := dao.GetOrmer().Update(task, cols...)
+	return err
+}
+
+// UpdateTaskStatus updates the status of task whose status code is less than the statusCode provided
+func UpdateTaskStatus(taskID int64, status string, statusCode int) error {
+	_, err := dao.GetOrmer().QueryTable(&models.RetentionTask{}).
+		Filter("ID", taskID).
+		Filter("StatusCode__lt", statusCode).
+		Update(orm.Params{
+			"Status":     status,
+			"StatusCode": statusCode,
+		})
 	return err
 }
 

--- a/src/pkg/retention/dao/retention_test.go
+++ b/src/pkg/retention/dao/retention_test.go
@@ -194,8 +194,12 @@ func TestTask(t *testing.T) {
 
 	// update
 	task.ID = id
-	task.Status = "running"
-	err = UpdateTask(task, "Status")
+	task.Total = 1
+	err = UpdateTask(task, "Total")
+	require.Nil(t, err)
+
+	// update status
+	err = UpdateTaskStatus(id, "running", 1)
 	require.Nil(t, err)
 
 	// list
@@ -205,8 +209,10 @@ func TestTask(t *testing.T) {
 	})
 	require.Nil(t, err)
 	require.Equal(t, 1, len(tasks))
+	assert.Equal(t, 1, tasks[0].Total)
 	assert.Equal(t, int64(1), tasks[0].ExecutionID)
 	assert.Equal(t, "running", tasks[0].Status)
+	assert.Equal(t, 1, tasks[0].StatusCode)
 
 	// delete
 	err = DeleteTask(id)

--- a/src/pkg/retention/launcher_test.go
+++ b/src/pkg/retention/launcher_test.go
@@ -126,6 +126,9 @@ func (f *fakeRetentionManager) CreateTask(task *Task) (int64, error) {
 func (f *fakeRetentionManager) UpdateTask(task *Task, cols ...string) error {
 	return nil
 }
+func (f *fakeRetentionManager) UpdateTaskStatus(int64, string) error {
+	return nil
+}
 func (f *fakeRetentionManager) GetTaskLog(taskID int64) ([]byte, error) {
 	return nil, nil
 }

--- a/src/pkg/retention/manager_test.go
+++ b/src/pkg/retention/manager_test.go
@@ -6,8 +6,8 @@ import (
 	"time"
 
 	"github.com/goharbor/harbor/src/common/dao"
-
 	"github.com/goharbor/harbor/src/common/job"
+	jjob "github.com/goharbor/harbor/src/jobservice/job"
 	"github.com/goharbor/harbor/src/pkg/retention/policy"
 	"github.com/goharbor/harbor/src/pkg/retention/policy/rule"
 	"github.com/goharbor/harbor/src/pkg/retention/q"
@@ -171,7 +171,9 @@ func TestTask(t *testing.T) {
 	task := &Task{
 		ExecutionID: 1,
 		JobID:       "1",
-		Status:      TaskStatusPending,
+		Status:      jjob.PendingStatus.String(),
+		StatusCode:  jjob.PendingStatus.Code(),
+		Total:       0,
 		StartTime:   time.Now(),
 	}
 	// create
@@ -185,23 +187,29 @@ func TestTask(t *testing.T) {
 
 	// update
 	task.ID = id
-	task.Status = TaskStatusInProgress
-	err = m.UpdateTask(task, "Status")
+	task.Total = 1
+	err = m.UpdateTask(task, "Total")
+	require.Nil(t, err)
+
+	// update status to success which is a final status
+	err = m.UpdateTaskStatus(id, jjob.SuccessStatus.String())
+	require.Nil(t, err)
+
+	// try to update status to running, as the status has already
+	// been updated to a final status, this updating shouldn't take effect
+	err = m.UpdateTaskStatus(id, jjob.RunningStatus.String())
 	require.Nil(t, err)
 
 	// list
 	tasks, err := m.ListTasks(&q.TaskQuery{
 		ExecutionID: 1,
-		Status:      TaskStatusInProgress,
 	})
 	require.Nil(t, err)
 	require.Equal(t, 1, len(tasks))
 	assert.Equal(t, int64(1), tasks[0].ExecutionID)
-	assert.Equal(t, TaskStatusInProgress, tasks[0].Status)
-
-	task.Status = TaskStatusFailed
-	err = m.UpdateTask(task, "Status")
-	require.Nil(t, err)
+	assert.Equal(t, 1, tasks[0].Total)
+	assert.Equal(t, jjob.SuccessStatus.String(), tasks[0].Status)
+	assert.Equal(t, jjob.SuccessStatus.Code(), tasks[0].StatusCode)
 
 	// get task log
 	job.GlobalClient = &tjob.MockJobClient{

--- a/src/pkg/retention/models.go
+++ b/src/pkg/retention/models.go
@@ -23,12 +23,6 @@ const (
 	ExecutionStatusFailed     string = "Failed"
 	ExecutionStatusStopped    string = "Stopped"
 
-	TaskStatusPending    string = "Pending"
-	TaskStatusInProgress string = "InProgress"
-	TaskStatusSucceed    string = "Succeed"
-	TaskStatusFailed     string = "Failed"
-	TaskStatusStopped    string = "Stopped"
-
 	CandidateKindImage string = "image"
 	CandidateKindChart string = "chart"
 
@@ -54,6 +48,7 @@ type Task struct {
 	Repository  string    `json:"repository"`
 	JobID       string    `json:"job_id"`
 	Status      string    `json:"status"`
+	StatusCode  int       `json:"status_code"`
 	StartTime   time.Time `json:"start_time"`
 	EndTime     time.Time `json:"end_time"`
 	Total       int       `json:"total"`


### PR DESCRIPTION
Compare the status code when updating retention task status to avoid the concurrent issue

Signed-off-by: Wenkai Yin <yinw@vmware.com>