### PR TITLE
fixt typo "an user" to "a user"

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -5054,7 +5054,7 @@ definitions:
         description: the role id
       entity_id:
         type: integer
-        description: 'the id of entity, if the member is an user, it is user_id in user table. if the member is an user group, it is the user group''s ID in user_group table.'
+        description: 'the id of entity, if the member is a user, it is user_id in user table. if the member is a user group, it is the user group''s ID in user_group table.'
       entity_type:
         type: string
         description: 'the entity''s type, u for user entity, g for group entity.'

--- a/src/core/controllers/oidc.go
+++ b/src/core/controllers/oidc.go
@@ -144,7 +144,7 @@ func (oc *OIDCController) Callback() {
 	}
 }
 
-// Onboard handles the request to onboard an user authenticated via OIDC provider
+// Onboard handles the request to onboard a user authenticated via OIDC provider
 func (oc *OIDCController) Onboard() {
 	u := &onboardReq{}
 	if err := oc.DecodeJSONReq(u); err != nil {

--- a/src/portal/src/i18n/lang/en-us-lang.json
+++ b/src/portal/src/i18n/lang/en-us-lang.json
@@ -275,7 +275,7 @@
         "USERS": "Users",
         "EMAIL": "Email",
         "ADD_USER": "Add User",
-        "NEW_USER_INFO": "Add an user to be a member of this project with specified role",
+        "NEW_USER_INFO": "Add a user to be a member of this project with specified role",
         "NEW_GROUP": "New Group",
         "IMPORT_GROUP": "Add Group Member",
         "NEW_GROUP_INFO": "Add an existing user group or select a user group from LDAP/AD to project member",

--- a/src/portal/src/i18n/lang/es-es-lang.json
+++ b/src/portal/src/i18n/lang/es-es-lang.json
@@ -276,7 +276,7 @@
         "USERS": "Users",
         "EMAIL": "Email",
         "ADD_USER": "Add User",
-        "NEW_USER_INFO": "Add an user to be a member of this project with specified role",
+        "NEW_USER_INFO": "Add a user to be a member of this project with specified role",
         "NEW_GROUP": "New Group",
         "IMPORT_GROUP": "Add Group Member",
         "NEW_GROUP_INFO": "Add an existing user group or select a user group from LDAP to project member",

--- a/src/portal/src/i18n/lang/fr-fr-lang.json
+++ b/src/portal/src/i18n/lang/fr-fr-lang.json
@@ -259,7 +259,7 @@
         "EMAIL": "Email",
         "ROLE": "Rôle",
         "ADD_USER": "Add User",
-        "NEW_USER_INFO": "Add an user to be a member of this project with specified role",
+        "NEW_USER_INFO": "Add a user to be a member of this project with specified role",
         "NEW_GROUP": "New Group",
         "IMPORT_GROUP": "Add Group Member",
         "NEW_GROUP_INFO": "Add an existing user group or select a user group from LDAP/AD to project member",


### PR DESCRIPTION
Signed-off-by: sakura longfei.shang@daocloud.io
Typo fix "an user" -> "a user"