### PR TITLE
Revert "Fix redirect login page when enter harbor through global search"

### DIFF
--- a/src/portal/src/app/shared/route/member-guard-activate.service.ts
+++ b/src/portal/src/app/shared/route/member-guard-activate.service.ts
@@ -41,19 +41,8 @@ export class MemberGuard implements CanActivate, CanActivateChild {
           this.checkMemberStatus(state.url, projectId).subscribe((res) => observer.next(res));
         }
         , error => {
-          // if it is public project return true;
-          this.projectService.getProject(projectId).subscribe(project => {
-            if (project.metadata.public) {
-              observer.next(true);
-            } else {
-              this.router.navigate([CommonRoutes.HARBOR_DEFAULT]);
-              observer.next(false);
-            }
-          }, err => {
-            this.router.navigate([CommonRoutes.HARBOR_DEFAULT]);
-            observer.next(false);
-          });
-
+          this.router.navigate([CommonRoutes.HARBOR_DEFAULT]);
+          observer.next(false);
         });
       } else {
         this.checkMemberStatus(state.url, projectId).subscribe((res) => observer.next(res));


### PR DESCRIPTION
revert the pr 8494; because of the backend Api is not ready.
https://github.com/goharbor/harbor/pull/8494
Signed-off-by: Yogi_Wang <yawang@vmware.com>