### PR TITLE
Handle error on OIDC callback

### DIFF
--- a/src/core/controllers/oidc.go
+++ b/src/core/controllers/oidc.go
@@ -82,6 +82,15 @@ func (oc *OIDCController) Callback() {
 		oc.SendBadRequestError(errors.New("State mismatch"))
 		return
 	}
+
+	error := oc.Ctx.Request.URL.Query().Get("error")
+	if error != "" {
+		errorDescription := oc.Ctx.Request.URL.Query().Get("error_description")
+		log.Errorf("OIDC callback returned error: %s - %s", error, errorDescription)
+		oc.SendBadRequestError(errors.Errorf("OIDC callback returned error: %s - %s", error, errorDescription))
+		return
+	}
+
 	code := oc.Ctx.Request.URL.Query().Get("code")
 	ctx := oc.Ctx.Request.Context()
 	token, err := oidc.ExchangeToken(ctx, code)

--- a/src/core/controllers/oidc.go
+++ b/src/core/controllers/oidc.go
@@ -83,11 +83,11 @@ func (oc *OIDCController) Callback() {
 		return
 	}
 
-	error := oc.Ctx.Request.URL.Query().Get("error")
-	if error != "" {
+	errorCode := oc.Ctx.Request.URL.Query().Get("error")
+	if errorCode != "" {
 		errorDescription := oc.Ctx.Request.URL.Query().Get("error_description")
-		log.Errorf("OIDC callback returned error: %s - %s", error, errorDescription)
-		oc.SendBadRequestError(errors.Errorf("OIDC callback returned error: %s - %s", error, errorDescription))
+		log.Errorf("OIDC callback returned error: %s - %s", errorCode, errorDescription)
+		oc.SendBadRequestError(errors.Errorf("OIDC callback returned error: %s - %s", errorCode, errorDescription))
 		return
 	}
 


### PR DESCRIPTION
If wrong OIDC scopes are defined, or there are some configuration errors, the OIDC callback query string might contain "error=..." with an error message. Intercept this case and show an error to the user instead of trying to exchange the token with a missing "code" parameter.

Signed-off-by: Iradier, AlvaroJose <AlvaroJose.Iradier@adidas.com>