### PR TITLE
Disable redis and db containers if external db enabled

### DIFF
--- a/make/photon/prepare/templates/docker_compose/docker-compose.yml.jinja
+++ b/make/photon/prepare/templates/docker_compose/docker-compose.yml.jinja
@@ -92,6 +92,7 @@ services:
       options:  
         syslog-address: "tcp://127.0.0.1:1514"
         tag: "registryctl"
+{% if external_database == False %}
   postgresql:
     image: goharbor/harbor-db:{{version}}
     container_name: harbor-db
@@ -107,16 +108,16 @@ services:
       - {{data_volume}}/database:/var/lib/postgresql/data:z
     networks:
       harbor:
-{% if with_notary %}
+  {% if with_notary %}
       harbor-notary:
         aliases:
           - harbor-db
-{% endif %}
-{% if with_clair %}
+  {% endif %}
+  {% if with_clair %}
       harbor-clair:
         aliases:
           - harbor-db
-{% endif %}
+  {% endif %}
     dns_search: .
     env_file:
       - ./common/config/db/env
@@ -127,6 +128,7 @@ services:
       options:  
         syslog-address: "tcp://127.0.0.1:1514"
         tag: "postgresql"
+{% endif %}
   core:
     image: goharbor/harbor-core:{{version}}
     container_name: harbor-core
@@ -176,6 +178,12 @@ services:
     depends_on:
       - log
       - registry
+{% if external_redis == False %}
+      - redis
+{% endif %}
+{% if external_database == False %}
+      - postgresql
+{% endif %}
     logging:
       driver: "syslog"
       options:  
@@ -197,7 +205,6 @@ services:
     dns_search: .
     depends_on:
       - log
-      - core
     logging:
       driver: "syslog"
       options:
@@ -228,13 +235,13 @@ services:
 {% endif %}
     dns_search: .
     depends_on:
-      - redis
       - core
     logging:
       driver: "syslog"
       options:
         syslog-address: "tcp://127.0.0.1:1514"
         tag: "jobservice"
+{% if external_redis == False %}
   redis:
     image: goharbor/redis-photon:{{redis_version}}
     container_name: redis
@@ -249,11 +256,11 @@ services:
       - {{data_volume}}/redis:/var/lib/redis
     networks:
       harbor:
-{% if with_chartmuseum %}
+  {% if with_chartmuseum %}
       harbor-chartmuseum:
           aliases:
             - redis
-{% endif %}
+  {% endif %}
     dns_search: .
     depends_on:
       - log
@@ -262,8 +269,9 @@ services:
       options:
         syslog-address: "tcp://127.0.0.1:1514"
         tag: "redis"
+{% endif %}
   proxy:
-    image: goharbor/nginx-photon:{{redis_version}}
+    image: goharbor/nginx-photon:{{version}}
     container_name: nginx
     restart: always
     cap_drop:
@@ -293,7 +301,6 @@ services:
       - 4443:4443
 {% endif %}
     depends_on:
-      - postgresql
       - registry
       - core
       - portal
@@ -323,7 +330,9 @@ services:
     env_file:
       - ./common/config/notary/server_env
     depends_on:
+  {% if external_database == False %}
       - postgresql
+  {% endif %}
       - notary-signer
     logging:
       driver: "syslog"
@@ -351,7 +360,10 @@ services:
     env_file:
       - ./common/config/notary/signer_env
     depends_on:
+      - log
+  {% if external_database == False %}
       - postgresql
+  {% endif %}
     logging:
       driver: "syslog"
       options:  
@@ -374,16 +386,19 @@ services:
     cpu_quota: 50000
     dns_search: .
     depends_on:
+      - log
+  {% if external_database == False %}
       - postgresql
+  {% endif %}
     volumes:
       - type: bind
         source: ./common/config/clair/config.yaml
         target: /etc/clair/config.yaml
-{%if registry_custom_ca_bundle_path %}
+  {%if registry_custom_ca_bundle_path %}
       - type: bind
         source: {{registry_custom_ca_bundle_path}}
         target: /harbor_cust_cert/custom-ca-bundle.crt
-{% endif %}
+  {% endif %}
     logging:
       driver: "syslog"
       options:
@@ -408,7 +423,7 @@ services:
       - harbor-chartmuseum
     dns_search: .
     depends_on:
-      - redis
+      - log
     volumes:
       - {{data_volume}}/chart_storage:/chart_storage:z
       - ./common/config/chartserver:/etc/chartserver:z

--- a/make/photon/prepare/utils/configs.py
+++ b/make/photon/prepare/utils/configs.py
@@ -230,6 +230,7 @@ def parse_yaml_config(config_file_path):
     # external DB, optional, if external_db enabled, it will cover the database config
     external_db_configs = configs.get('external_database') or {}
     if external_db_configs:
+        config_dict['external_database'] = True
         # harbor db
         config_dict['harbor_db_host'] = external_db_configs['harbor']['host']
         config_dict['harbor_db_port'] = external_db_configs['harbor']['port']
@@ -258,11 +259,14 @@ def parse_yaml_config(config_file_path):
         config_dict['notary_server_db_username'] = external_db_configs['notary_server']['username']
         config_dict['notary_server_db_password'] = external_db_configs['notary_server']['password']
         config_dict['notary_server_db_sslmode'] = external_db_configs['notary_server']['ssl_mode']
+    else:
+        config_dict['external_database'] = False
 
 
     # redis config
     redis_configs = configs.get("external_redis")
     if redis_configs:
+        config_dict['external_redis'] = True
         # using external_redis
         config_dict['redis_host'] = redis_configs['host']
         config_dict['redis_port'] = redis_configs['port']
@@ -271,6 +275,7 @@ def parse_yaml_config(config_file_path):
         config_dict['redis_db_index_js'] = redis_configs.get('jobservice_db_index') or 2
         config_dict['redis_db_index_chart'] = redis_configs.get('chartmuseum_db_index') or 3
     else:
+        config_dict['external_redis'] = False
         ## Using local redis
         config_dict['redis_host'] = 'redis'
         config_dict['redis_port'] = 6379

--- a/make/photon/prepare/utils/docker_compose.py
+++ b/make/photon/prepare/utils/docker_compose.py
@@ -28,6 +28,8 @@ def prepare_docker_compose(configs, with_clair, with_notary, with_chartmuseum):
         'protocol': configs['protocol'],
         'http_port': configs['http_port'],
         'registry_custom_ca_bundle_path': configs['registry_custom_ca_bundle_path'],
+        'external_redis': configs['external_redis'],
+        'external_database': configs['external_database'],
         'with_notary': with_notary,
         'with_clair': with_clair,
         'with_chartmuseum': with_chartmuseum

--- a/make/photon/prepare/utils/jinja.py
+++ b/make/photon/prepare/utils/jinja.py
@@ -1,7 +1,7 @@
 from jinja2 import Environment, FileSystemLoader
 from .misc import mark_file
 
-jinja_env = Environment(loader=FileSystemLoader('/'), trim_blocks=True)
+jinja_env = Environment(loader=FileSystemLoader('/'), trim_blocks=True, lstrip_blocks=True)
 
 def render_jinja(src, dest,mode=0o640, uid=0, gid=0, **kw):
     t = jinja_env.get_template(src)


### PR DESCRIPTION
If depend on external redis or pg. local db and redis should not start. Therefore can save some resources.

Signed-off-by: DQ <dengq@vmware.com>