### PR TITLE
Fix nightly case to handle new vuln found by Clair.

### DIFF
--- a/tests/robot-cases/Group1-Nightly/Clair.robot
+++ b/tests/robot-cases/Group1-Nightly/Clair.robot
@@ -212,7 +212,7 @@ Test Case - Verfiy Project Level CVE Whitelist By Quick Way of Add System
     Sign In Harbor    ${HARBOR_URL}    ${HARBOR_ADMIN}  ${HARBOR_PASSWORD}
     Switch To Configure
     Switch To Configuration System Setting
-    Add Items To System CVE Whitelist    CVE-2013-7445\nCVE-2019-15099\nCVE-2019-15504\nCVE-2019-15505\nCVE-2019-9511\nCVE-2019-9513
+    Add Items To System CVE Whitelist    CVE-2013-7445\nCVE-2019-15098\nCVE-2019-15099\nCVE-2019-15504\nCVE-2019-15505\nCVE-2019-9511\nCVE-2019-9513
     Logout Harbor
     Sign In Harbor    ${HARBOR_URL}    ${signin_user}    ${signin_pwd}
     Create An New Project    project${d}


### PR DESCRIPTION
Clair scan result is not accurate that when I script this case, only 6 high CVE-ID, but in today nightly result, one more CVE-ID popuped, so I have to add it.

Signed-off-by: danfengliu <danfengl@vmware.com>