### PR TITLE
fix #8807

### DIFF
--- a/src/common/utils/registry/repository.go
+++ b/src/common/utils/registry/repository.go
@@ -272,7 +272,10 @@ func (r *Repository) MountBlob(digest, from string) error {
 		if err != nil {
 			return err
 		}
-		return fmt.Errorf("status %d, body: %s", resp.StatusCode, string(b))
+		return &commonhttp.Error{
+			Code:    resp.StatusCode,
+			Message: string(b),
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Format the error of mount blob, return a http error so that the core can parse it.

Signed-off-by: wang yan <wangyan@vmware.com>