### PR TITLE
Handle error on OIDC callback

### DIFF
--- a/src/core/controllers/oidc.go
+++ b/src/core/controllers/oidc.go
@@ -83,6 +83,15 @@ func (oc *OIDCController) Callback() {
 		oc.SendBadRequestError(errors.New("State mismatch"))
 		return
 	}
+
+	errorCode := oc.Ctx.Request.URL.Query().Get("error")
+	if errorCode != "" {
+		errorDescription := oc.Ctx.Request.URL.Query().Get("error_description")
+		log.Errorf("OIDC callback returned error: %s - %s", errorCode, errorDescription)
+		oc.SendBadRequestError(errors.Errorf("OIDC callback returned error: %s - %s", errorCode, errorDescription))
+		return
+	}
+
 	code := oc.Ctx.Request.URL.Query().Get("code")
 	ctx := oc.Ctx.Request.Context()
 	token, err := oidc.ExchangeToken(ctx, code)


### PR DESCRIPTION
Same PR as https://github.com/goharbor/harbor/pull/8820 but rebased on **master** (although would be nice to merge also PR 8820 into 1.8.x).

If wrong OIDC scopes are defined, or there are some configuration errors, the OIDC callback query string might contain "error=..." with an error message. Intercept this case and show an error to the user instead of trying to exchange the token with a missing "code" parameter.
