### PR TITLE
Add no-cache to index.html

### DIFF
--- a/make/photon/portal/nginx.conf
+++ b/make/photon/portal/nginx.conf
@@ -30,5 +30,9 @@ http {
         location / {
             try_files $uri $uri/ /index.html;
         }
+
+        location = /index.html {
+            add_header Cache-Control "no-store, no-cache, must-revalidate";
+        }
     }
 }


### PR DESCRIPTION
shouldn't cache index.html for access fresh page after upgrade.

Signed-off-by: DQ <dengq@vmware.com>