### PR TITLE
The default item list should be empty list,not null

### DIFF
--- a/src/pkg/scan/whitelist/manager.go
+++ b/src/pkg/scan/whitelist/manager.go
@@ -41,6 +41,7 @@ type defaultManager struct{}
 func (d *defaultManager) CreateEmpty(projectID int64) error {
 	l := models.CVEWhitelist{
 		ProjectID: projectID,
+		Items:     []models.CVEWhitelistItem{},
 	}
 	_, err := dao.CreateCVEWhitelist(l)
 	if err != nil {
@@ -65,6 +66,9 @@ func (d *defaultManager) Get(projectID int64) (*models.CVEWhitelist, error) {
 	if wl == nil && err == nil {
 		log.Debugf("No CVE whitelist found for project %d, returning empty list.", projectID)
 		return &models.CVEWhitelist{ProjectID: projectID, Items: []models.CVEWhitelistItem{}}, nil
+	}
+	if wl.Items == nil {
+		wl.Items = []models.CVEWhitelistItem{}
 	}
 	return wl, err
 }


### PR DESCRIPTION
This commit make sure that the "items" in response of project level
CVE_whitelist is not null, even when it's null in the DB the API will
return an empty list

Signed-off-by: Daniel Jiang <jiangd@vmware.com>