### PR TITLE
Add CVE whitelist project level API test into travis tests.

### DIFF
--- a/tests/robot-cases/Group0-BAT/API_DB.robot
+++ b/tests/robot-cases/Group0-BAT/API_DB.robot
@@ -51,5 +51,5 @@ Test Case - Sign A Image
     Harbor API Test  ./tests/apitests/python/test_sign_image.py
 Test Case - System Level CVE Whitelist
     Harbor API Test  ./tests/apitests/python/test_sys_cve_whitelists.py
-#Test Case - Project Level CVE Whitelist
-#    Harbor API Test  ./tests/apitests/python/test_project_level_cve_whitelist.py
+Test Case - Project Level CVE Whitelist
+    Harbor API Test  ./tests/apitests/python/test_project_level_cve_whitelist.py


### PR DESCRIPTION
Add CVE whitelist project level API test into travis tests.
Signed-off-by: danfengliu <danfengl@vmware.com>