### PR TITLE
Replace CVE sample image from other to redis in union

### DIFF
--- a/tests/resources/Harbor-Pages/Configuration.robot
+++ b/tests/resources/Harbor-Pages/Configuration.robot
@@ -309,6 +309,7 @@ Add Items To System CVE Whitelist
     Retry Element Click    ${config_system_save_button_xpath}
 
 Delete Top Item In System CVE Whitelist
-    [Arguments]
-    Retry Element Click    ${configuration_system_wl_delete_a_cve_id_icon}
+    [Arguments]  ${count}=1
+    :FOR  ${idx}  IN RANGE  1  ${count}
+    \   Retry Element Click    ${configuration_system_wl_delete_a_cve_id_icon}
     Retry Element Click    ${config_system_save_button_xpath}

--- a/tests/robot-cases/Group1-Nightly/Clair.robot
+++ b/tests/robot-cases/Group1-Nightly/Clair.robot
@@ -148,15 +148,16 @@ Test Case - Verfiy System Level CVE Whitelist
     [Tags]  run-once
     Init Chrome Driver
     ${d}=    Get Current Date    result_format=%m%s
-    ${image}=    Set Variable    postgres
-    ${sha256}=  Set Variable  68b49a280d2fbe9330c0031970ebb72015e1272dfa25f0ed7557514f9e5ad7b7
+    ${image}=    Set Variable    redis
+    #version redis:
+    ${sha256}=  Set Variable  9755880356c4ced4ff7745bafe620f0b63dd17747caedba72504ef7bac882089
     ${signin_user}=    Set Variable  user025
     ${signin_pwd}=    Set Variable  Test1@34
     Sign In Harbor    ${HARBOR_URL}    ${signin_user}    ${signin_pwd}
     Create An New Project    project${d}
     Push Image    ${ip}    ${signin_user}    ${signin_pwd}    project${d}    ${image}    sha256=${sha256}  tag=${sha256}
     Go Into Project  project${d}
-    Set Vulnerabilty Serverity  0
+    Set Vulnerabilty Serverity  1
     Cannot Pull image    ${ip}    ${signin_user}    ${signin_pwd}    project${d}    ${image}    tag=${sha256}
     Go Into Project  project${d}
     Go Into Repo  project${d}/${image}
@@ -165,11 +166,11 @@ Test Case - Verfiy System Level CVE Whitelist
     Sign In Harbor    ${HARBOR_URL}    ${HARBOR_ADMIN}  ${HARBOR_PASSWORD}
     Switch To Configure
     Switch To Configuration System Setting
-    Add Items To System CVE Whitelist    CVE-2019-12900\nCVE-2017-14062\nCVE-2019-11068\nCVE-2016-9427\nCVE-2018-6551\nCVE-2018-1000001\nCVE-2018-6485\nCVE-2019-9169\nCVE-2016-2779\nCVE-2019-13917\nCVE-2017-12424
+    Add Items To System CVE Whitelist    CVE-2019-12904\nCVE-2011-3389\nCVE-2018-12886\nCVE-2019-3843\nCVE-2018-20839
     Cannot Pull image    ${ip}    ${signin_user}    ${signin_pwd}    project${d}    ${image}    tag=${sha256}
-    Add Items To System CVE Whitelist    CVE-2019-8457
+    Add Items To System CVE Whitelist    CVE-2019-3844
     Pull Image    ${ip}    ${signin_user}    ${signin_pwd}    project${d}    ${image}    tag=${sha256}
-    Delete Top Item In System CVE Whitelist
+    Delete Top Item In System CVE Whitelist  count=6
     Cannot Pull image    ${ip}    ${signin_user}    ${signin_pwd}    project${d}    ${image}    tag=${sha256}
     Close Browser
 
@@ -204,21 +205,20 @@ Test Case - Verfiy Project Level CVE Whitelist By Quick Way of Add System
     [Tags]  run-once
     Init Chrome Driver
     ${d}=    Get Current Date    result_format=%m%s
-    #Image for test: haproxy:1.5
-    ${image}=    Set Variable    haproxy
-    ${sha256}=  Set Variable  eca4db0f144d40554e97d000a414a0535720e5d6e559731860558676a57529f8
+    ${image}=    Set Variable    redis
+    ${sha256}=  Set Variable  9755880356c4ced4ff7745bafe620f0b63dd17747caedba72504ef7bac882089
     ${signin_user}=    Set Variable  user025
     ${signin_pwd}=    Set Variable  Test1@34
     Sign In Harbor    ${HARBOR_URL}    ${HARBOR_ADMIN}  ${HARBOR_PASSWORD}
     Switch To Configure
     Switch To Configuration System Setting
-    Add Items To System CVE Whitelist    CVE-2016-2779\nCVE-2017-12424\nCVE-2018-6551\nCVE-2019-9169\nCVE-2018-6485\nCVE-2018-1000001\nCVE-2019-12900
+    Add Items To System CVE Whitelist    CVE-2019-12904\nCVE-2011-3389\nCVE-2018-12886\nCVE-2019-3843\nCVE-2018-20839\nCVE-2019-3844
     Logout Harbor
     Sign In Harbor    ${HARBOR_URL}    ${signin_user}    ${signin_pwd}
     Create An New Project    project${d}
     Push Image    ${ip}    ${signin_user}    ${signin_pwd}    project${d}    ${image}    sha256=${sha256}  tag=${sha256}
     Go Into Project  project${d}
-    Set Vulnerabilty Serverity  0
+    Set Vulnerabilty Serverity  1
     Go Into Project  project${d}
     Go Into Repo  project${d}/${image}
     Scan Repo  ${sha256}  Succeed


### PR DESCRIPTION
Replace CVE sample image from other to redis in union, redis is stable in relative, so test result will be stable relatively

Signed-off-by: Danfeng Liu (c) <danfengl@vmware.com>