### PR TITLE
[Cherry-pick]Add the port 8080 to the default URL of portal to avoid the health check API failure

### DIFF
--- a/src/common/const.go
+++ b/src/common/const.go
@@ -131,7 +131,7 @@ const (
 	WithChartMuseum                   = "with_chartmuseum"
 	ChartRepoURL                      = "chart_repository_url"
 	DefaultChartRepoURL               = "http://chartmuseum:9999"
-	DefaultPortalURL                  = "http://portal"
+	DefaultPortalURL                  = "http://portal:8080"
 	DefaultRegistryCtlURL             = "http://registryctl:8080"
 	DefaultClairHealthCheckServerURL  = "http://clair:6061"
 	// Use this prefix to distinguish harbor user, the prefix contains a special character($), so it cannot be registered as a harbor user.


### PR DESCRIPTION
We changed the listenning port of portal from 80 to 8080 to run the process as non-root user, but the change didn't update the default URL of portal in source code, this causes the health check API fail.

Signed-off-by: Wenkai Yin <yinw@vmware.com>