### PR TITLE
Run frontend unit test in separate job in travis. Also upgrade the node js version in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,9 @@ matrix:
   - go: 1.12.5
     env:
     - OFFLINE=true
+  - node_js: 10.16.2
+    env:
+    - UI_UT=true
 env:
   global:
   - POSTGRESQL_HOST: localhost
@@ -64,3 +67,4 @@ script:
 - if [ "$APITEST_DB" == true ]; then bash ./tests/travis/api_run.sh DB $IP; fi
 - if [ "$APITEST_LDAP" == true ]; then bash ./tests/travis/api_run.sh LDAP $IP; fi
 - if [ "$OFFLINE" == true ]; then bash ./tests/travis/distro_installer.sh; fi
+- if [ "$UI_UT" == true ]; then bash ./tests/travis/ui_ut_run.sh ; fi

--- a/tests/travis/ui_ut_run.sh
+++ b/tests/travis/ui_ut_run.sh
@@ -1,0 +1,7 @@
+cd ./src/portal
+npm install -g -q --no-progress angular-cli
+npm install -g -q --no-progress karma
+npm install -q --no-progress
+npm run build_lib && npm run link_lib && cd ../..
+
+cd ./src/portal && npm run lint && npm run lint:lib && npm run test && cd -

--- a/tests/travis/ut_install.sh
+++ b/tests/travis/ut_install.sh
@@ -2,12 +2,6 @@
 
 set -e
 
-cd ./src/portal
-npm install -g -q --no-progress angular-cli
-npm install -g -q --no-progress karma
-npm install -q --no-progress
-npm run build_lib && npm run link_lib && cd ../..
-
 sudo apt-get update && sudo apt-get install -y libldap2-dev
 go get -d github.com/docker/distribution
 go get -d github.com/docker/libtrust

--- a/tests/travis/ut_run.sh
+++ b/tests/travis/ut_run.sh
@@ -8,7 +8,6 @@ export CHROME_BIN=chromium-browser
 export DISPLAY=:99.0
 sh -e /etc/init.d/xvfb start
 
-cd ./src/portal && npm run lint && npm run lint:lib && npm run test && cd -
 sudo docker-compose -f ./make/docker-compose.test.yml up -d
 sleep 10
 ./tests/pushimage.sh


### PR DESCRIPTION
The previous version of travis vm. the node js version is 8.9. It will fail when angular upgrade to 8. This pr focus on upgrade the node js version in CI and also split the frontend unit test in a separate job. 