### PR TITLE
Disable users with GuestRole to project logs

### DIFF
--- a/src/common/rbac/project/visitor_role.go
+++ b/src/common/rbac/project/visitor_role.go
@@ -249,8 +249,6 @@ var (
 			{Resource: rbac.ResourceMember, Action: rbac.ActionRead},
 			{Resource: rbac.ResourceMember, Action: rbac.ActionList},
 
-			{Resource: rbac.ResourceLog, Action: rbac.ActionList},
-
 			{Resource: rbac.ResourceLabel, Action: rbac.ActionRead},
 			{Resource: rbac.ResourceLabel, Action: rbac.ActionList},
 

--- a/src/common/rbac/project/visitor_role_test.go
+++ b/src/common/rbac/project/visitor_role_test.go
@@ -35,8 +35,8 @@ func (suite *VisitorRoleTestSuite) TestGetRoleName() {
 	guest := visitorRole{roleID: common.RoleGuest}
 	suite.Equal(guest.GetRoleName(), "guest")
 
-	unknow := visitorRole{roleID: 404}
-	suite.Equal(unknow.GetRoleName(), "")
+	unknown := visitorRole{roleID: 404}
+	suite.Equal(unknown.GetRoleName(), "")
 }
 
 func TestVisitorRoleTestSuite(t *testing.T) {

--- a/src/core/api/log_test.go
+++ b/src/core/api/log_test.go
@@ -19,48 +19,121 @@ import (
 	"testing"
 	"time"
 
+	"github.com/goharbor/harbor/src/common"
 	"github.com/goharbor/harbor/src/common/dao"
+	"github.com/goharbor/harbor/src/common/dao/project"
 	"github.com/goharbor/harbor/src/common/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestLogGet(t *testing.T) {
+const (
+	username             = "user_for_testing_log_api"
+	repositoryName       = "repository_for_testing_log_api"
+	repoTag              = "tag_for_testing_log_api"
+	operation            = "op_for_test_log_api"
+	apiURL               = "/api/logs"
+	projectID      int64 = 1
+)
+
+func TestLogGetUnauthenticated(t *testing.T) {
 	fmt.Println("Testing Log API")
 
-	var projectID int64 = 1
-	username := "user_for_testing_log_api"
-	repository := "repository_for_testing_log_api"
-	tag := "tag_for_testing_log_api"
-	operation := "op_for_test_log_api"
-	now := time.Now()
-	err := dao.AddAccessLog(models.AccessLog{
-		ProjectID: projectID,
-		Username:  username,
-		RepoName:  repository,
-		RepoTag:   tag,
-		Operation: operation,
-		OpTime:    now,
-	})
-	require.Nil(t, err)
-	defer dao.GetOrmer().QueryTable(&models.AccessLog{}).
-		Filter("username", username).Delete()
-
-	url := "/api/logs"
-	// 401
 	cc := &codeCheckingCase{
 		request: &testingRequest{
 			method: http.MethodGet,
-			url:    url,
+			url:    apiURL,
 		},
 		code: http.StatusUnauthorized,
 	}
 	runCodeCheckingCases(t, cc)
+}
 
-	// 200, empty log list
-	c := &testingRequest{
+func TestLogGetSuccessEmpty(t *testing.T) {
+	request := makeRequest()
+	logs := []*models.AccessLog{}
+	err := handleAndParse(request, &logs)
+	require.Nil(t, err)
+	require.Equal(t, 0, len(logs))
+}
+
+func TestLogGetSuccessEntry(t *testing.T) {
+	makeLogRecord(t, 1)
+	defer eraseLogRecord()
+
+	logs := []*models.AccessLog{}
+	request := makeRequest()
+	request.credential = projGuest
+
+	err := handleAndParse(request, &logs)
+	require.Nil(t, err)
+	require.Equal(t, 1, len(logs))
+	assert.Equal(t, projectID, logs[0].ProjectID)
+	assert.Equal(t, username, logs[0].Username)
+	assert.Equal(t, repositoryName, logs[0].RepoName)
+	assert.Equal(t, repoTag, logs[0].RepoTag)
+	assert.Equal(t, operation, logs[0].Operation)
+}
+
+func TestGuestAccess(t *testing.T) {
+	projektID, err := dao.AddProject(models.Project{Name: "private", OwnerID: 1, Metadata: map[string]string{models.ProMetaPublic: "false"}})
+	require.Nil(t, err)
+
+	makeLogRecord(t, projektID)
+	defer eraseLogRecord()
+
+	userID, err := dao.Register(models.User{
+		Username: "guest",
+		Email:    "guest@guest.com",
+		Password: "guest",
+	})
+
+	_, err = project.AddProjectMember(models.Member{
+		ProjectID:  projektID,
+		Role:       models.GUEST,
+		EntityID:   int(userID),
+		EntityType: common.UserMember,
+	})
+
+	require.Nil(t, err)
+
+	request := makeRequest()
+	request.credential = &usrInfo{Name: "guest", Passwd: "guest"}
+	request.queryStruct = struct {
+		Username string `url:"username"`
+	}{
+		Username: username,
+	}
+	logs := []*models.AccessLog{}
+
+	err = handleAndParse(request, &logs)
+	require.Nil(t, err)
+
+	require.Equal(t, 0, len(logs))
+}
+
+func makeLogRecord(t *testing.T, newProjectID int64) {
+	err := dao.AddAccessLog(models.AccessLog{
+		ProjectID: newProjectID,
+		Username:  username,
+		RepoName:  repositoryName,
+		RepoTag:   repoTag,
+		Operation: operation,
+		OpTime:    time.Now(),
+	})
+	require.Nil(t, err)
+}
+
+func eraseLogRecord() {
+	_, _ = dao.GetOrmer().QueryTable(&models.AccessLog{}).
+		Filter("username", username).Delete()
+}
+
+func makeRequest() *testingRequest {
+	now := time.Now()
+	return &testingRequest{
 		method:     http.MethodGet,
-		url:        url,
+		url:        apiURL,
 		credential: nonSysAdmin,
 		queryStruct: struct {
 			Username       string `url:"username"`
@@ -71,26 +144,11 @@ func TestLogGet(t *testing.T) {
 			EndTimestamp   int64  `url:"end_timestamp"`
 		}{
 			Username:       username,
-			Repository:     repository,
-			Tag:            tag,
+			Repository:     repositoryName,
+			Tag:            repoTag,
 			Operation:      operation,
 			BeginTimestamp: now.Add(-1 * time.Second).Unix(),
 			EndTimestamp:   now.Add(1 * time.Second).Unix(),
 		},
 	}
-	logs := []*models.AccessLog{}
-	err = handleAndParse(c, &logs)
-	require.Nil(t, err)
-	require.Equal(t, 0, len(logs))
-
-	// 200
-	c.credential = projGuest
-	err = handleAndParse(c, &logs)
-	require.Nil(t, err)
-	require.Equal(t, 1, len(logs))
-	assert.Equal(t, projectID, logs[0].ProjectID)
-	assert.Equal(t, username, logs[0].Username)
-	assert.Equal(t, repository, logs[0].RepoName)
-	assert.Equal(t, tag, logs[0].RepoTag)
-	assert.Equal(t, operation, logs[0].Operation)
 }

--- a/tests/apitests/python/test_assign_role_to_ldap_group.py
+++ b/tests/apitests/python/test_assign_role_to_ldap_group.py
@@ -118,7 +118,7 @@ class TestAssignRoleToLdapGroup(unittest.TestCase):
 
         self.assertTrue(self.queryUserLogs(username="admin_user", password="zhu88jie")>0, "admin user can see logs")
         self.assertTrue(self.queryUserLogs(username="dev_user", password="zhu88jie")>0, "dev user can see logs")
-        self.assertTrue(self.queryUserLogs(username="guest_user", password="zhu88jie")>0, "guest user can see logs")
+        self.assertTrue(self.queryUserLogs(username="guest_user", password="zhu88jie")==0, "guest user can see logs")
         self.assertTrue(self.queryUserLogs(username="test", password="123456")==0, "test user can not see any logs")
 
         pass

--- a/tests/apitests/python/test_assign_role_to_ldap_group.py
+++ b/tests/apitests/python/test_assign_role_to_ldap_group.py
@@ -118,7 +118,7 @@ class TestAssignRoleToLdapGroup(unittest.TestCase):
 
         self.assertTrue(self.queryUserLogs(username="admin_user", password="zhu88jie")>0, "admin user can see logs")
         self.assertTrue(self.queryUserLogs(username="dev_user", password="zhu88jie")>0, "dev user can see logs")
-        self.assertTrue(self.queryUserLogs(username="guest_user", password="zhu88jie")==0, "guest user can see logs")
+        self.assertTrue(self.queryUserLogs(username="guest_user", password="zhu88jie")==0, "guest user can not see logs")
         self.assertTrue(self.queryUserLogs(username="test", password="123456")==0, "test user can not see any logs")
 
         pass


### PR DESCRIPTION
Guests can have access to sensitive information through logs like usernames/emails. 

