### PR TITLE
Add groups claim to OIDC configuration

### DIFF
--- a/src/common/config/metadata/metadatalist.go
+++ b/src/common/config/metadata/metadatalist.go
@@ -143,6 +143,7 @@ var (
 		{Name: common.OIDCEndpoint, Scope: UserScope, Group: OIDCGroup, ItemType: &StringType{}},
 		{Name: common.OIDCCLientID, Scope: UserScope, Group: OIDCGroup, ItemType: &StringType{}},
 		{Name: common.OIDCClientSecret, Scope: UserScope, Group: OIDCGroup, ItemType: &PasswordType{}},
+		{Name: common.OIDCGroupsClaim, Scope: UserScope, Group: OIDCGroup, ItemType: &StringType{}},
 		{Name: common.OIDCScope, Scope: UserScope, Group: OIDCGroup, ItemType: &StringType{}},
 		{Name: common.OIDCVerifyCert, Scope: UserScope, Group: OIDCGroup, DefaultValue: "true", ItemType: &BoolType{}},
 

--- a/src/common/const.go
+++ b/src/common/const.go
@@ -109,6 +109,7 @@ const (
 	OIDCCLientID                     = "oidc_client_id"
 	OIDCClientSecret                 = "oidc_client_secret"
 	OIDCVerifyCert                   = "oidc_verify_cert"
+	OIDCGroupsClaim                  = "oidc_groups_claim"
 	OIDCScope                        = "oidc_scope"
 
 	DefaultClairEndpoint              = "http://clair:6060"

--- a/src/common/models/config.go
+++ b/src/common/models/config.go
@@ -82,6 +82,7 @@ type OIDCSetting struct {
 	VerifyCert   bool     `json:"verify_cert"`
 	ClientID     string   `json:"client_id"`
 	ClientSecret string   `json:"client_secret"`
+	GroupsClaim  string   `json:"groups_claim"`
 	RedirectURL  string   `json:"redirect_url"`
 	Scope        []string `json:"scope"`
 }

--- a/src/core/config/config.go
+++ b/src/core/config/config.go
@@ -512,6 +512,7 @@ func OIDCSetting() (*models.OIDCSetting, error) {
 		VerifyCert:   cfgMgr.Get(common.OIDCVerifyCert).GetBool(),
 		ClientID:     cfgMgr.Get(common.OIDCCLientID).GetString(),
 		ClientSecret: cfgMgr.Get(common.OIDCClientSecret).GetString(),
+		GroupsClaim:  cfgMgr.Get(common.OIDCGroupsClaim).GetString(),
 		RedirectURL:  extEndpoint + common.OIDCCallbackPath,
 		Scope:        scope,
 	}, nil

--- a/src/core/config/config_test.go
+++ b/src/core/config/config_test.go
@@ -253,6 +253,7 @@ func TestOIDCSetting(t *testing.T) {
 		common.OIDCEndpoint:     "https://oidc.test",
 		common.OIDCVerifyCert:   "true",
 		common.OIDCScope:        "openid, profile",
+		common.OIDCGroupsClaim:  "my_group",
 		common.OIDCCLientID:     "client",
 		common.OIDCClientSecret: "secret",
 		common.ExtEndpoint:      "https://harbor.test",
@@ -263,6 +264,7 @@ func TestOIDCSetting(t *testing.T) {
 	assert.Equal(t, "test", v.Name)
 	assert.Equal(t, "https://oidc.test", v.Endpoint)
 	assert.True(t, v.VerifyCert)
+	assert.Equal(t, "my_group", v.GroupsClaim)
 	assert.Equal(t, "client", v.ClientID)
 	assert.Equal(t, "secret", v.ClientSecret)
 	assert.Equal(t, "https://harbor.test/c/oidc/callback", v.RedirectURL)

--- a/src/core/filter/security_test.go
+++ b/src/core/filter/security_test.go
@@ -112,6 +112,7 @@ func TestConfigCtxModifier(t *testing.T) {
 		common.OIDCEndpoint:     "https://accounts.google.com",
 		common.OIDCVerifyCert:   "true",
 		common.OIDCScope:        "openid, profile, offline_access",
+		common.OIDCGroupsClaim:  "groups",
 		common.OIDCCLientID:     "client",
 		common.OIDCClientSecret: "secret",
 		common.ExtEndpoint:      "https://harbor.test",


### PR DESCRIPTION
This commit add the new setting "oidc_groups_claim" to Harbor's
configurations.
And add "group_claim" to OIDCSetting struct.

Signed-off-by: Daniel Jiang <jiangd@vmware.com>