### PR TITLE
Cherry pick syslog doc updates into 1.9 branch

### DIFF
--- a/docs/installation_guide.md
+++ b/docs/installation_guide.md
@@ -100,19 +100,24 @@ The parameters are described below - note that at the very least, you will need 
 
 - **harbor_admin_password**: The administrator's initial password. This password only takes effect for the first time Harbor launches. After that, this setting is ignored and the administrator's password should be set in the Portal. _Note that the default username/password are **admin/Harbor12345** ._
 
-
-
 - **database**: the configs related to local database
-  - **password**: The root password for the PostgreSQL database used for **db_auth**. _Change this password for any production use!_
+  - **password**: The root password for the PostgreSQL database. Change this password for any production use.
+  - **max_idle_conns**: The maximum number of connections in the idle connection pool. If <=0 no idle connections are retained. The default value is 50 and if it is not configured the value is 2.
+  - **max_open_conns**: The maximum number of open connections to the database. If <= 0 there is no limit on the number of open connections. The default value is 100 for the max connections to the Harbor database. If it is not configured the value is 0.
 
 - **jobservice**: jobservice related service
   - **max_job_workers**: The maximum number of replication workers in job service. For each image replication job, a worker synchronizes all tags of a repository to the remote destination. Increasing this number allows more concurrent replication jobs in the system. However, since each worker consumes a certain amount of network/CPU/IO resources, please carefully pick the value of this attribute based on the hardware resource of the host.
 - **log**: log related url
   - **level**: log level, options are debug, info, warning, error, fatal
-  - **rotate_count**: Log files are rotated **rotate_count** times before being removed. If count is 0, old versions are removed rather than rotated.
-  - **rotate_size**: Log files are rotated only if they grow bigger than **rotate_size** bytes. If size is followed by k, the size is assumed to be in kilobytes. If the M is used, the size is in megabytes, and if G is used, the size is in gigabytes. So size 100, size 100k, size 100M and size 100G are all valid.
-  - **location**: the directory to store log
-
+  - **local**: The default is to retain logs locally.
+      - **rotate_count**: Log files are rotated **rotate_count** times before being removed. If count is 0, old versions are removed rather than rotated.
+      - **rotate_size**: Log files are rotated only if they grow bigger than **rotate_size** bytes. If size is followed by k, the size is assumed to be in kilobytes. If the M is used, the size is in megabytes, and if G is used, the size is in gigabytes. So size 100, size 100k, size 100M and size 100G are all valid.
+      - **location**: the directory to store logs
+  - **external_endpoint**: Enable this option to forward logs to a syslog server.
+       - **protocol**: Transport protocol for the syslog server. Default is TCP.
+       - **host**: The URL of the syslog server.
+       - **port**: The port on which the syslog server listens.
+     
 ##### optional parameters
 
 - **http**:
@@ -143,6 +148,8 @@ refer to **[Configuring Harbor with HTTPS Access](configure_https.md)**.
     - **username**: username to connect harbor core database
     - **password**: password to harbor core database
     - **ssl_mode**: is enable ssl mode
+    - **max_idle_conns**: The maximum number of connections in the idle connection pool. If <=0 no idle connections are retained. The default value  is 2.
+    - **max_open_conns**: The maximum number of open connections to the database. If <= 0 there is no limit on the number of open connections. The default value is 0.
   - **clair**: clair's database configs
     - **host**: hostname for clair database
     - **port**: port of clair database


### PR DESCRIPTION
Cherry-picking the syslog and DB updates from https://github.com/goharbor/harbor/pull/9005 into the 1.9 branch.

@reasonerjt and @xaleeks can you please approve?

* Documented how to configure Syslog connection in harbor.yml

* Documenting DB connection pool

* Removed extraneous character

* Comments from Qian.

* Comment from Weiwei

* Another comment from Weiwei

* Added max_open_conns and max_idle_conns to the external DB

* Corrected defaults for max_open_conns and max_idle_conns