### PR TITLE
remove filter redeclared as imported package name in base.go

### DIFF
--- a/src/core/controllers/base.go
+++ b/src/core/controllers/base.go
@@ -25,8 +25,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/goharbor/harbor/src/core/filter"
-
 	"github.com/astaxie/beego"
 	"github.com/beego/i18n"
 	"github.com/goharbor/harbor/src/common"


### PR DESCRIPTION
It's introduced by https://github.com/goharbor/harbor/pull/8976

Signed-off-by: wang yan <wangyan@vmware.com>