### PR TITLE
Escape user dn in ldap group search filter

### DIFF
--- a/src/common/utils/ldap/ldap.go
+++ b/src/common/utils/ldap/ldap.go
@@ -444,7 +444,7 @@ func createGroupSearchFilter(oldFilter, groupName, groupNameAttribute string) st
 
 func createNestedGroupFilter(userDN string) string {
 	filter := ""
-	filter = "(&(objectClass=group)(member:1.2.840.113556.1.4.1941:=" + userDN + "))"
+	filter = "(&(objectClass=group)(member:1.2.840.113556.1.4.1941:=" + goldap.EscapeFilter(userDN) + "))"
 	return filter
 }
 


### PR DESCRIPTION
This PR escape the user dn in the ldap search filter for nested groups.
In our company, the dn contains the username surrounded by brackets. The login failed with the message 'Error occurred in UserLogin: LDAP Result Code 201 "": ldap: finished compiling filter with extra at end: OU=user,dc=example,dc=net))'