### PR TITLE
Add Secure flag to cookie  -- cherrypick to 1.9

### DIFF
--- a/make/photon/prepare/templates/nginx/nginx.https.conf.jinja
+++ b/make/photon/prepare/templates/nginx/nginx.https.conf.jinja
@@ -68,8 +68,7 @@ http {
       # When setting up Harbor behind other proxy, such as an Nginx instance, remove the below line if the proxy already has similar settings.
       proxy_set_header X-Forwarded-Proto $scheme;
 
-      # Add Secure flag when serving HTTPS
-      proxy_cookie_path / "/; secure";
+      proxy_cookie_path / "/; HttpOnly; Secure";
 
       proxy_buffering off;
       proxy_request_buffering off;
@@ -83,7 +82,9 @@ http {
 
       # When setting up Harbor behind other proxy, such as an Nginx instance, remove the below line if the proxy already has similar settings.
       proxy_set_header X-Forwarded-Proto $scheme;
-      
+
+      proxy_cookie_path / "/; Secure";
+
       proxy_buffering off;
       proxy_request_buffering off;
     }
@@ -96,6 +97,8 @@ http {
 
       # When setting up Harbor behind other proxy, such as an Nginx instance, remove the below line if the proxy already has similar settings.
       proxy_set_header X-Forwarded-Proto $scheme;
+
+      proxy_cookie_path / "/; Secure";
       
       proxy_buffering off;
       proxy_request_buffering off;
@@ -109,6 +112,8 @@ http {
 
       # When setting up Harbor behind other proxy, such as an Nginx instance, remove the below line if the proxy already has similar settings.
       proxy_set_header X-Forwarded-Proto $scheme;
+
+      proxy_cookie_path / "/; Secure";
       
       proxy_buffering off;
       proxy_request_buffering off;
@@ -138,6 +143,8 @@ http {
       
       # When setting up Harbor behind other proxy, such as an Nginx instance, remove the below line if the proxy already has similar settings.
       proxy_set_header X-Forwarded-Proto $scheme;
+
+      proxy_cookie_path / "/; Secure";
 
       proxy_buffering off;
       proxy_request_buffering off;


### PR DESCRIPTION
This commit modifies nginx configuration file to make sure the secure
flag is added to "Set-Cookie" header when Harbor is serving https

Signed-off-by: Daniel Jiang <jiangd@vmware.com>