### PR TITLE
Generate new session ID after login -- 1.9 cherrypick

### DIFF
--- a/src/core/api/base.go
+++ b/src/core/api/base.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/goharbor/harbor/src/common/models"
 	"net/http"
 
 	"github.com/ghodss/yaml"
@@ -37,6 +38,7 @@ import (
 
 const (
 	yamlFileContentType = "application/x-yaml"
+	userSessionKey      = "user"
 )
 
 // the managers/controllers used globally
@@ -166,6 +168,12 @@ func (b *BaseController) WriteYamlData(object interface{}) {
 	w.Header().Set("Content-Type", yamlFileContentType)
 	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write(yData)
+}
+
+// PopulateUserSession generates a new session ID and fill the user model in parm to the session
+func (b *BaseController) PopulateUserSession(u models.User) {
+	b.SessionRegenerateID()
+	b.SetSession(userSessionKey, u)
 }
 
 // Init related objects/configurations for the API controllers

--- a/src/core/controllers/base.go
+++ b/src/core/controllers/base.go
@@ -17,6 +17,7 @@ package controllers
 import (
 	"bytes"
 	"context"
+	"github.com/goharbor/harbor/src/core/api"
 	"github.com/goharbor/harbor/src/core/filter"
 	"html/template"
 	"net"
@@ -38,11 +39,9 @@ import (
 	"github.com/goharbor/harbor/src/core/config"
 )
 
-const userKey = "user"
-
 // CommonController handles request from UI that doesn't expect a page, such as /SwitchLanguage /logout ...
 type CommonController struct {
-	beego.Controller
+	api.BaseController
 	i18n.Locale
 }
 
@@ -50,6 +49,9 @@ type CommonController struct {
 func (cc *CommonController) Render() error {
 	return nil
 }
+
+// Prepare overwrites the Prepare func in api.BaseController to ignore unnecessary steps
+func (cc *CommonController) Prepare() {}
 
 type messageDetail struct {
 	Hint string
@@ -111,7 +113,7 @@ func (cc *CommonController) Login() {
 	if user == nil {
 		cc.CustomAbort(http.StatusUnauthorized, "")
 	}
-	cc.SetSession(userKey, *user)
+	cc.PopulateUserSession(*user)
 }
 
 // LogOut Habor UI

--- a/src/core/controllers/oidc.go
+++ b/src/core/controllers/oidc.go
@@ -148,7 +148,7 @@ func (oc *OIDCController) Callback() {
 			oc.SendInternalServerError(err)
 			return
 		}
-		oc.SetSession(userKey, *u)
+		oc.PopulateUserSession(*u)
 		oc.Controller.Redirect("/", http.StatusFound)
 	}
 }
@@ -219,8 +219,8 @@ func (oc *OIDCController) Onboard() {
 	}
 
 	user.OIDCUserMeta = nil
-	oc.SetSession(userKey, user)
 	oc.DelSession(userInfoKey)
+	oc.PopulateUserSession(user)
 }
 
 func secretAndToken(tokenBytes []byte) (string, string, error) {


### PR DESCRIPTION
This commit mitigates the Session Fixation issue by making sure a new
session ID is generated each time user logs in to Harbor

Signed-off-by: Daniel Jiang <jiangd@vmware.com>