### PR TITLE
Modify way of Project creation verifycation in migrate pipeline

### DIFF
--- a/tests/resources/Harbor-Pages/Verify.robot
+++ b/tests/resources/Harbor-Pages/Verify.robot
@@ -173,7 +173,8 @@ Verify System Setting
     Textfield Value Should Be  xpath=//*[@id='emailUsername']  @{emailuser}[0]
     Textfield Value Should Be  xpath=//*[@id='emailFrom']  @{emailfrom}[0]
     Switch To System Settings
-    Page Should Contain  @{creation}[0]
+    ${ret}  Get Selected List Value  xpath=//select[@id='proCreation']
+    Should Be Equal As Strings  ${ret}  @{creation}[0]
     Token Must Be Match  @{token}[0]
     Switch To Vulnerability Page
     Page Should Contain  None


### PR DESCRIPTION
After angular upgraded, all migrate pipelines failed at system setting project creation verification. Keyword of Page Should Contain is not working anymore in new UI, so I chosen a new more precise way of checking the select element value of 'everyone'

Signed-off-by: Danfeng Liu (c) <danfengl@vmware.com>