### PR TITLE
Use external_url if exists on Add Repo Command chart details page

### DIFF
--- a/src/portal/src/app/project/helm-chart/helm-chart-detail/chart-detail/chart-detail.component.ts
+++ b/src/portal/src/app/project/helm-chart/helm-chart-detail/chart-detail/chart-detail.component.ts
@@ -44,12 +44,16 @@ export class ChartDetailComponent implements OnInit {
   ngOnInit(): void {
     this.systemInfoService.getSystemInfo()
       .subscribe(systemInfo => {
-        let scheme = 'http://';
         this.systemInfo = systemInfo;
-        if (this.systemInfo.has_ca_root) {
-          scheme = 'https://';
+        if (this.systemInfo.external_url) {
+          this.repoURL = `${this.systemInfo.external_url}`;
+        } else {
+          let scheme = 'http://';
+          if (this.systemInfo.has_ca_root) {
+            scheme = 'https://';
+          }
+          this.repoURL = `${scheme}${this.systemInfo.registry_url}`;
         }
-        this.repoURL = `${scheme}${this.systemInfo.registry_url}`;
       }, error => this.errorHandler.error(error));
     this.refresh();
   }


### PR DESCRIPTION
If we have https reverse proxy in a front of harbor, we can set external_url and harbor will use it but not on chart details page within Add Repo command (it will be http://) if you have https -> http proxy setup.