### PR TITLE
Return the common error message when testing the webhook endpoint 

### DIFF
--- a/src/core/api/notification_policy.go
+++ b/src/core/api/notification_policy.go
@@ -7,6 +7,8 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/goharbor/harbor/src/common/utils/log"
+
 	"github.com/goharbor/harbor/src/common/models"
 	"github.com/goharbor/harbor/src/common/rbac"
 	"github.com/goharbor/harbor/src/common/utils"
@@ -273,7 +275,8 @@ func (w *NotificationPolicyAPI) Test() {
 	}
 
 	if err := notification.PolicyMgr.Test(policy); err != nil {
-		w.SendBadRequestError(fmt.Errorf("notification policy %s test failed: %v", policy.Name, err))
+		log.Errorf("notification policy %s test failed: %v", policy.Name, err)
+		w.SendBadRequestError(fmt.Errorf("notification policy %s test failed", policy.Name))
 		return
 	}
 }


### PR DESCRIPTION
This commit returns a common error message when testing the webhook endpoint and prints the detail in the log for debug

Signed-off-by: Wenkai Yin <yinw@vmware.com>