### PR TITLE
Add id for system configuration repo-readonly-checkbox in UI code

### DIFF
--- a/src/portal/lib/src/config/system/system-settings.component.html
+++ b/src/portal/lib/src/config/system/system-settings.component.html
@@ -58,7 +58,7 @@
             </clr-tooltip>
         </label>
         <clr-checkbox-container *ngIf="!withAdmiral">
-            <label for="repoReadOnly">{{'CONFIG.REPO_READ_ONLY' | translate}}
+            <label id="repo_read_only_lbl" for="repoReadOnly">{{'CONFIG.REPO_READ_ONLY' | translate}}
                 <clr-tooltip>
                     <clr-icon clrTooltipTrigger shape="info-circle" size="24"></clr-icon>
                     <clr-tooltip-content clrPosition="top-right" clrSize="lg" *clrIfOpen>

--- a/tests/resources/Harbor-Pages/Configuration_Elements.robot
+++ b/tests/resources/Harbor-Pages/Configuration_Elements.robot
@@ -36,3 +36,4 @@ ${configuration_system_wl_add_btn}    //*[@id='show-add-modal-button']
 ${configuration_system_wl_textarea}    //*[@id='whitelist-textarea']
 ${configuration_system_wl_add_confirm_btn}    //*[@id='add-to-system']
 ${configuration_system_wl_delete_a_cve_id_icon}    //system-settings/form/section//ul/li[1]/clr-icon
+${configuration_sys_repo_readonly_chb_id}  //*[@id='repo_read_only_lbl']


### PR DESCRIPTION
Add id for system configuration repo-readonly-checkbox in UI code, and add element locator in robot case.

Signed-off-by: Danfeng Liu (c) <danfengl@vmware.com>