### PR TITLE
Refect nightly test case keyword create-a-new-user

### DIFF
--- a/tests/resources/Harbor-Pages/HomePage.robot
+++ b/tests/resources/Harbor-Pages/HomePage.robot
@@ -42,28 +42,16 @@ Sign Up Should Not Display
 Create An New User
     [Arguments]  ${url}  ${username}  ${email}  ${realname}  ${newPassword}  ${comment}
     Go To    ${url}
-    Wait Until Element Is Visible  ${harbor_span_title}
-    Wait Until Element Is Visible  xpath=${sign_up_for_an_account_xpath}
-    Click Element  xpath=${sign_up_for_an_account_xpath}
-    Wait Until Element Is Visible  xpath=${username_xpath}
-    Input Text  xpath=${username_xpath}  ${username}
-    Wait Until Element Is Visible  xpath=${email_xpath}
-    Input Text  xpath=${email_xpath}  ${email}
-    Wait Until Element Is Visible  xpath=${realname_xpath}
-    Input Text  xpath=${realname_xpath}  ${realname}
-    Wait Until Element Is Visible  xpath=${newPassword_xpath}
-    Input Text  xpath=${newPassword_xpath}  ${newPassword}
-    Wait Until Element Is Visible  xpath=${confirmPassword_xpath}
-    Input Text  xpath=${confirmPassword_xpath}  ${newPassword}
-    Wait Until Element Is Visible  xpath=${comment_xpath}
-    Input Text  xpath=${comment_xpath}  ${comment}
-    Wait Until Element Is Visible  xpath=${signup_xpath}
-    Click button  xpath=${signup_xpath}
-    Sleep  2
-    Wait Until Element Is Visible  ${login_name}
-    Input Text  ${login_name}  ${username}
-    Wait Until Element Is Visible  ${login_pwd}
-    Input Text  ${login_pwd}  ${newPassword}
-    Wait Until Element Is Visible  ${login_btn}
-    Click button  ${login_btn}
-    Wait Until Element Is Visible  xpath=//span[contains(., '${username}')]
+    Retry Wait Element  ${harbor_span_title}
+    Retry Element Click  xpath=${sign_up_for_an_account_xpath}
+    Retry Text Input  xpath=${username_xpath}  ${username}
+    Retry Text Input  xpath=${email_xpath}  ${email}
+    Retry Text Input  xpath=${realname_xpath}  ${realname}
+    Retry Text Input  xpath=${newPassword_xpath}  ${newPassword}
+    Retry Text Input  xpath=${confirmPassword_xpath}  ${newPassword}
+    Retry Text Input  xpath=${comment_xpath}  ${comment}
+    Retry Double Keywords When Error  Retry Element Click  ${signup_xpath}  Retry Wait Until Page Not Contains Element  ${signup_xpath}
+    Retry Text Input  ${login_name}  ${username}
+    Retry Text Input  ${login_pwd}  ${newPassword}
+    Retry Double Keywords When Error  Retry Element Click  ${login_btn}  Retry Wait Until Page Not Contains Element  ${login_btn}
+    Retry Wait Element  xpath=//span[contains(., '${username}')]


### PR DESCRIPTION
After angular upgrade, in DB.robot, 4 test cases failed at create-a-new-user, the reason is that no sleep between input or click action, some blank was not inputed, so I add retry keyword for those actions.

Signed-off-by: danfengliu <danfengl@vmware.com>