### PR TITLE
Add a keyword 'Retry Keyword When Return Value Mismatch'

### DIFF
--- a/tests/resources/Harbor-Pages/Configuration.robot
+++ b/tests/resources/Harbor-Pages/Configuration.robot
@@ -155,6 +155,7 @@ Switch To System Settings
 Switch To Project Quotas
     Sleep  1
     Retry Element Click  xpath=${configuration_xpath}
+    Retry Element Click  xpath=${configuration_system_tabsheet_id}
     Retry Element Click  xpath=${configuration_project_quotas_tabsheet_id}
     Sleep  1
 

--- a/tests/resources/Harbor-Pages/Project_Elements.robot
+++ b/tests/resources/Harbor-Pages/Project_Elements.robot
@@ -60,4 +60,3 @@ ${project_config_save_btn}    xpath=//hbr-project-policy-config//button[contains
 ${project_add_count_quota_input_text_id}    xpath=//*[@id='create_project_count_limit']
 ${project_add_storage_quota_input_text_id}    xpath=//*[@id='create_project_storage_limit']
 ${project_add_storage_quota_unit_id}    xpath=//*[@id='create_project_storage_limit_unit']
-

--- a/tests/resources/Util.robot
+++ b/tests/resources/Util.robot
@@ -234,6 +234,18 @@ Retry Keyword When Error
     Run Keyword If  '${out[0]}'=='FAIL'  Capture Page Screenshot
     Should Be Equal As Strings  '${out[0]}'  'PASS'
 
+Retry Keyword When Return Value Mismatch
+    [Arguments]  ${keyword}  ${expected_value}  @{elements}  ${count}=6
+    :For  ${n}  IN RANGE  1  ${count}
+    \    Log To Console  Trying ${keyword} ${n} times ...
+    \    ${out}  Run Keyword And Ignore Error  ${keyword}  @{elements}
+    \    Log To Console  Return value is ${out[1]}
+    \    ${status}=  Set Variable If  '${out[1]}'=='${expected_value}'  'PASS'  'FAIL'
+    \    Exit For Loop If  '${out[1]}'=='${expected_value}'
+    \    Sleep  2
+    Run Keyword If  ${status}=='FAIL'  Capture Page Screenshot
+    Should Be Equal As Strings  ${status}  'PASS'
+
 Retry Double Keywords When Error
     [Arguments]  ${keyword1}  ${element1}  ${keyword2}  ${element2}
     :For  ${n}  IN RANGE  1  3

--- a/tests/robot-cases/Group1-Nightly/Common.robot
+++ b/tests/robot-cases/Group1-Nightly/Common.robot
@@ -558,6 +558,6 @@ Test Case - Project Quotas Control Under GC
     Create An New Project  project${d}  storage_quota=${storage_quota}  storage_quota_unit=${storage_quota_unit}
     Cannot Push image  ${ip}  ${HARBOR_ADMIN}  ${HARBOR_PASSWORD}  project${d}  ${image_a}:${image_a_ver}  err_msg=Quota exceeded when processing the request of adding 82.5 MiB of storage resource, which when updated to current usage of 166.6 MiB will exceed the configured upper limit of 200.0 MiB
     GC Now  ${HARBOR_URL}  ${HARBOR_ADMIN}  ${HARBOR_PASSWORD}
-    ${storage_quota_ret}=  Get Project Storage Quota Text From Project Quotas List  project${d}
-    Should Be Equal As Strings  ${storage_quota_ret}  0Byte of ${storage_quota}${storage_quota_unit}
+    @{param}  Create List  project${d}
+    Retry Keyword When Return Value Mismatch  Get Project Storage Quota Text From Project Quotas List  0Byte of ${storage_quota}${storage_quota_unit}  @{param}  count=60
     Close Browser


### PR DESCRIPTION
In nightly helm pipeline, test case 'Project Quotas Control Under GC' failed, it should be timing issue that the valuse in UI is not ready, so I add a keyword 'Retry Keyword When Return Value Mismatch' to retry value getting action.

Signed-off-by: Danfeng Liu (c) <danfengl@vmware.com>