### PR TITLE
add the cache of immutable tag

### DIFF
--- a/src/pkg/immutable/cache/cache.go
+++ b/src/pkg/immutable/cache/cache.go
@@ -1,0 +1,36 @@
+package cache
+
+import (
+	"errors"
+	"github.com/goharbor/harbor/src/pkg/art"
+)
+
+// Cache ...
+type Cache interface {
+	// Set add a immutable to the project immutable list
+	Set(pid int64, imc IMCandidate) error
+
+	// Stat check whether the tag is immutable
+	Stat(pid int64, repository string, tag string) (bool, error)
+
+	// SetMultiple a list of immutable tags in project
+	SetMultiple(pid int64, icands []IMCandidate) error
+
+	// Clear remove the tag from the project immutable list
+	Clear(pid int64, imc IMCandidate) error
+
+	// Flush remove all of immutable tags of a specific project
+	Flush(pid int64) error
+}
+
+// IMCandidate ...
+type IMCandidate struct {
+	art.Candidate
+	Immutable bool
+}
+
+// ErrTagUnknown ...
+var ErrTagUnknown = errors.New("tag unknown")
+
+// ErrRepoUnknown ...
+var ErrRepoUnknown = errors.New("repository unknown")

--- a/src/pkg/immutable/cache/memory/memory.go
+++ b/src/pkg/immutable/cache/memory/memory.go
@@ -1,0 +1,98 @@
+package memory
+
+import (
+	"fmt"
+	"github.com/goharbor/harbor/src/pkg/immutable/cache"
+	"sync"
+)
+
+// Cache ...
+type Cache struct {
+	mu            sync.RWMutex
+	repostitories map[int64]map[string]interface{}
+	immutable     map[string]bool
+}
+
+// NewMemoryCache ...
+func NewMemoryCache() Cache {
+	return Cache{
+		repostitories: make(map[int64]map[string]interface{}),
+		immutable:     make(map[string]bool),
+	}
+}
+
+// Set ...
+func (immc *Cache) Set(pid int64, imc cache.IMCandidate) error {
+	immc.mu.Lock()
+	defer immc.mu.Unlock()
+
+	return immc.set(pid, imc)
+}
+
+// SetMultiple ...
+func (immc *Cache) SetMultiple(pid int64, imcs []cache.IMCandidate) error {
+	immc.mu.Lock()
+	defer immc.mu.Unlock()
+
+	for _, imc := range imcs {
+		if err := immc.set(pid, imc); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Set ...
+func (immc *Cache) set(pid int64, imc cache.IMCandidate) error {
+	_, proExist := immc.repostitories[pid]
+	if !proExist {
+		immc.repostitories[pid] = make(map[string]interface{})
+	}
+
+	repos := immc.repostitories[pid]
+	_, tagExist := repos[imc.Repository+"::"+imc.Tag]
+	if !tagExist {
+		repos[imc.Repository+"::"+imc.Tag] = struct{}{}
+		immc.immutable[imc.Repository+"::"+imc.Tag] = imc.Immutable
+	}
+	return nil
+}
+
+// Stat ...
+func (immc *Cache) Stat(pid int64, repository string, tag string) (bool, error) {
+	immc.mu.RLock()
+	defer immc.mu.RUnlock()
+
+	repositories := immc.repostitories[pid]
+	_, exist := repositories[repository+"::"+tag]
+	if !exist {
+		return false, fmt.Errorf("no repository:%s and tag:%s found in project repositories", repository, tag)
+	}
+
+	_, exist = immc.immutable[repository+"::"+tag]
+	if !exist {
+		return false, fmt.Errorf("no immutable found for tagL %s::%s", repository, tag)
+	}
+
+	return immc.immutable[repository+"::"+tag], nil
+}
+
+// Clear ...
+func (immc *Cache) Clear(pid int64, imc cache.IMCandidate) error {
+	immc.mu.Lock()
+	defer immc.mu.Unlock()
+
+	repos := immc.repostitories[pid]
+	delete(repos, imc.Repository+"::"+imc.Tag)
+	delete(immc.immutable, imc.Repository+"::"+imc.Tag)
+	return nil
+}
+
+// Flush ...
+func (immc *Cache) Flush(pid int64) error {
+	immc.mu.Lock()
+	defer immc.mu.Unlock()
+
+	delete(immc.repostitories, pid)
+	return nil
+}

--- a/src/pkg/immutable/cache/memory/memory_test.go
+++ b/src/pkg/immutable/cache/memory/memory_test.go
@@ -1,0 +1,80 @@
+package memory
+
+import (
+	"github.com/stretchr/testify/suite"
+
+	"github.com/goharbor/harbor/src/pkg/art"
+	immu_cache "github.com/goharbor/harbor/src/pkg/immutable/cache"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+// MemoryRunnerTestSuite tests functions of redis runner
+type MemoryRunnerTestSuite struct {
+	suite.Suite
+}
+
+// TestRedisRunnerTestSuite is entry of go test
+func TestRedisRunnerTestSuite(t *testing.T) {
+	suite.Run(t, new(MemoryRunnerTestSuite))
+}
+
+// SetupSuite prepares test suite
+func (suite *MemoryRunnerTestSuite) SetupSuite() {
+}
+
+// TestMemCache tests the cache with memory
+func (suite *MemoryRunnerTestSuite) TestMemCache() {
+	cache := NewMemoryCache()
+	immc := immu_cache.IMCandidate{
+		Candidate: art.Candidate{
+			Repository: "test_set_repo",
+			Tag:        "test_set_tag",
+		},
+		Immutable: true,
+	}
+	err := cache.Set(1, immc)
+	require.NoError(suite.T(), err, "nil error expected but got %s", err)
+
+	isImmu, err := cache.Stat(1, immc.Repository, immc.Tag)
+	require.NoError(suite.T(), err, "nil error expected but got %s", err)
+	require.True(suite.T(), isImmu)
+
+	err = cache.Clear(1, immc)
+	require.NoError(suite.T(), err, "nil error expected but got %s", err)
+
+	isImmuAfterDel, err := cache.Stat(1, immc.Repository, immc.Tag)
+	require.Error(suite.T(), err, "error expected, %s", err)
+	require.False(suite.T(), isImmuAfterDel)
+
+	var immcMul []immu_cache.IMCandidate
+	immcMul1 := immu_cache.IMCandidate{
+		Candidate: art.Candidate{
+			Repository: "immc_mul1_repo",
+			Tag:        "immc_mul1_tag",
+		},
+		Immutable: true,
+	}
+	immcMul2 := immu_cache.IMCandidate{
+		Candidate: art.Candidate{
+			Repository: "immc_mul2_repo",
+			Tag:        "immc_mul2_tag",
+		},
+		Immutable: false,
+	}
+	immcMul = append(immcMul, immcMul1)
+	immcMul = append(immcMul, immcMul2)
+
+	err = cache.SetMultiple(1, immcMul)
+	require.NoError(suite.T(), err, "nil error expected but got %s", err)
+	_, err = cache.Stat(1, immcMul1.Repository, immcMul1.Tag)
+	require.NoError(suite.T(), err, "nil error expected but got %s", err)
+
+	err = cache.Flush(1)
+	require.NoError(suite.T(), err, "nil error expected but got %s", err)
+
+	_, err = cache.Stat(1, immcMul1.Repository, immcMul1.Tag)
+	require.Error(suite.T(), err, "error expected, %s", err)
+	_, err = cache.Stat(1, immcMul2.Repository, immcMul2.Tag)
+	require.Error(suite.T(), err, "error expected, %s", err)
+}

--- a/src/pkg/immutable/cache/redis/redis.go
+++ b/src/pkg/immutable/cache/redis/redis.go
@@ -1,0 +1,175 @@
+package redis
+
+import (
+	"fmt"
+	"github.com/goharbor/harbor/src/common/utils/log"
+	"github.com/goharbor/harbor/src/pkg/immutable/cache"
+	"github.com/gomodule/redigo/redis"
+	"github.com/pkg/errors"
+)
+
+// Cache ...
+type Cache struct {
+	pool *redis.Pool
+}
+
+// NewRedisCache ...
+func NewRedisCache(pool *redis.Pool) Cache {
+	return Cache{
+		pool: pool,
+	}
+}
+
+// Set ...
+func (imrc *Cache) Set(pid int64, imc cache.IMCandidate) error {
+	conn := imrc.pool.Get()
+	defer conn.Close()
+
+	return imrc.set(conn, pid, imc)
+}
+
+// SetMultiple ...
+func (imrc *Cache) SetMultiple(pid int64, imcs []cache.IMCandidate) error {
+	conn := imrc.pool.Get()
+	defer conn.Close()
+
+	for _, c := range imcs {
+		if err := imrc.set(conn, pid, c); err != nil {
+			log.Warning(err.Error())
+			continue
+		}
+	}
+
+	return nil
+}
+
+// set ...
+func (imrc *Cache) set(conn redis.Conn, pid int64, imc cache.IMCandidate) error {
+	if _, err := conn.Do("SADD", imrc.repositoryKey(pid), imc.Repository+"::"+imc.Tag); err != nil {
+		return err
+	}
+
+	if _, err := conn.Do("HSET", imrc.tagKey(pid, imc.Repository, imc.Tag), "immutable", imc.Immutable); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Stat ...
+func (imrc *Cache) Stat(pid int64, repository string, tag string) (bool, error) {
+	conn := imrc.pool.Get()
+	defer conn.Close()
+
+	member, err := redis.Bool(conn.Do("SISMEMBER", imrc.repositoryKey(pid), repository+"::"+tag))
+	if err != nil {
+		return false, err
+	}
+
+	if !member {
+		return false, cache.ErrRepoUnknown
+	}
+
+	isImmutable, err := redis.Bool(conn.Do("HGET", imrc.tagKey(pid, repository, tag), "immutable"))
+	if err != nil {
+		return false, err
+	}
+
+	return isImmutable, nil
+}
+
+// Clear ...
+func (imrc *Cache) Clear(pid int64, imc cache.IMCandidate) error {
+	conn := imrc.pool.Get()
+	defer conn.Close()
+
+	// Check membership to repository first
+	member, err := redis.Bool(conn.Do("SISMEMBER", imrc.repositoryKey(pid), imc.Repository+"::"+imc.Tag))
+	if err != nil {
+		return err
+	}
+
+	if !member {
+		return cache.ErrRepoUnknown
+	}
+
+	remRepo, err := redis.Bool(conn.Do("SREM", imrc.repositoryKey(pid), imc.Repository+"::"+imc.Tag))
+	if err != nil {
+		return err
+	}
+
+	if !remRepo {
+		return errors.New("failed to remove repository from project repo list")
+	}
+
+	remTag, err := conn.Do("DEL", imrc.tagKey(pid, imc.Repository, imc.Tag))
+	if err != nil {
+		return err
+	}
+
+	if remTag == 0 {
+		return cache.ErrTagUnknown
+	}
+
+	return nil
+}
+
+// Flush ...
+func (imrc *Cache) Flush(pid int64) error {
+	conn := imrc.pool.Get()
+	defer conn.Close()
+
+	reply, err := conn.Do("DEL", imrc.repositoryKey(pid))
+	if err != nil {
+		return err
+	}
+
+	if reply == 0 {
+		return cache.ErrRepoUnknown
+	}
+
+	return delKeys(conn, imrc.tagKeyPrfix(pid))
+}
+
+func (imrc *Cache) tagKeyPrfix(pid int64) string {
+	return fmt.Sprintf("immutable::project::tags::%d*", pid)
+}
+
+func (imrc *Cache) tagKey(pid int64, repository string, tag string) string {
+	return fmt.Sprintf("immutable::project::tags::%d::repo::%s::tag::%s", pid, repository, tag)
+}
+
+func (imrc *Cache) repositoryKey(pid int64) string {
+	return fmt.Sprintf("immutable::project::%d::repositories", pid)
+}
+
+func delKeys(con redis.Conn, pattern string) error {
+	iter := 0
+	keys := make([]string, 0)
+	for {
+		arr, err := redis.Values(con.Do("SCAN", iter, "MATCH", pattern))
+		if err != nil {
+			return fmt.Errorf("error retrieving '%s' keys", pattern)
+		}
+		iter, err = redis.Int(arr[0], nil)
+		if err != nil {
+			return fmt.Errorf("unexpected type for Int, got type %T", err)
+		}
+		k, err := redis.Strings(arr[1], nil)
+		if err != nil {
+			return fmt.Errorf("converts an array command reply to a []string %v", err)
+		}
+		keys = append(keys, k...)
+
+		if iter == 0 {
+			break
+		}
+	}
+	for _, key := range keys {
+		_, err := con.Do("DEL", key)
+		if err != nil {
+			return fmt.Errorf("failed to clean registry cache %v", err)
+		}
+	}
+	return nil
+}

--- a/src/pkg/immutable/cache/redis/redis_test.go
+++ b/src/pkg/immutable/cache/redis/redis_test.go
@@ -1,0 +1,84 @@
+package redis
+
+import (
+	"github.com/goharbor/harbor/src/jobservice/tests"
+	"github.com/gomodule/redigo/redis"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/goharbor/harbor/src/pkg/art"
+	immu_cache "github.com/goharbor/harbor/src/pkg/immutable/cache"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+// RedisRunnerTestSuite tests functions of redis runner
+type RedisRunnerTestSuite struct {
+	suite.Suite
+	pool *redis.Pool
+}
+
+// TestRedisRunnerTestSuite is entry of go test
+func TestRedisRunnerTestSuite(t *testing.T) {
+	suite.Run(t, new(RedisRunnerTestSuite))
+}
+
+// SetupSuite prepares test suite
+func (suite *RedisRunnerTestSuite) SetupSuite() {
+	suite.pool = tests.GiveMeRedisPool()
+}
+
+// TestRedisCache tests the redis job wrapper
+func (suite *RedisRunnerTestSuite) TestRedisCache() {
+	cache := NewRedisCache(suite.pool)
+	immc := immu_cache.IMCandidate{
+		Candidate: art.Candidate{
+			Repository: "test_set_repo",
+			Tag:        "test_set_tag",
+		},
+		Immutable: true,
+	}
+	err := cache.Set(1, immc)
+	require.NoError(suite.T(), err, "nil error expected but got %s", err)
+
+	isImmu, err := cache.Stat(1, immc.Repository, immc.Tag)
+	require.NoError(suite.T(), err, "nil error expected but got %s", err)
+	require.True(suite.T(), isImmu)
+
+	err = cache.Clear(1, immc)
+	require.NoError(suite.T(), err, "nil error expected but got %s", err)
+
+	isImmuAfterDel, err := cache.Stat(1, immc.Repository, immc.Tag)
+	require.Error(suite.T(), err, "error expected, %s", err)
+	require.False(suite.T(), isImmuAfterDel)
+
+	var immuMul []immu_cache.IMCandidate
+	immcMul1 := immu_cache.IMCandidate{
+		Candidate: art.Candidate{
+			Repository: "immc_mul1_repo",
+			Tag:        "immc_mul1_tag",
+		},
+		Immutable: true,
+	}
+	immcMul2 := immu_cache.IMCandidate{
+		Candidate: art.Candidate{
+			Repository: "immc_mul2_repo",
+			Tag:        "immc_mul2_tag",
+		},
+		Immutable: false,
+	}
+	immuMul = append(immuMul, immcMul1)
+	immuMul = append(immuMul, immcMul2)
+
+	err = cache.SetMultiple(1, immuMul)
+	require.NoError(suite.T(), err, "nil error expected but got %s", err)
+	_, err = cache.Stat(1, immcMul1.Repository, immcMul1.Tag)
+	require.NoError(suite.T(), err, "nil error expected but got %s", err)
+
+	err = cache.Flush(1)
+	require.NoError(suite.T(), err, "nil error expected but got %s", err)
+
+	_, err = cache.Stat(1, immcMul1.Repository, immcMul1.Tag)
+	require.Error(suite.T(), err, "error expected, %s", err)
+	_, err = cache.Stat(1, immcMul2.Repository, immcMul2.Tag)
+	require.Error(suite.T(), err, "error expected, %s", err)
+}


### PR DESCRIPTION
this commit is to add cache for immutable tag, in order to reduce the IO of docker push,
every push request will be checked in cache firstly, if hit, the request will be rejected.

Signed-off-by: wang yan <wangyan@vmware.com>