### PR TITLE
Make the username required when searching user

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -774,20 +774,15 @@ paths:
           description: Internal errors.
   /users/search:
     get:
-      summary: Search users by username, email
+      summary: Search users by username
       description: |
-        This endpoint is to search the users by username, email.
+        This endpoint is to search the users by username.
       parameters:
         - name: username
           in: query
           type: string
-          required: false
+          required: true
           description: Username for filtering results.
-        - name: email
-          in: query
-          type: string
-          required: false
-          description: Email for filtering results.
         - name: page
           in: query
           type: integer

--- a/src/core/api/user.go
+++ b/src/core/api/user.go
@@ -222,11 +222,14 @@ func (ua *UserAPI) Search() {
 	}
 	query := &models.UserQuery{
 		Username: ua.GetString("username"),
-		Email:    ua.GetString("email"),
 		Pagination: &models.Pagination{
 			Page: page,
 			Size: size,
 		},
+	}
+	if len(query.Username) == 0 {
+		ua.SendBadRequestError(errors.New("username is required"))
+		return
 	}
 
 	total, err := dao.GetTotalOfUsers(query)


### PR DESCRIPTION
Make the username required when searching user and remove the support for query email

Signed-off-by: Wenkai Yin <yinw@vmware.com>