### PR TITLE
#9174 config migration fails with python error: jinja2.exceptions.UndefinedError: 'chart' is undefined

### DIFF
--- a/tools/migration/cfg/migrator_1_9_0/harbor.yml.jinja
+++ b/tools/migration/cfg/migrator_1_9_0/harbor.yml.jinja
@@ -117,9 +117,11 @@ notification:
   # Maximum retry count for webhook job
   webhook_job_max_retry: 10
 
+{% if chart is defined %}
 chart:
   # Change the value of absolute_url to enabled can enable absolute url in chart
   absolute_url: {{ chart.absolute_url if chart.absolute_url == 'enabled' else 'disabled' }}
+{% endif %}
 
 # Log configurations
 log:


### PR DESCRIPTION
Possible fix for: https://github.com/goharbor/harbor/issues/9174
As far as I'm aware chart is only available if the stack was started with `./install.sh --with-chartmuseum` so I guess it's fair to add a check if the property is available.