### PR TITLE
Check the existence of project before the next action

### DIFF
--- a/src/core/middlewares/util/util.go
+++ b/src/core/middlewares/util/util.go
@@ -40,7 +40,7 @@ import (
 	"github.com/goharbor/harbor/src/core/config"
 	"github.com/goharbor/harbor/src/core/promgr"
 	"github.com/goharbor/harbor/src/pkg/scan/whitelist"
-	"github.com/opencontainers/go-digest"
+	digest "github.com/opencontainers/go-digest"
 )
 
 type contextKey string
@@ -345,6 +345,10 @@ func (pc PmsPolicyChecker) ContentTrustEnabled(name string) bool {
 	if err != nil {
 		log.Errorf("Unexpected error when getting the project, error: %v", err)
 		return true
+	}
+	if project == nil {
+		log.Debugf("project %s not found", name)
+		return false
 	}
 	return project.ContentTrustEnabled()
 }

--- a/src/core/middlewares/util/util_test.go
+++ b/src/core/middlewares/util/util_test.go
@@ -32,7 +32,7 @@ import (
 	notarytest "github.com/goharbor/harbor/src/common/utils/notary/test"
 	testutils "github.com/goharbor/harbor/src/common/utils/test"
 	"github.com/goharbor/harbor/src/core/config"
-	"github.com/opencontainers/go-digest"
+	digest "github.com/opencontainers/go-digest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -187,6 +187,9 @@ func TestPMSPolicyChecker(t *testing.T) {
 	assert.True(t, projectVulnerableEnabled)
 	assert.Equal(t, projectVulnerableSeverity, models.SevLow)
 	assert.Empty(t, wl.Items)
+
+	contentTrustFlag = GetPolicyChecker().ContentTrustEnabled("non_exist_project")
+	assert.False(t, contentTrustFlag)
 }
 
 func TestCopyResp(t *testing.T) {


### PR DESCRIPTION
Fixes #8234, check the existence of project to avoid the panic

Signed-off-by: Wenkai Yin <yinw@vmware.com>