### PR TITLE
[cherry-pick]fix quota migration still execute on launch even data sync success

### DIFF
--- a/src/core/main.go
+++ b/src/core/main.go
@@ -84,14 +84,19 @@ func updateInitPassword(userID int, password string) error {
 
 // Quota migration
 func quotaSync() error {
-	usages, err := dao.ListQuotaUsages()
-	if err != nil {
-		log.Errorf("list quota usage error, %v", err)
-		return err
-	}
 	projects, err := dao.GetProjects(nil)
 	if err != nil {
 		log.Errorf("list project error, %v", err)
+		return err
+	}
+
+	var pids []string
+	for _, project := range projects {
+		pids = append(pids, strconv.FormatInt(project.ProjectID, 10))
+	}
+	usages, err := dao.ListQuotaUsages(&models.QuotaUsageQuery{Reference: "project", ReferenceIDs: pids})
+	if err != nil {
+		log.Errorf("list quota usage error, %v", err)
 		return err
 	}
 


### PR DESCRIPTION
This commit is to fix the issue for the following scenario:
1, user success migrate harbor to v1.9.0 from a previous version
2, add a project, push images into the project.
3, delete images and then to delete the project.
4, re-launch harbor.

After that, it still execute the quota migration as the condition doesn't consider the deleted projects usage.
And in this case, the harbor core crashes with a duplicate sql err, and unable to launch.

[Workaroud]
Clean table of project_blob with: TRUNCATE TABLE project_blob, and re-launch harbor, wait for quota sync success.

Signed-off-by: wang yan <wangyan@vmware.com>