### PR TITLE
Add option for search nested LDAP group

### DIFF
--- a/docs/manage_role_by_ldap_group.md
+++ b/docs/manage_role_by_ldap_group.md
@@ -55,3 +55,7 @@ If a user is in the LDAP groups with admin privilege (ldap_group_admin_dn), the 
 ## User privileges and group privileges
 
 If a user has both user-level role and group-level role, these privileges are merged together.
+
+## Enable nested group in LDAP/AD
+
+If you need to search the user's nested group and the LDAP/AD server support to [search for LDAP_MATCHING_RULE_IN_CHAIN groups](https://ldapwiki.com/wiki/1.2.840.113556.1.4.1941), you can enabled it by checking the "Enable Nested Group" in LDAP group configure, it is disabled by default.

--- a/src/common/config/metadata/metadatalist.go
+++ b/src/common/config/metadata/metadatalist.go
@@ -105,6 +105,7 @@ var (
 		{Name: common.LDAPURL, Scope: UserScope, Group: LdapBasicGroup, EnvKey: "LDAP_URL", DefaultValue: "", ItemType: &NonEmptyStringType{}, Editable: false},
 		{Name: common.LDAPVerifyCert, Scope: UserScope, Group: LdapBasicGroup, EnvKey: "LDAP_VERIFY_CERT", DefaultValue: "true", ItemType: &BoolType{}, Editable: false},
 		{Name: common.LDAPGroupMembershipAttribute, Scope: UserScope, Group: LdapBasicGroup, EnvKey: "LDAP_GROUP_MEMBERSHIP_ATTRIBUTE", DefaultValue: "memberof", ItemType: &StringType{}, Editable: true},
+		{Name: common.LDAPGroupEnableNested, Scope: UserScope, Group: LdapBasicGroup, EnvKey: "LDAP_ENABLE_NESTED_GROUP", DefaultValue: "false", ItemType: &BoolType{}, Editable: false},
 
 		{Name: common.MaxJobWorkers, Scope: SystemScope, Group: BasicGroup, EnvKey: "MAX_JOB_WORKERS", DefaultValue: "10", ItemType: &IntType{}, Editable: false},
 		{Name: common.NotaryURL, Scope: SystemScope, Group: BasicGroup, EnvKey: "NOTARY_URL", DefaultValue: "http://notary-server:4443", ItemType: &StringType{}, Editable: false},

--- a/src/common/const.go
+++ b/src/common/const.go
@@ -129,6 +129,7 @@ const (
 	OIDCGroupType                     = 3
 	LDAPGroupAdminDn                  = "ldap_group_admin_dn"
 	LDAPGroupMembershipAttribute      = "ldap_group_membership_attribute"
+	LDAPGroupEnableNested             = "ldap_group_enable_nested"
 	DefaultRegistryControllerEndpoint = "http://registryctl:8080"
 	WithChartMuseum                   = "with_chartmuseum"
 	ChartRepoURL                      = "chart_repository_url"

--- a/src/common/models/ldap.go
+++ b/src/common/models/ldap.go
@@ -35,6 +35,7 @@ type LdapGroupConf struct {
 	LdapGroupSearchScope         int    `json:"ldap_group_search_scope"`
 	LdapGroupAdminDN             string `json:"ldap_group_admin_dn,omitempty"`
 	LdapGroupMembershipAttribute string `json:"ldap_group_membership_attribute,omitempty"`
+	LdapGroupEnableNested        bool   `json:"ldap_group_enable_nested,omitempty"`
 }
 
 // LdapUser ...

--- a/src/common/utils/ldap/ldap_test.go
+++ b/src/common/utils/ldap/ldap_test.go
@@ -179,12 +179,12 @@ func TestSearchUser(t *testing.T) {
 
 	defer session.Close()
 
-	result, err := session.SearchUser("test")
+	result, err := session.SearchUser("test", false)
 	if err != nil || len(result) == 0 {
 		t.Fatalf("failed to search user test!")
 	}
 
-	result2, err := session.SearchUser("mike")
+	result2, err := session.SearchUser("mike", false)
 	if err != nil || len(result2) == 0 {
 		t.Fatalf("failed to search user mike!")
 	}

--- a/src/core/api/ldap.go
+++ b/src/core/api/ldap.go
@@ -118,7 +118,7 @@ func (l *LdapAPI) Search() {
 
 	searchName := l.GetString("username")
 
-	ldapUsers, err = ldapSession.SearchUser(searchName)
+	ldapUsers, err = ldapSession.SearchUser(searchName, false)
 
 	if err != nil {
 		l.SendInternalServerError(fmt.Errorf("LDAP search fail, error: %v", err))
@@ -183,7 +183,7 @@ func importUsers(ldapImportUsers []string, ldapConfig *ldapUtils.Session) ([]mod
 			continue
 		}
 
-		ldapUsers, err := ldapSession.SearchUser(u.UID)
+		ldapUsers, err := ldapSession.SearchUser(u.UID, false)
 		if err != nil {
 			u.UID = tempUID
 			u.Error = "failed_search_user"

--- a/src/core/config/config.go
+++ b/src/core/config/config.go
@@ -226,6 +226,7 @@ func LDAPGroupConf() (*models.LdapGroupConf, error) {
 		LdapGroupSearchScope:         cfgMgr.Get(common.LDAPGroupSearchScope).GetInt(),
 		LdapGroupAdminDN:             cfgMgr.Get(common.LDAPGroupAdminDn).GetString(),
 		LdapGroupMembershipAttribute: cfgMgr.Get(common.LDAPGroupMembershipAttribute).GetString(),
+		LdapGroupEnableNested:        cfgMgr.Get(common.LDAPGroupEnableNested).GetBool(),
 	}, nil
 }
 


### PR DESCRIPTION
Fix issue #9326 #9092 #9110 by adding a configure option (ldap_group_enable_nested in properties) to enable/disable nested ldap group. its default value is false.
Signed-off-by: stonezdj <stonezdj@gmail.com>