### PR TITLE
perf(test): speed up TestAddBlobsToProject test in dao pkg

### DIFF
--- a/src/common/dao/project_blob.go
+++ b/src/common/dao/project_blob.go
@@ -54,7 +54,7 @@ func AddBlobsToProject(projectID int64, blobs ...*models.Blob) (int64, error) {
 		})
 	}
 
-	cnt, err := GetOrmer().InsertMulti(10, projectBlobs)
+	cnt, err := GetOrmer().InsertMulti(100, projectBlobs)
 	if err != nil {
 		if strings.Contains(err.Error(), "duplicate key value violates unique constraint") {
 			return cnt, ErrDupRows
@@ -121,7 +121,7 @@ func CountSizeOfProject(pid int64) (int64, error) {
 	var blobs []models.Blob
 
 	sql := `
-SELECT 
+SELECT
     DISTINCT bb.digest,
     bb.id,
     bb.content_type,
@@ -132,7 +132,7 @@ JOIN artifact_blob afnb
     ON af.digest = afnb.digest_af
 JOIN BLOB bb
     ON afnb.digest_blob = bb.digest
-WHERE af.project_id = ? 
+WHERE af.project_id = ?
 AND bb.content_type != ?
 `
 	_, err := GetOrmer().Raw(sql, pid, common.ForeignLayer).QueryRows(&blobs)
@@ -152,7 +152,7 @@ AND bb.content_type != ?
 func RemoveUntaggedBlobs(pid int64) error {
 	var blobs []models.Blob
 	sql := `
-SELECT 
+SELECT
     DISTINCT bb.digest,
     bb.id,
     bb.content_type,
@@ -163,7 +163,7 @@ JOIN artifact_blob afnb
     ON af.digest = afnb.digest_af
 JOIN BLOB bb
     ON afnb.digest_blob = bb.digest
-WHERE af.project_id = ? 
+WHERE af.project_id = ?
 `
 	_, err := GetOrmer().Raw(sql, pid).QueryRows(&blobs)
 	if len(blobs) == 0 {

--- a/src/common/dao/project_blob_test.go
+++ b/src/common/dao/project_blob_test.go
@@ -49,19 +49,20 @@ func TestAddBlobsToProject(t *testing.T) {
 		OwnerID: 1,
 	})
 	require.Nil(t, err)
+	defer DeleteProject(pid)
 
-	for i := 0; i < 88888; i++ {
+	blobsCount := 88888
+	for i := 0; i < blobsCount; i++ {
 		blob := &models.Blob{
+			ID:     int64(100000 + i), // Use fake id to speed this test
 			Digest: digest.FromString(utils.GenerateRandomString()).String(),
 			Size:   100,
 		}
-		_, err := AddBlob(blob)
-		require.Nil(t, err)
 		blobs = append(blobs, blob)
 	}
 	cnt, err := AddBlobsToProject(pid, blobs...)
 	require.Nil(t, err)
-	require.Equal(t, cnt, int64(88888))
+	require.Equal(t, cnt, int64(blobsCount))
 }
 
 func TestHasBlobInProject(t *testing.T) {


### PR DESCRIPTION
1. Use fake id of blobs to reduce the time for preparing the blobs
2. Increment the batch size form 10 to 100 in `AddBlobsToProject` fn

These reduce the test running time of `common/dao` package from 400s to 18s and `UTTEST` job from 33m to 24m.

Signed-off-by: He Weiwei <hweiwei@vmware.com>