### PR TITLE
bug(k8s-prepare):update k8s-prepare cfg and init ui dir

### DIFF
--- a/make/kubernetes/k8s-prepare
+++ b/make/kubernetes/k8s-prepare
@@ -23,7 +23,7 @@ if sys.version_info[:3][0] == 3:
 base_dir = os.path.dirname(os.path.abspath(__file__))
 
 parser = argparse.ArgumentParser(description='Generate *.cm.yaml')
-parser.add_argument('-f', default=os.path.join(base_dir, '../harbor.cfg'),
+parser.add_argument('-f', default=os.path.join(base_dir, '../harbor.yml'),
                     dest='config_file', help='[Optional] path of harbor config file')
 parser.add_argument('-k', default='',
                     dest='private_key', help='[Optional] path of harbor https private key(pem)')
@@ -140,7 +140,7 @@ else:
 if cert_path != '':
     if os.path.isfile(cert_path):
         with open(cert_path, 'r') as cert:
-            set_config('https_cert', cert.read())i
+            set_config('https_cert', cert.read())
     else:
         raise Exception('Error: https cert is not existing')
 else:


### PR DESCRIPTION
run k8s-prepare and have tree error

1. [root@localhost kubernetes]# ./k8s-prepare
  **File "./k8s-prepare", line 143
    set_config('https_cert', cert.read())i**
                                         ^
SyntaxError: invalid syntax

2. [root@localhost kubernetes]# ./k8s-prepare
Traceback (most recent call last):
  File "./k8s-prepare", line 45, in <module>
    raise Exception('Error: No such file(' + args.config_file + ')')
Exception: Error: No such file(/work/harbor/make/kubernetes/../**harbor.cfg**)


3. [root@localhost kubernetes]# ./k8s-prepare
Warning: Key(ssl_cert_key) is not existing. Use empty string as default
Warning: Key(ssl_cert) is not existing. Use empty string as default
Warning: Key(ui_url_protocol) is not existing. Use empty string as default
Warning: Key(ui_url_protocol) is not existing. Use empty string as default
Traceback (most recent call last):
  File "./k8s-prepare", line 210, in <module>
    generate_template(os.path.join(template_dir, 'ui.cm.yaml'), os.path.join(output_dir, 'ui/ui.cm.yaml'))
  File "./k8s-prepare", line 204, in generate_template
    with open(dest, 'w') as dest:
IOError: [Errno 2] **No such file or directory: u'/work/harbor/make/kubernetes/ui/ui.cm.yaml'**

