### PR TITLE
[Don't Merge]Add configuration item to support configuring replication adapters

### DIFF
--- a/make/harbor.yml
+++ b/make/harbor.yml
@@ -161,3 +161,6 @@ proxy:
     - core
     - jobservice
     - clair
+
+# Comma-separated adapters for replication. All adapters are supported if not specify 
+# replication_adapters:

--- a/make/photon/prepare/templates/core/env.jinja
+++ b/make/photon/prepare/templates/core/env.jinja
@@ -43,6 +43,7 @@ RELOAD_KEY={{reload_key}}
 CHART_REPOSITORY_URL={{chart_repository_url}}
 REGISTRY_CONTROLLER_URL={{registry_controller_url}}
 WITH_CHARTMUSEUM={{with_chartmuseum}}
+REPLICATION_ADAPTERS={{replication_adapters}}
 
 HTTP_PROXY={{core_http_proxy}}
 HTTPS_PROXY={{core_https_proxy}}

--- a/make/photon/prepare/utils/configs.py
+++ b/make/photon/prepare/utils/configs.py
@@ -310,4 +310,7 @@ def parse_yaml_config(config_file_path, with_notary, with_clair, with_chartmuseu
     # UAA configs
     config_dict['uaa'] = configs.get('uaa') or {}
 
+    # replication adapters
+    config_dict['replication_adapters'] = configs.get("replication_adapters") or ""
+
     return config_dict

--- a/src/core/config/config.go
+++ b/src/core/config/config.go
@@ -538,3 +538,12 @@ func QuotaSetting() (*models.QuotaSetting, error) {
 		StoragePerProject: cfgMgr.Get(common.StoragePerProject).GetInt64(),
 	}, nil
 }
+
+// SupportedReplicationAdapters returns the supported adapters for replication
+func SupportedReplicationAdapters() []string {
+	adapters := os.Getenv("REPLICATION_ADAPTERS")
+	if len(adapters) == 0 {
+		return []string{}
+	}
+	return strings.Split(adapters, ",")
+}

--- a/src/replication/adapter/adapter_test.go
+++ b/src/replication/adapter/adapter_test.go
@@ -17,6 +17,7 @@ package adapter
 import (
 	"testing"
 
+	"github.com/goharbor/harbor/src/replication/config"
 	"github.com/goharbor/harbor/src/replication/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -38,6 +39,7 @@ func TestRegisterFactory(t *testing.T) {
 }
 
 func TestGetFactory(t *testing.T) {
+	config.Config = &config.Configuration{}
 	registry = map[model.RegistryType]Factory{}
 	require.Nil(t, RegisterFactory("harbor", fakedFactory))
 	// doesn't exist
@@ -46,6 +48,13 @@ func TestGetFactory(t *testing.T) {
 	// pass
 	_, err = GetFactory("harbor")
 	assert.Nil(t, err)
+	// configure only support docker hub
+	config.Config.SupportedAdapters = []string{"docker-hub"}
+	defer func() {
+		config.Config.SupportedAdapters = nil
+	}()
+	_, err = GetFactory("harbor")
+	assert.NotNil(t, err)
 }
 
 func TestListRegisteredAdapterTypes(t *testing.T) {

--- a/src/replication/config/config.go
+++ b/src/replication/config/config.go
@@ -26,6 +26,7 @@ type Configuration struct {
 	JobserviceURL   string
 	SecretKey       string
 	// TODO consider to use a specified secret for replication
-	CoreSecret       string
-	JobserviceSecret string
+	CoreSecret        string
+	JobserviceSecret  string
+	SupportedAdapters []string
 }

--- a/src/replication/replication.go
+++ b/src/replication/replication.go
@@ -70,12 +70,13 @@ func Init(closing, done chan struct{}) error {
 		return err
 	}
 	config.Config = &config.Configuration{
-		CoreURL:          cfg.InternalCoreURL(),
-		TokenServiceURL:  cfg.InternalTokenServiceEndpoint(),
-		JobserviceURL:    cfg.InternalJobServiceURL(),
-		SecretKey:        secretKey,
-		CoreSecret:       cfg.CoreSecret(),
-		JobserviceSecret: cfg.JobserviceSecret(),
+		CoreURL:           cfg.InternalCoreURL(),
+		TokenServiceURL:   cfg.InternalTokenServiceEndpoint(),
+		JobserviceURL:     cfg.InternalJobServiceURL(),
+		SecretKey:         secretKey,
+		CoreSecret:        cfg.CoreSecret(),
+		JobserviceSecret:  cfg.JobserviceSecret(),
+		SupportedAdapters: cfg.SupportedReplicationAdapters(),
 	}
 	// TODO use a global http transport
 	js := job.NewDefaultClient(config.Config.JobserviceURL, config.Config.CoreSecret)


### PR DESCRIPTION
Fixes #9342, add configuration item to support configuring replication adapters

Signed-off-by: Wenkai Yin <yinw@vmware.com>