### PR TITLE
[cherry-pick to release-1.9.0]Add a keyword 'Retry Keyword When Return Value Mismatch' to retry value getting action

### DIFF
--- a/tests/resources/Util.robot
+++ b/tests/resources/Util.robot
@@ -242,7 +242,11 @@ Retry Keyword When Error
     Should Be Equal As Strings  '${out[0]}'  'PASS'
 
 Retry Keyword When Return Value Mismatch
+<<<<<<< HEAD
     [Arguments]  ${keyword}  ${expected_value}  ${count}  @{elements}
+=======
+    [Arguments]  ${keyword}  ${expected_value}  @{elements}  ${count}=6
+>>>>>>> 20dc24563... In nightly helm pipeline, test case 'Project Quotas Control Under GC' failed, it should be timing issue that the valuse in UI is not ready, so I add a keyword 'Retry Keyword When Return Value Mismatch' to retry value getting action.
     :For  ${n}  IN RANGE  1  ${count}
     \    Log To Console  Trying ${keyword} ${n} times ...
     \    ${out}  Run Keyword And Ignore Error  ${keyword}  @{elements}

--- a/tests/robot-cases/Group1-Nightly/Common.robot
+++ b/tests/robot-cases/Group1-Nightly/Common.robot
@@ -559,6 +559,7 @@ Test Case - Project Quotas Control Under GC
     Cannot Push image  ${ip}  ${HARBOR_ADMIN}  ${HARBOR_PASSWORD}  project${d}  ${image_a}:${image_a_ver}  err_msg=Quota exceeded when processing the request of adding 82.5 MiB of storage resource, which when updated to current usage of 166.6 MiB will exceed the configured upper limit of 200.0 MiB
     GC Now  ${HARBOR_URL}  ${HARBOR_ADMIN}  ${HARBOR_PASSWORD}
     @{param}  Create List  project${d}
+<<<<<<< HEAD
     Retry Keyword When Return Value Mismatch  Get Project Storage Quota Text From Project Quotas List  0Byte of ${storage_quota}${storage_quota_unit}  60  @{param}
     Close Browser
 
@@ -585,3 +586,7 @@ Test Case - Can Not Retag Image In ReadOnly Mode
     Go Into Project  project${random_num2}  has_image=${false}
     Disable Read Only
     Close Browser
+=======
+    Retry Keyword When Return Value Mismatch  Get Project Storage Quota Text From Project Quotas List  0Byte of ${storage_quota}${storage_quota_unit}  @{param}  count=60
+    Close Browser
+>>>>>>> 20dc24563... In nightly helm pipeline, test case 'Project Quotas Control Under GC' failed, it should be timing issue that the valuse in UI is not ready, so I add a keyword 'Retry Keyword When Return Value Mismatch' to retry value getting action.


### PR DESCRIPTION
In nightly helm pipeline, test case 'Project Quotas Control Under GC' failed, it should be timing issue that the valuse in UI is not ready, so I add a keyword 'Retry Keyword When Return Value Mismatch' to retry value getting action.

Signed-off-by: Danfeng Liu (c) <danfengl@vmware.com>