### PR TITLE
[cherry-pick to release-1.9.0] Add a keyword 'Retry Keyword When Return Value Mismatch' to retry value getting action

### DIFF
--- a/tests/resources/Harbor-Pages/Configuration.robot
+++ b/tests/resources/Harbor-Pages/Configuration.robot
@@ -150,7 +150,20 @@ Project Creation Should Not Display
 Switch To System Settings
     Sleep  1
     Retry Element Click  xpath=${configuration_xpath}
+<<<<<<< HEAD
     Retry Element Click  xpath=${system_config_xpath}
+=======
+    Retry Element Click  xpath=${configuration_system_tabsheet_id}
+    Sleep  1
+
+Switch To Project Quotas
+    Sleep  1
+    Retry Element Click  xpath=${configuration_xpath}
+    Retry Element Click  xpath=${configuration_system_tabsheet_id}
+    Retry Element Click  xpath=${configuration_project_quotas_tabsheet_id}
+    Sleep  1
+
+>>>>>>> 20dc24563... In nightly helm pipeline, test case 'Project Quotas Control Under GC' failed, it should be timing issue that the valuse in UI is not ready, so I add a keyword 'Retry Keyword When Return Value Mismatch' to retry value getting action.
 Modify Token Expiration
     [Arguments]  ${minutes}
     Input Text  xpath=//*[@id='tokenExpiration']  ${minutes}

--- a/tests/resources/Harbor-Pages/Project_Elements.robot
+++ b/tests/resources/Harbor-Pages/Project_Elements.robot
@@ -57,3 +57,9 @@ ${project_config_project_wl_radio_input}    xpath=//clr-radio-wrapper//label[con
 ${project_config_project_wl_add_btn}    xpath=//*[@id='show-add-modal']
 ${project_config_project_wl_add_confirm_btn}    xpath=//*[@id='add-to-whitelist']
 ${project_config_save_btn}    xpath=//hbr-project-policy-config//button[contains(.,'SAVE')]
+<<<<<<< HEAD
+=======
+${project_add_count_quota_input_text_id}    xpath=//*[@id='create_project_count_limit']
+${project_add_storage_quota_input_text_id}    xpath=//*[@id='create_project_storage_limit']
+${project_add_storage_quota_unit_id}    xpath=//*[@id='create_project_storage_limit_unit']
+>>>>>>> 20dc24563... In nightly helm pipeline, test case 'Project Quotas Control Under GC' failed, it should be timing issue that the valuse in UI is not ready, so I add a keyword 'Retry Keyword When Return Value Mismatch' to retry value getting action.

--- a/tests/resources/Util.robot
+++ b/tests/resources/Util.robot
@@ -228,6 +228,18 @@ Retry Keyword When Error
     Run Keyword If  '${out[0]}'=='FAIL'  Capture Page Screenshot
     Should Be Equal As Strings  '${out[0]}'  'PASS'
 
+Retry Keyword When Return Value Mismatch
+    [Arguments]  ${keyword}  ${expected_value}  @{elements}  ${count}=6
+    :For  ${n}  IN RANGE  1  ${count}
+    \    Log To Console  Trying ${keyword} ${n} times ...
+    \    ${out}  Run Keyword And Ignore Error  ${keyword}  @{elements}
+    \    Log To Console  Return value is ${out[1]}
+    \    ${status}=  Set Variable If  '${out[1]}'=='${expected_value}'  'PASS'  'FAIL'
+    \    Exit For Loop If  '${out[1]}'=='${expected_value}'
+    \    Sleep  2
+    Run Keyword If  ${status}=='FAIL'  Capture Page Screenshot
+    Should Be Equal As Strings  ${status}  'PASS'
+
 Retry Double Keywords When Error
     [Arguments]  ${keyword1}  ${element1}  ${keyword2}  ${element2}
     :For  ${n}  IN RANGE  1  3

--- a/tests/robot-cases/Group1-Nightly/Common.robot
+++ b/tests/robot-cases/Group1-Nightly/Common.robot
@@ -449,3 +449,116 @@ Test Case - Retag A Image Tag
     Page Should Contain Element  xpath=${tag_value_xpath}
     Close Browser
 
+Test Case - Create An New Project With Quotas Set
+    Init Chrome Driver
+    ${d}=  Get Current Date  result_format=%m%s
+    ${count_quota}=  Set Variable  1234
+    ${storage_quota}=  Set Variable  600
+    ${storage_quota_unit}=  Set Variable  GB
+    Sign In Harbor  ${HARBOR_URL}  ${HARBOR_ADMIN}  ${HARBOR_PASSWORD}
+    Create An New Project    project${d}  count_quota=${count_quota}  storage_quota=${storage_quota}  storage_quota_unit=${storage_quota_unit}
+    ${count_quota_ret}=  Get Project Count Quota Text From Project Quotas List  project${d}
+    Should Be Equal As Strings  ${count_quota_ret}  0 of ${count_quota}
+    ${storage_quota_ret}=  Get Project Storage Quota Text From Project Quotas List  project${d}
+    Should Be Equal As Strings  ${storage_quota_ret}  0Byte of ${storage_quota}${storage_quota_unit}
+    Close Browser
+
+Test Case - Project Image And Chart Artifact Count Quotas Dispaly And Control
+    Init Chrome Driver
+    ${d}=  Get Current Date  result_format=%m%s
+    ${count_quota}=  Set Variable  2
+    ${storage_quota}=  Set Variable  500
+    ${storage_quota_unit}=  Set Variable  MB
+    ${image}=  Set Variable  redis
+    ${sha256}=  Set Variable  9755880356c4ced4ff7745bafe620f0b63dd17747caedba72504ef7bac882089
+    ${image_size}=    Set Variable    34.14MB
+    Sign In Harbor  ${HARBOR_URL}  ${HARBOR_ADMIN}  ${HARBOR_PASSWORD}
+    Create An New Project  project${d}  count_quota=${count_quota}  storage_quota=${storage_quota}  storage_quota_unit=${storage_quota_unit}
+    Push Image  ${ip}  ${HARBOR_ADMIN}  ${HARBOR_PASSWORD}  project${d}  ${image}  sha256=${sha256}
+    ${count_quota_ret}=  Get Project Count Quota Text From Project Quotas List  project${d}
+    Should Be Equal As Strings  ${count_quota_ret}  1 of ${count_quota}
+    ${storage_quota_ret}=  Get Project Storage Quota Text From Project Quotas List  project${d}
+    Should Be Equal As Strings  ${storage_quota_ret}  ${image_size} of ${storage_quota}${storage_quota_unit}
+    #Push Image  ${ip}  ${HARBOR_ADMIN}  ${HARBOR_PASSWORD}  project${d}  alpine
+    Go Into Project  project${d}
+    Switch To Project Charts
+    Upload Chart files
+    Cannot Push image  ${ip}  ${HARBOR_ADMIN}  ${HARBOR_PASSWORD}  project${d}  busybox  err_msg=Quota exceeded when processing the request of adding 1 of count resource, which when updated to current usage of 2 will exceed the configured upper limit of 2
+    ${count_quota_ret}=  Get Project Count Quota Text From Project Quotas List  project${d}
+    Should Be Equal As Strings  ${count_quota_ret}  2 of ${count_quota}
+    Go Into Project  project${d}
+    Delete Repo  project${d}/${image}
+    ${count_quota_ret}=  Get Project Count Quota Text From Project Quotas List  project${d}
+    Should Be Equal As Strings  ${count_quota_ret}  1 of ${count_quota}
+    Push image  ${ip}  ${HARBOR_ADMIN}  ${HARBOR_PASSWORD}  project${d}  busybox
+    Close Browser
+
+Test Case - Project Storage Quotas Dispaly And Control
+    Init Chrome Driver
+    ${d}=  Get Current Date  result_format=%m%s
+    ${storage_quota}=  Set Variable  330
+    ${storage_quota_unit}=  Set Variable  MB
+    ${image_a}=  Set Variable  redis
+    ${image_b}=  Set Variable  logstash
+    ${image_a_size}=    Set Variable    34.14MB
+    ${image_b_size}=    Set Variable    321.03MB
+    ${image_a_ver}=  Set Variable  5.0
+    ${image_b_ver}=  Set Variable  6.8.3
+    Sign In Harbor  ${HARBOR_URL}  ${HARBOR_ADMIN}  ${HARBOR_PASSWORD}
+    Create An New Project  project${d}  storage_quota=${storage_quota}  storage_quota_unit=${storage_quota_unit}
+    Push Image With Tag  ${ip}  ${HARBOR_ADMIN}  ${HARBOR_PASSWORD}  project${d}  ${image_b}  tag=${image_b_ver}  tag1=${image_b_ver}
+    ${storage_quota_ret}=  Get Project Storage Quota Text From Project Quotas List  project${d}
+    Should Be Equal As Strings  ${storage_quota_ret}  ${image_b_size} of ${storage_quota}${storage_quota_unit}
+    Cannot Push image  ${ip}  ${HARBOR_ADMIN}  ${HARBOR_PASSWORD}  project${d}  ${image_a}:${image_a_ver}  err_msg=Quota exceeded when processing the request of adding 25.8 MiB of storage resource, which when updated to current usage of 329.3 MiB will exceed the configured upper limit of 330.0 MiB
+    Go Into Project  project${d}
+    Delete Repo  project${d}/${image_b}
+    Push Image With Tag  ${ip}  ${HARBOR_ADMIN}  ${HARBOR_PASSWORD}  project${d}  ${image_a}  tag=${image_a_ver}  tag1=${image_a_ver}
+    ${storage_quota_ret}=  Get Project Storage Quota Text From Project Quotas List  project${d}
+    Should Be Equal As Strings  ${storage_quota_ret}  ${image_a_size} of ${storage_quota}${storage_quota_unit}
+    Close Browser
+
+Test Case - Project Quotas Control Under Retag
+    Init Chrome Driver
+    ${d}=  Get Current Date  result_format=%m%s
+    ${count_quota}=  Set Variable  1
+    ${image_a}=  Set Variable  redis
+    ${image_b}=  Set Variable  logstash
+    ${image_a_ver}=  Set Variable  5.0
+    ${image_b_ver}=  Set Variable  6.8.3
+    Sign In Harbor  ${HARBOR_URL}  ${HARBOR_ADMIN}  ${HARBOR_PASSWORD}
+    Create An New Project  project_a_${d}
+    Create An New Project  project_b_${d}  count_quota=${count_quota}
+    Push Image With Tag  ${ip}  ${HARBOR_ADMIN}  ${HARBOR_PASSWORD}  project_a_${d}  ${image_a}  tag=${image_a_ver}  tag1=${image_a_ver}
+    Push Image With Tag  ${ip}  ${HARBOR_ADMIN}  ${HARBOR_PASSWORD}  project_a_${d}  ${image_b}  tag=${image_b_ver}  tag1=${image_b_ver}
+    Go Into Project  project_a_${d}
+    Go Into Repo  project_a_${d}/${image_a}
+    Retag Image  ${image_a_ver}  project_b_${d}  ${image_a}  ${image_a_ver}
+    Retry Wait Element Not Visible  ${repo_retag_confirm_dlg}
+    Go Into Project  project_a_${d}
+    Go Into Repo  project_a_${d}/${image_b}
+    Retag Image  ${image_b_ver}  project_b_${d}  ${image_b}  ${image_b_ver}
+    Retry Wait Element Not Visible  ${repo_retag_confirm_dlg}
+    Sleep  2
+    Go Into Project  project_b_${d}
+    Sleep  2
+    Capture Page Screenshot
+    Retry Wait Until Page Contains Element  xpath=//clr-dg-cell[contains(.,'${image_a}')]/a
+    Retry Wait Until Page Not Contains Element  xpath=//clr-dg-cell[contains(.,'${image_b}')]/a
+    Capture Page Screenshot
+    Close Browser
+
+Test Case - Project Quotas Control Under GC
+    Init Chrome Driver
+    ${d}=  Get Current Date  result_format=%m%s
+    ${storage_quota}=  Set Variable  200
+    ${storage_quota_unit}=  Set Variable  MB
+    ${image_a}=  Set Variable  logstash
+    ${image_a_size}=    Set Variable    321.03MB
+    ${image_a_ver}=  Set Variable  6.8.3
+    Sign In Harbor  ${HARBOR_URL}  ${HARBOR_ADMIN}  ${HARBOR_PASSWORD}
+    Create An New Project  project${d}  storage_quota=${storage_quota}  storage_quota_unit=${storage_quota_unit}
+    Cannot Push image  ${ip}  ${HARBOR_ADMIN}  ${HARBOR_PASSWORD}  project${d}  ${image_a}:${image_a_ver}  err_msg=Quota exceeded when processing the request of adding 82.5 MiB of storage resource, which when updated to current usage of 166.6 MiB will exceed the configured upper limit of 200.0 MiB
+    GC Now  ${HARBOR_URL}  ${HARBOR_ADMIN}  ${HARBOR_PASSWORD}
+    @{param}  Create List  project${d}
+    Retry Keyword When Return Value Mismatch  Get Project Storage Quota Text From Project Quotas List  0Byte of ${storage_quota}${storage_quota_unit}  @{param}  count=60
+    Close Browser


### PR DESCRIPTION
In nightly helm pipeline, test case 'Project Quotas Control Under GC' failed, it should be timing issue that the valuse in UI is not ready, so I add a keyword 'Retry Keyword When Return Value Mismatch' to retry value getting action.

Signed-off-by: Danfeng Liu (c) <danfengl@vmware.com>