### PR TITLE
Remove validation for item in CVE whitelist -- Cherrypick to 1.9

### DIFF
--- a/src/core/api/sys_cve_whitelist_test.go
+++ b/src/core/api/sys_cve_whitelist_test.go
@@ -115,6 +115,7 @@ func TestSysCVEWhitelistAPIPut(t *testing.T) {
 					ExpiresAt: &s,
 					Items: []models.CVEWhitelistItem{
 						{CVEID: "CVE-2019-12310"},
+						{CVEID: "RHSA-2019:2237"},
 					},
 				},
 				credential: sysAdmin,

--- a/src/pkg/scan/whitelist/validator.go
+++ b/src/pkg/scan/whitelist/validator.go
@@ -17,7 +17,6 @@ package whitelist
 import (
 	"fmt"
 	"github.com/goharbor/harbor/src/common/models"
-	"regexp"
 )
 
 type invalidErr struct {
@@ -46,11 +45,12 @@ const cveIDPattern = `^CVE-\d{4}-\d+$`
 // Validate help validates the CVE whitelist, to ensure the CVE ID is valid and there's no duplication
 func Validate(wl models.CVEWhitelist) error {
 	m := map[string]struct{}{}
-	re := regexp.MustCompile(cveIDPattern)
+	//	re := regexp.MustCompile(cveIDPattern)
 	for _, it := range wl.Items {
-		if !re.MatchString(it.CVEID) {
-			return &invalidErr{fmt.Sprintf("invalid CVE ID: %s", it.CVEID)}
-		}
+		//	 Bypass the cve format checking
+		//		if !re.MatchString(it.CVEID) {
+		//			return &invalidErr{fmt.Sprintf("invalid CVE ID: %s", it.CVEID)}
+		//		}
 		if _, ok := m[it.CVEID]; ok {
 			return &invalidErr{fmt.Sprintf("duplicate CVE ID in whitelist: %s", it.CVEID)}
 		}

--- a/src/pkg/scan/whitelist/validator_test.go
+++ b/src/pkg/scan/whitelist/validator_test.go
@@ -67,6 +67,7 @@ func TestValidate(t *testing.T) {
 			l: models.CVEWhitelist{
 				Items: []models.CVEWhitelistItem{
 					{CVEID: "breakit"},
+					{CVEID: "breakit"},
 				},
 			},
 			noError: false,


### PR DESCRIPTION
To contain various vulnerabilities in the CVE whitelist, this commit
removes the validation.
Fixes #9242

Signed-off-by: Daniel Jiang <jiangd@vmware.com>