### PR TITLE
Currently, self registration was disabled after harbor deployment, so…

### DIFF
--- a/tests/robot-cases/Group1-Nightly/DB.robot
+++ b/tests/robot-cases/Group1-Nightly/DB.robot
@@ -26,6 +26,7 @@ ${HARBOR_ADMIN}  admin
 Test Case - Create An New User
     Init Chrome Driver
     ${d}=    Get Current Date    result_format=%m%s
+    Enable Self Reg
     Create An New User  url=${HARBOR_URL}  username=tester${d}  email=tester${d}@vmware.com  realname=harbortest  newPassword=Test1@34  comment=harbortest
     Close Browser
 


### PR DESCRIPTION
… all nightly db.robot test cases failed. To correct this, we should enable self-registration before running db test cases.

Signed-off-by: Danfeng Liu (c) <danfengl@vmware.com>