### PR TITLE
Hide DB URL from notary migrator script

### DIFF
--- a/make/photon/notary/builder
+++ b/make/photon/notary/builder
@@ -24,6 +24,8 @@ docker cp $ID:/go/bin/notary-signer binary/
 docker cp $ID:/go/bin/migrate binary/
 docker cp $ID:/migrations binary/
 
+sed -i 's/waiting for $DB_URL/waiting for database/g' binary/migrations/migrate.sh
+
 docker rm -f $ID
 docker rmi -f notary-binary
 


### PR DESCRIPTION
This commit modify the log message from upstream notary DB migrator, to
make sure the DB URL is not displayed.
Fixes #7510

Signed-off-by: Daniel Jiang <jiangd@vmware.com>