### PR TITLE
Remove the health checker for Clair in health check API

### DIFF
--- a/src/common/const.go
+++ b/src/common/const.go
@@ -137,7 +137,6 @@ const (
 	DefaultChartRepoURL               = "http://chartmuseum:9999"
 	DefaultPortalURL                  = "http://portal:8080"
 	DefaultRegistryCtlURL             = "http://registryctl:8080"
-	DefaultClairHealthCheckServerURL  = "http://clair:6061"
 	// Use this prefix to distinguish harbor user, the prefix contains a special character($), so it cannot be registered as a harbor user.
 	RobotPrefix = "robot$"
 	// Use this prefix to index user who tries to login with web hook token.

--- a/src/core/api/health.go
+++ b/src/core/api/health.go
@@ -22,14 +22,12 @@ import (
 	"sync"
 	"time"
 
-	"github.com/goharbor/harbor/src/common/utils"
-
+	"github.com/docker/distribution/health"
 	"github.com/goharbor/harbor/src/common/dao"
 	httputil "github.com/goharbor/harbor/src/common/http"
+	"github.com/goharbor/harbor/src/common/utils"
 	"github.com/goharbor/harbor/src/common/utils/log"
 	"github.com/goharbor/harbor/src/core/config"
-
-	"github.com/docker/distribution/health"
 	"github.com/gomodule/redigo/redis"
 )
 
@@ -240,14 +238,6 @@ func chartmuseumHealthChecker() health.Checker {
 	return PeriodicHealthChecker(checker, period)
 }
 
-func clairHealthChecker() health.Checker {
-	url := config.GetClairHealthCheckServerURL() + "/health"
-	timeout := 60 * time.Second
-	period := 10 * time.Second
-	checker := HTTPStatusCodeHealthChecker(http.MethodGet, url, nil, timeout, http.StatusOK)
-	return PeriodicHealthChecker(checker, period)
-}
-
 func notaryHealthChecker() health.Checker {
 	url := config.InternalNotaryEndpoint() + "/_notary_server/health"
 	timeout := 60 * time.Second
@@ -300,9 +290,6 @@ func registerHealthCheckers() {
 	HealthCheckerRegistry["redis"] = redisHealthChecker()
 	if config.WithChartMuseum() {
 		HealthCheckerRegistry["chartmuseum"] = chartmuseumHealthChecker()
-	}
-	if config.WithClair() {
-		HealthCheckerRegistry["clair"] = clairHealthChecker()
 	}
 	if config.WithNotary() {
 		HealthCheckerRegistry["notary"] = notaryHealthChecker()

--- a/src/core/config/config.go
+++ b/src/core/config/config.go
@@ -461,16 +461,6 @@ func GetRegistryCtlURL() string {
 	return url
 }
 
-// GetClairHealthCheckServerURL returns the URL of
-// the health check server of Clair
-func GetClairHealthCheckServerURL() string {
-	url := os.Getenv("CLAIR_HEALTH_CHECK_SERVER_URL")
-	if len(url) == 0 {
-		return common.DefaultClairHealthCheckServerURL
-	}
-	return url
-}
-
 // HTTPAuthProxySetting returns the setting of HTTP Auth proxy.  the settings are only meaningful when the auth_mode is
 // set to http_auth
 func HTTPAuthProxySetting() (*models.HTTPAuthProxy, error) {


### PR DESCRIPTION
As we introduce the pluggable scanner, users can add the external scanners, so we remove the Clair from the health check API

Signed-off-by: Wenkai Yin <yinw@vmware.com>