### PR TITLE
build(portal): npm registry configurable

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+src/portal/node_modules/

--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,7 @@ CLAIRFLAG=false
 HTTPPROXY=
 BUILDBIN=false
 MIGRATORFLAG=false
+NPM_REGISTRY=https://registry.npmjs.org
 # enable/disable chart repo supporting
 CHARTFLAG=false
 
@@ -306,7 +307,8 @@ build:
 	 -e REGISTRYVERSION=$(REGISTRYVERSION) -e NGINXVERSION=$(NGINXVERSION) -e NOTARYVERSION=$(NOTARYVERSION) -e NOTARYMIGRATEVERSION=$(NOTARYMIGRATEVERSION) \
 	 -e CLAIRVERSION=$(CLAIRVERSION) -e CLAIRDBVERSION=$(CLAIRDBVERSION) -e VERSIONTAG=$(VERSIONTAG) \
 	 -e BUILDBIN=$(BUILDBIN) -e REDISVERSION=$(REDISVERSION) -e MIGRATORVERSION=$(MIGRATORVERSION) \
-	 -e CHARTMUSEUMVERSION=$(CHARTMUSEUMVERSION) -e DOCKERIMAGENAME_CHART_SERVER=$(DOCKERIMAGENAME_CHART_SERVER)
+	 -e CHARTMUSEUMVERSION=$(CHARTMUSEUMVERSION) -e DOCKERIMAGENAME_CHART_SERVER=$(DOCKERIMAGENAME_CHART_SERVER) \
+	 -e NPM_REGISTRY=$(NPM_REGISTRY)
 
 install: compile ui_version build prepare start
 
@@ -434,7 +436,7 @@ swagger_client:
 	mkdir harborclient
 	java -jar swagger-codegen-cli.jar generate -i docs/swagger.yaml -l python -o harborclient
 	cd harborclient; python ./setup.py install
-	pip install docker -q 
+	pip install docker -q
 	pip freeze
 
 cleanbinary:

--- a/make/photon/Makefile
+++ b/make/photon/Makefile
@@ -1,5 +1,5 @@
 # Makefile for a harbor project
-#	
+#
 # Targets:
 #
 # build: 	build harbor photon images
@@ -109,20 +109,20 @@ _build_db:
 
 _build_portal:
 	@echo "building portal container for photon..."
-	$(DOCKERBUILD) -f $(DOCKERFILEPATH_PORTAL)/$(DOCKERFILENAME_PORTAL) -t $(DOCKERIMAGENAME_PORTAL):$(VERSIONTAG) .
+	$(DOCKERBUILD) --build-arg npm_registry=$(NPM_REGISTRY) -f $(DOCKERFILEPATH_PORTAL)/$(DOCKERFILENAME_PORTAL) -t $(DOCKERIMAGENAME_PORTAL):$(VERSIONTAG) .
 	@echo "Done."
 
-_build_core:	
+_build_core:
 	@echo "building core container for photon..."
 	@$(DOCKERBUILD) -f $(DOCKERFILEPATH_CORE)/$(DOCKERFILENAME_CORE) -t $(DOCKERIMAGENAME_CORE):$(VERSIONTAG) .
 	@echo "Done."
-	
-_build_jobservice:		
+
+_build_jobservice:
 	@echo "building jobservice container for photon..."
 	@$(DOCKERBUILD) -f $(DOCKERFILEPATH_JOBSERVICE)/$(DOCKERFILENAME_JOBSERVICE) -t $(DOCKERIMAGENAME_JOBSERVICE):$(VERSIONTAG) .
 	@echo "Done."
 
-_build_log:	
+_build_log:
 	@echo "building log container for photon..."
 	$(DOCKERBUILD) -f $(DOCKERFILEPATH_LOG)/$(DOCKERFILENAME_LOG) -t $(DOCKERIMAGENAME_LOG):$(VERSIONTAG) .
 	@echo "Done."
@@ -154,7 +154,7 @@ _build_chart_server:
 		rm -rf $(DOCKERFILEPATH_CHART_SERVER)/binary; \
 		echo "Done." ; \
 	fi
-		
+
 _build_nginx:
 	@echo "building nginx container for photon..."
 	@$(DOCKERBUILD) -f $(DOCKERFILEPATH_NGINX)/$(DOCKERFILENAME_NGINX) -t $(DOCKERIMAGENAME_NGINX):$(NGINXVERSION) .
@@ -175,7 +175,7 @@ _build_notary:
 		rm -rf $(DOCKERFILEPATH_NOTARY)/binary; \
 		echo "Done."; \
 	fi
-		
+
 _build_registry:
 	@if [ "$(BUILDBIN)" != "true" ] ; then \
 		rm -rf $(DOCKERFILEPATH_REG)/binary && mkdir -p $(DOCKERFILEPATH_REG)/binary && \
@@ -187,7 +187,7 @@ _build_registry:
 	@chmod 655 $(DOCKERFILEPATH_REG)/binary/registry && $(DOCKERBUILD) -f $(DOCKERFILEPATH_REG)/$(DOCKERFILENAME_REG) -t $(DOCKERIMAGENAME_REG):$(REGISTRYVERSION)-$(VERSIONTAG) .
 	@echo "Done."
 
-_build_registryctl:		
+_build_registryctl:
 	@echo "building registry controller for photon..."
 	@$(DOCKERBUILD) -f $(DOCKERFILEPATH_REGISTRYCTL)/$(DOCKERFILENAME_REGISTRYCTL) -t $(DOCKERIMAGENAME_REGISTRYCTL):$(VERSIONTAG) .
 	@rm -rf $(DOCKERFILEPATH_REG)/binary
@@ -217,7 +217,7 @@ cleanimage:
 	- $(DOCKERRMIMAGE) -f $(DOCKERIMAGENAME_CORE):$(VERSIONTAG)
 	- $(DOCKERRMIMAGE) -f $(DOCKERIMAGENAME_JOBSERVICE):$(VERSIONTAG)
 	- $(DOCKERRMIMAGE) -f $(DOCKERIMAGENAME_LOG):$(VERSIONTAG)
-	
+
 .PHONY: clean
 clean: cleanimage
 

--- a/make/photon/portal/Dockerfile
+++ b/make/photon/portal/Dockerfile
@@ -1,5 +1,8 @@
 FROM node:10.15.0 as nodeportal
 
+ARG npm_registry=https://registry.npmjs.org
+ENV NPM_CONFIG_REGISTRY=${npm_registry}
+
 RUN mkdir -p /portal_src
 RUN mkdir -p /build_dir
 


### PR DESCRIPTION
1. Introduce NPM_REGISTRY in Makefile to support npm registry configuration when build portal image.

Signed-off-by: He Weiwei <hweiwei@vmware.com>