### PR TITLE
Fix broken about dialog on sign in page

### DIFF
--- a/src/portal/src/app/sign-in/sign-in.component.html
+++ b/src/portal/src/app/sign-in/sign-in.component.html
@@ -1,6 +1,6 @@
 <clr-main-container>
     <global-message [isAppLevel]="true"></global-message>
-    <navigator></navigator>
+    <navigator (showPwdChangeModal)="openModal($event)"></navigator>
     <search-result></search-result>
     <div class="login-wrapper" [ngStyle]="{'background-image': customLoginBgImg? 'url(/images/' + customLoginBgImg + ')': ''}">
         <form #signInForm="ngForm" class="login">
@@ -46,3 +46,4 @@
 </clr-main-container>
 <sign-up #signupDialog (userCreation)="handleUserCreation($event)"></sign-up>
 <forgot-password #forgotPwdDialog></forgot-password>
+<about-dialog></about-dialog>

--- a/src/portal/src/app/sign-in/sign-in.component.ts
+++ b/src/portal/src/app/sign-in/sign-in.component.ts
@@ -29,6 +29,9 @@ import { User } from '../user/user';
 
 import { CookieService, CookieOptions } from 'ngx-cookie';
 import { SkinableConfig } from "../skinable-config.service";
+import {ModalEvent} from "../base/modal-event";
+import {modalEvents} from "../base/modal-events.const";
+import {AboutDialogComponent} from "../shared/about-dialog/about-dialog.component";
 
 // Define status flags for signing in states
 export const signInStatusNormal = 0;
@@ -57,6 +60,7 @@ export class SignInComponent implements AfterViewChecked, OnInit {
     @ViewChild('signInForm', {static: true}) currentForm: NgForm;
     @ViewChild('signupDialog', {static: false}) signUpDialog: SignUpComponent;
     @ViewChild('forgotPwdDialog', {static: false}) forgotPwdDialog: ForgotPasswordComponent;
+    @ViewChild(AboutDialogComponent, {static: false}) aboutDialog: AboutDialogComponent;
 
     // Status flag
     signInStatus: number = signInStatusNormal;
@@ -283,6 +287,16 @@ export class SignInComponent implements AfterViewChecked, OnInit {
         this.forgotPwdDialog.open();
     }
 
+    // Open modal dialog
+    openModal(event: ModalEvent): void {
+        switch (event.modalName) {
+            case modalEvents.ABOUT:
+                this.aboutDialog.open();
+                break;
+            default:
+                break;
+        }
+    }
 }
 
 


### PR DESCRIPTION
Currently when you click on the `About` link in the top right on the sign in page, the modal is not opened. This PR fixes this.