### PR TITLE
property use_internal_addr can not be updated

### DIFF
--- a/src/core/api/scanners.go
+++ b/src/core/api/scanners.go
@@ -329,4 +329,5 @@ func getChanges(e *scanner.Registration, eChange *scanner.Registration) {
 	e.AccessCredential = eChange.AccessCredential
 	e.Disabled = eChange.Disabled
 	e.SkipCertVerify = eChange.SkipCertVerify
+	e.UseInternalAddr = eChange.UseInternalAddr
 }


### PR DESCRIPTION
- pick up `use_internal_addr` in the update API

Signed-off-by: Steven Zou <szou@vmware.com>