### PR TITLE
Fix quota sync crash on getting the unknown mainfest

### DIFF
--- a/src/core/api/internal.go
+++ b/src/core/api/internal.go
@@ -172,7 +172,8 @@ func (ia *InternalAPI) SyncQuota() {
 			cfgMgr.Save()
 		}()
 		log.Info("start to sync quota(API), the system will be set to ReadOnly and back it normal once it done.")
-		err := quota.Sync(ia.ProjectMgr, false)
+		// As the sync function ignores all of duplicate error, it's safe to enable persist DB.
+		err := quota.Sync(ia.ProjectMgr, true)
 		if err != nil {
 			log.Errorf("fail to sync quota(API), but with error: %v, please try to do it again.", err)
 			return

--- a/src/core/api/quota/migrator.go
+++ b/src/core/api/quota/migrator.go
@@ -22,7 +22,6 @@ import (
 	"github.com/goharbor/harbor/src/core/config"
 	"github.com/goharbor/harbor/src/core/promgr"
 	"github.com/goharbor/harbor/src/pkg/types"
-	"math/rand"
 	"strconv"
 	"time"
 )
@@ -80,7 +79,6 @@ func Register(name string, adapter Instance) {
 
 // Sync ...
 func Sync(pm promgr.ProjectManager, populate bool) error {
-	rand.Seed(time.Now().UnixNano())
 	totalUsage := make(map[string][]ProjectUsage)
 	for name, instanceFunc := range adapters {
 		if !config.WithChartMuseum() {


### PR DESCRIPTION
1, eat the unknown manifest error, and log it. The migration process will not crashed on it.
2, enable to persist DB of sync quota API.
3, add empty project support.

Signed-off-by: wang yan <wangyan@vmware.com>

append empty project