### PR TITLE
Add registry middleware to provide more efficient delivery

### DIFF
--- a/docs/installation_guide.md
+++ b/docs/installation_guide.md
@@ -18,17 +18,17 @@ In addition, the Harbor community created instructions describing how to deploy 
 
 The table below lists the components that are deployed when you deploy Harbor.
 
-|Component|Version|
-|---|---|
-|Postgresql|9.6.10-1.ph2|
-|Redis|4.0.10-1.ph2|
-|Clair|2.0.8|
-|Beego|1.9.0|
-|Chartmuseum|0.9.0|
-|Docker/distribution|2.7.1|
-|Docker/notary|0.6.1|
-|Helm|2.9.1|
-|Swagger-ui|3.22.1|
+| Component           | Version      |
+| ------------------- | ------------ |
+| Postgresql          | 9.6.10-1.ph2 |
+| Redis               | 4.0.10-1.ph2 |
+| Clair               | 2.0.8        |
+| Beego               | 1.9.0        |
+| Chartmuseum         | 0.9.0        |
+| Docker/distribution | 2.7.1        |
+| Docker/notary       | 0.6.1        |
+| Helm                | 2.9.1        |
+| Swagger-ui          | 3.22.1       |
 
 ## Deployment Prerequisites for the Target Host
 
@@ -38,31 +38,31 @@ Harbor is deployed as several Docker containers. You can therefore deploy it on 
 
 The following table lists the minimum and recommended hardware configurations for deploying Harbor.
 
-|Resource|Minimum|Recommended|
-|---|---|---|
-|CPU|2 CPU|4 CPU|
-|Mem|4 GB|8 GB|
-|Disk|40 GB|160 GB|
+| Resource | Minimum | Recommended |
+| -------- | ------- | ----------- |
+| CPU      | 2 CPU   | 4 CPU       |
+| Mem      | 4 GB    | 8 GB        |
+| Disk     | 40 GB   | 160 GB      |
 
 ### Software
 
 The following table lists the software versions that must be installed on the target host.
 
-|Software|Version|Description|
-|---|---|---|
-|Docker engine|version 17.06.0-ce+ or higher|For installation instructions, see [docker engine doc](https://docs.docker.com/engine/installation/)|
-|Docker Compose|version 1.18.0 or higher|For installation instructions, see [docker compose doc](https://docs.docker.com/compose/install/)|
-|Openssl|latest is preferred|Used to generate certificate and keys for Harbor|
+| Software       | Version                       | Description                                                                                          |
+| -------------- | ----------------------------- | ---------------------------------------------------------------------------------------------------- |
+| Docker engine  | version 17.06.0-ce+ or higher | For installation instructions, see [docker engine doc](https://docs.docker.com/engine/installation/) |
+| Docker Compose | version 1.18.0 or higher      | For installation instructions, see [docker compose doc](https://docs.docker.com/compose/install/)    |
+| Openssl        | latest is preferred           | Used to generate certificate and keys for Harbor                                                     |
 
 ### Network ports
 
 Harbor requires that the following ports be open on the target host.
 
-|Port|Protocol|Description|
-|---|---|---|
-|443|HTTPS|Harbor portal and core API accept HTTPS requests on this port. You can change this port in the configuration file.|
-|4443|HTTPS|Connections to the Docker Content Trust service for Harbor. Only required if Notary is enabled. You can change this port in the configuration file.|
-|80|HTTP|Harbor portal and core API accept HTTP requests on this port. You can change this port in the configuration file.|
+| Port | Protocol | Description                                                                                                                                         |
+| ---- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 443  | HTTPS    | Harbor portal and core API accept HTTPS requests on this port. You can change this port in the configuration file.                                  |
+| 4443 | HTTPS    | Connections to the Docker Content Trust service for Harbor. Only required if Notary is enabled. You can change this port in the configuration file. |
+| 80   | HTTP     | Harbor portal and core API accept HTTP requests on this port. You can change this port in the configuration file.                                   |
 
 ## Installation Procedure
 
@@ -280,6 +280,16 @@ The following table lists the additional, optional parameters that you can set t
     <td valign="top"><code>redirect</code></td>
     <td valign="top">Set <code>disable</code> to <code>true</code> when you want to disable registry redirect</td>
   </tr>
+ <tr>
+    <td valign="top"><code>middleware_service</code></td>
+    <td valign="top">&nbsp;</td>
+    <td valign="top">By default, Harbor do not use middleware services of registry, but you can optionally configure the `middleware_service` setting so that Harbor uses middleware service.</td>
+  </tr>
+  <tr>
+    <td valign="top">&nbsp;</td>
+    <td valign="top">None</td>
+    <td valign="top">You can set <code>cloudfront</code> or <code>redirect</code>. For information about how to configure other middleware, see <a href="#middleware">Configuring a Middleware Services</a> below.</td>
+  </tr>
   <tr>
     <td valign="top"><code>external_database</code></td>
     <td valign="top">&nbsp;</td>
@@ -405,6 +415,19 @@ storage_service:
     disable: false
 ```
 
+<a id="middleware"></a>
+### Configuring a Middleware Service
+
+By default, Harbor do not use middleware services of registry, but you can optionally configure the `middleware_service` setting so that Harbor uses middleware service. For information about how to configure the middleware service of a registry, see the [Middleware Configuration Reference](https://docs.docker.com/registry/configuration/#middleware).  For example, you may consider used a more efficient delivery like Cloudfront, Redirect ( proxy cache for the layer ).
+
+``` yaml
+middleware_service:
+  cloudfront:
+      baseurl: http://d111111abcdef8.cloudfront.net
+      privatekey: /path/to/asecret.pem
+      keypairid: asecret
+      duration: 60s
+```
 
 ## Installating and starting Harbor
 

--- a/make/harbor.yml
+++ b/make/harbor.yml
@@ -54,6 +54,20 @@ data_volume: /data
 #   redirect:
 #     disabled: false
 
+# Uncomment middleware_service setting If you want to using a registry middleware
+# middleware_service:
+#   cloudfront:
+#     baseurl: https://my.cloudfronted.domain.com/
+#     privatekey: /path/to/pem
+#     keypairid: cloudfrontkeypairid
+#     duration: 3000s
+#     ipfilteredby: awsregion
+#     awsregion: us-east-1, use-east-2
+#     updatefrenquency: 12h
+#     iprangesurl: https://ip-ranges.amazonaws.com/ip-ranges.json
+#   redirect:
+#     baseurl: https://example.com/
+
 # Clair configuration
 clair:
   # The interval of clair updaters, the unit is hour, set to 0 to disable the updaters.

--- a/make/photon/prepare/templates/registry/config.yml.jinja
+++ b/make/photon/prepare/templates/registry/config.yml.jinja
@@ -31,6 +31,12 @@ auth:
     realm: {{public_url}}/service/token
     rootcertbundle: /etc/registry/root.crt
     service: harbor-registry
+middleware:
+{% if middleware_storage_name %}
+  storage:
+    - name: {{ middleware_storage_name }}
+      options: {{ middleware_storage_config }}
+{% endif %}
 validation:
   disabled: true
 notifications:

--- a/make/photon/prepare/utils/configs.py
+++ b/make/photon/prepare/utils/configs.py
@@ -35,12 +35,23 @@ def validate(conf: dict, **kwargs):
     if ('log_ep_protocol' in conf) and (conf['log_ep_protocol'] not in ['udp', 'tcp']):
         raise Exception("Protocol in external log endpoint must be one of 'udp' or 'tcp' ")
 
+   # Middleware validate
+    valid_middleware_storage = ["cloudfront", "redirect"]
+    middleware_provider_name = conf.get("middleware_provider_name")
+    if middleware_provider_name and middleware_provider_name not in valid_middleware_storage:
+        raise Exception("Error: middleware storage %s is not supported, only the following ones are supported: %s" % (
+            middleware_provider_name, ",".join(valid_middleware_storage)))
+
     # Storage validate
     valid_storage_drivers = ["filesystem", "azure", "gcs", "s3", "swift", "oss"]
     storage_provider_name = conf.get("storage_provider_name")
     if storage_provider_name not in valid_storage_drivers:
         raise Exception("Error: storage driver %s is not supported, only the following ones are supported: %s" % (
             storage_provider_name, ",".join(valid_storage_drivers)))
+
+    # Cloudfront + S3 validate
+    if middleware_provider_name == "cloudfront" and storage_provider_name != "s3":
+        raise Exception("Error: middleware cloudfront work only with s3 storage")
 
     storage_provider_config = conf.get("storage_provider_config") ## original is registry_storage_provider_config
     if storage_provider_name != "filesystem":
@@ -161,6 +172,16 @@ def parse_yaml_config(config_file_path, with_notary, with_clair, with_chartmuseu
 
     # Initial Admin Password
     config_dict['harbor_admin_password'] = configs["harbor_admin_password"]
+
+    # Registry middleware configs
+    middleware_config = configs.get('middleware_service') or {}
+
+    if middleware_config.get('cloudfront'):
+        config_dict['middleware_storage_name'] = 'cloudfront'
+        config_dict['middleware_storage_config'] = middleware_config['cloudfront']
+    elif middleware_config.get('redirect'):
+        config_dict['middleware_storage_name'] = 'redirect'
+        config_dict['middleware_storage_config'] = middleware_config['redirect']
 
     # Registry storage configs
     storage_config = configs.get('storage_service') or {}


### PR DESCRIPTION
In some cases, you like to add a registry middleware to increase images delivery performance. 
This PR only whitelist storages middleware like cloudfront, redirect. 

