### PR TITLE
strenth xpath locator of project member remove button

### DIFF
--- a/tests/resources/Harbor-Pages/ToolKit_Elements.robot
+++ b/tests/resources/Harbor-Pages/ToolKit_Elements.robot
@@ -17,4 +17,4 @@ Documentation  This resource provides any keywords related to the Harbor private
 
 *** Variables ***
 ${member_action_xpath}  //*[@id="member-action"]
-${delete_action_xpath}  //clr-dropdown/clr-dropdown-menu/button[5]
+${delete_action_xpath}  //clr-dropdown/clr-dropdown-menu/button[contains(.,'Remove')]


### PR DESCRIPTION
In nightly test case of project members, xpath locator of remove a member is not strong enough for location, it used index of element, so it should be update by the meaning of this button.

Signed-off-by: Danfeng Liu (c) <danfengl@vmware.com>