### PR TITLE
fixed bug of enable self reg, explore should be opened and navigate to harbor log in page

### DIFF
--- a/tests/robot-cases/Group1-Nightly/Common.robot
+++ b/tests/robot-cases/Group1-Nightly/Common.robot
@@ -499,7 +499,7 @@ Test Case - Project Storage Quotas Dispaly And Control
     ${storage_quota_unit}=  Set Variable  MB
     ${image_a}=  Set Variable  redis
     ${image_b}=  Set Variable  logstash
-    ${image_a_size}=    Set Variable    34.14MB
+    ${image_a_size}=    Set Variable    34.16MB
     ${image_b_size}=    Set Variable    321.03MB
     ${image_a_ver}=  Set Variable  5.0
     ${image_b_ver}=  Set Variable  6.8.3

--- a/tests/robot-cases/Group1-Nightly/DB.robot
+++ b/tests/robot-cases/Group1-Nightly/DB.robot
@@ -26,7 +26,13 @@ ${HARBOR_ADMIN}  admin
 Test Case - Create An New User
     Init Chrome Driver
     ${d}=    Get Current Date    result_format=%m%s
+    Sign In Harbor  ${HARBOR_URL}  ${HARBOR_ADMIN}  ${HARBOR_PASSWORD}
+    Switch To Configure
+    Self Reg Should Be Disabled
+    Sleep  1
     Enable Self Reg
+    Logout Harbor
+
     Create An New User  url=${HARBOR_URL}  username=tester${d}  email=tester${d}@vmware.com  realname=harbortest  newPassword=Test1@34  comment=harbortest
     Close Browser
 


### PR DESCRIPTION
Before user keyword Enable Self Reg, explore should be opened and navigate to harbor login page.

Signed-off-by: Danfeng Liu (c) <danfengl@vmware.com>