### PR TITLE
fix the bug of returning errors when nothing is updated

### DIFF
--- a/src/core/service/notifications/jobs/handler.go
+++ b/src/core/service/notifications/jobs/handler.go
@@ -93,10 +93,12 @@ func (h *Handler) Prepare() {
 
 // HandleScan handles the webhook of scan job
 func (h *Handler) HandleScan() {
-	log.Debugf("Received scan job status update event: job UUID: %s, status: %s, track_id: %s, is checkin: %v",
+	log.Debugf(
+		"Received scan job status update event: job UUID: %s, status: %s, track_id: %s, revision: %d, is checkin: %v",
 		h.change.JobID,
 		h.status,
 		h.trackID,
+		h.revision,
 		len(h.checkIn) > 0,
 	)
 

--- a/src/pkg/scan/dao/scan/report.go
+++ b/src/pkg/scan/dao/scan/report.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/astaxie/beego/orm"
 	"github.com/goharbor/harbor/src/common/dao"
+	"github.com/goharbor/harbor/src/common/utils/log"
 	"github.com/goharbor/harbor/src/pkg/q"
 	"github.com/pkg/errors"
 )
@@ -97,8 +98,10 @@ func UpdateReportData(uuid string, report string, statusRev int64) error {
 		return err
 	}
 
+	// Update has preconditions which may NOT be matched, and then count may equal 0.
+	// Just need log, no error need to be returned.
 	if count == 0 {
-		return errors.Errorf("no report with uuid %s updated", uuid)
+		log.Warningf("Data of report with uuid %s is not updated as preconditions may not be matched: status change revision %d", uuid, statusRev)
 	}
 
 	return nil
@@ -128,8 +131,10 @@ func UpdateReportStatus(trackID string, status string, statusCode int, statusRev
 		return err
 	}
 
+	// Update has preconditions which may NOT be matched, and then count may equal 0.
+	// Just need log, no error need to be returned.
 	if count == 0 {
-		return errors.Errorf("no report with track_id %s updated", trackID)
+		log.Warningf("Status of report with track ID %s is not updated as preconditions may not be matched: status change revision %d, status code %d", trackID, statusRev, statusCode)
 	}
 
 	return nil

--- a/src/pkg/scan/dao/scan/report_test.go
+++ b/src/pkg/scan/dao/scan/report_test.go
@@ -116,7 +116,7 @@ func (suite *ReportTestSuite) TestReportUpdateReportData() {
 	assert.Equal(suite.T(), "{}", l[0].Report)
 
 	err = UpdateReportData("uuid", "{\"a\": 900}", 900)
-	require.Error(suite.T(), err)
+	require.NoError(suite.T(), err)
 }
 
 // TestReportUpdateStatus tests update the report status.
@@ -125,8 +125,8 @@ func (suite *ReportTestSuite) TestReportUpdateStatus() {
 	require.NoError(suite.T(), err)
 
 	err = UpdateReportStatus("track-uuid", job.RunningStatus.String(), job.RunningStatus.Code(), 900)
-	require.Error(suite.T(), err)
+	require.NoError(suite.T(), err)
 
 	err = UpdateReportStatus("track-uuid", job.PendingStatus.String(), job.PendingStatus.Code(), 1000)
-	require.Error(suite.T(), err)
+	require.NoError(suite.T(), err)
 }


### PR DESCRIPTION
- bug details: #9629
- root cause: the preconditions for updating may not be matched

Signed-off-by: Steven Zou <szou@vmware.com>