### PR TITLE
chore(log): log level support for clair adapter

### DIFF
--- a/make/photon/prepare/templates/clair-adapter/env.jinja
+++ b/make/photon/prepare/templates/clair-adapter/env.jinja
@@ -1,1 +1,2 @@
+SCANNER_LOG_LEVEL={{log_level}}
 SCANNER_CLAIR_URL={{clair_url}}


### PR DESCRIPTION
1. Set log level for clair adapter to make it match the setting in `harbor.yml`

Signed-off-by: He Weiwei <hweiwei@vmware.com>