### PR TITLE
FetchUserInfo retrieving details about the logged-in user

### DIFF
--- a/src/common/utils/oidc/helper.go
+++ b/src/common/utils/oidc/helper.go
@@ -208,6 +208,24 @@ func RefreshToken(ctx context.Context, token *Token) (*Token, error) {
 	return &Token{Token: *t, IDToken: it}, nil
 }
 
+// FetchUserInfo retrieving details about the logged-in user
+// https://connect2id.com/products/server/docs/api/userinfo
+// 
+// The Claims requested by the profile, email, address, and phone scope values are returned from the UserInfo Endpoint,
+// as described in Section 5.3.2, when a response_type value is used that results in an Access Token being issued. 
+// However, when no Access Token is issued (which is the case for the response_type value id_token),
+// the resulting Claims are returned in the ID Token.
+// https://openid.net/specs/openid-connect-core-1_0.html#ScopeClaims
+func FetchUserInfo(ctx context.Context, token *Token) (*gooidc.UserInfo, error) {
+	p, err := provider.get()
+	if err != nil {
+		return nil, err
+	}
+	setting := provider.setting.Load().(models.OIDCSetting)
+	ctx = clientCtx(ctx, setting.VerifyCert)
+	return p.UserInfo(ctx, oauth2.StaticTokenSource(&token.Token))
+}
+
 // GroupsFromToken returns the list of group name in the token, the claims of the group list is set in OIDCSetting.
 // It's designed not to return errors, in case of unexpected situation it will log and return empty list.
 func GroupsFromToken(token *gooidc.IDToken) []string {

--- a/src/common/utils/oidc/helper.go
+++ b/src/common/utils/oidc/helper.go
@@ -210,9 +210,9 @@ func RefreshToken(ctx context.Context, token *Token) (*Token, error) {
 
 // FetchUserInfo retrieving details about the logged-in user
 // https://connect2id.com/products/server/docs/api/userinfo
-// 
+//
 // The Claims requested by the profile, email, address, and phone scope values are returned from the UserInfo Endpoint,
-// as described in Section 5.3.2, when a response_type value is used that results in an Access Token being issued. 
+// as described in Section 5.3.2, when a response_type value is used that results in an Access Token being issued.
 // However, when no Access Token is issued (which is the case for the response_type value id_token),
 // the resulting Claims are returned in the ID Token.
 // https://openid.net/specs/openid-connect-core-1_0.html#ScopeClaims

--- a/src/core/controllers/oidc.go
+++ b/src/core/controllers/oidc.go
@@ -111,6 +111,15 @@ func (oc *OIDCController) Callback() {
 		return
 	}
 	d := &oidcUserData{}
+
+	// fetch user info for email
+	userInfo, err := oidc.FetchUserInfo(ctx, token)
+	if err == nil {
+		err = userInfo.Claims(d);
+	} else {
+		log.Warningf("OIDC endpoint does not support /userinfo, due to error: %v", err)
+	}
+	
 	err = idToken.Claims(d)
 	if err != nil {
 		oc.SendInternalServerError(err)

--- a/src/core/controllers/oidc.go
+++ b/src/core/controllers/oidc.go
@@ -115,11 +115,11 @@ func (oc *OIDCController) Callback() {
 	// fetch user info for email
 	userInfo, err := oidc.FetchUserInfo(ctx, token)
 	if err == nil {
-		err = userInfo.Claims(d);
+		err = userInfo.Claims(d)
 	} else {
 		log.Warningf("OIDC endpoint does not support /userinfo, due to error: %v", err)
 	}
-	
+
 	err = idToken.Claims(d)
 	if err != nil {
 		oc.SendInternalServerError(err)


### PR DESCRIPTION
According to the openidconnect spec when `response_type=code` `id_token` does not need to include user detail claims (e.g. `email`) if Access Token is being issued.

> In this case the Claims requested by the `profile, email, address, and phone` scope values are returned from the UserInfo Endpoint, as described in Section 5.3.2

http://openid.net/specs/openid-connect-core-1_0.html#ScopeClaims

This solution first unmarshals claims from `userInfo` (if present) and then overrides the values with possible claims from `IdToken` therefore keeping backwards compatibility.

Should fix #7885 and #9600

Signed-off-by: jsimomaa <jani.simomaa@gmail.com>