### PR TITLE
[cherry-pick]add a switcher for quota sync on core launch

### DIFF
--- a/make/photon/prepare/templates/core/env.jinja
+++ b/make/photon/prepare/templates/core/env.jinja
@@ -2,6 +2,7 @@ CONFIG_PATH=/etc/core/app.conf
 UAA_CA_ROOT=/etc/core/certificates/uaa_ca.pem
 _REDIS_URL={{redis_host}}:{{redis_port}},100,{{redis_password}}
 SYNC_REGISTRY=false
+SYNC_QUOTA=true
 CHART_CACHE_DRIVER={{chart_cache_driver}}
 _REDIS_URL_REG={{redis_url_reg}}
 

--- a/src/core/main.go
+++ b/src/core/main.go
@@ -253,8 +253,18 @@ func main() {
 		log.Fatalf("init proxy error, %v", err)
 	}
 
-	if err := quotaSync(); err != nil {
-		log.Fatalf("quota migration error, %v", err)
+	syncQuota := os.Getenv("SYNC_QUOTA")
+	doSyncQuota, err := strconv.ParseBool(syncQuota)
+	if err != nil {
+		log.Errorf("Failed to parse SYNC_QUOTA: %v", err)
+		doSyncQuota = true
+	}
+	if doSyncQuota {
+		if err := quotaSync(); err != nil {
+			log.Fatalf("quota migration error, %v", err)
+		}
+	} else {
+		log.Infof("Because SYNC_QUOTA set false , no need to sync quota \n")
 	}
 
 	beego.Run()


### PR DESCRIPTION
As the quota sync is default called by harbor-core on every launch, and it will break the launch process if any failure throwed.

1, The commit is to provide an switcher for the system admin to bypass the quota sync.
2, In case Harbor goes into the restarting cycle.

Harbor already provides an internal API to sync quota data, in the failure case,
system admin can launch harbor and call the /api/internal/syncquota to sync quota.

Signed-off-by: wang yan <wangyan@vmware.com>