### PR TITLE
Modify nightly test case due to replication rule element is modified from selector to input

### DIFF
--- a/tests/resources/Harbor-Pages/Replication.robot
+++ b/tests/resources/Harbor-Pages/Replication.robot
@@ -44,8 +44,8 @@ Select Trigger
 
 Select Destination URL
     [Arguments]    ${type}
-    Retry Element Click    ${destination_url_xpath}
-    Retry Element Click    ${destination_url_xpath}//option[contains(.,'${type}')]
+    Retry Element Click  ${destination_url_xpath}
+    Retry Element Click  //div[contains(@class, 'selectBox')]//li[contains(.,'${type}')]
 
 Check New Rule UI Without Endpoint
     Retry Element Click    ${new_replication-rule_button}


### PR DESCRIPTION
Replication rule element is modified from selector to input, so nightly test case should be updated.

Signed-off-by: Danfeng Liu (c) <danfengl@vmware.com>