### PR TITLE
fix(policy-checker): add func to transform project severity to vuln.Severity

### DIFF
--- a/src/common/models/pro_meta.go
+++ b/src/common/models/pro_meta.go
@@ -26,7 +26,7 @@ const (
 	ProMetaSeverity             = "severity"
 	ProMetaAutoScan             = "auto_scan"
 	ProMetaReuseSysCVEWhitelist = "reuse_sys_cve_whitelist"
-	SeverityNone                = "negligible"
+	SeverityNegligible          = "negligible"
 	SeverityLow                 = "low"
 	SeverityMedium              = "medium"
 	SeverityHigh                = "high"

--- a/src/core/api/metadata.go
+++ b/src/core/api/metadata.go
@@ -231,7 +231,7 @@ func validateProjectMetadata(metas map[string]string) (map[string]string, error)
 	value, exist := metas[models.ProMetaSeverity]
 	if exist {
 		switch strings.ToLower(value) {
-		case models.SeverityHigh, models.SeverityMedium, models.SeverityLow, models.SeverityNone:
+		case models.SeverityHigh, models.SeverityMedium, models.SeverityLow, models.SeverityNegligible:
 			metas[models.ProMetaSeverity] = strings.ToLower(value)
 		default:
 			return nil, fmt.Errorf("invalid severity %s", value)

--- a/src/core/middlewares/util/util_test.go
+++ b/src/core/middlewares/util/util_test.go
@@ -171,7 +171,7 @@ func TestPMSPolicyChecker(t *testing.T) {
 		Metadata: map[string]string{
 			models.ProMetaEnableContentTrust:   "true",
 			models.ProMetaPreventVul:           "true",
-			models.ProMetaSeverity:             "Low",
+			models.ProMetaSeverity:             "low", // validateProjectMetadata function make the severity to lowercase
 			models.ProMetaReuseSysCVEWhitelist: "false",
 		},
 	})


### PR DESCRIPTION
The severity saved in db is lowercase but the severities in vuln pkg
begin with upper letter, this fix use func to transform project severity
value from db to vuln.Severity.

Signed-off-by: He Weiwei <hweiwei@vmware.com>