### PR TITLE
Fix a bug that when someone edits a rule with same name ,it displays the name is already in use

### DIFF
--- a/src/portal/lib/src/create-edit-rule/create-edit-rule.component.ts
+++ b/src/portal/lib/src/create-edit-rule/create-edit-rule.component.ts
@@ -123,7 +123,7 @@ export class CreateEditRuleComponent implements OnInit, OnDestroy {
             this.inNameChecking = true;
             this.repService.getReplicationRules(0, ruleName)
               .subscribe(response => {
-                if (response.some(rule => rule.name === ruleName)) {
+                if (response.some(rule => (rule.name === ruleName && rule.id !== this.policyId))) {
                   this.ruleNameTooltip = "TOOLTIP.RULE_USER_EXISTING";
                   this.isRuleNameValid = false;
                 }


### PR DESCRIPTION
Fix #8810 
Signed-off-by: Yogi_Wang <yawang@vmware.com>