### PR TITLE
fix(robot,project-member): check owner of member, robot when update, …

### DIFF
--- a/src/common/api/base.go
+++ b/src/common/api/base.go
@@ -48,6 +48,11 @@ func (b *BaseAPI) GetInt64FromPath(key string) (int64, error) {
 	return strconv.ParseInt(value, 10, 64)
 }
 
+// ParamExistsInPath returns true when param exists in the path
+func (b *BaseAPI) ParamExistsInPath(key string) bool {
+	return b.GetStringFromPath(key) != ""
+}
+
 // Render returns nil as it won't render template
 func (b *BaseAPI) Render() error {
 	return nil

--- a/src/core/api/harborapi_test.go
+++ b/src/core/api/harborapi_test.go
@@ -26,6 +26,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strconv"
+	"strings"
 
 	"github.com/astaxie/beego"
 	"github.com/dghubble/sling"
@@ -229,19 +230,25 @@ func init() {
 	defer mockServer.Close()
 }
 
-func request(_sling *sling.Sling, acceptHeader string, authInfo ...usrInfo) (int, []byte, error) {
+func request0(_sling *sling.Sling, acceptHeader string, authInfo ...usrInfo) (int, http.Header, []byte, error) {
 	_sling = _sling.Set("Accept", acceptHeader)
 	req, err := _sling.Request()
 	if err != nil {
-		return 400, nil, err
+		return 400, nil, nil, err
 	}
 	if len(authInfo) > 0 {
 		req.SetBasicAuth(authInfo[0].Name, authInfo[0].Passwd)
 	}
 	w := httptest.NewRecorder()
 	beego.BeeApp.Handlers.ServeHTTP(w, req)
+
 	body, err := ioutil.ReadAll(w.Body)
-	return w.Code, body, err
+	return w.Code, w.Header(), body, err
+}
+
+func request(_sling *sling.Sling, acceptHeader string, authInfo ...usrInfo) (int, []byte, error) {
+	code, _, body, err := request0(_sling, acceptHeader, authInfo...)
+	return code, body, err
 }
 
 // Search for projects and repositories
@@ -525,23 +532,35 @@ func (a testapi) GetProjectMembersByProID(prjUsr usrInfo, projectID string) (int
 }
 
 // Add project role member accompany with  projectID
-// func (a testapi) AddProjectMember(prjUsr usrInfo, projectID string, roles apilib.RoleParam) (int, error) {
-func (a testapi) AddProjectMember(prjUsr usrInfo, projectID string, member *models.MemberReq) (int, error) {
+// func (a testapi) AddProjectMember(prjUsr usrInfo, projectID string, roles apilib.RoleParam) (int, int, error) {
+func (a testapi) AddProjectMember(prjUsr usrInfo, projectID string, member *models.MemberReq) (int, int, error) {
 	_sling := sling.New().Post(a.basePath)
 
 	path := "/api/projects/" + projectID + "/members/"
 	_sling = _sling.Path(path)
 	_sling = _sling.BodyJSON(member)
-	httpStatusCode, _, err := request(_sling, jsonAcceptHeader, prjUsr)
-	return httpStatusCode, err
+	httpStatusCode, header, _, err := request0(_sling, jsonAcceptHeader, prjUsr)
 
+	var memberID int
+	location := header.Get("Location")
+	if location != "" {
+		parts := strings.Split(location, "/")
+		if len(parts) > 0 {
+			i, err := strconv.Atoi(parts[len(parts)-1])
+			if err == nil {
+				memberID = i
+			}
+		}
+	}
+
+	return httpStatusCode, memberID, err
 }
 
 // Delete project role member accompany with  projectID
-func (a testapi) DeleteProjectMember(authInfo usrInfo, projectID string, userID string) (int, error) {
+func (a testapi) DeleteProjectMember(authInfo usrInfo, projectID string, memberID string) (int, error) {
 	_sling := sling.New().Delete(a.basePath)
 
-	path := "/api/projects/" + projectID + "/members/" + userID
+	path := "/api/projects/" + projectID + "/members/" + memberID
 	_sling = _sling.Path(path)
 	httpStatusCode, _, err := request(_sling, jsonAcceptHeader, authInfo)
 	return httpStatusCode, err

--- a/src/core/api/project_test.go
+++ b/src/core/api/project_test.go
@@ -213,7 +213,8 @@ func TestListProjects(t *testing.T) {
 		},
 	}
 	projectID := strconv.Itoa(addPID)
-	httpStatusCode, err = apiTest.AddProjectMember(*admin, projectID, member)
+	var memberID int
+	httpStatusCode, memberID, err = apiTest.AddProjectMember(*admin, projectID, member)
 	if err != nil {
 		t.Error("Error whihle add project role member", err.Error())
 		t.Log(err)
@@ -233,8 +234,7 @@ func TestListProjects(t *testing.T) {
 		assert.Equal("true", result[0].Metadata[models.ProMetaPublic], "Public is wrong")
 		assert.Equal(int32(2), result[0].CurrentUserRoleId, "User project role is wrong")
 	}
-	id := strconv.Itoa(CommonGetUserID())
-	httpStatusCode, err = apiTest.DeleteProjectMember(*admin, projectID, id)
+	httpStatusCode, err = apiTest.DeleteProjectMember(*admin, projectID, strconv.Itoa(memberID))
 	if err != nil {
 		t.Error("Error whihle add project role member", err.Error())
 		t.Log(err)

--- a/src/core/api/projectmember_test.go
+++ b/src/core/api/projectmember_test.go
@@ -268,6 +268,23 @@ func TestProjectMemberAPI_PutAndDelete(t *testing.T) {
 	if err != nil {
 		t.Errorf("Error occurred when add project member: %v", err)
 	}
+
+	projectID, err := dao.AddProject(models.Project{Name: "memberputanddelete", OwnerID: 1})
+	if err != nil {
+		t.Errorf("Error occurred when add project: %v", err)
+	}
+	defer dao.DeleteProject(projectID)
+
+	memberID, err := project.AddProjectMember(models.Member{
+		ProjectID:  projectID,
+		Role:       1,
+		EntityID:   int(userID),
+		EntityType: "u",
+	})
+	if err != nil {
+		t.Errorf("Error occurred when add project member: %v", err)
+	}
+
 	URL := fmt.Sprintf("/api/projects/1/members/%v", ID)
 	badURL := fmt.Sprintf("/api/projects/1/members/%v", 0)
 	cases := []*codeCheckingCase{
@@ -330,6 +347,18 @@ func TestProjectMemberAPI_PutAndDelete(t *testing.T) {
 			},
 			code: http.StatusBadRequest,
 		},
+		// 404
+		{
+			request: &testingRequest{
+				method: http.MethodPut,
+				url:    fmt.Sprintf("/api/projects/1/members/%v", memberID),
+				bodyJSON: &models.Member{
+					Role: 2,
+				},
+				credential: admin,
+			},
+			code: http.StatusNotFound,
+		},
 		// 200
 		{
 			request: &testingRequest{
@@ -338,6 +367,18 @@ func TestProjectMemberAPI_PutAndDelete(t *testing.T) {
 				credential: admin,
 			},
 			code: http.StatusOK,
+		},
+		// 404
+		{
+			request: &testingRequest{
+				method: http.MethodDelete,
+				url:    fmt.Sprintf("/api/projects/1/members/%v", memberID),
+				bodyJSON: &models.Member{
+					Role: 2,
+				},
+				credential: admin,
+			},
+			code: http.StatusNotFound,
 		},
 	}
 

--- a/src/core/api/robot_test.go
+++ b/src/core/api/robot_test.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/goharbor/harbor/src/common/dao"
 	"github.com/goharbor/harbor/src/common/models"
 	"github.com/goharbor/harbor/src/common/rbac"
 )
@@ -163,6 +164,12 @@ func TestRobotAPIPost(t *testing.T) {
 }
 
 func TestRobotAPIGet(t *testing.T) {
+	projectID, err := dao.AddProject(models.Project{Name: "robotget", OwnerID: 1})
+	if err != nil {
+		t.Errorf("Error occurred when add project: %v", err)
+	}
+	defer dao.DeleteProject(projectID)
+
 	cases := []*codeCheckingCase{
 		// 400
 		{
@@ -179,6 +186,16 @@ func TestRobotAPIGet(t *testing.T) {
 				method:     http.MethodGet,
 				url:        fmt.Sprintf("%s/%d", robotPath, 1000),
 				credential: projDeveloper,
+			},
+			code: http.StatusNotFound,
+		},
+
+		// 404 robot 1 not belong to the project
+		{
+			request: &testingRequest{
+				method:     http.MethodGet,
+				url:        fmt.Sprintf("/api/projects/%d/robots/1", projectID),
+				credential: sysAdmin,
 			},
 			code: http.StatusNotFound,
 		},
@@ -251,6 +268,12 @@ func TestRobotAPIList(t *testing.T) {
 }
 
 func TestRobotAPIPut(t *testing.T) {
+	projectID, err := dao.AddProject(models.Project{Name: "robotput", OwnerID: 1})
+	if err != nil {
+		t.Errorf("Error occurred when add project: %v", err)
+	}
+	defer dao.DeleteProject(projectID)
+
 	cases := []*codeCheckingCase{
 		// 401
 		{
@@ -277,6 +300,16 @@ func TestRobotAPIPut(t *testing.T) {
 				method:     http.MethodPut,
 				url:        fmt.Sprintf("%s/%d", robotPath, 10000),
 				credential: projAdmin4Robot,
+			},
+			code: http.StatusNotFound,
+		},
+
+		// 404 robot 1 not belong to the project
+		{
+			request: &testingRequest{
+				method:     http.MethodPut,
+				url:        fmt.Sprintf("/api/projects/%d/robots/1", projectID),
+				credential: sysAdmin,
 			},
 			code: http.StatusNotFound,
 		},
@@ -319,6 +352,12 @@ func TestRobotAPIPut(t *testing.T) {
 }
 
 func TestRobotAPIDelete(t *testing.T) {
+	projectID, err := dao.AddProject(models.Project{Name: "robotdelete", OwnerID: 1})
+	if err != nil {
+		t.Errorf("Error occurred when add project: %v", err)
+	}
+	defer dao.DeleteProject(projectID)
+
 	cases := []*codeCheckingCase{
 		// 401
 		{
@@ -345,6 +384,16 @@ func TestRobotAPIDelete(t *testing.T) {
 				method:     http.MethodDelete,
 				url:        fmt.Sprintf("%s/%d", robotPath, 10000),
 				credential: projAdmin4Robot,
+			},
+			code: http.StatusNotFound,
+		},
+
+		// 404 robot 1 not belong to the project
+		{
+			request: &testingRequest{
+				method:     http.MethodDelete,
+				url:        fmt.Sprintf("/api/projects/%d/robots/1", projectID),
+				credential: sysAdmin,
 			},
 			code: http.StatusNotFound,
 		},


### PR DESCRIPTION
1. Ensure the project id of the project member match the project id in the URL when update and delete project member.
2. Ensure the project id of the robot account match the project id in the URL when update and delete robot account.

Signed-off-by: He Weiwei <hweiwei@vmware.com>