### PR TITLE
Modify event panel

### DIFF
--- a/src/portal/src/lib/_animations/slide-in-out.animation.ts
+++ b/src/portal/src/lib/_animations/slide-in-out.animation.ts
@@ -4,44 +4,13 @@ import {AnimationTriggerMetadata, trigger, state, animate, transition, style } f
 export const SlideInOutAnimation: AnimationTriggerMetadata =
     // trigger name for attaching this animation to an element using the [@triggerName] syntax
     trigger('SlideInOutAnimation', [
-
-        // end state styles for route container (host)
         state('in', style({
-            // the view covers the whole screen with a semi tranparent background
-            position: 'fix',
             right: 0,
-            width: '350px',
-            bottom: 0
-            // backgroundColor: 'rgba(0, 0, 0, 0.8)'
         })),
         state('out', style({
-            // the view covers the whole screen with a semi tranparent background
-            position: 'fix',
-            width: '30px',
-            bottom: 0
-            // backgroundColor: 'rgba(0, 0, 0, 0.8)'
+            right: '-325px',
         })),
-        // route 'enter' transition
-        transition('out => in', [
-            // animation and styles at end of transition
-            animate('.5s ease-in-out', style({
-                // transition the right position to 0 which slides the content into view
-                width: '350px',
-
-                // transition the background opacity to 0.8 to fade it in
-                // backgroundColor: 'rgba(0, 0, 0, 0.8)'
-            }))
-        ]),
-
-        // route 'leave' transition
-        transition('in => out', [
-            // animation and styles at end of transition
-            animate('.5s ease-in-out', style({
-                // transition the right position to -400% which slides the content out of view
-                width: '30px',
-
-                // transition the background opacity to 0 to fade it out
-                // backgroundColor: 'rgba(0, 0, 0, 0)'
-            }))
+        transition('in <=> out', [
+            animate('0.5s ease-in-out')
         ])
     ]);

--- a/src/portal/src/lib/components/operation/operation.component.css
+++ b/src/portal/src/lib/components/operation/operation.component.css
@@ -17,22 +17,32 @@
 .eventTarget{display: inline-flex; width: 172px; font-size: 12px; flex-shrink:1; overflow: hidden; text-overflow: ellipsis;white-space: nowrap;}
 .eventTime{ float: right; font-size: 12px;}
 :host >>> .nav{padding-left: 38px;}
-.operDiv{position: fixed; top: 60px; right: 0; z-index:100}
-.toolBar{
-    float: left;border-top: 1px solid #ccc;
-    transform: rotate(-90deg);
+
+.operDiv {
+    position: fixed;
+    top: 60px;
+    z-index: 600;
+    width: 350px;
+    bottom: 0
+}
+
+.toolBar {
+    position: absolute;
+    transform-origin: top right;
+    border-top: 1px solid #ccc;
+    transform: translate(-100%, 0) rotate(-90deg);
     margin-top: 10px;
-    padding: 2px 4px;
-    width: 86px;
-    height: 84px;
+    padding: 0 10px;
+    height: 25px;
+    line-height: 25px;
     background-color: white;
     letter-spacing: 1.2px;
     font-weight: 500;
     box-shadow: -2px -1px 3px #bebbbb;
     cursor: pointer;
-    text-align: center;
+    text-align: left;
     text-decoration: none;
-   }
+}
 .freshIcon{float: right;     margin-right: 20px;  margin-top: -10px;cursor: pointer;}
 #contentFailed, #contentAll, #contentRun{
     position: absolute;
@@ -64,4 +74,7 @@
 
 .hidden-info {
     display: none;
+}
+.margin-left-5 {
+    margin-left: 5px;
 }

--- a/src/portal/src/lib/components/operation/operation.component.html
+++ b/src/portal/src/lib/components/operation/operation.component.html
@@ -1,6 +1,7 @@
-<div class="operDiv" [@SlideInOutAnimation]="animationState">
-    <a class="toolBar" (click)="slideOut()">{{'OPERATION.EVENT_LOG' | translate}}<!--<clr-icon shape="angle-double" style="transform: rotate(90deg)"></clr-icon>--></a>
-    <div class="side-form">
+<div class="operDiv" [@SlideInOutAnimation]="animationState" (mouseover)="mouseover()" (mouseleave)="mouseleave()" >
+    <div class="position-relative w-100 h-100">
+        <a class="toolBar" (click)="slideOut()">{{'OPERATION.EVENT_LOG' | translate}}<span *ngIf="getNewMessageCountStr()" class="badge badge-danger margin-left-5">{{getNewMessageCountStr()}}</span></a>
+        <div class="side-form">
         <clr-icon shape="refresh" class="freshIcon" (click)="TabEvent()"></clr-icon>
         <h3 class="custom-h2 event-text">{{'OPERATION.LOCAL_EVENT' | translate}}</h3>
         <div class="tab-top">
@@ -59,6 +60,7 @@
                 </clr-tab>
             </clr-tabs>
         </div>
+    </div>
     </div>
 </div>
 


### PR DESCRIPTION
Fix #9176 ,fix #9175 
1.New one(temporary env: https://10.161.67.1:8082)
![image](https://user-images.githubusercontent.com/30999793/68830725-6af6e980-06e7-11ea-867e-e195a712bad3.png)
When a new event occurs, the event panel won't be opened automatically, but will show a badges.
The opened panel will be closed in 5 seconds automatically after your mouse leaves the panel.

Signed-off-by: AllForNothing <sshijun@vmware.com>