### PR TITLE
Update drone.yml for harbor-e2e-engine upgrade

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -27,7 +27,7 @@ pipeline:
       status: success
 
   test-and-issue-build:
-    image: goharbor/harbor-e2e-engine:1.42
+    image: goharbor/harbor-e2e-engine:1.43
     pull: true
     privileged: true
     environment:


### PR DESCRIPTION
There is a new commit in harbor-e2e-engine:1.42, which is upgrade docker to the latest version, so drone.yml should be update to the new one.

Signed-off-by: Danfeng Liu (c) <danfengl@vmware.com>