### PR TITLE
fix(limited-guest): fix limited guest info missing in summary page

### DIFF
--- a/src/core/api/project.go
+++ b/src/core/api/project.go
@@ -696,6 +696,7 @@ func getProjectMemberSummary(projectID int64, summary *models.ProjectSummary) {
 		{common.RoleMaster, &summary.MasterCount},
 		{common.RoleDeveloper, &summary.DeveloperCount},
 		{common.RoleGuest, &summary.GuestCount},
+		{common.RoleLimitedGuest, &summary.LimitedGuestCount},
 	} {
 		wg.Add(1)
 		go func(role int, count *int64) {

--- a/src/portal/src/app/project/summary/summary.component.html
+++ b/src/portal/src/app/project/summary/summary.component.html
@@ -19,6 +19,7 @@
         <li>{{ summaryInformation?.master_count }} {{'SUMMARY.MASTER' | translate}}</li>
         <li>{{ summaryInformation?.developer_count }} {{'SUMMARY.DEVELOPER' | translate}}</li>
         <li>{{ summaryInformation?.guest_count }} {{'SUMMARY.GUEST' | translate}}</li>
+        <li>{{ summaryInformation?.limited_guest_count }} {{'SUMMARY.LIMITED_GUEST' | translate}}</li>
       </ul>
     </div>
   </div>


### PR DESCRIPTION
The issue of limited guest info missing in summary page was cuased by PR #9490

Signed-off-by: He Weiwei <hweiwei@vmware.com>