### PR TITLE
Failed to start harbor when proxy is set

### DIFF
--- a/make/harbor.yml
+++ b/make/harbor.yml
@@ -157,7 +157,7 @@ _version: 1.10.0
 proxy:
   http_proxy:
   https_proxy:
-  no_proxy: 127.0.0.1,localhost,.local,.internal,log,db,redis,nginx,core,portal,postgresql,jobservice,registry,registryctl,clair
+  no_proxy: 127.0.0.1,localhost,.local,.internal,log,db,redis,nginx,core,portal,postgresql,jobservice,registry,registryctl,clair,chartmuseum,notary-server,clair-adapter
   components:
     - core
     - jobservice


### PR DESCRIPTION
All communication between internal components should bypass the proxy
Add chartmuseum, notary-server,clair-adapter to the no_proxy list in harbor.yml

Signed-off-by: stonezdj <stonezdj@gmail.com>