### PR TITLE
Failed to start harbor when proxy is set

### DIFF
--- a/make/harbor.yml
+++ b/make/harbor.yml
@@ -156,7 +156,7 @@ _version: 1.9.0
 proxy:
   http_proxy:
   https_proxy:
-  no_proxy: 127.0.0.1,localhost,.local,.internal,log,db,redis,nginx,core,portal,postgresql,jobservice,registry,registryctl,clair
+  no_proxy: 127.0.0.1,localhost,.local,.internal,log,db,redis,nginx,core,portal,postgresql,jobservice,registry,registryctl,clair,chartmuseum,notary-server
   components:
     - core
     - jobservice


### PR DESCRIPTION
Fix #9614, all communication between internal components should bypass the proxy
Add chartmuseum, notary-server to the no_proxy list in harbor.yml

Signed-off-by: stonezdj <stonezdj@gmail.com>