### PR TITLE
[Cherry-Pick 1.9.0] Modify CVE whitelist nightly test cases regarding to the solid Clair DB

### DIFF
--- a/tests/robot-cases/Group1-Nightly/Clair.robot
+++ b/tests/robot-cases/Group1-Nightly/Clair.robot
@@ -24,14 +24,12 @@ ${SSH_USER}  root
 ${HARBOR_ADMIN}  admin
 
 *** Test Cases ***
-Test Case - Vulnerability Data Not Ready
-#This case must run before vulnerability db ready
+Test Case - Clair Is Default Scanner And It Is Immutable
     Init Chrome Driver
     Sign In Harbor  ${HARBOR_URL}  ${HARBOR_ADMIN}  ${HARBOR_PASSWORD}
-    Go Into Project  library  has_image=${false}
-    Vulnerability Not Ready Project Hint
-    Switch To Vulnerability Page
-    Vulnerability Not Ready Config Hint
+    Switch To Scanners Page
+    Should Display The Default Clair Scanner
+    Clair Is Immutable Scanner
 
 Test Case - Disable Scan Schedule
     Init Chrome Driver
@@ -66,7 +64,7 @@ Test Case - Scan Image With Empty Vul
     Go Into Repo  busybox
     Scan Repo  latest  Succeed
     Move To Summary Chart
-    Wait Until Page Contains  Unknow
+    Wait Until Page Contains  No vulnerability
     Close Browser
 
 Test Case - Manual Scan All
@@ -74,7 +72,7 @@ Test Case - Manual Scan All
     Push Image  ${ip}  ${HARBOR_ADMIN}  ${HARBOR_PASSWORD}  library  redis
     Sign In Harbor  ${HARBOR_URL}  ${HARBOR_ADMIN}  ${HARBOR_PASSWORD}
     Switch To Vulnerability Page
-    Trigger Scan Now
+    Trigger Scan Now And Wait Until The Result Appears
     Navigate To Projects
     Go Into Project  library
     Go Into Repo  redis
@@ -96,7 +94,6 @@ Test Case - View Scan Error
 
 Test Case - Scan Image On Push
     [Tags]  run-once
-    Wait Unitl Vul Data Ready  ${HARBOR_URL}  7200  30
     Init Chrome Driver
     Push Image  ${ip}  ${HARBOR_ADMIN}  ${HARBOR_PASSWORD}  library  hello-world
     Sign In Harbor  ${HARBOR_URL}  ${HARBOR_ADMIN}  ${HARBOR_PASSWORD}
@@ -130,8 +127,8 @@ Test Case - Project Level Image Serverity Policy
     Init Chrome Driver
     Sign In Harbor  ${HARBOR_URL}  ${HARBOR_ADMIN}  ${HARBOR_PASSWORD}
     ${d}=  get current date  result_format=%m%s
-    ${sha256}=  Set Variable  68b49a280d2fbe9330c0031970ebb72015e1272dfa25f0ed7557514f9e5ad7b7
-    ${image}=  Set Variable  postgres
+    ${sha256}=  Set Variable  9755880356c4ced4ff7745bafe620f0b63dd17747caedba72504ef7bac882089
+    ${image}=  Set Variable  redis
     Create An New Project  project${d}
     Push Image  ${ip}  ${HARBOR_ADMIN}  ${HARBOR_PASSWORD}  project${d}  ${image}  sha256=${sha256}
     Go Into Project  project${d}
@@ -139,7 +136,7 @@ Test Case - Project Level Image Serverity Policy
     Scan Repo  ${sha256}  Succeed
     Navigate To Projects
     Go Into Project  project${d}
-    Set Vulnerabilty Serverity  2
+    Set Vulnerabilty Serverity  3
     Cannot pull image  ${ip}  ${HARBOR_ADMIN}  ${HARBOR_PASSWORD}  project${d}  ${image}  tag=${sha256}
     Close Browser
 
@@ -148,15 +145,15 @@ Test Case - Verfiy System Level CVE Whitelist
     [Tags]  run-once
     Init Chrome Driver
     ${d}=    Get Current Date    result_format=%m%s
-    ${image}=    Set Variable    redis
-    ${sha256}=  Set Variable  9755880356c4ced4ff7745bafe620f0b63dd17747caedba72504ef7bac882089
+    ${image}=    Set Variable    mariadb
+    ${sha256}=  Set Variable  c396eb803be99041e69eed84b0eb880d5474a6b2c1fd5a84268ce0420088d20d
     ${signin_user}=    Set Variable  user025
     ${signin_pwd}=    Set Variable  Test1@34
     Sign In Harbor    ${HARBOR_URL}    ${signin_user}    ${signin_pwd}
     Create An New Project    project${d}
     Push Image    ${ip}    ${signin_user}    ${signin_pwd}    project${d}    ${image}    sha256=${sha256}
     Go Into Project  project${d}
-    Set Vulnerabilty Serverity  1
+    Set Vulnerabilty Serverity  2
     Cannot Pull image    ${ip}    ${signin_user}    ${signin_pwd}    project${d}    ${image}    tag=${sha256}
     Go Into Project  project${d}
     Go Into Repo  project${d}/${image}
@@ -165,9 +162,9 @@ Test Case - Verfiy System Level CVE Whitelist
     Sign In Harbor    ${HARBOR_URL}    ${HARBOR_ADMIN}  ${HARBOR_PASSWORD}
     Switch To Configure
     Switch To Configuration System Setting
-    Add Items To System CVE Whitelist    CVE-2019-12904\nCVE-2011-3389\nCVE-2018-12886\nCVE-2019-3843\nCVE-2018-20839\nCVE-2019-5094\nCVE-2019-15847\nCVE-2019-13627
+    Add Items To System CVE Whitelist    CVE-2019-13050\nCVE-2018-19591\nCVE-2018-11236\nCVE-2018-11237\nCVE-2019-13627\nCVE-2018-20839\nCVE-2019-2923\nCVE-2019-2922\nCVE-2019-2911\nCVE-2019-2914\nCVE-2019-2924\nCVE-2019-2910\nCVE-2019-2938\nCVE-2019-2993\nCVE-2019-2974\nCVE-2019-2960\nCVE-2019-2948\nCVE-2019-2946
     Cannot Pull image    ${ip}    ${signin_user}    ${signin_pwd}    project${d}    ${image}    tag=${sha256}
-    Add Items To System CVE Whitelist    CVE-2019-3844
+    Add Items To System CVE Whitelist    CVE-2019-2969
     Pull Image    ${ip}    ${signin_user}    ${signin_pwd}    project${d}    ${image}    tag=${sha256}
     Delete Top Item In System CVE Whitelist  count=6
     Cannot Pull image    ${ip}    ${signin_user}    ${signin_pwd}    project${d}    ${image}    tag=${sha256}
@@ -177,8 +174,8 @@ Test Case - Verfiy Project Level CVE Whitelist
     [Tags]  run-once
     Init Chrome Driver
     ${d}=    Get Current Date    result_format=%m%s
-    ${image}=    Set Variable    redis
-    ${sha256}=  Set Variable  9755880356c4ced4ff7745bafe620f0b63dd17747caedba72504ef7bac882089
+    ${image}=    Set Variable    mariadb
+    ${sha256}=  Set Variable  c396eb803be99041e69eed84b0eb880d5474a6b2c1fd5a84268ce0420088d20d
     ${signin_user}=    Set Variable  user025
     ${signin_pwd}=    Set Variable  Test1@34
     Sign In Harbor    ${HARBOR_URL}    ${signin_user}    ${signin_pwd}
@@ -186,15 +183,15 @@ Test Case - Verfiy Project Level CVE Whitelist
     Push Image    ${ip}    ${signin_user}    ${signin_pwd}    project${d}    ${image}    sha256=${sha256}
     Pull Image    ${ip}    ${signin_user}    ${signin_pwd}    project${d}    ${image}    tag=${sha256}
     Go Into Project  project${d}
-    Set Vulnerabilty Serverity  1
+    Set Vulnerabilty Serverity  2
     Cannot Pull image    ${ip}    ${signin_user}    ${signin_pwd}    project${d}    ${image}    tag=${sha256}
     Go Into Project  project${d}
     Go Into Repo  project${d}/${image}
     Scan Repo  ${sha256}  Succeed
     Go Into Project  project${d}
-    Add Items to Project CVE Whitelist    CVE-2019-12904\nCVE-2011-3389\nCVE-2018-12886\nCVE-2019-3843\nCVE-2018-20839\nCVE-2019-5094\nCVE-2019-15847\nCVE-2019-13627
+    Add Items to Project CVE Whitelist    CVE-2019-13050\nCVE-2018-19591\nCVE-2018-11236\nCVE-2018-11237\nCVE-2019-13627\nCVE-2018-20839\nCVE-2019-2923\nCVE-2019-2922\nCVE-2019-2911\nCVE-2019-2914\nCVE-2019-2924\nCVE-2019-2910\nCVE-2019-2938\nCVE-2019-2993\nCVE-2019-2974\nCVE-2019-2960\nCVE-2019-2948\nCVE-2019-2946
     Cannot Pull image    ${ip}    ${signin_user}    ${signin_pwd}    project${d}    ${image}    tag=${sha256}
-    Add Items to Project CVE Whitelist    CVE-2019-3844
+    Add Items to Project CVE Whitelist    CVE-2019-2969
     Pull Image    ${ip}    ${signin_user}    ${signin_pwd}    project${d}    ${image}    tag=${sha256}
     Delete Top Item In Project CVE Whitelist
     Cannot Pull image    ${ip}    ${signin_user}    ${signin_pwd}    project${d}    ${image}    tag=${sha256}
@@ -204,20 +201,20 @@ Test Case - Verfiy Project Level CVE Whitelist By Quick Way of Add System
     [Tags]  run-once
     Init Chrome Driver
     ${d}=    Get Current Date    result_format=%m%s
-    ${image}=    Set Variable    redis
-    ${sha256}=  Set Variable  9755880356c4ced4ff7745bafe620f0b63dd17747caedba72504ef7bac882089
+    ${image}=    Set Variable    mariadb
+    ${sha256}=  Set Variable  c396eb803be99041e69eed84b0eb880d5474a6b2c1fd5a84268ce0420088d20d
     ${signin_user}=    Set Variable  user025
     ${signin_pwd}=    Set Variable  Test1@34
     Sign In Harbor    ${HARBOR_URL}    ${HARBOR_ADMIN}  ${HARBOR_PASSWORD}
     Switch To Configure
     Switch To Configuration System Setting
-    Add Items To System CVE Whitelist    CVE-2019-12904\nCVE-2011-3389\nCVE-2018-12886\nCVE-2019-3843\nCVE-2018-20839\nCVE-2019-3844\nCVE-2019-5094\nCVE-2019-15847\nCVE-2019-13627
+    Add Items To System CVE Whitelist    CVE-2019-13050\nCVE-2018-19591\nCVE-2018-11236\nCVE-2018-11237\nCVE-2019-13627\nCVE-2018-20839\nCVE-2019-2923\nCVE-2019-2922\nCVE-2019-2911\nCVE-2019-2914\nCVE-2019-2924\nCVE-2019-2910\nCVE-2019-2938\nCVE-2019-2993\nCVE-2019-2974\nCVE-2019-2960\nCVE-2019-2948\nCVE-2019-2946\nCVE-2019-2969
     Logout Harbor
     Sign In Harbor    ${HARBOR_URL}    ${signin_user}    ${signin_pwd}
     Create An New Project    project${d}
     Push Image    ${ip}    ${signin_user}    ${signin_pwd}    project${d}    ${image}    sha256=${sha256}
     Go Into Project  project${d}
-    Set Vulnerabilty Serverity  1
+    Set Vulnerabilty Serverity  2
     Go Into Project  project${d}
     Go Into Repo  project${d}/${image}
     Scan Repo  ${sha256}  Succeed


### PR DESCRIPTION
Clair DB has already been populated by existing data right after harbor deployed in nightly test, so Clair test case modify some CVE IDs for this Clair DB data.

Signed-off-by: Danfeng Liu (c) <danfengl@vmware.com>