### PR TITLE
Modify redis image size for verification as a temporary solution

### DIFF
--- a/tests/robot-cases/Group1-Nightly/Common.robot
+++ b/tests/robot-cases/Group1-Nightly/Common.robot
@@ -499,7 +499,7 @@ Test Case - Project Storage Quotas Dispaly And Control
     ${storage_quota_unit}=  Set Variable  MB
     ${image_a}=  Set Variable  redis
     ${image_b}=  Set Variable  logstash
-    ${image_a_size}=    Set Variable    34.16MB
+    ${image_a_size}=    Set Variable    34.15MB
     ${image_b_size}=    Set Variable    321.03MB
     ${image_a_ver}=  Set Variable  5.0
     ${image_b_ver}=  Set Variable  6.8.3


### PR DESCRIPTION
It's a temporary solution for quotas case, after internal registry in service, image size will not change any longer.

Signed-off-by: Danfeng Liu (c) <danfengl@vmware.com>