### PR TITLE
[Nightly Test]Add a replication scope keyword for waiting the completion of replication result

### DIFF
--- a/tests/resources/Harbor-Pages/Replication.robot
+++ b/tests/resources/Harbor-Pages/Replication.robot
@@ -235,3 +235,17 @@ Delete Replication Rule
     Retry Element Click  ${action_bar_delete}
     Wait Until Page Contains Element  ${dialog_delete}
     Retry Element Click  ${dialog_delete}
+
+Image Should Be Replicated To Project
+    [Arguments]  ${project}  ${image}  ${period}=60  ${times}=10
+    :For  ${n}  IN RANGE  1  ${times}
+    \    Sleep  ${period}
+    \    Go Into Project    ${project}
+    \    Switch To Project Repo
+    \    #In AWS-ECR, under repository a, there're only several images: httpd,alpine,hello-world.
+    \    ${out}  Run Keyword And Ignore Error  Retry Wait Until Page Contains  ${project}/${image}
+    \    Log To Console  Return value is ${out[0]}
+    \    Exit For Loop If  '${out[0]}'=='PASS'
+    \    Sleep  5
+    Run Keyword If  '${out[0]}'=='FAIL'  Capture Page Screenshot
+    Should Be Equal As Strings  '${out[0]}'  'PASS'

--- a/tests/robot-cases/Group1-Nightly/Replication.robot
+++ b/tests/robot-cases/Group1-Nightly/Replication.robot
@@ -156,14 +156,9 @@ Test Case - Replication Of Pull Images from DockerHub To Self
     Switch To Replication Manage
     Create A Rule With Existing Endpoint    rule${d}    pull    danfengliu/*    image    e${d}    project${d}
     Select Rule And Replicate  rule${d}
-    Sleep    30
-    Go Into Project    project${d}
-    Switch To Project Repo
     #In docker-hub, under repository danfengliu, there're only 2 images: centos,mariadb.
-    Retry Wait Until Page Contains    project${d}/centos
-    Go Into Project    project${d}
-    Switch To Project Repo
-    Retry Wait Until Page Contains    project${d}/mariadb
+    Image Should Be Replicated To Project  project${d}  centos
+    Image Should Be Replicated To Project  project${d}  mariadb
     Close Browser
 
 Test Case - Replication Of Push Images from Self To Harbor
@@ -188,13 +183,11 @@ Test Case - Replication Of Push Images from Self To Harbor
     Sign In Harbor    ${HARBOR_URL}    ${HARBOR_ADMIN}    ${HARBOR_PASSWORD}
     Switch To Replication Manage
     Select Rule And Replicate  rule${d}
-    Sleep    20
+    Sleep  20
     Logout Harbor
     Sign In Harbor    https://${ip1}    ${HARBOR_ADMIN}    ${HARBOR_PASSWORD}
-    Go Into Project    project_dest${d}
-    Switch To Project Repo
-    Retry Wait Until Page Contains    project_dest${d}/hello-world
-    Retry Wait Until Page Contains    project_dest${d}/busybox
+    Image Should Be Replicated To Project  project_dest${d}  hello-world
+    Image Should Be Replicated To Project  project_dest${d}  busybox
     Close Browser
 
 Test Case - Replication Of Push Chart from Self To Harbor
@@ -245,10 +238,7 @@ Test Case - Replication Of Push Images from Self To Harbor By Push Event
     Sign In Harbor    https://${ip1}    ${HARBOR_ADMIN}    ${HARBOR_PASSWORD}
     Create An New Project    project_dest${d}
     Push Image    ${ip}    ${HARBOR_ADMIN}    ${HARBOR_PASSWORD}    project${d}    centos
-    Sleep  10
-    Go Into Project    project_dest${d}
-    Switch To Project Repo
-    Retry Wait Until Page Contains    project_dest${d}/centos
+    Image Should Be Replicated To Project  project_dest${d}  centos
     Close Browser
 
 Test Case - Replication Of Pull Images from AWS-ECR To Self
@@ -262,15 +252,9 @@ Test Case - Replication Of Pull Images from AWS-ECR To Self
     Switch To Replication Manage
     Create A Rule With Existing Endpoint    rule${d}    pull    a/*    image    e${d}    project${d}
     Select Rule And Replicate  rule${d}
-    Sleep    60
-    Go Into Project    project${d}
-    Switch To Project Repo
-    #In AWS-ECR, under repository a, there're only several images: httpd,alpine,hello-world.
-    Retry Wait Until Page Contains    project${d}/httpd
-    Go Into Project    project${d}
-    Switch To Project Repo
-    Retry Wait Until Page Contains    project${d}/alpine
-    Retry Wait Until Page Contains    project${d}/hello-world
+    Image Should Be Replicated To Project  project${d}  httpd
+    Image Should Be Replicated To Project  project${d}  alpine
+    Image Should Be Replicated To Project  project${d}  hello-world
     Close Browser
 
 Test Case - Replication Of Pull Images from Google-GCR To Self
@@ -285,12 +269,6 @@ Test Case - Replication Of Pull Images from Google-GCR To Self
     Create A Rule With Existing Endpoint    rule${d}    pull    eminent-nation-87317/*    image    e${d}    project${d}
     Filter Replicatin Rule  rule${d}
     Select Rule And Replicate  rule${d}
-    Sleep    30
-    Go Into Project    project${d}
-    Switch To Project Repo
-    #In Google-GCR, under repository a, there're only several images: httpd,tomcat.
-    Retry Wait Until Page Contains    project${d}/httpd
-    Go Into Project    project${d}
-    Switch To Project Repo
-    Retry Wait Until Page Contains    project${d}/tomcat
+    Image Should Be Replicated To Project  project${d}  httpd
+    Image Should Be Replicated To Project  project${d}  tomcat
     Close Browser


### PR DESCRIPTION
Add a replication scope keyword for waiting the completion of replication result. All replication test case must use this keyword to verify if image was pulled.

Signed-off-by: Danfeng Liu (c) <danfengl@vmware.com>