### PR TITLE
Core ca bundle bind mount

### DIFF
--- a/make/harbor.yml
+++ b/make/harbor.yml
@@ -4,9 +4,9 @@
 # DO NOT use localhost or 127.0.0.1, because Harbor needs to be accessed by external clients.
 hostname: reg.mydomain.com
 
-# core related config
-core:
-  ca_bundle: /etc/pki/tls/certs/ca-bundle.crt
+# Uncomment the following section if you want to override the default system CA bundle
+# core:
+#  ca_bundle: /etc/pki/tls/certs/ca-bundle.crt
 
 # http related config
 http:

--- a/make/harbor.yml
+++ b/make/harbor.yml
@@ -4,6 +4,10 @@
 # DO NOT use localhost or 127.0.0.1, because Harbor needs to be accessed by external clients.
 hostname: reg.mydomain.com
 
+# core related config
+core:
+  ca_bundle: /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+
 # http related config
 http:
   # port for http, default is 80. If https enabled, this port will redirect to https port

--- a/make/harbor.yml
+++ b/make/harbor.yml
@@ -6,7 +6,7 @@ hostname: reg.mydomain.com
 
 # core related config
 core:
-  ca_bundle: /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+  ca_bundle: /etc/pki/tls/certs/ca-bundle.crt
 
 # http related config
 http:

--- a/make/photon/prepare/templates/docker_compose/docker-compose.yml.jinja
+++ b/make/photon/prepare/templates/docker_compose/docker-compose.yml.jinja
@@ -159,6 +159,11 @@ services:
         source: {{uaa_ca_file}}
         target: /etc/core/certificates/uaa_ca.pem
 {% endif %}
+{% if core_custom_ca_bundle_path %}
+      - type: bind
+        source: {{core_custom_ca_bundle_path}}
+        target: /etc/pki/tls/certs/ca-bundle.crt
+{% endif %}
     networks:
       harbor:
 {% if with_notary %}

--- a/make/photon/prepare/utils/configs.py
+++ b/make/photon/prepare/utils/configs.py
@@ -54,7 +54,7 @@ def validate(conf: dict, **kwargs):
     for conf_key in ('registry_custom_ca_bundle_path', 'core_custom_ca_bundle_path'):
         if conf.get(conf_key):
             custom_ca_bundle_path = conf.get(conf_key) or ''
-            ca_bundle_host_path = os.path.join(host_root_dir, custom_ca_bundle_path)
+            ca_bundle_host_path = os.path.join(host_root_dir, custom_ca_bundle_path.strip('/'))
             try:
                 uid = os.stat(ca_bundle_host_path).st_uid
                 st_mode = os.stat(ca_bundle_host_path).st_mode


### PR DESCRIPTION
We have a need to be able to use ldaps for authentication services against an internal LDAP server that uses an internal PKI. The harbor code utilises golang crypto/tls, which utilises system installed CA bundle for RootCAs when not set. This patch adds that support, as well as a small bug fix for path joining against host_root_dir utilised by prepare.