### PR TITLE
Fix ca bundle path join issue

### DIFF
--- a/make/photon/prepare/utils/configs.py
+++ b/make/photon/prepare/utils/configs.py
@@ -53,7 +53,10 @@ def validate(conf: dict, **kwargs):
     # ca_bundle validate
     if conf.get('registry_custom_ca_bundle_path'):
         registry_custom_ca_bundle_path = conf.get('registry_custom_ca_bundle_path') or ''
-        ca_bundle_host_path = os.path.join(host_root_dir, registry_custom_ca_bundle_path)
+        if registry_custom_ca_bundle_path.startswith('/data/'):
+            ca_bundle_host_path = registry_custom_ca_bundle_path
+        else:
+            ca_bundle_host_path = os.path.join(host_root_dir, registry_custom_ca_bundle_path.lstrip('/'))
         try:
             uid = os.stat(ca_bundle_host_path).st_uid
             st_mode = os.stat(ca_bundle_host_path).st_mode


### PR DESCRIPTION
CA bundle name start with '/' will break the os path join

Signed-off-by: DQ <dengq@vmware.com>