### PR TITLE
Add nightly test case of Robot-Account and fixed 2 issues

### DIFF
--- a/tests/resources/Docker-Util.robot
+++ b/tests/resources/Docker-Util.robot
@@ -23,22 +23,24 @@ Run Docker Info
     Wait Unitl Command Success  docker ${docker-params} info
 
 Pull image
-    [Arguments]  ${ip}  ${user}  ${pwd}  ${project}  ${image}  ${tag}=${null}
+    [Arguments]  ${ip}  ${user}  ${pwd}  ${project}  ${image}  ${tag}=${null}  ${is_robot}=${false}
     Log To Console  \nRunning docker pull ${image}...
     ${image_with_tag}=  Set Variable If  '${tag}'=='${null}'  ${image}  ${image}:${tag}
-    Wait Unitl Command Success  docker login -u ${user} -p ${pwd} ${ip}
+    Run Keyword If  ${is_robot}==${false}  Wait Unitl Command Success  docker login -u ${user} -p ${pwd} ${ip}
+    ...  ELSE  Wait Unitl Command Success  docker login -u robot\\\$${user} -p ${pwd} ${ip}
     ${output}=  Wait Unitl Command Success  docker pull ${ip}/${project}/${image_with_tag}
     Should Contain  ${output}  Digest:
     Should Contain  ${output}  Status:
     Should Not Contain  ${output}  No such image:
 
 Push image
-    [Arguments]  ${ip}  ${user}  ${pwd}  ${project}  ${image}  ${sha256}=${null}
+    [Arguments]  ${ip}  ${user}  ${pwd}  ${project}  ${image}  ${sha256}=${null}  ${is_robot}=${false}
     ${image_with_sha256}=  Set Variable If  '${sha256}'=='${null}'  ${image}  ${image}@sha256:${sha256}
     ${image_with_tag}=  Set Variable If  '${sha256}'=='${null}'  ${image}  ${image}:${sha256}
     Log To Console  \nRunning docker push ${image}...
     Wait Unitl Command Success  docker pull ${image_with_sha256}
-    Wait Unitl Command Success  docker login -u ${user} -p ${pwd} ${ip}
+    Run Keyword If  ${is_robot}==${false}  Wait Unitl Command Success  docker login -u ${user} -p ${pwd} ${ip}
+    ...  ELSE  Wait Unitl Command Success  docker login -u robot\\\$${user} -p ${pwd} ${ip}
     Wait Unitl Command Success  docker tag ${image_with_sha256} ${ip}/${project}/${image_with_tag}
     Wait Unitl Command Success  docker push ${ip}/${project}/${image_with_tag}
     Wait Unitl Command Success  docker logout ${ip}

--- a/tests/resources/Harbor-Pages/Project.robot
+++ b/tests/resources/Harbor-Pages/Project.robot
@@ -182,10 +182,12 @@ Do Log Advanced Search
 
 Go Into Repo
     [Arguments]  ${repoName}
+    Sleep  2
+    Retry Wait Until Page Not Contains Element  ${repo_list_spinner}
     ${repo_name_element}=  Set Variable  xpath=//clr-dg-cell[contains(.,'${repoName}')]/a
     Retry Element Click  ${repo_search_icon}
     Retry Text Input  ${repo_search_input}  ${repoName}
-    Retry Double Keywords When Error  Retry Element Click  ${repo_name_element}  Page Should Not Contain Element  ${repo_name_element}
+    Retry Double Keywords When Error  Retry Element Click  ${repo_name_element}  Retry Wait Until Page Not Contains Element  ${repo_name_element}
     Retry Wait Element  ${tag_table_column_pull_command}
     Retry Wait Element  ${tag_images_btn}
     Capture Page Screenshot  gointo_${repoName}.png

--- a/tests/resources/Harbor-Pages/Project_Elements.robot
+++ b/tests/resources/Harbor-Pages/Project_Elements.robot
@@ -43,6 +43,7 @@ ${tag_delete_btn}  xpath=//tag-repository//clr-datagrid//button[contains(.,'Dele
 ${user_delete_btn}  xpath=/clr-dropdown-menu//button[contains(.,'Delete')]
 #${repo_search_icon}  xpath=//hbr-filter//clr-icon
 #${repo_search_input}  xpath=//hbr-filter//input
+${repo_list_spinner}  xpath=//clr-datagrid//clr-spinner
 ${repo_search_icon}  xpath=//hbr-repository-gridview//clr-datagrid//clr-dg-column[contains(.,'Name')]//clr-dg-string-filter//button//clr-icon
 ${repo_search_input}  xpath=//div[@class[contains(.,'datagrid-filter')]]//input
 ${repo_tag_1st_checkbox}  xpath=//clr-datagrid//clr-dg-row//clr-checkbox-wrapper

--- a/tests/resources/Harbor-Pages/Project_Robot_Account.robot
+++ b/tests/resources/Harbor-Pages/Project_Robot_Account.robot
@@ -1,0 +1,23 @@
+*** Settings ***
+
+Resource  ../../resources/Util.robot
+
+*** Variables ***
+
+*** Keywords ***
+Switch To Project Robot Account
+    Switch To Project Tab Overflow
+    Retry Element Click  ${project_robot_account_tabpage}
+    Retry Wait Until Page Contains Element  ${project_robot_account_create_btn}
+
+Create A Robot Account And Return Token
+    [Arguments]    ${projectname}    ${robot_account_name}    ${project_has_image}=${false}
+    Go Into Project    ${projectname}    has_image=${project_has_image}
+    Switch To Project Robot Account
+    Retry Element Click    ${project_robot_account_create_btn}
+    Retry Text Input    ${project_robot_account_create_name_input}    ${robot_account_name}
+    Retry Double Keywords When Error    Retry Element Click    ${project_robot_account_create_save_btn}    Retry Wait Until Page Not Contains Element    ${project_robot_account_create_save_btn}
+    ${token}=    Get Value    ${project_robot_account_token_input}
+    [Return]    ${token}
+
+

--- a/tests/resources/Harbor-Pages/Project_Robot_Account_Elements.robot
+++ b/tests/resources/Harbor-Pages/Project_Robot_Account_Elements.robot
@@ -1,0 +1,9 @@
+*** Settings ***
+Documentation  This resource provides any keywords related to the Harbor robot-account feature
+
+*** Variables ***
+${project_robot_account_tabpage}  xpath=//project-detail//a[contains(.,'Robot Accounts')]
+${project_robot_account_create_btn}  xpath=//project-detail/app-robot-account//button
+${project_robot_account_token_input}  xpath=//app-robot-account//hbr-copy-input//input
+${project_robot_account_create_name_input}  //input[@id='robot_name']
+${project_robot_account_create_save_btn}  //add-robot//button[contains(.,'SAVE')]

--- a/tests/resources/Util.robot
+++ b/tests/resources/Util.robot
@@ -47,6 +47,8 @@ Resource  Harbor-Pages/Project-Retag.robot
 Resource  Harbor-Pages/Project-Retag_Elements.robot
 Resource  Harbor-Pages/Project-Tag-Retention.robot
 Resource  Harbor-Pages/Project-Tag-Retention_Elements.robot
+Resource  Harbor-Pages/Project_Robot_Account.robot
+Resource  Harbor-Pages/Project_Robot_Account_Elements.robot
 Resource  Harbor-Pages/Replication.robot
 Resource  Harbor-Pages/Replication_Elements.robot
 Resource  Harbor-Pages/UserProfile.robot

--- a/tests/robot-cases/Group1-Nightly/Common.robot
+++ b/tests/robot-cases/Group1-Nightly/Common.robot
@@ -42,20 +42,6 @@ Test Case - Delete A Project
     Delete A Project Without Sign In Harbor
     Close Browser
 
-Test Case - Read Only Mode
-    Init Chrome Driver
-    ${d}=   Get Current Date    result_format=%m%s
-    Sign In Harbor  ${HARBOR_URL}  ${HARBOR_ADMIN}  ${HARBOR_PASSWORD}
-    Create An New Project  project${d}
-
-    Enable Read Only
-    Cannot Push image  ${ip}  ${HARBOR_ADMIN}  ${HARBOR_PASSWORD}  project${d}  busybox:latest
-
-    Disable Read Only
-    Sleep  5
-    Push image  ${ip}  ${HARBOR_ADMIN}  ${HARBOR_PASSWORD}  project${d}  busybox:latest
-    Close Browser
-
 Test Case - Repo Size
     Init Chrome Driver
     ${d}=  Get Current Date    result_format=%m%s
@@ -567,30 +553,6 @@ Test Case - Project Quotas Control Under GC
     Retry Keyword When Return Value Mismatch  Get Project Storage Quota Text From Project Quotas List  0Byte of ${storage_quota}${storage_quota_unit}  60  @{param}
     Close Browser
 
-Test Case - Can Not Retag Image In ReadOnly Mode
-    Init Chrome Driver
-    ${random_num1}=   Get Current Date    result_format=%m%s
-    ${random_num2}=   Evaluate  str(random.randint(1000,9999))  modules=random
-
-    Sign In Harbor  ${HARBOR_URL}  ${HARBOR_ADMIN}  ${HARBOR_PASSWORD}
-    Create An New Project  project${random_num1}
-    Create An New Project  project${random_num1}${random_num2}
-
-    Go Into Project  project${random_num1}  has_image=${false}
-    Sleep  1
-    Push Image With Tag  ${ip}  ${HARBOR_ADMIN}  ${HARBOR_PASSWORD}  project${random_num1}  redis  ${image_tag}
-    Sleep  1
-    Enable Read Only
-    Go Into Repo  project${random_num1}/redis
-    Retag Image  ${image_tag}  project${random_num1}${random_num2}  ${target_image_name}  ${target_tag_value}
-    Retry Wait Element Not Visible  ${repo_retag_confirm_dlg}
-    Navigate To Projects
-    Go Into Project  project${random_num1}${random_num2}  has_image=${false}
-    Sleep  10
-    Go Into Project  project${random_num1}${random_num2}  has_image=${false}
-    Disable Read Only
-    Close Browser
-
 Test Case - Create New Webhook
     Init Chrome Driver
     ${d}=    Get Current Date    result_format=%m%s
@@ -642,3 +604,54 @@ Test Case - Tag Retention
     Execute Dry Run
     Execute Run
     Close Browser
+
+Test Case - Robot Account
+    Init Chrome Driver
+    ${d}=    Get Current Date    result_format=%m%s
+    Sign In Harbor    ${HARBOR_URL}    ${HARBOR_ADMIN}    ${HARBOR_PASSWORD}
+    Create An New Project    project${d}
+    ${token}=    Create A Robot Account And Return Token    project${d}    robot${d}
+    Log To Console    ${token}
+    Log    ${token}
+    Push image  ${ip}  robot${d}  ${token}  project${d}  hello-world:latest  is_robot=${true}
+    Pull image  ${ip}  robot${d}  ${token}  project${d}  hello-world:latest  is_robot=${true}
+
+Test Case - Read Only Mode
+    Init Chrome Driver
+    ${d}=   Get Current Date    result_format=%m%s
+    Sign In Harbor  ${HARBOR_URL}  ${HARBOR_ADMIN}  ${HARBOR_PASSWORD}
+    Create An New Project  project${d}
+
+    Enable Read Only
+    Cannot Push image  ${ip}  ${HARBOR_ADMIN}  ${HARBOR_PASSWORD}  project${d}  busybox:latest
+
+    Disable Read Only
+    Sleep  5
+    Push image  ${ip}  ${HARBOR_ADMIN}  ${HARBOR_PASSWORD}  project${d}  busybox:latest
+    Close Browser
+
+Test Case - Can Not Retag Image In ReadOnly Mode
+    Init Chrome Driver
+    ${random_num1}=   Get Current Date    result_format=%m%s
+    ${random_num2}=   Evaluate  str(random.randint(1000,9999))  modules=random
+
+    Sign In Harbor  ${HARBOR_URL}  ${HARBOR_ADMIN}  ${HARBOR_PASSWORD}
+    Create An New Project  project${random_num1}
+    Create An New Project  project${random_num1}${random_num2}
+
+    Go Into Project  project${random_num1}  has_image=${false}
+    Sleep  1
+    Push Image With Tag  ${ip}  ${HARBOR_ADMIN}  ${HARBOR_PASSWORD}  project${random_num1}  redis  ${image_tag}
+    Sleep  1
+    Enable Read Only
+    Go Into Repo  project${random_num1}/redis
+    Retag Image  ${image_tag}  project${random_num1}${random_num2}  ${target_image_name}  ${target_tag_value}
+    Retry Wait Element Not Visible  ${repo_retag_confirm_dlg}
+    Navigate To Projects
+    Go Into Project  project${random_num1}${random_num2}  has_image=${false}
+    Sleep  10
+    Go Into Project  project${random_num1}${random_num2}  has_image=${false}
+    Disable Read Only
+    Close Browser
+
+


### PR DESCRIPTION
1. Add nightly test case of Robot-Account; 2. In Go Into Repo keyword, filter element should not be clicked since list in loading state, so add some sleep and waiting for the cirlce icon is gone; 3. Move read-only test case in the end of common.robot.

Signed-off-by: Danfeng Liu (c) <danfengl@vmware.com>