### PR TITLE
Return HTTP 400 instead of 500 internalServerError when token service parse image repository string

### DIFF
--- a/src/core/service/token/creator.go
+++ b/src/core/service/token/creator.go
@@ -88,6 +88,12 @@ type image struct {
 	tag       string
 }
 
+type parseImageError struct{}
+
+func (e *parseImageError) Error() string {
+	return "ParseImageError"
+}
+
 type basicParser struct{}
 
 func (b basicParser) parse(s string) (*image, error) {
@@ -101,7 +107,8 @@ type endpointParser struct {
 func (e endpointParser) parse(s string) (*image, error) {
 	repo := strings.SplitN(s, "/", 2)
 	if len(repo) < 2 {
-		return nil, fmt.Errorf("Unable to parse image from string: %s", s)
+		log.Errorf("Unable to parse image from string: %s", s)
+		return nil, &parseImageError{}
 	}
 	if repo[0] != e.endpoint {
 		return nil, fmt.Errorf("Mismatch endpoint from string: %s, expected endpoint: %s", s, e.endpoint)
@@ -113,7 +120,8 @@ func (e endpointParser) parse(s string) (*image, error) {
 func parseImg(s string) (*image, error) {
 	repo := strings.SplitN(s, "/", 2)
 	if len(repo) < 2 {
-		return nil, fmt.Errorf("Unable to parse image from string: %s", s)
+		log.Errorf("Unable to parse image from string: %s", s)
+		return nil, &parseImageError{}
 	}
 	i := strings.SplitN(repo[1], ":", 2)
 	res := &image{

--- a/src/core/service/token/token.go
+++ b/src/core/service/token/token.go
@@ -44,6 +44,10 @@ func (h *Handler) Get() {
 	if err != nil {
 		if _, ok := err.(*unauthorizedError); ok {
 			h.CustomAbort(http.StatusUnauthorized, "")
+		} else if _, ok :=err.(*parseImageError); ok {
+			errMsg := fmt.Sprintf("invalid project name")
+			log.Errorf(errMsg)
+			h.CustomAbort(http.StatusBadRequest, "")
 		}
 		log.Errorf("Unexpected error when creating the token, error: %v", err)
 		h.CustomAbort(http.StatusInternalServerError, "")

--- a/src/core/service/token/token.go
+++ b/src/core/service/token/token.go
@@ -44,7 +44,7 @@ func (h *Handler) Get() {
 	if err != nil {
 		if _, ok := err.(*unauthorizedError); ok {
 			h.CustomAbort(http.StatusUnauthorized, "")
-		} else if _, ok :=err.(*parseImageError); ok {
+		} else if _, ok := err.(*parseImageError); ok {
 			errMsg := fmt.Sprintf("invalid project name")
 			log.Errorf(errMsg)
 			h.CustomAbort(http.StatusBadRequest, "")


### PR DESCRIPTION
When I pull docker image just like 
`docker pull my.harbor.com/pause:3.1`

I got error：
> Get https://my.harbor.com/v2/pause/manifests/3.1: received unexpected HTTP status: 500 Internal Server Error

It's  a little bit misleading  that user might thought something wrong with harbor serivce.

IMHO, may be return HTTP 400 is more helpful