### PR TITLE
chore[api]:rename API folder to api

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -452,7 +452,7 @@ swagger_client:
 	wget -q http://central.maven.org/maven2/io/swagger/swagger-codegen-cli/2.3.1/swagger-codegen-cli-2.3.1.jar -O swagger-codegen-cli.jar
 	rm -rf harborclient
 	mkdir harborclient
-	java -jar swagger-codegen-cli.jar generate -i API/harbor/swagger.yaml -l python -o harborclient
+	java -jar swagger-codegen-cli.jar generate -i api/harbor/swagger.yaml -l python -o harborclient
 	cd harborclient; python ./setup.py install
 	pip install docker -q
 	pip freeze

--- a/api/harbor/README
+++ b/api/harbor/README
@@ -1,0 +1,18 @@
+# References
+ 
+This file lists all the files that are referring the swagger yaml file.
+
+- Makefile
+  - `java -jar swagger-codegen-cli.jar generate -i api/harbor/swagger.yaml -l python -o harborclient`
+- README
+  - `Harbor RESTful API` in `API` section
+- docs/configure_swagger.md
+  - `https://raw.githubusercontent.com/goharbor/harbor/master/api/harbor/swagger.yaml`
+- make/photon/portal/Dockerfile
+  - `COPY ./api/harbor/swagger.yaml /build_dir`
+- tests/swaggerchecker.sh
+  - `HARBOR_SWAGGER_FILE="https://raw.githubusercontent.com/$TRAVIS_REPO_SLUG/$TRAVIS_COMMIT/api/harbor/swagger.yaml"`
+  - else `HARBOR_SWAGGER_FILE="https://raw.githubusercontent.com/$TRAVIS_PULL_REQUEST_SLUG/$TRAVIS_PULL_REQUEST_SHA/api/harbor/swagger.yaml"`
+
+
+**Notes:** Base path is the code repository root dir.

--- a/docs/configure_swagger.md
+++ b/docs/configure_swagger.md
@@ -14,7 +14,7 @@ From time to time, you may need to mannually test Harbor REST API. You can deplo
 
 * Download _prepare-swagger.sh_ and _swagger.yaml_ under the _docs_ directory to your local Harbor directory, e.g. **~/harbor**.
 ```sh
-  wget https://raw.githubusercontent.com/goharbor/harbor/master/docs/prepare-swagger.sh https://raw.githubusercontent.com/goharbor/harbor/master/API/harbor/swagger.yaml
+  wget https://raw.githubusercontent.com/goharbor/harbor/master/docs/prepare-swagger.sh https://raw.githubusercontent.com/goharbor/harbor/master/api/harbor/swagger.yaml
 ```
 * Edit the script file _prepare-swagger.sh_.
 ```sh

--- a/make/photon/portal/Dockerfile
+++ b/make/photon/portal/Dockerfile
@@ -13,7 +13,7 @@ COPY src/portal/package-lock.json /build_dir
 ENV NPM_CONFIG_REGISTRY=${npm_registry}
 RUN npm install
 
-COPY ./API/harbor/swagger.yaml /build_dir
+COPY ./api/harbor/swagger.yaml /build_dir
 RUN python -c 'import sys, yaml, json; y=yaml.load(sys.stdin.read()); print json.dumps(y)' < swagger.yaml > swagger.json
 
 COPY ./LICENSE /build_dir

--- a/tests/swaggerchecker.sh
+++ b/tests/swaggerchecker.sh
@@ -4,9 +4,9 @@ set +e
 
 SWAGGER_ONLINE_VALIDATOR="http://online.swagger.io/validator"
 if [ $TRAVIS_EVENT_TYPE = "push" ]; then
-	HARBOR_SWAGGER_FILE="https://raw.githubusercontent.com/$TRAVIS_REPO_SLUG/$TRAVIS_COMMIT/API/harbor/swagger.yaml"
+	HARBOR_SWAGGER_FILE="https://raw.githubusercontent.com/$TRAVIS_REPO_SLUG/$TRAVIS_COMMIT/api/harbor/swagger.yaml"
 elif [ $TRAVIS_EVENT_TYPE = "pull_request" ]; then
-	HARBOR_SWAGGER_FILE="https://raw.githubusercontent.com/$TRAVIS_PULL_REQUEST_SLUG/$TRAVIS_PULL_REQUEST_SHA/API/harbor/swagger.yaml"
+	HARBOR_SWAGGER_FILE="https://raw.githubusercontent.com/$TRAVIS_PULL_REQUEST_SLUG/$TRAVIS_PULL_REQUEST_SHA/api/harbor/swagger.yaml"
 else
 	echo "* don't support this kinds of action ($TRAVIS_EVENT_TYPE), but don't fail the travis CI."
 	exit 0


### PR DESCRIPTION
- update swagger yaml file reference in `Makefile`
- update swagger yaml file reference in `README`
- update swagger yaml file reference in `docs/configure_swagger.md`
- update swagger yaml file reference in `make/photon/portal/Dockerfile`
- update swagger yaml file reference in `tests/swaggerchecker.sh`

Signed-off-by: Steven Zou <szou@vmware.com>