### PR TITLE
redirect http request to https when harbor use https

### DIFF
--- a/make/photon/prepare/templates/nginx/nginx.https.conf.jinja
+++ b/make/photon/prepare/templates/nginx/nginx.https.conf.jinja
@@ -38,6 +38,10 @@ http {
 
   server {
     listen 8443 ssl;
+
+    if ($scheme = http ) {
+       return 301 https://$host:5000$request_uri; }
+
 #    server_name harbordomain.com;
     server_tokens off;
     # SSL

--- a/make/photon/prepare/templates/nginx/nginx.https.conf.jinja
+++ b/make/photon/prepare/templates/nginx/nginx.https.conf.jinja
@@ -39,15 +39,15 @@ http {
   server {
     listen 8443 ssl;
 
-    if ($scheme = http ) {
-       return 301 https://$host:8443$request_uri; }
-
 #    server_name harbordomain.com;
     server_tokens off;
     # SSL
     ssl_certificate {{ssl_cert}};
     ssl_certificate_key {{ssl_cert_key}};
-  
+
+    # use nginx 497 error code to redirect http request to https
+    error_page 497 301 =307 https://$host:$server_port$request_uri;
+
     # Recommendations from https://raymii.org/s/tutorials/Strong_SSL_Security_On_nginx.html
     ssl_protocols TLSv1.2;
     ssl_ciphers '!aNULL:kECDH+AESGCM:ECDH+AESGCM:RSA+AESGCM:kECDH+AES:ECDH+AES:RSA+AES:';

--- a/make/photon/prepare/templates/nginx/nginx.https.conf.jinja
+++ b/make/photon/prepare/templates/nginx/nginx.https.conf.jinja
@@ -40,7 +40,7 @@ http {
     listen 8443 ssl;
 
     if ($scheme = http ) {
-       return 301 https://$host:5000$request_uri; }
+       return 301 https://$host:8443$request_uri; }
 
 #    server_name harbordomain.com;
     server_tokens off;


### PR DESCRIPTION
user will get 400 bad request when open harbor url without https schem.
![image](https://user-images.githubusercontent.com/7972153/70677555-762f3c00-1cca-11ea-9d31-6ceca2a4b95a.png)

It would be convenient for user If we add redirect http request to https 