### PR TITLE
Fixing swagger.yaml link

### DIFF
--- a/docs/configure_swagger.md
+++ b/docs/configure_swagger.md
@@ -2,7 +2,7 @@
 A Swagger file is provided for viewing and testing Harbor REST API.
 
 ### Viewing Harbor REST API
-* Open the file **swagger.yaml** under the _docs_ directory in Harbor project;
+* Open the file **swagger.yaml** under the _api/harbor_ directory in Harbor project;
 * Paste all its content into the online Swagger Editor at http://editor.swagger.io. The descriptions of Harbor API will be shown on the right pane of the page.
 
 ![Swagger Editor](img/swaggerEditor.png)


### PR DESCRIPTION
swagger.yaml does not exist under harbor/docs anymore
It exists under harbor/api/harbor