### PR TITLE
Stastics API should handle group members - cherrypick to 1.10

### DIFF
--- a/src/core/api/statistic.go
+++ b/src/core/api/statistic.go
@@ -67,7 +67,7 @@ func (s *StatisticAPI) Get() {
 	if len(pubProjs) == 0 {
 		statistic[PubRC] = 0
 	} else {
-		ids := []int64{}
+		ids := make([]int64, 0)
 		for _, p := range pubProjs {
 			ids = append(ids, p.ProjectID)
 		}
@@ -101,30 +101,26 @@ func (s *StatisticAPI) Get() {
 		statistic[TRC] = n
 		statistic[PriRC] = n - statistic[PubRC]
 	} else {
-		value := false
-		result, err := s.ProjectMgr.List(&models.ProjectQueryParam{
-			Public: &value,
-			Member: &models.MemberQuery{
-				Name: s.username,
-			},
-		})
+		// including the public ones
+		myProjects, err := s.SecurityCtx.GetMyProjects()
+		privProjectIDs := make([]int64, 0)
 		if err != nil {
 			s.ParseAndHandleError(fmt.Sprintf(
 				"failed to get projects of user %s", s.username), err)
 			return
 		}
+		for _, p := range myProjects {
+			if !p.IsPublic() {
+				privProjectIDs = append(privProjectIDs, p.ProjectID)
+			}
+		}
 
-		statistic[PriPC] = result.Total
-		if result.Total == 0 {
+		statistic[PriPC] = int64(len(privProjectIDs))
+		if statistic[PriPC] == 0 {
 			statistic[PriRC] = 0
 		} else {
-			ids := []int64{}
-			for _, p := range result.Projects {
-				ids = append(ids, p.ProjectID)
-			}
-
 			n, err := dao.GetTotalOfRepositories(&models.RepositoryQuery{
-				ProjectIDs: ids,
+				ProjectIDs: privProjectIDs,
 			})
 			if err != nil {
 				s.SendInternalServerError(fmt.Errorf(


### PR DESCRIPTION
statistic API use security Context to list project rather than calling
projectmanager directly, such that the group membership will be taken
into account.
fixes #10230

It should be cherry picked to 1.9.x and 1.10.x branches

Signed-off-by: Daniel Jiang <jiangd@vmware.com>