### PR TITLE
docs: fix mismatched tags names in Tag Retention Rules

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -1151,7 +1151,7 @@ For example, you have following tags, listed according to their push time, and a
 - `harbor-nightly`, pushed 8/14/2019 06:00am
 - `harbor-latest`, pushed 8/14/2019 09:00am
 
-You configure a retention policy to retain the two latest tags that match `harbor-*`, so that `harbor-rc` and `harbor-latest` are deleted. However, since all tags refer to the same SHA digest, this policy would also delete the tags `harbor-1.8` and `harbor-release`, so all tags are retained.
+You configure a retention policy to retain the two latest tags that match `harbor-*`, so that `harbor-release` and `harbor-nightly` are deleted. However, since all tags refer to the same SHA digest, this policy would also delete the tags `harbor-1.8` and `harbor-latest`, so all tags are retained.
 
 ### Combining Rules on a Repository
 


### PR DESCRIPTION
I found the mismatch docs while reading user guide and fix it, please check.