### PR TITLE
Fix search response schema in swagger

### DIFF
--- a/api/harbor/swagger.yaml
+++ b/api/harbor/swagger.yaml
@@ -46,11 +46,9 @@ paths:
         - Products
       responses:
         '200':
-          description: An array of search results
+          description: Search results
           schema:
-            type: array
-            items:
-              $ref: '#/definitions/Search'
+            $ref: '#/definitions/Search'
         '500':
           description: Unexpected internal errors.
   /projects:


### PR DESCRIPTION
A small fix to the swagger definition since the search response is not an array but an object.