### PR TITLE
Disable XSRF check for /service/token - cherry pick to 1.10

### DIFF
--- a/src/core/service/token/token.go
+++ b/src/core/service/token/token.go
@@ -27,6 +27,13 @@ type Handler struct {
 	beego.Controller
 }
 
+// Prepare disables xsrf for /service/token endpoint.
+// This is done on purpose b/c containerd will try to send POST and fallback to GET
+// more details see #10305
+func (h *Handler) Prepare() {
+	h.EnableXSRF = false
+}
+
 // Get handles GET request, it checks the http header for user credentials
 // and parse service and scope based on docker registry v2 standard,
 // checks the permission against local DB and generates jwt token.


### PR DESCRIPTION
This commit disables XSRF check for "service/token" so that when
containerd sends `POST` it will not return 403 and containerd can
fallback to `GET` to complete the workflow.

Fixes #10305

Signed-off-by: Daniel Jiang <jiangd@vmware.com>