### PR TITLE
Populate basic auth information for registry

### DIFF
--- a/make/harbor.yml.tmpl
+++ b/make/harbor.yml.tmpl
@@ -26,6 +26,9 @@ https:
 # Remember Change the admin password from UI after launching Harbor.
 harbor_admin_password: Harbor12345
 
+#TODO: remove this temporary flag before ships v1.11/v2, this should always be true
+registry_use_basic_auth: false
+
 # Harbor DB configuration
 database:
   # The password for the root user of Harbor DB. Change this before any production use.

--- a/make/photon/prepare/Dockerfile.base
+++ b/make/photon/prepare/Dockerfile.base
@@ -1,5 +1,6 @@
 FROM photon:2.0
 
-RUN tdnf install -y python3 \
-    && tdnf install -y python3-pip
+RUN tdnf install -y python3 python3-pip httpd
 RUN pip3 install pipenv==2018.11.26
+
+

--- a/make/photon/prepare/main.py
+++ b/make/photon/prepare/main.py
@@ -35,7 +35,7 @@ def main(conf, with_notary, with_clair, with_chartmuseum):
     try:
         validate(config_dict, notary_mode=with_notary)
     except Exception as e:
-        logging.info('Error happend in config validation...')
+        logging.info('Error happened in config validation...')
         logging.error(e)
         sys.exit(-1)
 

--- a/make/photon/prepare/templates/core/env.jinja
+++ b/make/photon/prepare/templates/core/env.jinja
@@ -44,6 +44,8 @@ RELOAD_KEY={{reload_key}}
 CHART_REPOSITORY_URL={{chart_repository_url}}
 REGISTRY_CONTROLLER_URL={{registry_controller_url}}
 WITH_CHARTMUSEUM={{with_chartmuseum}}
+REGISTRY_CREDENTIAL_USERNAME={{registry_username}}
+REGISTRY_CREDENTIAL_PASSWORD={{registry_password}}
 
 HTTP_PROXY={{core_http_proxy}}
 HTTPS_PROXY={{core_https_proxy}}

--- a/make/photon/prepare/templates/registry/config.yml.jinja
+++ b/make/photon/prepare/templates/registry/config.yml.jinja
@@ -26,11 +26,17 @@ http:
   debug:
     addr: localhost:5001
 auth:
+{% if registry_use_basic_auth %}
+  htpasswd:
+    realm: harbor-registry-basic-realm
+    path: /etc/registry/passwd
+{% else %}
   token:
     issuer: harbor-token-issuer
     realm: {{public_url}}/service/token
     rootcertbundle: /etc/registry/root.crt
     service: harbor-registry
+{% endif %}
 validation:
   disabled: true
 notifications:

--- a/make/photon/prepare/utils/cert.py
+++ b/make/photon/prepare/utils/cert.py
@@ -1,14 +1,14 @@
 # Get or generate private key
-import os, sys, subprocess, shutil
+import os, subprocess, shutil
 from pathlib import Path
 from subprocess import DEVNULL
-from functools import wraps
 
 from g import DEFAULT_GID, DEFAULT_UID
 from .misc import (
     mark_file,
     generate_random_string,
-    check_permission)
+    check_permission,
+    stat_decorator)
 
 SSL_CERT_PATH = os.path.join("/etc/cert", "server.crt")
 SSL_CERT_KEY_PATH = os.path.join("/etc/cert", "server.key")
@@ -43,19 +43,6 @@ def get_secret_key(path):
 def get_alias(path):
     alias = _get_secret(path, "defaultalias", length=8)
     return alias
-
-## decorator actions
-def stat_decorator(func):
-    @wraps(func)
-    def check_wrapper(*args, **kw):
-        stat = func(*args, **kw)
-        if stat == 0:
-            print("Generated certificate, key file: {key_path}, cert file: {cert_path}".format(**kw))
-        else:
-            print("Fail to generate key file: {key_path}, cert file: {cert_path}".format(**kw))
-            sys.exit(1)
-    return check_wrapper
-
 
 @stat_decorator
 def create_root_cert(subj, key_path="./k.key", cert_path="./cert.crt"):

--- a/make/photon/prepare/utils/configs.py
+++ b/make/photon/prepare/utils/configs.py
@@ -9,6 +9,8 @@ default_db_max_open_conns = 0  # NOTE: https://golang.org/pkg/database/sql/#DB.S
 default_https_cert_path = '/your/certificate/path'
 default_https_key_path = '/your/certificate/path'
 
+REGISTRY_USER_NAME = 'harbor_registry_user'
+
 
 def validate(conf: dict, **kwargs):
     # hostname validate
@@ -83,12 +85,14 @@ def validate(conf: dict, **kwargs):
     # TODO:
     # If user enable trust cert dir, need check if the files in this dir is readable.
 
+
 def parse_versions():
     if not versions_file_path.is_file():
         return {}
     with open('versions') as f:
         versions = yaml.load(f)
     return versions
+
 
 def parse_yaml_config(config_file_path, with_notary, with_clair, with_chartmuseum):
     '''
@@ -320,6 +324,12 @@ def parse_yaml_config(config_file_path, with_notary, with_clair, with_chartmuseu
 
     # UAA configs
     config_dict['uaa'] = configs.get('uaa') or {}
+
+    config_dict['registry_username'] = REGISTRY_USER_NAME
+    config_dict['registry_password'] = generate_random_string(32)
+
+    # TODO: remove the flag before release
+    config_dict['registry_use_basic_auth'] = configs['registry_use_basic_auth']
 
     return config_dict
 

--- a/make/photon/prepare/utils/misc.py
+++ b/make/photon/prepare/utils/misc.py
@@ -1,10 +1,9 @@
-import os
-import string
+import os, string, sys
 import secrets
 from pathlib import Path
+from functools import wraps
 
 from g import DEFAULT_UID, DEFAULT_GID
-
 
 # To meet security requirement
 # By default it will change file mode to 0600, and make the owner of the file to 10000:10000
@@ -154,3 +153,18 @@ def other_can_read(st_mode: int) -> bool:
     Check if other user have the read permission of this st_mode
     """
     return True if st_mode & 0o004 else False
+
+
+# decorator actions
+def stat_decorator(func):
+    @wraps(func)
+    def check_wrapper(*args, **kw):
+        stat = func(*args, **kw)
+        if stat == 0:
+            print("Successfully called func: %s" % func.__name__)
+        else:
+            print("Failed to call func: %s" % func.__name__)
+            sys.exit(1)
+    return check_wrapper
+
+

--- a/src/core/config/config.go
+++ b/src/core/config/config.go
@@ -299,6 +299,11 @@ func CoreSecret() string {
 	return os.Getenv("CORE_SECRET")
 }
 
+// RegistryCredential returns the username and password the core uses to access registry
+func RegistryCredential() (string, string) {
+	return os.Getenv("REGISTRY_CREDENTIAL_USERNAME"), os.Getenv("REGISTRY_CREDENTIAL_PASSWORD")
+}
+
 // JobserviceSecret returns a secret to mark Jobservice when communicate with
 // other component
 // TODO replace it with method of SecretStore


### PR DESCRIPTION
This commit updates `prepare` and templates to populate the credential
for registry for basic authentication.

A temporary flag `registry_use_basic_auth` was added to avoid breakage.
It MUST be removed before the release.

Signed-off-by: Daniel Jiang <jiangd@vmware.com>