### PR TITLE
fix(scan-job): fetch bearer token for scanner adapter in scan job

### DIFF
--- a/src/common/config/context.go
+++ b/src/common/config/context.go
@@ -1,0 +1,32 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"context"
+)
+
+type cfgMgrKey struct{}
+
+// FromContext returns CfgManager from context
+func FromContext(ctx context.Context) (*CfgManager, bool) {
+	m, ok := ctx.Value(cfgMgrKey{}).(*CfgManager)
+	return m, ok
+}
+
+// NewContext returns context with CfgManager
+func NewContext(ctx context.Context, m *CfgManager) context.Context {
+	return context.WithValue(ctx, cfgMgrKey{}, m)
+}

--- a/src/jobservice/job/impl/context.go
+++ b/src/jobservice/job/impl/context.go
@@ -16,12 +16,12 @@ package impl
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"sync"
 	"time"
 
-	"errors"
 	comcfg "github.com/goharbor/harbor/src/common/config"
 	"github.com/goharbor/harbor/src/common/dao"
 	"github.com/goharbor/harbor/src/jobservice/config"
@@ -53,7 +53,7 @@ type Context struct {
 // NewContext ...
 func NewContext(sysCtx context.Context, cfgMgr *comcfg.CfgManager) *Context {
 	return &Context{
-		sysContext: sysCtx,
+		sysContext: comcfg.NewContext(sysCtx, cfgMgr),
 		cfgMgr:     *cfgMgr,
 		properties: make(map[string]interface{}),
 	}

--- a/src/pkg/robot/controller.go
+++ b/src/pkg/robot/controller.go
@@ -2,6 +2,8 @@ package robot
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/dgrijalva/jwt-go"
 	"github.com/goharbor/harbor/src/common"
 	"github.com/goharbor/harbor/src/common/utils/log"
@@ -11,8 +13,9 @@ import (
 	"github.com/goharbor/harbor/src/pkg/token"
 	robot_claim "github.com/goharbor/harbor/src/pkg/token/claims/robot"
 	"github.com/pkg/errors"
-	"time"
 )
+
+// go:generate mockery -case underscore -name Controller
 
 var (
 	// RobotCtr is a global variable for the default robot account controller implementation

--- a/src/pkg/robot/model/robot.go
+++ b/src/pkg/robot/model/robot.go
@@ -1,11 +1,14 @@
 package model
 
 import (
+	"encoding/json"
+	"errors"
+	"time"
+
 	"github.com/astaxie/beego/orm"
 	"github.com/astaxie/beego/validation"
 	"github.com/goharbor/harbor/src/common/rbac"
 	"github.com/goharbor/harbor/src/common/utils"
-	"time"
 )
 
 // RobotTable is the name of table in DB that holds the robot object
@@ -32,6 +35,25 @@ type Robot struct {
 // TableName ...
 func (r *Robot) TableName() string {
 	return RobotTable
+}
+
+// FromJSON parses robot from json data
+func (r *Robot) FromJSON(jsonData string) error {
+	if len(jsonData) == 0 {
+		return errors.New("empty json data to parse")
+	}
+
+	return json.Unmarshal([]byte(jsonData), r)
+}
+
+// ToJSON marshals Robot to JSON data
+func (r *Robot) ToJSON() (string, error) {
+	data, err := json.Marshal(r)
+	if err != nil {
+		return "", err
+	}
+
+	return string(data), nil
 }
 
 // RobotQuery ...

--- a/src/pkg/scan/api/scan/base_controller_test.go
+++ b/src/pkg/scan/api/scan/base_controller_test.go
@@ -15,7 +15,6 @@
 package scan
 
 import (
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"testing"
@@ -184,8 +183,7 @@ func (suite *ControllerTestSuite) SetupSuite() {
 	// Set job parameters
 	req := &v1.ScanRequest{
 		Registry: &v1.Registry{
-			URL:           "https://core.com",
-			Authorization: "Basic " + base64.StdEncoding.EncodeToString([]byte(common.RobotPrefix+"the-uuid-123:robot-account")),
+			URL: "https://core.com",
 		},
 		Artifact: suite.artifact,
 	}
@@ -196,12 +194,17 @@ func (suite *ControllerTestSuite) SetupSuite() {
 	regJSON, err := suite.registration.ToJSON()
 	require.NoError(suite.T(), err)
 
+	rb, _ := rc.CreateRobotAccount(account)
+	robotJSON, err := rb.ToJSON()
+	require.NoError(suite.T(), err)
+
 	jc := &MockJobServiceClient{}
 	params := make(map[string]interface{})
 	params[sca.JobParamRegistration] = regJSON
 	params[sca.JobParameterRequest] = rJSON
 	params[sca.JobParameterMimes] = []string{v1.MimeTypeNativeReport}
-	params[sca.JobParameterRobotID] = int64(1)
+	params[sca.JobParameterAuthType] = "Basic"
+	params[sca.JobParameterRobot] = robotJSON
 
 	j := &jm.JobData{
 		Name: job.ImageScanJob,

--- a/src/pkg/scan/job_test.go
+++ b/src/pkg/scan/job_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/goharbor/harbor/src/jobservice/job"
 	"github.com/goharbor/harbor/src/jobservice/logger"
+	"github.com/goharbor/harbor/src/pkg/robot/model"
 	"github.com/goharbor/harbor/src/pkg/scan/dao/scanner"
 	v1 "github.com/goharbor/harbor/src/pkg/scan/rest/v1"
 	"github.com/goharbor/harbor/src/pkg/scan/vuln"
@@ -77,7 +78,7 @@ func (suite *JobTestSuite) TestJob() {
 	sr := &v1.ScanRequest{
 		Registry: &v1.Registry{
 			URL:           "http://localhost:5000",
-			Authorization: "the_token",
+			Authorization: "Basic cm9ib3Q6dG9rZW4=",
 		},
 		Artifact: &v1.Artifact{
 			Repository: "library/test_job",
@@ -89,12 +90,23 @@ func (suite *JobTestSuite) TestJob() {
 	sData, err := sr.ToJSON()
 	require.NoError(suite.T(), err)
 
+	robot := &model.Robot{
+		ID:    1,
+		Name:  "robot",
+		Token: "token",
+	}
+
+	robotData, err := robot.ToJSON()
+	require.NoError(suite.T(), err)
+
 	mimeTypes := []string{v1.MimeTypeNativeReport}
 
 	jp := make(job.Parameters)
 	jp[JobParamRegistration] = rData
 	jp[JobParameterRequest] = sData
 	jp[JobParameterMimes] = mimeTypes
+	jp[JobParameterAuthType] = "Basic"
+	jp[JobParameterRobot] = robotData
 
 	mc := &MockClient{}
 	sre := &v1.ScanResponse{

--- a/src/pkg/scan/rest/v1/models.go
+++ b/src/pkg/scan/rest/v1/models.go
@@ -123,8 +123,7 @@ func (s *ScanRequest) ToJSON() (string, error) {
 // Validate ScanRequest
 func (s *ScanRequest) Validate() error {
 	if s.Registry == nil ||
-		len(s.Registry.URL) == 0 ||
-		len(s.Registry.Authorization) == 0 {
+		len(s.Registry.URL) == 0 {
 		return errors.New("scan request: invalid registry")
 	}
 


### PR DESCRIPTION
Before submit scan job the authorization computed and send to the scan
job and then scan job may in pending state for a long time before it
begins to run.
When the pending more than 30 min which is the default bearer token
expiration time, the authorization had been expired when execute scan
job.
This PR changes the time of computing authorization from before
submitting the scan job to executing the job.

Closes #10325

Signed-off-by: He Weiwei <hweiwei@vmware.com>