### PR TITLE
fix(cicd) Use fixed golang version 1.13.4 and fail early

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Go 1.13
         uses: actions/setup-go@v1
         with:
-           go-version: 1.13
+           go-version: 1.13.4
         id: go
       - name: setup Docker
         uses: docker-practice/actions-setup-docker@0.0.1
@@ -84,7 +84,7 @@ jobs:
       - name: Set up Go 1.13
         uses: actions/setup-go@v1
         with:
-          go-version: 1.13
+          go-version: 1.13.4
         id: go
       - name: setup Docker
         uses: docker-practice/actions-setup-docker@0.0.1
@@ -138,7 +138,7 @@ jobs:
       - name: Set up Go 1.13
         uses: actions/setup-go@v1
         with:
-          go-version: 1.13
+          go-version: 1.13.4
         id: go
       - name: setup Docker
         uses: docker-practice/actions-setup-docker@0.0.1
@@ -192,7 +192,7 @@ jobs:
       - name: Set up Go 1.13
         uses: actions/setup-go@v1
         with:
-          go-version: 1.13
+          go-version: 1.13.4
         id: go
       - name: setup Docker
         uses: docker-practice/actions-setup-docker@0.0.1

--- a/tests/travis/api_run.sh
+++ b/tests/travis/api_run.sh
@@ -31,7 +31,7 @@ docker ps
 
 # run db auth api cases
 if [ "$1" = 'DB' ]; then
-    pybot -v ip:$2 -v HARBOR_PASSWORD:Harbor12345 $DIR/../../tests/robot-cases/Group0-BAT/API_DB.robot
+    pybot -X -v ip:$2 -v HARBOR_PASSWORD:Harbor12345 $DIR/../../tests/robot-cases/Group0-BAT/API_DB.robot
 elif [ "$1" = 'LDAP' ]; then
     # run ldap api cases
     python $DIR/../../tests/configharbor.py -H $IP -u $HARBOR_ADMIN -p $HARBOR_ADMIN_PASSWD -c auth_mode=ldap_auth \
@@ -40,7 +40,7 @@ elif [ "$1" = 'LDAP' ]; then
                                   ldap_search_password=admin \
                                   ldap_base_dn=dc=example,dc=com \
                                   ldap_uid=cn
-    pybot -v ip:$2 -v HARBOR_PASSWORD:Harbor12345 $DIR/../../tests/robot-cases/Group0-BAT/API_LDAP.robot
+    pybot -X -v ip:$2 -v HARBOR_PASSWORD:Harbor12345 $DIR/../../tests/robot-cases/Group0-BAT/API_LDAP.robot
 else
     rc=999
 fi


### PR DESCRIPTION
Sometimes github action test case will fail
1. UTTEST jobservice/period, 10 minutes timeout panic
2. docker push mysql with api, 30s timeout fail

These seems relative with the latest golang 1.13.6, so use the same sdk golang 1.13.4 as src build

Signed-off-by: Ziming Zhang <zziming@vmware.com>
