### PR TITLE
build(swagger): change download link of swagger-codegen-cli

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -473,7 +473,7 @@ down:
 
 swagger_client:
 	@echo "Generate swagger client"
-	wget -q http://central.maven.org/maven2/io/swagger/swagger-codegen-cli/2.3.1/swagger-codegen-cli-2.3.1.jar -O swagger-codegen-cli.jar
+	wget -q https://repo1.maven.org/maven2/io/swagger/swagger-codegen-cli/2.3.1/swagger-codegen-cli-2.3.1.jar -O swagger-codegen-cli.jar
 	rm -rf harborclient
 	mkdir harborclient
 	java -jar swagger-codegen-cli.jar generate -i api/harbor/swagger.yaml -l python -o harborclient


### PR DESCRIPTION
The http://central.maven.org is not available now so change the download
link of swagger-codegen-cli to https://repo1.maven.org

Signed-off-by: He Weiwei <hweiwei@vmware.com>