### PR TITLE
Try to parse the type of the artifact based on the media type when no resolver found

### DIFF
--- a/src/api/artifact/abstractor/abstractor_test.go
+++ b/src/api/artifact/abstractor/abstractor_test.go
@@ -294,6 +294,28 @@ func (a *abstractorTestSuite) TestAbstractUnsupported() {
 	a.fetcher.AssertExpectations(a.T())
 }
 
+func (a *abstractorTestSuite) TestParseArtifactType() {
+	mediaType := ""
+	typee := parseArtifactType(mediaType)
+	a.Equal(ArtifactTypeUnknown, typee)
+
+	mediaType = "unknown"
+	typee = parseArtifactType(mediaType)
+	a.Equal(ArtifactTypeUnknown, typee)
+
+	mediaType = "application/vnd.oci.image.config.v1+json"
+	typee = parseArtifactType(mediaType)
+	a.Equal("IMAGE", typee)
+
+	mediaType = "application/vnd.cncf.helm.chart.config.v1+json"
+	typee = parseArtifactType(mediaType)
+	a.Equal("HELM.CHART", typee)
+
+	mediaType = "application/vnd.sylabs.sif.config.v1+json"
+	typee = parseArtifactType(mediaType)
+	a.Equal("SIF", typee)
+}
+
 func TestAbstractorTestSuite(t *testing.T) {
 	suite.Run(t, &abstractorTestSuite{})
 }

--- a/src/api/artifact/abstractor/resolver/resolver.go
+++ b/src/api/artifact/abstractor/resolver/resolver.go
@@ -49,10 +49,6 @@ func Register(resolver Resolver, mediaTypes ...string) error {
 }
 
 // Get the resolver according to the media type
-func Get(mediaType string) (Resolver, error) {
-	resolver, exist := registry[mediaType]
-	if !exist {
-		return nil, fmt.Errorf("resolver resolves %s not found", mediaType)
-	}
-	return resolver, nil
+func Get(mediaType string) Resolver {
+	return registry[mediaType]
 }

--- a/src/api/artifact/abstractor/resolver/resolver_test.go
+++ b/src/api/artifact/abstractor/resolver/resolver_test.go
@@ -11,9 +11,21 @@
 package resolver
 
 import (
+	"context"
+	"github.com/goharbor/harbor/src/pkg/artifact"
 	"github.com/stretchr/testify/suite"
 	"testing"
 )
+
+type fakeResolver struct{}
+
+func (f *fakeResolver) ArtifactType() string {
+	return ""
+
+}
+func (f *fakeResolver) Resolve(ctx context.Context, manifest []byte, artifact *artifact.Artifact) error {
+	return nil
+}
 
 type resolverTestSuite struct {
 	suite.Suite
@@ -37,16 +49,16 @@ func (r *resolverTestSuite) TestRegister() {
 func (r *resolverTestSuite) TestGet() {
 	// registry a resolver
 	mediaType := "fake_media_type"
-	err := Register(nil, mediaType)
+	err := Register(&fakeResolver{}, mediaType)
 	r.Assert().Nil(err)
 
 	// get the resolver
-	_, err = Get(mediaType)
-	r.Assert().Nil(err)
+	resolver := Get(mediaType)
+	r.Assert().NotNil(resolver)
 
 	// get the not exist resolver
-	_, err = Get("not_existing_media_type")
-	r.Assert().NotNil(err)
+	resolver = Get("not_existing_media_type")
+	r.Assert().Nil(resolver)
 }
 
 func TestResolverTestSuite(t *testing.T) {


### PR DESCRIPTION
Try to parse the type of the artifact based on the media type when no resolver found, if parse failed, set it's type to unknown. This won't block the pushing for artifacts that has no resolver registered in Harbor

Signed-off-by: Wenkai Yin <yinw@vmware.com>