### PR TITLE
Fix githubactions testcase timeout

### DIFF
--- a/tests/apitests/python/library/docker_api.py
+++ b/tests/apitests/python/library/docker_api.py
@@ -11,7 +11,7 @@ except ImportError:
 
 class DockerAPI(object):
     def __init__(self):
-        self.DCLIENT = docker.APIClient(base_url='unix://var/run/docker.sock',version='auto',timeout=10)
+        self.DCLIENT = docker.APIClient(base_url='unix://var/run/docker.sock',version='auto',timeout=30)
         self.DCLIENT2 = docker.from_env()
 
     def docker_login(self, registry, username, password, expected_error_message = None):


### PR DESCRIPTION
Sometimes test case test_robot_account.py may failed with docker push read timeout in github action CI.
Try increase the docker client timeout.