### PR TITLE
Refactor email authentication

### DIFF
--- a/src/common/utils/email/mail_test.go
+++ b/src/common/utils/email/mail_test.go
@@ -64,6 +64,7 @@ func TestSend(t *testing.T) {
 			t.Errorf("unexpected error: %v", err)
 		}
 	}
+
 }
 
 func TestPing(t *testing.T) {
@@ -101,5 +102,20 @@ func TestPing(t *testing.T) {
 		if !strings.Contains(err.Error(), "535") {
 			t.Errorf("unexpected error: %v", err)
 		}
+	}
+}
+
+func TestEmailNoUsernameStillOk(t *testing.T) {
+	host := "smtp.gmail.com"
+	identity := ""
+	username := ""
+	password := ""
+
+	a, err := handleAuth(host, identity, username, password, "CRAM-MD5")
+	if err != nil {
+		t.Errorf("there should be no error")
+	}
+	if a != nil {
+		t.Errorf("no auth method should be returned")
 	}
 }


### PR DESCRIPTION
This refactors how the email package processes authentication against a SMTP server. It now checks the returned login mechanisms and allows for a short circuiting when no username is specified. The latter is the mean reason I created this PR as our mail relays allow for instances to be whitelisted, thus requiring no auth, but the smtp server still returns the extension.