### PR TITLE
[WIP]: Basic authorizer for registry

### DIFF
--- a/make/harbor.yml.tmpl
+++ b/make/harbor.yml.tmpl
@@ -26,9 +26,6 @@ https:
 # Remember Change the admin password from UI after launching Harbor.
 harbor_admin_password: Harbor12345
 
-#TODO: remove this temporary flag before ships v1.11/v2, this should always be true
-registry_use_basic_auth: false
-
 # Harbor DB configuration
 database:
   # The password for the root user of Harbor DB. Change this before any production use.

--- a/make/photon/prepare/templates/registry/config.yml.jinja
+++ b/make/photon/prepare/templates/registry/config.yml.jinja
@@ -26,17 +26,9 @@ http:
   debug:
     addr: localhost:5001
 auth:
-{% if registry_use_basic_auth %}
   htpasswd:
     realm: harbor-registry-basic-realm
     path: /etc/registry/passwd
-{% else %}
-  token:
-    issuer: harbor-token-issuer
-    realm: {{public_url}}/service/token
-    rootcertbundle: /etc/registry/root.crt
-    service: harbor-registry
-{% endif %}
 validation:
   disabled: true
 notifications:

--- a/make/photon/prepare/utils/configs.py
+++ b/make/photon/prepare/utils/configs.py
@@ -327,10 +327,6 @@ def parse_yaml_config(config_file_path, with_notary, with_clair, with_chartmuseu
 
     config_dict['registry_username'] = REGISTRY_USER_NAME
     config_dict['registry_password'] = generate_random_string(32)
-
-    # TODO: remove the flag before release
-    config_dict['registry_use_basic_auth'] = configs['registry_use_basic_auth']
-
     return config_dict
 
 

--- a/make/photon/prepare/utils/registry.py
+++ b/make/photon/prepare/utils/registry.py
@@ -24,8 +24,7 @@ def prepare_registry(config_dict):
     prepare_dir(registry_data_dir, uid=DEFAULT_UID, gid=DEFAULT_GID)
     prepare_dir(registry_config_dir)
 
-    if config_dict['registry_use_basic_auth']:
-        gen_passwd_file(config_dict)
+    gen_passwd_file(config_dict)
     storage_provider_info = get_storage_provider_info(
     config_dict['storage_provider_name'],
     config_dict['storage_provider_config'])

--- a/src/api/artifact/abstractor/blob/fetcher.go
+++ b/src/api/artifact/abstractor/blob/fetcher.go
@@ -21,7 +21,6 @@ import (
 	"github.com/goharbor/harbor/src/common/utils/registry"
 	"github.com/goharbor/harbor/src/common/utils/registry/auth"
 	"github.com/goharbor/harbor/src/core/config"
-	"github.com/goharbor/harbor/src/core/service/token"
 	coreutils "github.com/goharbor/harbor/src/core/utils"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"io/ioutil"
@@ -86,7 +85,7 @@ func newRepositoryClient(repository string) (*registry.Repository, error) {
 	uam := &auth.UserAgentModifier{
 		UserAgent: "harbor-registry-client",
 	}
-	authorizer := auth.NewRawTokenAuthorizer("admin", token.Registry)
+	authorizer := auth.DefaultBasicAuthorizer()
 	transport := registry.NewTransport(http.DefaultTransport, authorizer, uam)
 	client := &http.Client{
 		Transport: transport,

--- a/src/common/utils/registry/auth/basicauthorizer.go
+++ b/src/common/utils/registry/auth/basicauthorizer.go
@@ -1,0 +1,40 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package auth
+
+import (
+	"github.com/goharbor/harbor/src/common/http/modifier"
+	"github.com/goharbor/harbor/src/core/config"
+	"sync"
+)
+
+// NewBasicAuthorizer create an authorizer to add basic auth header as is set in the parameter
+func NewBasicAuthorizer(u, p string) modifier.Modifier {
+	return NewBasicAuthCredential(u, p)
+}
+
+var (
+	defaultAuthorizer modifier.Modifier
+	once              sync.Once
+)
+
+// DefaultBasicAuthorizer returns the basic authorizer that sets the basic auth as configured in env variables
+func DefaultBasicAuthorizer() modifier.Modifier {
+	once.Do(func() {
+		u, p := config.RegistryCredential()
+		defaultAuthorizer = NewBasicAuthCredential(u, p)
+	})
+	return defaultAuthorizer
+}

--- a/src/common/utils/registry/auth/basicauthorizer_test.go
+++ b/src/common/utils/registry/auth/basicauthorizer_test.go
@@ -1,0 +1,39 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package auth
+
+import (
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"os"
+	"testing"
+)
+
+func TestDefaultBasicAuthorizer(t *testing.T) {
+	os.Setenv("REGISTRY_CREDENTIAL_USERNAME", "testuser")
+	os.Setenv("REGISTRY_CREDENTIAL_PASSWORD", "testpassword")
+	defer func() {
+		os.Unsetenv("REGISTRY_CREDENTIAL_USERNAME")
+		os.Unsetenv("REGISTRY_CREDENTIAL_PASSWORD")
+	}()
+	req, _ := http.NewRequest(http.MethodGet, "http://127.0.0.1", nil)
+	a := DefaultBasicAuthorizer()
+	err := a.Modify(req)
+	assert.Nil(t, err)
+	u, p, ok := req.BasicAuth()
+	assert.True(t, ok)
+	assert.Equal(t, "testuser", u)
+	assert.Equal(t, "testpassword", p)
+}

--- a/src/core/api/utils.go
+++ b/src/core/api/utils.go
@@ -29,7 +29,6 @@ import (
 	"github.com/goharbor/harbor/src/common/utils/registry/auth"
 	"github.com/goharbor/harbor/src/core/config"
 	"github.com/goharbor/harbor/src/core/promgr"
-	"github.com/goharbor/harbor/src/core/service/token"
 	coreutils "github.com/goharbor/harbor/src/core/utils"
 )
 
@@ -248,7 +247,7 @@ func initRegistryClient() (r *registry.Registry, err error) {
 		return nil, err
 	}
 
-	authorizer := auth.NewRawTokenAuthorizer("harbor-core", token.Registry)
+	authorizer := auth.DefaultBasicAuthorizer()
 	return registry.NewRegistry(endpoint, &http.Client{
 		Transport: registry.NewTransport(registry.GetHTTPTransport(), authorizer),
 	})

--- a/src/core/utils/utils.go
+++ b/src/core/utils/utils.go
@@ -24,7 +24,6 @@ import (
 	"github.com/goharbor/harbor/src/common/utils/registry"
 	"github.com/goharbor/harbor/src/common/utils/registry/auth"
 	"github.com/goharbor/harbor/src/core/config"
-	"github.com/goharbor/harbor/src/core/service/token"
 )
 
 // NewRepositoryClientForUI creates a repository client that can only be used to
@@ -51,7 +50,7 @@ func newRepositoryClient(endpoint, username, repository string) (*registry.Repos
 	uam := &auth.UserAgentModifier{
 		UserAgent: "harbor-registry-client",
 	}
-	authorizer := auth.NewRawTokenAuthorizer(username, token.Registry)
+	authorizer := auth.DefaultBasicAuthorizer()
 	transport := registry.NewTransport(http.DefaultTransport, authorizer, uam)
 	client := &http.Client{
 		Transport: transport,

--- a/src/jobservice/job/impl/utils/utils.go
+++ b/src/jobservice/job/impl/utils/utils.go
@@ -20,52 +20,12 @@ import (
 	"os"
 	"sync"
 
-	"github.com/docker/distribution/registry/auth/token"
 	httpauth "github.com/goharbor/harbor/src/common/http/modifier/auth"
 	"github.com/goharbor/harbor/src/common/utils/registry"
-	"github.com/goharbor/harbor/src/common/utils/registry/auth"
 )
 
 var coreClient *http.Client
 var mutex = &sync.Mutex{}
-
-// NewRepositoryClient creates a repository client with standard token authorizer
-func NewRepositoryClient(endpoint string, insecure bool, credential auth.Credential,
-	tokenServiceEndpoint, repository string) (*registry.Repository, error) {
-
-	transport := registry.GetHTTPTransport(insecure)
-
-	authorizer := auth.NewStandardTokenAuthorizer(&http.Client{
-		Transport: transport,
-	}, credential, tokenServiceEndpoint)
-
-	uam := &UserAgentModifier{
-		UserAgent: "harbor-registry-client",
-	}
-
-	return registry.NewRepository(repository, endpoint, &http.Client{
-		Transport: registry.NewTransport(transport, authorizer, uam),
-	})
-}
-
-// NewRepositoryClientForJobservice creates a repository client that can only be used to
-// access the internal registry
-func NewRepositoryClientForJobservice(repository, internalRegistryURL, secret, internalTokenServiceURL string) (*registry.Repository, error) {
-	transport := registry.GetHTTPTransport()
-	credential := httpauth.NewSecretAuthorizer(secret)
-
-	authorizer := auth.NewStandardTokenAuthorizer(&http.Client{
-		Transport: transport,
-	}, credential, internalTokenServiceURL)
-
-	uam := &UserAgentModifier{
-		UserAgent: "harbor-registry-client",
-	}
-
-	return registry.NewRepository(repository, internalRegistryURL, &http.Client{
-		Transport: registry.NewTransport(transport, authorizer, uam),
-	})
-}
 
 // UserAgentModifier adds the "User-Agent" header to the request
 type UserAgentModifier struct {
@@ -76,27 +36,6 @@ type UserAgentModifier struct {
 func (u *UserAgentModifier) Modify(req *http.Request) error {
 	req.Header.Set(http.CanonicalHeaderKey("User-Agent"), u.UserAgent)
 	return nil
-}
-
-// BuildBlobURL ...
-func BuildBlobURL(endpoint, repository, digest string) string {
-	return fmt.Sprintf("%s/v2/%s/blobs/%s", endpoint, repository, digest)
-}
-
-// GetTokenForRepo is used for job handler to get a token for clair.
-func GetTokenForRepo(repository, secret, internalTokenServiceURL string) (string, error) {
-	credential := httpauth.NewSecretAuthorizer(secret)
-	t, err := auth.GetToken(internalTokenServiceURL, false, credential,
-		[]*token.ResourceActions{{
-			Type:    "repository",
-			Name:    repository,
-			Actions: []string{"pull"},
-		}})
-	if err != nil {
-		return "", err
-	}
-
-	return t.Token, nil
 }
 
 // GetClient returns the HTTP client that will attach jobservce secret to the request, which can be used for

--- a/src/server/middleware/v2auth/auth.go
+++ b/src/server/middleware/v2auth/auth.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package authz
+package v2auth
 
 import (
 	"fmt"
@@ -36,6 +36,7 @@ func (rc *reqChecker) check(req *http.Request) error {
 	if err != nil {
 		return err
 	}
+
 	if a, ok := middleware.ArtifactInfoFromContext(req.Context()); ok {
 		action := getAction(req)
 		if action == "" {
@@ -62,6 +63,8 @@ func (rc *reqChecker) check(req *http.Request) error {
 		}
 	} else if len(middleware.V2CatalogURLRe.FindStringSubmatch(req.URL.Path)) == 1 && !securityCtx.IsSysAdmin() {
 		return fmt.Errorf("unauthorized to list catalog")
+	} else if req.URL.Path == "/v2/" && !securityCtx.IsAuthenticated() {
+		return fmt.Errorf("not authenticated")
 	}
 	return nil
 }

--- a/src/server/middleware/v2auth/auth_test.go
+++ b/src/server/middleware/v2auth/auth_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package authz
+package v2auth
 
 import (
 	"github.com/goharbor/harbor/src/common/models"

--- a/src/server/registry/handler.go
+++ b/src/server/registry/handler.go
@@ -15,6 +15,7 @@
 package registry
 
 import (
+	"github.com/goharbor/harbor/src/core/config"
 	pkg_repo "github.com/goharbor/harbor/src/pkg/repository"
 	pkg_tag "github.com/goharbor/harbor/src/pkg/tag"
 	"github.com/goharbor/harbor/src/server/middleware"
@@ -34,9 +35,9 @@ import (
 
 // New return the registry instance to handle the registry APIs
 func New(url *url.URL) http.Handler {
-	// TODO add a director to add the basic auth for docker registry
 	// TODO customize the reverse proxy to improve the performance?
 	proxy := httputil.NewSingleHostReverseProxy(url)
+	proxy.Director = basicAuthDirector(proxy.Director)
 
 	// create the root rooter
 	rootRouter := mux.NewRouter()
@@ -74,4 +75,12 @@ func New(url *url.URL) http.Handler {
 	// rootRouter.Use(mux.MiddlewareFunc(middleware))
 
 	return rootRouter
+}
+
+func basicAuthDirector(d func(*http.Request)) func(*http.Request) {
+	return func(r *http.Request) {
+		d(r)
+		u, p := config.RegistryCredential()
+		r.SetBasicAuth(u, p)
+	}
 }

--- a/src/server/registry/route.go
+++ b/src/server/registry/route.go
@@ -17,8 +17,11 @@ package registry
 import (
 	"github.com/goharbor/harbor/src/core/config"
 	"github.com/goharbor/harbor/src/server/middleware/immutable"
+
+	"github.com/goharbor/harbor/src/server/middleware/artifactinfo"
 	"github.com/goharbor/harbor/src/server/middleware/manifestinfo"
 	"github.com/goharbor/harbor/src/server/middleware/readonly"
+	"github.com/goharbor/harbor/src/server/middleware/v2auth"
 	"github.com/goharbor/harbor/src/server/registry/manifest"
 	"github.com/goharbor/harbor/src/server/router"
 	"net/http"
@@ -33,7 +36,10 @@ func RegisterRoutes() {
 	url, _ := url.Parse(regURL)
 	proxy := httputil.NewSingleHostReverseProxy(url)
 
-	router.NewRoute().Path("/v2/*").Handler(New(url))
+	router.NewRoute().Path("/v2/*").
+		Middleware(artifactinfo.Middleware()).
+		Middleware(v2auth.Middleware()).
+		Handler(New(url))
 	router.NewRoute().
 		Method(http.MethodPut).
 		Path("/v2/*/manifests/:reference").


### PR DESCRIPTION
This commit adds basic authorizer for registry which modify the request
to add basic authorization header to request based on configuration.
It switches the registry to use basic auth by default and use the basic
authorizer to access Harbor.

Signed-off-by: Daniel Jiang <jiangd@vmware.com>