### PR TITLE
refactor(security): add `NewContext` and `FromContext` to security pkg

### DIFF
--- a/src/common/security/context.go
+++ b/src/common/security/context.go
@@ -15,12 +15,16 @@
 package security
 
 import (
+	"context"
+
 	"github.com/goharbor/harbor/src/common/models"
 	"github.com/goharbor/harbor/src/common/rbac"
 )
 
 // Context abstracts the operations related with authN and authZ
 type Context interface {
+	// Name returns the name of the security context
+	Name() string
 	// IsAuthenticated returns whether the context has been authenticated or not
 	IsAuthenticated() bool
 	// GetUsername returns the username of user related to the context
@@ -35,4 +39,17 @@ type Context interface {
 	GetProjectRoles(projectIDOrName interface{}) []int
 	// Can returns whether the user can do action on resource
 	Can(action rbac.Action, resource rbac.Resource) bool
+}
+
+type securityKey struct{}
+
+// NewContext returns context with security context
+func NewContext(ctx context.Context, security Context) context.Context {
+	return context.WithValue(ctx, securityKey{}, security)
+}
+
+// FromContext returns security context from the context
+func FromContext(ctx context.Context) (Context, bool) {
+	c, ok := ctx.Value(securityKey{}).(Context)
+	return c, ok
 }

--- a/src/common/security/local/context.go
+++ b/src/common/security/local/context.go
@@ -38,6 +38,11 @@ func NewSecurityContext(user *models.User, pm promgr.ProjectManager) *SecurityCo
 	}
 }
 
+// Name returns the name of the security context
+func (s *SecurityContext) Name() string {
+	return "local"
+}
+
 // IsAuthenticated returns true if the user has been authenticated
 func (s *SecurityContext) IsAuthenticated() bool {
 	return s.user != nil

--- a/src/common/security/robot/context.go
+++ b/src/common/security/robot/context.go
@@ -37,6 +37,11 @@ func NewSecurityContext(robot *model.Robot, pm promgr.ProjectManager, policy []*
 	}
 }
 
+// Name returns the name of the security context
+func (s *SecurityContext) Name() string {
+	return "robot"
+}
+
 // IsAuthenticated returns true if the user has been authenticated
 func (s *SecurityContext) IsAuthenticated() bool {
 	return s.robot != nil

--- a/src/common/security/secret/context.go
+++ b/src/common/security/secret/context.go
@@ -38,6 +38,11 @@ func NewSecurityContext(secret string, store *secret.Store) *SecurityContext {
 	}
 }
 
+// Name returns the name of the security context
+func (s *SecurityContext) Name() string {
+	return "secret"
+}
+
 // IsAuthenticated returns true if the secret is valid
 func (s *SecurityContext) IsAuthenticated() bool {
 	if s.store == nil {

--- a/src/core/api/base.go
+++ b/src/core/api/base.go
@@ -18,11 +18,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/goharbor/harbor/src/common/models"
 	"net/http"
 
 	"github.com/ghodss/yaml"
 	"github.com/goharbor/harbor/src/common/api"
+	"github.com/goharbor/harbor/src/common/models"
 	"github.com/goharbor/harbor/src/common/rbac"
 	"github.com/goharbor/harbor/src/common/security"
 	"github.com/goharbor/harbor/src/common/utils"
@@ -68,9 +68,9 @@ type BaseController struct {
 // Prepare inits security context and project manager from request
 // context
 func (b *BaseController) Prepare() {
-	ctx, err := filter.GetSecurityContext(b.Ctx.Request)
-	if err != nil {
-		log.Errorf("failed to get security context: %v", err)
+	ctx, ok := security.FromContext(b.Ctx.Request.Context())
+	if !ok {
+		log.Errorf("failed to get security context")
 		b.SendInternalServerError(errors.New(""))
 		return
 	}

--- a/src/core/api/config.go
+++ b/src/core/api/config.go
@@ -23,11 +23,10 @@ import (
 	"github.com/goharbor/harbor/src/common/config"
 	"github.com/goharbor/harbor/src/common/config/metadata"
 	"github.com/goharbor/harbor/src/common/dao"
-	"github.com/goharbor/harbor/src/common/security/secret"
+	"github.com/goharbor/harbor/src/common/security"
 	"github.com/goharbor/harbor/src/common/utils/log"
 	"github.com/goharbor/harbor/src/core/api/models"
 	corecfg "github.com/goharbor/harbor/src/core/config"
-	"github.com/goharbor/harbor/src/core/filter"
 )
 
 // ConfigAPI ...
@@ -47,7 +46,7 @@ func (c *ConfigAPI) Prepare() {
 
 	// Only internal container can access /api/internal/configurations
 	if strings.EqualFold(c.Ctx.Request.RequestURI, "/api/internal/configurations") {
-		if _, ok := c.Ctx.Request.Context().Value(filter.SecurCtxKey).(*secret.SecurityContext); !ok {
+		if s, ok := security.FromContext(c.Ctx.Request.Context()); !ok || s.Name() != "secret" {
 			c.SendUnAuthorizedError(errors.New("UnAuthorized"))
 			return
 		}

--- a/src/core/filter/security.go
+++ b/src/core/filter/security.go
@@ -51,9 +51,6 @@ type pathMethod struct {
 }
 
 const (
-	// SecurCtxKey is context value key for security context
-	SecurCtxKey ContextValueKey = "harbor_security_context"
-
 	// PmKey is context value key for the project manager
 	PmKey ContextValueKey = "harbor_project_manager"
 	// AuthModeKey is context key for auth mode
@@ -426,31 +423,12 @@ func (u *unauthorizedReqCtxModifier) Modify(ctx *beegoctx.Context) bool {
 }
 
 func setSecurCtxAndPM(req *http.Request, ctx security.Context, pm promgr.ProjectManager) {
-	addToReqContext(req, SecurCtxKey, ctx)
+	*req = *(req.WithContext(security.NewContext(req.Context(), ctx)))
 	addToReqContext(req, PmKey, pm)
 }
 
 func addToReqContext(req *http.Request, key, value interface{}) {
 	*req = *(req.WithContext(context.WithValue(req.Context(), key, value)))
-}
-
-// GetSecurityContext tries to get security context from request and returns it
-func GetSecurityContext(req *http.Request) (security.Context, error) {
-	if req == nil {
-		return nil, fmt.Errorf("request is nil")
-	}
-
-	ctx := req.Context().Value(SecurCtxKey)
-	if ctx == nil {
-		return nil, fmt.Errorf("the security context got from request is nil")
-	}
-
-	c, ok := ctx.(security.Context)
-	if !ok {
-		return nil, fmt.Errorf("the variable got from request is not security context type")
-	}
-
-	return c, nil
 }
 
 // GetProjectManager tries to get project manager from request and returns it

--- a/src/core/middlewares/inlet.go
+++ b/src/core/middlewares/inlet.go
@@ -16,11 +16,12 @@ package middlewares
 
 import (
 	"errors"
+	"net/http"
+
+	"github.com/goharbor/harbor/src/common/security"
 	"github.com/goharbor/harbor/src/common/utils/log"
-	"github.com/goharbor/harbor/src/core/filter"
 	"github.com/goharbor/harbor/src/core/middlewares/registryproxy"
 	"github.com/goharbor/harbor/src/core/middlewares/util"
-	"net/http"
 )
 
 var head http.Handler
@@ -37,9 +38,9 @@ func Init() error {
 
 // Handle handles the request.
 func Handle(rw http.ResponseWriter, req *http.Request) {
-	securityCtx, err := filter.GetSecurityContext(req)
-	if err != nil {
-		log.Errorf("failed to get security context in middlerware: %v", err)
+	securityCtx, ok := security.FromContext(req.Context())
+	if !ok {
+		log.Errorf("failed to get security context in middlerware")
 		// error to get security context, use the default chain.
 		head = New(Middlewares).Create().Then(proxy)
 	} else {

--- a/src/core/service/token/creator.go
+++ b/src/core/service/token/creator.go
@@ -203,8 +203,8 @@ func (g generalCreator) Create(r *http.Request) (*models.Token, error) {
 	scopes := parseScopes(r.URL)
 	log.Debugf("scopes: %v", scopes)
 
-	ctx, err := filter.GetSecurityContext(r)
-	if err != nil {
+	ctx, ok := security.FromContext(r.Context())
+	if !ok {
 		return nil, fmt.Errorf("failed to  get security context from request")
 	}
 

--- a/src/core/service/token/token_test.go
+++ b/src/core/service/token/token_test.go
@@ -226,6 +226,10 @@ type fakeSecurityContext struct {
 	isAdmin bool
 }
 
+func (f *fakeSecurityContext) Name() string {
+	return "fake"
+}
+
 func (f *fakeSecurityContext) IsAuthenticated() bool {
 	return true
 }

--- a/src/server/middleware/v2auth/auth_test.go
+++ b/src/server/middleware/v2auth/auth_test.go
@@ -15,19 +15,20 @@
 package v2auth
 
 import (
-	"github.com/goharbor/harbor/src/common/models"
-	"github.com/goharbor/harbor/src/common/rbac"
-	"github.com/goharbor/harbor/src/core/filter"
-	"github.com/goharbor/harbor/src/core/promgr/metamgr"
-	"github.com/goharbor/harbor/src/server/middleware"
-	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/goharbor/harbor/src/common/models"
+	"github.com/goharbor/harbor/src/common/rbac"
+	"github.com/goharbor/harbor/src/common/security"
+	"github.com/goharbor/harbor/src/core/promgr/metamgr"
+	"github.com/goharbor/harbor/src/server/middleware"
+	"github.com/stretchr/testify/assert"
 )
 
 type mockPM struct{}
@@ -77,6 +78,10 @@ func (mockPM) GetMetadataManager() metamgr.ProjectMetadataManager {
 }
 
 type mockSC struct{}
+
+func (mockSC) Name() string {
+	return "mock"
+}
 
 func (mockSC) IsAuthenticated() bool {
 	return true
@@ -136,7 +141,7 @@ func TestMiddleware(t *testing.T) {
 		w.WriteHeader(200)
 	})
 
-	baseCtx := context.WithValue(context.Background(), filter.SecurCtxKey, mockSC{})
+	baseCtx := security.NewContext(context.Background(), mockSC{})
 	ar1 := &middleware.ArtifactInfo{
 		Repository:  "project_1/hello-world",
 		Reference:   "v1",


### PR DESCRIPTION
1. Add `NewContext` and `FromContext` funcs in security pkg.
2. Add `Name` func in `security.Context` interface to make the checking
for the `/api/internal/configurations` API clear.
3. Get the security from the context to prepare change the security
filter to middleware.
4. Remove `GetSecurityContext` in filter pkg.

Signed-off-by: He Weiwei <hweiwei@vmware.com>