### PR TITLE
Add child artifact digest in reference model

### DIFF
--- a/api/v2.0/swagger.yaml
+++ b/api/v2.0/swagger.yaml
@@ -467,6 +467,9 @@ definitions:
         type: integer
         format: int64
         description: The child ID of the reference
+      child_digest:
+        type: string
+        description: The digest of the child artifact
       platform:
         $ref: '#/definitions/Platform'
   Platform:

--- a/src/api/artifact/model.go
+++ b/src/api/artifact/model.go
@@ -47,8 +47,9 @@ func (a *Artifact) ToSwagger() *models.Artifact {
 	}
 	for _, reference := range a.References {
 		ref := &models.Reference{
-			ChildID:  reference.ChildID,
-			ParentID: reference.ParentID,
+			ChildID:     reference.ChildID,
+			ChildDigest: reference.ChildDigest,
+			ParentID:    reference.ParentID,
 		}
 		if reference.Platform != nil {
 			ref.Platform = &models.Platform{

--- a/src/pkg/artifact/manager.go
+++ b/src/pkg/artifact/manager.go
@@ -127,6 +127,11 @@ func (m *manager) assemble(ctx context.Context, art *dao.Artifact) (*Artifact, e
 	for _, ref := range refs {
 		reference := &Reference{}
 		reference.From(ref)
+		art, err := m.dao.Get(ctx, reference.ChildID)
+		if err != nil {
+			return nil, err
+		}
+		reference.ChildDigest = art.Digest
 		artifact.References = append(artifact.References, reference)
 	}
 	return artifact, nil

--- a/src/pkg/artifact/manager_test.go
+++ b/src/pkg/artifact/manager_test.go
@@ -105,6 +105,9 @@ func (m *managerTestSuite) TestAssemble() {
 			ChildID:  3,
 		},
 	}, nil)
+	m.dao.On("Get").Return(&dao.Artifact{
+		Digest: "digest",
+	}, nil)
 	artifact, err := m.mgr.assemble(nil, art)
 	m.Require().Nil(err)
 	m.dao.AssertExpectations(m.T())

--- a/src/pkg/artifact/model.go
+++ b/src/pkg/artifact/model.go
@@ -101,9 +101,10 @@ func (a *Artifact) To() *dao.Artifact {
 
 // Reference records the child artifact referenced by parent artifact
 type Reference struct {
-	ParentID int64
-	ChildID  int64
-	Platform *v1.Platform
+	ParentID    int64
+	ChildID     int64
+	ChildDigest string // As we only provide the API based on digest rather than ID, the digest of child artifact is needed
+	Platform    *v1.Platform
 }
 
 // From converts the data level reference to business level


### PR DESCRIPTION
As we only provide the API to get artifact information via project name, repository name and digest, the digest of child artifact must be returned

Signed-off-by: Wenkai Yin <yinw@vmware.com>