### PR TITLE
[Cherry-Pick To 1.10] Fix description issue of test in robot account and quotas API test

### DIFF
--- a/tests/apitests/python/test_project_quota.py
+++ b/tests/apitests/python/test_project_quota.py
@@ -66,6 +66,7 @@ class TestProjects(unittest.TestCase):
         self.project.add_project_members(TestProjects.project_test_quota_id, TestProjects.user_test_quota_id, **ADMIN_CLIENT)
 
         #4.Push an image to project(PA) by user(UA), then check the project quota usage; -- {"count": 1, "storage": 2791709}
+        #image = "harbor-repo.vmware.com/harbor-ci/alpine"
         image = "alpine"
         src_tag = "3.10"
         TestProjects.repo_name, _ = push_image_to_project(project_test_quota_name, harbor_server, user_test_quota_name, user_001_password, image, src_tag)
@@ -73,7 +74,8 @@ class TestProjects(unittest.TestCase):
         #5. Get project quota
         quota = self.system.get_project_quota("project", TestProjects.project_test_quota_id, **ADMIN_CLIENT)
         self.assertEqual(quota[0].used["count"], 1)
-        self.assertEqual(quota[0].used["storage"], 2789174)
+        #self.assertEqual(quota[0].used["storage"], 2789174)
+        self.assertEqual(quota[0].used["storage"], 2789002)
 
         #6. Delete repository(RA) by user(UA);
         self.repo.delete_repoitory(TestProjects.repo_name, **ADMIN_CLIENT)

--- a/tests/apitests/python/test_robot_account.py
+++ b/tests/apitests/python/test_robot_account.py
@@ -41,7 +41,7 @@ class TestProjects(unittest.TestCase):
         self.project.delete_project(TestProjects.project_ra_id_b, **TestProjects.USER_RA_CLIENT)
         self.project.delete_project(TestProjects.project_ra_id_c, **TestProjects.USER_RA_CLIENT)
 
-        #3. Delete user(UA);
+        #3. Delete user(UA).
         self.user.delete_user(TestProjects.user_ra_id, **ADMIN_CLIENT)
 
     def testRobotAccount(self):
@@ -63,10 +63,11 @@ class TestProjects(unittest.TestCase):
 			12. Update action property of robot account(RA);
 			13. Pull image(ImagePA) from project(PA) by robot account(RA), it must be not successful;
 			14. Push image(ImageRA) to project(PA) by robot account(RA), it must be not successful;
-			15. Push image(ImageRA) to project(PA) by robot account(RA), it must be not successful;
+			15. Delete robot account(RA), it must be not successful.
         Tear down:
-            1. Delete project(PA) (PB) (PC);
-            2. Delete user(UA).
+            1. Delete repository(RA) by user(UA);
+            2. Delete project(PA);
+            3. Delete user(UA).
         """
         url = ADMIN_CLIENT["endpoint"]
         admin_name = ADMIN_CLIENT["username"]
@@ -128,7 +129,7 @@ class TestProjects(unittest.TestCase):
         print "#14. Push image(ImageRA) to project(PA) by robot account(RA), it must be not successful;"
         push_image_to_project(project_ra_name_a, harbor_server, robot_account.name, robot_account.token, image_robot_account, tag, expected_login_error_message = "401 Client Error: Unauthorized")
 
-        print "#15. Delete robot account(RA), it must be not successful;"
+        print "#15. Delete robot account(RA), it must be not successful."
         self.project.delete_project_robot_account(TestProjects.project_ra_id_a, robot_id, **TestProjects.USER_RA_CLIENT)
 
 if __name__ == '__main__':

--- a/tests/resources/Helm-Util.robot
+++ b/tests/resources/Helm-Util.robot
@@ -28,8 +28,8 @@ Helm Repo Add
     Wait Unitl Command Success  helm repo add --ca-file /helm_ca/server.crt --username=${user} --password=${pwd} ${helm_repo_name} ${harbor_url}/chartrepo/${project_name}
 
 Helm Repo Push
-    [Arguments]  ${user}  ${pwd}  ${chart_filename}  ${helm_repo_name}=myrepo
+    [Arguments]  ${user}  ${pwd}  ${chart_filename}  ${helm_repo_name}=myrepo  ${helm_cmd}=helm
     ${current_dir}=  Run  pwd
     Run  cd ${current_dir}
     Run  wget ${harbor_chart_file_url}
-    Wait Unitl Command Success  helm push --ca-file=/helm_ca/server.crt --username=${user} --password=${pwd} ${chart_filename} ${helm_repo_name}
+    Wait Unitl Command Success  ${helm_cmd} push --ca-file=/helm_ca/server.crt --username=${user} --password=${pwd} ${chart_filename} ${helm_repo_name}

--- a/tests/resources/TestCaseBody.robot
+++ b/tests/resources/TestCaseBody.robot
@@ -161,9 +161,8 @@ Helm3 CLI Push Without Sign In Harbor
     [Arguments]  ${sign_in_user}  ${sign_in_pwd}
     ${d}=   Get Current Date    result_format=%m%s
     Create An New Project  project${d}
-    Helm Repo Push  ${sign_in_user}  ${sign_in_pwd}  ${harbor_chart_filename}  helm_repo_name=${HARBOR_URL}/chartrepo/project${d}
+    Helm Repo Push  ${sign_in_user}  ${sign_in_pwd}  ${harbor_chart_filename}  helm_repo_name=${HARBOR_URL}/chartrepo/project${d}  helm_cmd=helm3
     Go Into Project  project${d}  has_image=${false}
     Switch To Project Charts
-    Go Into Chart Version  ${harbor_chart_name}
-    Retry Wait Until Page Contains  ${harbor_chart_version}
+    Retry Double Keywords When Error  Go Into Chart Version  ${harbor_chart_name}  Retry Wait Until Page Contains  ${harbor_chart_version}
     Capture Page Screenshot


### PR DESCRIPTION
Fix description issue of test in robot account API test and issue of Helm3 test

1. Fix issue that test step descriton was mismatch with test step;
2. Wrong helm command was used in Helm3 test, replace helm with helm3;
3. In API test, images were pulled from docker-hub registry, images size changed sometime, so we like to use internal registry.

Signed-off-by: danfengliu <danfengl@vmware.com>