### PR TITLE
Fix project quotas API test issue

### DIFF
--- a/tests/apitests/python/test_project_quota.py
+++ b/tests/apitests/python/test_project_quota.py
@@ -66,7 +66,7 @@ class TestProjects(unittest.TestCase):
         self.project.add_project_members(TestProjects.project_test_quota_id, TestProjects.user_test_quota_id, **ADMIN_CLIENT)
 
         #4.Push an image to project(PA) by user(UA), then check the project quota usage; -- {"count": 1, "storage": 2791709}
-        image = "harbor-repo.vmware.com/harbor-ci/alpine"
+        image = "goharbor/alpine"
         src_tag = "3.10"
         TestProjects.repo_name, _ = push_image_to_project(project_test_quota_name, harbor_server, user_test_quota_name, user_001_password, image, src_tag)
 

--- a/tests/resources/Harbor-Pages/Project.robot
+++ b/tests/resources/Harbor-Pages/Project.robot
@@ -106,7 +106,9 @@ Make Project Private
     Retry Checkbox Should Be Selected  ${project_config_public_checkbox}
     Retry Double Keywords When Error  Retry Element Click  ${project_config_public_checkbox_label}  Retry Checkbox Should Not Be Selected  ${project_config_public_checkbox}
     Retry Element Click  //button[contains(.,'SAVE')]
-    Retry Wait Until Page Contains  Configuration has been successfully saved
+    Go Into Project  ${project name}
+    Switch To Project Configuration
+    Retry Checkbox Should Not Be Selected  ${project_config_public_checkbox}
 
 Make Project Public
     [Arguments]  ${projectname}
@@ -115,7 +117,9 @@ Make Project Public
     Retry Checkbox Should Not Be Selected  ${project_config_public_checkbox}
     Retry Double Keywords When Error  Retry Element Click  ${project_config_public_checkbox_label}  Retry Checkbox Should Be Selected  ${project_config_public_checkbox}
     Retry Element Click  //button[contains(.,'SAVE')]
-    Retry Wait Until Page Contains  Configuration has been successfully saved
+    Go Into Project  ${project name}
+    Switch To Project Configuration
+    Retry Checkbox Should Be Selected  ${project_config_public_checkbox}
 
 Delete Repo
     [Arguments]  ${projectname}


### PR DESCRIPTION
In project quotas API test, pull images from goharbor namespace instead of library.
Signed-off-by: danfengliu <danfengl@vmware.com>