### PR TITLE
Implement get addition API for image

### DIFF
--- a/api/v2.0/swagger.yaml
+++ b/api/v2.0/swagger.yaml
@@ -249,6 +249,39 @@ paths:
           $ref: '#/responses/404'
         '500':
           $ref: '#/responses/500'
+  /projects/{project_name}/repositories/{repository_name}/artifacts/{reference}/additions/{addition}:
+    get:
+      summary: Get the addition of the specific artifact
+      description: Get the addition of the artifact specified by the reference under the project and repository.
+      tags:
+        - artifact
+      operationId: getAddition
+      parameters:
+        - $ref: '#/parameters/requestId'
+        - $ref: '#/parameters/projectName'
+        - $ref: '#/parameters/repositoryName'
+        - $ref: '#/parameters/reference'
+        - name: addition
+          in: path
+          description: The addition name, "build_history" for images; "values.yaml", "readme", "dependencies" for charts
+          type: string
+          enum: [build_history, values.yaml, readme, dependencies]
+          required: true
+      responses:
+        '200':
+          description: Success
+          schema:
+            type: string
+        '400':
+          $ref: '#/responses/400'
+        '401':
+          $ref: '#/responses/401'
+        '403':
+          $ref: '#/responses/403'
+        '404':
+          $ref: '#/responses/404'
+        '500':
+          $ref: '#/responses/500'
 parameters:
   requestId:
     name: X-Request-Id
@@ -425,8 +458,8 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/Tag'
-      sub_resource_links:
-        $ref: '#/definitions/SubResourceLinks'
+      addition_links:
+        $ref: '#/definitions/AdditionLinks'
   Tag:
     type: object
     properties:
@@ -455,6 +488,7 @@ definitions:
         description: The latest pull time of the tag
       immutable:
         type: boolean
+        x-omitempty: false
         description: The immutable status of the tag
   ExtraAttrs:
     type: object
@@ -464,20 +498,19 @@ definitions:
     type: object
     additionalProperties:
       type: string
-  SubResourceLinks:
+  AdditionLinks:
     type: object
     additionalProperties:
-      type: array
-      items:
-        $ref: '#/definitions/ResourceLink'
-  ResourceLink:
+      $ref: '#/definitions/AdditionLink'
+  AdditionLink:
     type: object
     properties:
       href:
         type: string
-        description: The link of the resource
+        description: The link of the addition
       absolute:
         type: boolean
+        x-omitempty: false
         description: Determine whether the link is an absolute URL or not
   Reference:
     type: object
@@ -515,3 +548,4 @@ definitions:
       variant:
         type: string
         description: The variant of the CPU
+

--- a/src/api/artifact/abstractor/resolver/chart/chart_test.go
+++ b/src/api/artifact/abstractor/resolver/chart/chart_test.go
@@ -40,11 +40,7 @@ func (r *resolverTestSuite) SetupTest() {
 
 }
 
-func (r *resolverTestSuite) TestArtifactType() {
-	r.Assert().Equal(ArtifactTypeChart, r.resolver.ArtifactType())
-}
-
-func (r *resolverTestSuite) TestResolve() {
+func (r *resolverTestSuite) TestResolveMetadata() {
 	content := `{
   "schemaVersion": 2,
   "config": {
@@ -91,12 +87,21 @@ func (r *resolverTestSuite) TestResolve() {
 	artifact := &artifact.Artifact{}
 	r.repoMgr.On("Get").Return(&models.RepoRecord{}, nil)
 	r.blobFetcher.On("FetchLayer").Return([]byte(config), nil)
-	err := r.resolver.Resolve(nil, []byte(content), artifact)
+	err := r.resolver.ResolveMetadata(nil, []byte(content), artifact)
 	r.Require().Nil(err)
 	r.repoMgr.AssertExpectations(r.T())
 	r.blobFetcher.AssertExpectations(r.T())
 	r.Assert().Equal("1.1.2", artifact.ExtraAttrs["version"].(string))
 	r.Assert().Equal("1.8.2", artifact.ExtraAttrs["appVersion"].(string))
+}
+
+func (r *resolverTestSuite) TestGetArtifactType() {
+	r.Assert().Equal(ArtifactTypeChart, r.resolver.GetArtifactType())
+}
+
+func (r *resolverTestSuite) TestListAdditionTypes() {
+	additions := r.resolver.ListAdditionTypes()
+	r.EqualValues([]string{AdditionTypeValues, AdditionTypeReadme, AdditionTypeDependencies}, additions)
 }
 
 func TestResolverTestSuite(t *testing.T) {

--- a/src/api/artifact/abstractor/resolver/image/manifest_v1_test.go
+++ b/src/api/artifact/abstractor/resolver/image/manifest_v1_test.go
@@ -15,6 +15,7 @@
 package image
 
 import (
+	ierror "github.com/goharbor/harbor/src/internal/error"
 	"github.com/goharbor/harbor/src/pkg/artifact"
 	"github.com/stretchr/testify/suite"
 	"testing"
@@ -30,11 +31,7 @@ func (m *manifestV1ResolverTestSuite) SetupSuite() {
 
 }
 
-func (m *manifestV1ResolverTestSuite) TestArtifactType() {
-	m.Assert().Equal(ArtifactTypeImage, m.resolver.ArtifactType())
-}
-
-func (m *manifestV1ResolverTestSuite) TestResolve() {
+func (m *manifestV1ResolverTestSuite) TestResolveMetadata() {
 	manifest := `{
    "name": "hello-world",
    "tag": "latest",
@@ -81,9 +78,23 @@ func (m *manifestV1ResolverTestSuite) TestResolve() {
 }
 `
 	artifact := &artifact.Artifact{}
-	err := m.resolver.Resolve(nil, []byte(manifest), artifact)
+	err := m.resolver.ResolveMetadata(nil, []byte(manifest), artifact)
 	m.Require().Nil(err)
 	m.Assert().Equal("amd64", artifact.ExtraAttrs["architecture"].(string))
+}
+
+func (m *manifestV1ResolverTestSuite) TestResolveAddition() {
+	_, err := m.resolver.ResolveAddition(nil, nil, AdditionTypeBuildHistory)
+	m.True(ierror.IsErr(err, ierror.BadRequestCode))
+}
+
+func (m *manifestV1ResolverTestSuite) TestGetArtifactType() {
+	m.Assert().Equal(ArtifactTypeImage, m.resolver.GetArtifactType())
+}
+
+func (m *manifestV1ResolverTestSuite) TestListAdditionTypes() {
+	additions := m.resolver.ListAdditionTypes()
+	m.Len(additions, 0)
 }
 
 func TestManifestV1ResolverTestSuite(t *testing.T) {

--- a/src/api/artifact/abstractor/resolver/resolver.go
+++ b/src/api/artifact/abstractor/resolver/resolver.go
@@ -27,12 +27,14 @@ var (
 
 // Resolver resolves the detail information for a specific kind of artifact
 type Resolver interface {
-	// ArtifactType returns the type of artifact that the resolver handles
-	ArtifactType() string
-	// Resolve receives the manifest content, resolves the detail information
+	// ResolveMetadata receives the manifest content, resolves the metadata
 	// from the manifest or the layers referenced by the manifest, and populates
-	// the detail information into the artifact
-	Resolve(ctx context.Context, manifest []byte, artifact *artifact.Artifact) error
+	// the metadata into the artifact
+	ResolveMetadata(ctx context.Context, manifest []byte, artifact *artifact.Artifact) error
+	// ResolveAddition returns the addition of the artifact.
+	// The additions are different for different artifacts:
+	// build history for image; values.yaml, readme and dependencies for chart, etc
+	ResolveAddition(ctx context.Context, artifact *artifact.Artifact, additionType string) (addition *Addition, err error)
 }
 
 // Register resolver, one resolver can handle multiple media types for one kind of artifact
@@ -51,4 +53,10 @@ func Register(resolver Resolver, mediaTypes ...string) error {
 // Get the resolver according to the media type
 func Get(mediaType string) Resolver {
 	return registry[mediaType]
+}
+
+// Addition defines the specific addition of different artifacts: build history for image, values.yaml for chart, etc
+type Addition struct {
+	Content     []byte // the content of the addition
+	ContentType string // the content type of the addition, returned as "Content-Type" header in API
 }

--- a/src/api/artifact/abstractor/resolver/resolver_test.go
+++ b/src/api/artifact/abstractor/resolver/resolver_test.go
@@ -23,12 +23,11 @@ import (
 
 type fakeResolver struct{}
 
-func (f *fakeResolver) ArtifactType() string {
-	return ""
-
-}
-func (f *fakeResolver) Resolve(ctx context.Context, manifest []byte, artifact *artifact.Artifact) error {
+func (f *fakeResolver) ResolveMetadata(ctx context.Context, manifest []byte, artifact *artifact.Artifact) error {
 	return nil
+}
+func (f *fakeResolver) ResolveAddition(ctx context.Context, artifact *artifact.Artifact, additionType string) (*Addition, error) {
+	return nil, nil
 }
 
 type resolverTestSuite struct {

--- a/src/api/artifact/descriptor/descriptor.go
+++ b/src/api/artifact/descriptor/descriptor.go
@@ -1,0 +1,72 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package descriptor
+
+import (
+	"fmt"
+	"github.com/goharbor/harbor/src/common/utils/log"
+)
+
+var (
+	registry = map[string]Descriptor{}
+)
+
+// Descriptor describes the static information for one kind of media type
+type Descriptor interface {
+	// GetArtifactType returns the type of one kind of artifact specified by media type
+	GetArtifactType() string
+	// ListAdditionTypes returns the supported addition types of one kind of artifact specified by media type
+	ListAdditionTypes() []string
+}
+
+// Register descriptor, one descriptor can handle multiple media types for one kind of artifact
+func Register(descriptor Descriptor, mediaTypes ...string) error {
+	for _, mediaType := range mediaTypes {
+		_, exist := registry[mediaType]
+		if exist {
+			return fmt.Errorf("descriptor to handle media type %s already exists", mediaType)
+		}
+		registry[mediaType] = descriptor
+		log.Infof("descriptor to handle media type %s registered", mediaType)
+	}
+	return nil
+}
+
+// Get the descriptor according to the media type
+func Get(mediaType string) (Descriptor, error) {
+	descriptor := registry[mediaType]
+	if descriptor == nil {
+		return nil, fmt.Errorf("descriptor for media type %s not found", mediaType)
+	}
+	return descriptor, nil
+}
+
+// GetArtifactType gets the artifact type according to the media type
+func GetArtifactType(mediaType string) (string, error) {
+	descriptor, err := Get(mediaType)
+	if err != nil {
+		return "", err
+	}
+	return descriptor.GetArtifactType(), nil
+}
+
+// ListAdditionTypes lists the supported addition types according to the media type
+func ListAdditionTypes(mediaType string) ([]string, error) {
+	descriptor, err := Get(mediaType)
+	if err != nil {
+		return nil, err
+	}
+	return descriptor.ListAdditionTypes(), nil
+}

--- a/src/api/artifact/model.go
+++ b/src/api/artifact/model.go
@@ -24,8 +24,8 @@ import (
 // Artifact is the overall view of artifact
 type Artifact struct {
 	artifact.Artifact
-	Tags             []*Tag                     // the list of tags that attached to the artifact
-	SubResourceLinks map[string][]*ResourceLink // the resource link for build history(image), values.yaml(chart), dependency(chart), etc
+	Tags          []*Tag                   // the list of tags that attached to the artifact
+	AdditionLinks map[string]*AdditionLink // the link for build history(image), values.yaml(chart), dependency(chart), etc
 	// TODO add other attrs: signature, scan result, etc
 }
 
@@ -73,15 +73,13 @@ func (a *Artifact) ToSwagger() *models.Artifact {
 			Immutable:    tag.Immutable,
 		})
 	}
-	for resource, links := range a.SubResourceLinks {
-		for _, link := range links {
-			art.SubResourceLinks[resource] = []models.ResourceLink{}
-			if link != nil {
-				art.SubResourceLinks[resource] = append(art.SubResourceLinks[resource], models.ResourceLink{
-					Absolute: link.Absolute,
-					Href:     link.HREF,
-				})
-			}
+	for addition, link := range a.AdditionLinks {
+		if art.AdditionLinks == nil {
+			art.AdditionLinks = make(map[string]models.AdditionLink)
+		}
+		art.AdditionLinks[addition] = models.AdditionLink{
+			Absolute: link.Absolute,
+			Href:     link.HREF,
 		}
 	}
 	return art
@@ -94,14 +92,8 @@ type Tag struct {
 	// TODO add other attrs: signature, label, etc
 }
 
-// Resource defines the specific resource of different artifacts: build history for image, values.yaml for chart, etc
-type Resource struct {
-	Content     []byte // the content of the resource
-	ContentType string // the content type of the resource, returned as "Content-Type" header in API
-}
-
-// ResourceLink is a link via that a resource can be fetched
-type ResourceLink struct {
+// AdditionLink is a link via that the addition can be fetched
+type AdditionLink struct {
 	HREF     string
 	Absolute bool // specify the href is an absolute URL or not
 }

--- a/src/common/rbac/const.go
+++ b/src/common/rbac/const.go
@@ -64,5 +64,6 @@ const (
 	ResourceScanner                    = Resource("scanner")
 	ResourceArtifact                   = Resource("artifact")
 	ResourceTag                        = Resource("tag")
+	ResourceArtifactAddition           = Resource("artifact-addition")
 	ResourceSelf                       = Resource("") // subresource for self
 )

--- a/src/common/rbac/project/util.go
+++ b/src/common/rbac/project/util.go
@@ -51,6 +51,7 @@ var (
 
 		{Resource: rbac.ResourceArtifact, Action: rbac.ActionRead},
 		{Resource: rbac.ResourceArtifact, Action: rbac.ActionList},
+		{Resource: rbac.ResourceArtifactAddition, Action: rbac.ActionRead},
 	}
 
 	// all policies for the projects

--- a/src/common/rbac/project/visitor_role.go
+++ b/src/common/rbac/project/visitor_role.go
@@ -131,6 +131,7 @@ var (
 			{Resource: rbac.ResourceArtifact, Action: rbac.ActionRead},
 			{Resource: rbac.ResourceArtifact, Action: rbac.ActionDelete},
 			{Resource: rbac.ResourceArtifact, Action: rbac.ActionList},
+			{Resource: rbac.ResourceArtifactAddition, Action: rbac.ActionRead},
 
 			{Resource: rbac.ResourceTag, Action: rbac.ActionCreate},
 			{Resource: rbac.ResourceTag, Action: rbac.ActionDelete},
@@ -227,6 +228,7 @@ var (
 			{Resource: rbac.ResourceArtifact, Action: rbac.ActionRead},
 			{Resource: rbac.ResourceArtifact, Action: rbac.ActionDelete},
 			{Resource: rbac.ResourceArtifact, Action: rbac.ActionList},
+			{Resource: rbac.ResourceArtifactAddition, Action: rbac.ActionRead},
 
 			{Resource: rbac.ResourceTag, Action: rbac.ActionCreate},
 			{Resource: rbac.ResourceTag, Action: rbac.ActionDelete},
@@ -289,6 +291,7 @@ var (
 
 			{Resource: rbac.ResourceArtifact, Action: rbac.ActionRead},
 			{Resource: rbac.ResourceArtifact, Action: rbac.ActionList},
+			{Resource: rbac.ResourceArtifactAddition, Action: rbac.ActionRead},
 
 			{Resource: rbac.ResourceTag, Action: rbac.ActionCreate},
 		},
@@ -338,6 +341,7 @@ var (
 
 			{Resource: rbac.ResourceArtifact, Action: rbac.ActionRead},
 			{Resource: rbac.ResourceArtifact, Action: rbac.ActionList},
+			{Resource: rbac.ResourceArtifactAddition, Action: rbac.ActionRead},
 		},
 
 		"limitedGuest": {
@@ -369,6 +373,7 @@ var (
 
 			{Resource: rbac.ResourceArtifact, Action: rbac.ActionRead},
 			{Resource: rbac.ResourceArtifact, Action: rbac.ActionList},
+			{Resource: rbac.ResourceArtifactAddition, Action: rbac.ActionRead},
 		},
 	}
 )

--- a/src/internal/context.go
+++ b/src/internal/context.go
@@ -1,0 +1,53 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import "context"
+
+type contextKey string
+
+// define all context key here to avoid conflict
+const (
+	contextKeyAPIVersion contextKey = "apiVersion"
+)
+
+func setToContext(ctx context.Context, key contextKey, value interface{}) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, key, value)
+}
+
+func getFromContext(ctx context.Context, key contextKey) interface{} {
+	if ctx == nil {
+		return nil
+	}
+	return ctx.Value(key)
+}
+
+// SetAPIVersion sets the API version into the context
+func SetAPIVersion(ctx context.Context, version string) context.Context {
+	return setToContext(ctx, contextKeyAPIVersion, version)
+}
+
+// GetAPIVersion gets the API version from the context
+func GetAPIVersion(ctx context.Context) string {
+	version := ""
+	value := getFromContext(ctx, contextKeyAPIVersion)
+	if value != nil {
+		version = value.(string)
+	}
+	return version
+}

--- a/src/internal/context_test.go
+++ b/src/internal/context_test.go
@@ -12,25 +12,30 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package blob
+package internal
 
 import (
-	"github.com/stretchr/testify/mock"
+	"context"
+	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
-// FakeFetcher is a fake blob fetcher that implement the src/api/artifact/abstractor/blob.Fetcher interface
-type FakeFetcher struct {
-	mock.Mock
+func TestSetAPIVersion(t *testing.T) {
+	ctx := SetAPIVersion(context.Background(), "1.0")
+	assert.NotNil(t, ctx)
 }
 
-// FetchManifest ...
-func (f *FakeFetcher) FetchManifest(repoFullName, digest string) (string, []byte, error) {
-	args := f.Called(mock.Anything)
-	return args.String(0), args.Get(1).([]byte), args.Error(2)
-}
+func TestGetAPIVersion(t *testing.T) {
+	// nil context
+	version := GetAPIVersion(nil)
+	assert.Empty(t, version)
 
-// FetchLayer ...
-func (f *FakeFetcher) FetchLayer(repoFullName, digest string) (content []byte, err error) {
-	args := f.Called(mock.Anything)
-	return args.Get(0).([]byte), args.Error(1)
+	// no version set in context
+	version = GetAPIVersion(context.Background())
+	assert.Empty(t, version)
+
+	// version set in context
+	ctx := SetAPIVersion(context.Background(), "1.0")
+	version = GetAPIVersion(ctx)
+	assert.Equal(t, "1.0", version)
 }

--- a/src/server/middleware/apiversion/api_version.go
+++ b/src/server/middleware/apiversion/api_version.go
@@ -12,25 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package blob
+package apiversion
 
 import (
-	"github.com/stretchr/testify/mock"
+	"github.com/goharbor/harbor/src/internal"
+	"github.com/goharbor/harbor/src/server/middleware"
+	"net/http"
 )
 
-// FakeFetcher is a fake blob fetcher that implement the src/api/artifact/abstractor/blob.Fetcher interface
-type FakeFetcher struct {
-	mock.Mock
-}
-
-// FetchManifest ...
-func (f *FakeFetcher) FetchManifest(repoFullName, digest string) (string, []byte, error) {
-	args := f.Called(mock.Anything)
-	return args.String(0), args.Get(1).([]byte), args.Error(2)
-}
-
-// FetchLayer ...
-func (f *FakeFetcher) FetchLayer(repoFullName, digest string) (content []byte, err error) {
-	args := f.Called(mock.Anything)
-	return args.Get(0).([]byte), args.Error(1)
+// Middleware returns a middleware that set the API version into the context
+func Middleware(version string) middleware.Middleware {
+	return func(handler http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			ctx := internal.SetAPIVersion(req.Context(), version)
+			handler.ServeHTTP(w, req.WithContext(ctx))
+		})
+	}
 }

--- a/src/server/middleware/apiversion/api_version_test.go
+++ b/src/server/middleware/apiversion/api_version_test.go
@@ -12,25 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package blob
+package apiversion
 
 import (
-	"github.com/stretchr/testify/mock"
+	"github.com/goharbor/harbor/src/internal"
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"net/http/httptest"
+	"testing"
 )
 
-// FakeFetcher is a fake blob fetcher that implement the src/api/artifact/abstractor/blob.Fetcher interface
-type FakeFetcher struct {
-	mock.Mock
-}
-
-// FetchManifest ...
-func (f *FakeFetcher) FetchManifest(repoFullName, digest string) (string, []byte, error) {
-	args := f.Called(mock.Anything)
-	return args.String(0), args.Get(1).([]byte), args.Error(2)
-}
-
-// FetchLayer ...
-func (f *FakeFetcher) FetchLayer(repoFullName, digest string) (content []byte, err error) {
-	args := f.Called(mock.Anything)
-	return args.Get(0).([]byte), args.Error(1)
+func TestMiddleware(t *testing.T) {
+	version := ""
+	middleware := Middleware("1.0")
+	req := httptest.NewRequest("GET", "http://localhost", nil)
+	handler := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		version = internal.GetAPIVersion(req.Context())
+	})
+	middleware(handler).ServeHTTP(nil, req)
+	assert.Equal(t, "1.0", version)
 }

--- a/src/server/v2.0/handler/repository.go
+++ b/src/server/v2.0/handler/repository.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/goharbor/harbor/src/api/repository"
+	"github.com/goharbor/harbor/src/common/rbac"
 	operation "github.com/goharbor/harbor/src/server/v2.0/restapi/operations/repository"
 )
 
@@ -34,6 +35,9 @@ type repositoryAPI struct {
 }
 
 func (r *repositoryAPI) DeleteRepository(ctx context.Context, params operation.DeleteRepositoryParams) middleware.Responder {
+	if err := r.RequireProjectAccess(ctx, params.ProjectName, rbac.ActionDelete, rbac.ResourceRepository); err != nil {
+		return r.SendError(ctx, err)
+	}
 	repository, err := r.repoCtl.GetByName(ctx, fmt.Sprintf("%s/%s", params.ProjectName, params.RepositoryName))
 	if err != nil {
 		return r.SendError(ctx, err)

--- a/src/server/v2.0/route/route.go
+++ b/src/server/v2.0/route/route.go
@@ -15,11 +15,18 @@
 package route
 
 import (
+	"github.com/goharbor/harbor/src/server/middleware/apiversion"
 	"github.com/goharbor/harbor/src/server/router"
 	"github.com/goharbor/harbor/src/server/v2.0/handler"
 )
 
+const (
+	version = "v2.0"
+)
+
 // RegisterRoutes for Harbor v2.0 APIs
 func RegisterRoutes() {
-	router.NewRoute().Path("/api/v2.0/*").Handler(handler.New())
+	router.NewRoute().Path("/api/" + version + "/*").
+		Middleware(apiversion.Middleware(version)).
+		Handler(handler.New())
 }

--- a/src/testing/api/artifact/abstractor/resolver/resolver.go
+++ b/src/testing/api/artifact/abstractor/resolver/resolver.go
@@ -1,0 +1,43 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resolver
+
+import (
+	"context"
+	"github.com/goharbor/harbor/src/api/artifact/abstractor/resolver"
+	"github.com/goharbor/harbor/src/pkg/artifact"
+	"github.com/stretchr/testify/mock"
+)
+
+// FakeResolver is a fake resolver that implement the src/api/artifact/abstractor/resolver.Resolver interface
+type FakeResolver struct {
+	mock.Mock
+}
+
+// ResolveMetadata ...
+func (f *FakeResolver) ResolveMetadata(ctx context.Context, manifest []byte, artifact *artifact.Artifact) error {
+	args := f.Called()
+	return args.Error(0)
+}
+
+// ResolveAddition ...
+func (f *FakeResolver) ResolveAddition(ctx context.Context, artifact *artifact.Artifact, additionType string) (*resolver.Addition, error) {
+	args := f.Called()
+	var addition *resolver.Addition
+	if args.Get(0) != nil {
+		addition = args.Get(0).(*resolver.Addition)
+	}
+	return addition, args.Error(1)
+}

--- a/src/testing/api/artifact/controller.go
+++ b/src/testing/api/artifact/controller.go
@@ -17,6 +17,7 @@ package artifact
 import (
 	"context"
 	"github.com/goharbor/harbor/src/api/artifact"
+	"github.com/goharbor/harbor/src/api/artifact/abstractor/resolver"
 	"github.com/goharbor/harbor/src/pkg/q"
 	"github.com/stretchr/testify/mock"
 	"time"
@@ -97,12 +98,12 @@ func (f *FakeController) UpdatePullTime(ctx context.Context, artifactID int64, t
 	return args.Error(0)
 }
 
-// GetSubResource ...
-func (f *FakeController) GetSubResource(ctx context.Context, artifactID int64, resource string) (*artifact.Resource, error) {
+// GetAddition ...
+func (f *FakeController) GetAddition(ctx context.Context, artifactID int64, addition string) (*resolver.Addition, error) {
 	args := f.Called()
-	var res *artifact.Resource
+	var res *resolver.Addition
 	if args.Get(0) != nil {
-		res = args.Get(0).(*artifact.Resource)
+		res = args.Get(0).(*resolver.Addition)
 	}
 	return res, args.Error(1)
 }


### PR DESCRIPTION
This commit implements the API to get build history of image with manifest version 2 and populates the addition links when listing/getting the artifact

Signed-off-by: Wenkai Yin <yinw@vmware.com>