### PR TITLE
fix(middleware): escape and clean path for the skipper

### DIFF
--- a/src/core/middlewares/middlewares.go
+++ b/src/core/middlewares/middlewares.go
@@ -16,6 +16,7 @@ package middlewares
 
 import (
 	"net/http"
+	"path"
 	"regexp"
 	"strings"
 
@@ -37,8 +38,9 @@ var (
 
 // legacyAPISkipper skip middleware for legacy APIs
 func legacyAPISkipper(r *http.Request) bool {
+	path := path.Clean(r.URL.EscapedPath())
 	for _, prefix := range []string{"/v2/", "/api/v2.0/"} {
-		if strings.HasPrefix(r.URL.Path, prefix) {
+		if strings.HasPrefix(path, prefix) {
 			return false
 		}
 	}

--- a/src/core/middlewares/middlewares_test.go
+++ b/src/core/middlewares/middlewares_test.go
@@ -41,3 +41,27 @@ func Test_fetchBlobAPISkipper(t *testing.T) {
 		})
 	}
 }
+
+func Test_legacyAPISkipper(t *testing.T) {
+	type args struct {
+		r *http.Request
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{"/api/v2.0/projects", args{httptest.NewRequest(http.MethodGet, "/api/v2.0/projects", nil)}, false},
+		{"//api/v2.0/projects", args{httptest.NewRequest(http.MethodGet, "//api/v2.0/projects", nil)}, false},
+		{"/api/v2.0//projects", args{httptest.NewRequest(http.MethodGet, "/api/v2.0//projects", nil)}, false},
+		{"/v2/library/photon/tags", args{httptest.NewRequest(http.MethodGet, "/v2/library/photon/tags", nil)}, false},
+		{"/api/projects", args{httptest.NewRequest(http.MethodGet, "/api/projects", nil)}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := legacyAPISkipper(tt.args.r); got != tt.want {
+				t.Errorf("legacyAPISkipper() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/src/server/middleware/skipper.go
+++ b/src/server/middleware/skipper.go
@@ -16,6 +16,7 @@ package middleware
 
 import (
 	"net/http"
+	"path"
 	"regexp"
 )
 
@@ -28,7 +29,8 @@ type Skipper func(*http.Request) bool
 // when method is "*" it equals all http method
 func MethodAndPathSkipper(method string, re *regexp.Regexp) func(r *http.Request) bool {
 	return func(r *http.Request) bool {
-		if (method == "*" || r.Method == method) && re.MatchString(r.URL.Path) {
+		path := path.Clean(r.URL.EscapedPath())
+		if (method == "*" || r.Method == method) && re.MatchString(path) {
 			return true
 		}
 


### PR DESCRIPTION
1. Escape and clean request path for `legacyAPISkipper`.
2. Escape and clean request path for `MethodAndPathSkipper`.

Signed-off-by: He Weiwei <hweiwei@vmware.com>