### PR TITLE
Fix bugs when pushing image(with index) and CNAB

### DIFF
--- a/src/api/artifact/abstractor/resolver/image/index_test.go
+++ b/src/api/artifact/abstractor/resolver/image/index_test.go
@@ -120,15 +120,13 @@ func (i *indexResolverTestSuite) TestResolveMetadata() {
   "schemaVersion": 2
 }`
 	art := &artifact.Artifact{}
-	i.artMgr.On("List").Return(1, []*artifact.Artifact{
-		{
-			ID: 1,
-		},
+	i.artMgr.On("GetByDigest").Return(&artifact.Artifact{
+		ID: 1,
 	}, nil)
 	err := i.resolver.ResolveMetadata(nil, []byte(manifest), art)
 	i.Require().Nil(err)
 	i.artMgr.AssertExpectations(i.T())
-	i.Assert().Len(art.References, 8)
+	i.Require().Len(art.References, 8)
 	i.Assert().Equal(int64(1), art.References[0].ChildID)
 	i.Assert().Equal("amd64", art.References[0].Platform.Architecture)
 }

--- a/src/api/artifact/controller_test.go
+++ b/src/api/artifact/controller_test.go
@@ -158,10 +158,8 @@ func (c *controllerTestSuite) TestEnsureArtifact() {
 	digest := "sha256:418fb88ec412e340cdbef913b8ca1bbe8f9e8dc705f9617414c1f2c8db980180"
 
 	// the artifact already exists
-	c.artMgr.On("List").Return(1, []*artifact.Artifact{
-		{
-			ID: 1,
-		},
+	c.artMgr.On("GetByDigest").Return(&artifact.Artifact{
+		ID: 1,
 	}, nil)
 	created, id, err := c.ctl.ensureArtifact(nil, 1, digest)
 	c.Require().Nil(err)
@@ -175,7 +173,7 @@ func (c *controllerTestSuite) TestEnsureArtifact() {
 	c.repoMgr.On("Get").Return(&models.RepoRecord{
 		ProjectID: 1,
 	}, nil)
-	c.artMgr.On("List").Return(1, []*artifact.Artifact{}, nil)
+	c.artMgr.On("GetByDigest").Return(nil, ierror.NotFoundError(nil))
 	c.artMgr.On("Create").Return(1, nil)
 	c.abstractor.On("AbstractMetadata").Return(nil)
 	created, id, err = c.ctl.ensureArtifact(nil, 1, digest)
@@ -233,7 +231,7 @@ func (c *controllerTestSuite) TestEnsure() {
 	c.repoMgr.On("Get").Return(&models.RepoRecord{
 		ProjectID: 1,
 	}, nil)
-	c.artMgr.On("List").Return(1, []*artifact.Artifact{}, nil)
+	c.artMgr.On("GetByDigest").Return(nil, ierror.NotFoundError(nil))
 	c.artMgr.On("Create").Return(1, nil)
 	c.tagMgr.On("List").Return(1, []*tag.Tag{}, nil)
 	c.tagMgr.On("Create").Return(1, nil)
@@ -298,7 +296,7 @@ func (c *controllerTestSuite) TestGetByDigest() {
 	c.repoMgr.On("GetByName").Return(&models.RepoRecord{
 		RepositoryID: 1,
 	}, nil)
-	c.artMgr.On("List").Return(0, nil, nil)
+	c.artMgr.On("GetByDigest").Return(nil, ierror.NotFoundError(nil))
 	c.abstractor.On("ListSupportedAdditions").Return([]string{"BUILD_HISTORY"})
 	art, err := c.ctl.getByDigest(nil, "library/hello-world",
 		"sha256:418fb88ec412e340cdbef913b8ca1bbe8f9e8dc705f9617414c1f2c8db980180", nil)
@@ -312,11 +310,9 @@ func (c *controllerTestSuite) TestGetByDigest() {
 	c.repoMgr.On("GetByName").Return(&models.RepoRecord{
 		RepositoryID: 1,
 	}, nil)
-	c.artMgr.On("List").Return(1, []*artifact.Artifact{
-		{
-			ID:           1,
-			RepositoryID: 1,
-		},
+	c.artMgr.On("GetByDigest").Return(&artifact.Artifact{
+		ID:           1,
+		RepositoryID: 1,
 	}, nil)
 	c.abstractor.On("ListSupportedAdditions").Return([]string{"BUILD_HISTORY"})
 	art, err = c.ctl.getByDigest(nil, "library/hello-world",
@@ -367,11 +363,9 @@ func (c *controllerTestSuite) TestGetByReference() {
 	c.repoMgr.On("GetByName").Return(&models.RepoRecord{
 		RepositoryID: 1,
 	}, nil)
-	c.artMgr.On("List").Return(1, []*artifact.Artifact{
-		{
-			ID:           1,
-			RepositoryID: 1,
-		},
+	c.artMgr.On("GetByDigest").Return(&artifact.Artifact{
+		ID:           1,
+		RepositoryID: 1,
 	}, nil)
 	c.abstractor.On("ListSupportedAdditions").Return([]string{"BUILD_HISTORY"})
 	art, err := c.ctl.GetByReference(nil, "library/hello-world",

--- a/src/go.mod
+++ b/src/go.mod
@@ -35,8 +35,12 @@ require (
 	github.com/garyburd/redigo v1.6.0
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-openapi/errors v0.19.2
+	github.com/go-openapi/loads v0.19.3
 	github.com/go-openapi/runtime v0.19.5
+	github.com/go-openapi/spec v0.19.3
 	github.com/go-openapi/strfmt v0.19.3
+	github.com/go-openapi/swag v0.19.5
+	github.com/go-openapi/validate v0.19.3
 	github.com/go-sql-driver/mysql v1.4.1
 	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/gocraft/work v0.5.1

--- a/src/pkg/artifact/dao/dao_test.go
+++ b/src/pkg/artifact/dao/dao_test.go
@@ -322,6 +322,19 @@ func (d *daoTestSuite) TestGet() {
 	d.Equal(d.parentArtID, artifact.ID)
 }
 
+func (d *daoTestSuite) TestGetByDigest() {
+	// get the non-exist artifact
+	_, err := d.dao.GetByDigest(d.ctx, 1, "non_existing_digest")
+	d.Require().NotNil(err)
+	d.True(ierror.IsErr(err, ierror.NotFoundCode))
+
+	// get the exist artifact
+	artifact, err := d.dao.GetByDigest(d.ctx, 1, "child_digest_02")
+	d.Require().Nil(err)
+	d.Require().NotNil(artifact)
+	d.Equal(d.childArt02ID, artifact.ID)
+}
+
 func (d *daoTestSuite) TestCreate() {
 	// the happy pass case is covered in Setup
 

--- a/src/server/error/error.go
+++ b/src/server/error/error.go
@@ -58,6 +58,9 @@ func SendError(w http.ResponseWriter, err error) {
 		// only log the error whose status code < 500 when debugging to avoid log flooding
 		log.Debug(errPayload)
 	}
+	if statusCode == http.StatusUnauthorized {
+		w.Header().Set("Www-Authenticate", `Basic realm="harbor"`)
+	}
 	w.WriteHeader(statusCode)
 	fmt.Fprintln(w, errPayload)
 }

--- a/src/server/error/error_test.go
+++ b/src/server/error/error_test.go
@@ -25,9 +25,17 @@ import (
 )
 
 func TestSendError(t *testing.T) {
-	// internal server error
+	// unauthorized error
 	rw := httptest.NewRecorder()
-	err := ierror.New(nil).WithCode(ierror.GeneralCode).WithMessage("unknown")
+	err := ierror.New(nil).WithCode(ierror.UnAuthorizedCode).WithMessage("unauthorized")
+	SendError(rw, err)
+	assert.Equal(t, http.StatusUnauthorized, rw.Code)
+	assert.Equal(t, `{"errors":[{"code":"UNAUTHORIZED","message":"unauthorized"}]}`+"\n", rw.Body.String())
+	assert.Equal(t, `Basic realm="harbor"`, rw.Header().Get("Www-Authenticate"))
+
+	// internal server error
+	rw = httptest.NewRecorder()
+	err = ierror.New(nil).WithCode(ierror.GeneralCode).WithMessage("unknown")
 	SendError(rw, err)
 	assert.Equal(t, http.StatusInternalServerError, rw.Code)
 	assert.Equal(t, `{"errors":[{"code":"UNKNOWN","message":"internal server error"}]}`+"\n", rw.Body.String())

--- a/src/server/middleware/util.go
+++ b/src/server/middleware/util.go
@@ -34,8 +34,6 @@ const (
 	manifestInfoKey = contextKey("ManifestInfo")
 	// ScannerPullCtxKey the context key for robot account to bypass the pull policy check.
 	ScannerPullCtxKey = contextKey("ScannerPullCheck")
-	// SkipInjectRegistryCredKey is the context key telling registry proxy to skip adding credentials
-	SkipInjectRegistryCredKey = contextKey("SkipInjectRegistryCredential")
 )
 
 var (
@@ -94,12 +92,6 @@ type ArtifactInfo struct {
 func ArtifactInfoFromContext(ctx context.Context) (*ArtifactInfo, bool) {
 	info, ok := ctx.Value(ArtifactInfoKey).(*ArtifactInfo)
 	return info, ok
-}
-
-// SkipInjectRegistryCred reflects whether the inject credentials should be skipped
-func SkipInjectRegistryCred(ctx context.Context) bool {
-	res, ok := ctx.Value(SkipInjectRegistryCredKey).(bool)
-	return ok && res
 }
 
 // NewManifestInfoContext returns context with manifest info

--- a/src/server/middleware/v2auth/auth.go
+++ b/src/server/middleware/v2auth/auth.go
@@ -15,7 +15,7 @@
 package v2auth
 
 import (
-	"context"
+	"errors"
 	"fmt"
 	serror "github.com/goharbor/harbor/src/server/error"
 	"net/http"
@@ -70,8 +70,7 @@ func (rc *reqChecker) check(req *http.Request) error {
 	} else if len(middleware.V2CatalogURLRe.FindStringSubmatch(req.URL.Path)) == 1 && !securityCtx.IsSysAdmin() {
 		return fmt.Errorf("unauthorized to list catalog")
 	} else if req.URL.Path == "/v2/" && !securityCtx.IsAuthenticated() {
-		ctx := context.WithValue(req.Context(), middleware.SkipInjectRegistryCredKey, true)
-		*req = *(req.WithContext(ctx))
+		return errors.New("unauthorized")
 	}
 	return nil
 }

--- a/src/server/registry/proxy.go
+++ b/src/server/registry/proxy.go
@@ -17,7 +17,6 @@ package registry
 import (
 	"fmt"
 	"github.com/goharbor/harbor/src/core/config"
-	"github.com/goharbor/harbor/src/server/middleware"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -39,7 +38,7 @@ func newProxy() http.Handler {
 func basicAuthDirector(d func(*http.Request)) func(*http.Request) {
 	return func(r *http.Request) {
 		d(r)
-		if r != nil && !middleware.SkipInjectRegistryCred(r.Context()) {
+		if r != nil {
 			u, p := config.RegistryCredential()
 			r.SetBasicAuth(u, p)
 		}

--- a/src/testing/pkg/artifact/manager.go
+++ b/src/testing/pkg/artifact/manager.go
@@ -47,6 +47,16 @@ func (f *FakeManager) Get(ctx context.Context, id int64) (*artifact.Artifact, er
 	return art, args.Error(1)
 }
 
+// GetByDigest ...
+func (f *FakeManager) GetByDigest(ctx context.Context, repositoryID int64, digest string) (*artifact.Artifact, error) {
+	args := f.Called()
+	var art *artifact.Artifact
+	if args.Get(0) != nil {
+		art = args.Get(0).(*artifact.Artifact)
+	}
+	return art, args.Error(1)
+}
+
 // Create ...
 func (f *FakeManager) Create(ctx context.Context, artifact *artifact.Artifact) (int64, error) {
 	args := f.Called()


### PR DESCRIPTION
1. As "List" method of artifact DAO doesn't return the artifacts that referenced by other and without tag, so we introduce a new method "GetByDigest" to check the existence of artifact
2. The "Www-Authenticate" header is needed to be returned when the request is unauthorized. This is required in the OCI distribution spec and is needed when pushing CNAB

Signed-off-by: Wenkai Yin <yinw@vmware.com>