### PR TITLE
Move the scan overview populating logic to API handler

### DIFF
--- a/api/v2.0/swagger.yaml
+++ b/api/v2.0/swagger.yaml
@@ -478,6 +478,10 @@ definitions:
         description: The error message
   Artifact:
     type: object
+    x-go-type:
+      import:
+        package: "github.com/goharbor/harbor/src/server/v2.0/handler/model"
+      type: "Artifact"
     properties:
       id:
         type: integer

--- a/src/api/artifact/abstractor/resolver/image/manifest_v2.go
+++ b/src/api/artifact/abstractor/resolver/image/manifest_v2.go
@@ -31,9 +31,8 @@ import (
 // const definitions
 const (
 	// ArtifactTypeImage is the artifact type for image
-	ArtifactTypeImage           = "IMAGE"
-	AdditionTypeBuildHistory    = "BUILD_HISTORY"
-	AdditionTypeVulnerabilities = "VULNERABILITIES"
+	ArtifactTypeImage        = "IMAGE"
+	AdditionTypeBuildHistory = "BUILD_HISTORY"
 )
 
 func init() {
@@ -129,5 +128,5 @@ func (m *manifestV2Resolver) GetArtifactType() string {
 }
 
 func (m *manifestV2Resolver) ListAdditionTypes() []string {
-	return []string{AdditionTypeBuildHistory, AdditionTypeVulnerabilities}
+	return []string{AdditionTypeBuildHistory}
 }

--- a/src/api/artifact/abstractor/resolver/image/manifest_v2_test.go
+++ b/src/api/artifact/abstractor/resolver/image/manifest_v2_test.go
@@ -171,7 +171,7 @@ func (m *manifestV2ResolverTestSuite) TestGetArtifactType() {
 
 func (m *manifestV2ResolverTestSuite) TestListAdditionTypes() {
 	additions := m.resolver.ListAdditionTypes()
-	m.EqualValues([]string{AdditionTypeBuildHistory, AdditionTypeVulnerabilities}, additions)
+	m.EqualValues([]string{AdditionTypeBuildHistory}, additions)
 }
 
 func TestManifestV2ResolverTestSuite(t *testing.T) {

--- a/src/api/artifact/controller_test.go
+++ b/src/api/artifact/controller_test.go
@@ -129,8 +129,7 @@ func (c *controllerTestSuite) TestAssembleArtifact() {
 		TagOption: &TagOption{
 			WithImmutableStatus: false,
 		},
-		WithLabel:        true,
-		WithScanOverview: true,
+		WithLabel: true,
 	}
 	tg := &tag.Tag{
 		ID:           1,
@@ -259,8 +258,7 @@ func (c *controllerTestSuite) TestEnsure() {
 func (c *controllerTestSuite) TestList() {
 	query := &q.Query{}
 	option := &Option{
-		WithTag:          true,
-		WithScanOverview: true,
+		WithTag: true,
 	}
 	c.artMgr.On("List").Return(1, []*artifact.Artifact{
 		{

--- a/src/api/artifact/model.go
+++ b/src/api/artifact/model.go
@@ -15,12 +15,10 @@
 package artifact
 
 import (
-	"github.com/go-openapi/strfmt"
 	cmodels "github.com/goharbor/harbor/src/common/models"
 	"github.com/goharbor/harbor/src/pkg/artifact"
 	"github.com/goharbor/harbor/src/pkg/signature"
 	"github.com/goharbor/harbor/src/pkg/tag/model/tag"
-	"github.com/goharbor/harbor/src/server/v2.0/models"
 )
 
 // Artifact is the overall view of artifact
@@ -29,77 +27,6 @@ type Artifact struct {
 	Tags          []*Tag                   // the list of tags that attached to the artifact
 	AdditionLinks map[string]*AdditionLink // the resource link for build history(image), values.yaml(chart), dependency(chart), etc
 	Labels        []*cmodels.Label
-	// TODO add other attrs: signature, scan result, etc
-}
-
-// ToSwagger converts the artifact to the swagger model
-func (a *Artifact) ToSwagger() *models.Artifact {
-	art := &models.Artifact{
-		ID:                a.ID,
-		Type:              a.Type,
-		MediaType:         a.MediaType,
-		ManifestMediaType: a.ManifestMediaType,
-		ProjectID:         a.ProjectID,
-		RepositoryID:      a.RepositoryID,
-		Digest:            a.Digest,
-		Size:              a.Size,
-		PullTime:          strfmt.DateTime(a.PullTime),
-		PushTime:          strfmt.DateTime(a.PushTime),
-		ExtraAttrs:        a.ExtraAttrs,
-		Annotations:       a.Annotations,
-	}
-	for _, reference := range a.References {
-		ref := &models.Reference{
-			ChildID:     reference.ChildID,
-			ChildDigest: reference.ChildDigest,
-			ParentID:    reference.ParentID,
-		}
-		if reference.Platform != nil {
-			ref.Platform = &models.Platform{
-				Architecture: reference.Platform.Architecture,
-				Os:           reference.Platform.OS,
-				OsFeatures:   reference.Platform.OSFeatures,
-				OsVersion:    reference.Platform.OSVersion,
-				Variant:      reference.Platform.Variant,
-			}
-		}
-		art.References = append(art.References, ref)
-	}
-	for _, tag := range a.Tags {
-		art.Tags = append(art.Tags, &models.Tag{
-			ArtifactID:   tag.ArtifactID,
-			ID:           tag.ID,
-			Name:         tag.Name,
-			PullTime:     strfmt.DateTime(tag.PullTime),
-			PushTime:     strfmt.DateTime(tag.PushTime),
-			RepositoryID: tag.RepositoryID,
-			Immutable:    tag.Immutable,
-			Signed:       tag.Signed,
-		})
-	}
-	for addition, link := range a.AdditionLinks {
-		if art.AdditionLinks == nil {
-			art.AdditionLinks = make(map[string]models.AdditionLink)
-		}
-		art.AdditionLinks[addition] = models.AdditionLink{
-			Absolute: link.Absolute,
-			Href:     link.HREF,
-		}
-	}
-	for _, label := range a.Labels {
-		art.Labels = append(art.Labels, &models.Label{
-			ID:           label.ID,
-			Name:         label.Name,
-			Description:  label.Description,
-			Color:        label.Color,
-			CreationTime: strfmt.DateTime(label.CreationTime),
-			ProjectID:    label.ProjectID,
-			Scope:        label.Scope,
-			UpdateTime:   strfmt.DateTime(label.UpdateTime),
-			Deleted:      label.Deleted,
-		})
-	}
-	return art
 }
 
 // Tag is the overall view of tag
@@ -107,7 +34,6 @@ type Tag struct {
 	tag.Tag
 	Immutable bool
 	Signed    bool
-	// TODO add other attrs: label, etc
 }
 
 // AdditionLink is a link via that the addition can be fetched
@@ -118,10 +44,9 @@ type AdditionLink struct {
 
 // Option is used to specify the properties returned when listing/getting artifacts
 type Option struct {
-	WithTag          bool
-	TagOption        *TagOption // only works when WithTag is set to true
-	WithLabel        bool
-	WithScanOverview bool
+	WithTag   bool
+	TagOption *TagOption // only works when WithTag is set to true
+	WithLabel bool
 }
 
 // TagOption is used to specify the properties returned when listing/getting tags
@@ -130,9 +55,3 @@ type TagOption struct {
 	WithSignature       bool
 	SignatureChecker    *signature.Checker
 }
-
-// TODO move this to GC controller?
-// Option for pruning artifact records
-// type Option struct {
-//	 KeepUntagged bool // keep the untagged artifacts or not
-// }

--- a/src/server/v2.0/handler/model/artifact.go
+++ b/src/server/v2.0/handler/model/artifact.go
@@ -1,0 +1,23 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import "github.com/goharbor/harbor/src/api/artifact"
+
+// Artifact model
+type Artifact struct {
+	artifact.Artifact
+	// TODO add other properties: scan result
+}


### PR DESCRIPTION
Move the scan overview populating logic to API handler to avoid importing cycle

Signed-off-by: Wenkai Yin <yinw@vmware.com>