### PR TITLE
Bugfix/core ca bundle bind mount

### DIFF
--- a/make/harbor.yml.tmpl
+++ b/make/harbor.yml.tmpl
@@ -4,6 +4,10 @@
 # DO NOT use localhost or 127.0.0.1, because Harbor needs to be accessed by external clients.
 hostname: reg.mydomain.com
 
+# Uncomment the following section if you want to override the default system CA bundle
+# core:
+#  ca_bundle: /etc/pki/tls/certs/ca-bundle.crt
+
 # http related config
 http:
   # port for http, default is 80. If https enabled, this port will redirect to https port

--- a/make/photon/prepare/templates/docker_compose/docker-compose.yml.jinja
+++ b/make/photon/prepare/templates/docker_compose/docker-compose.yml.jinja
@@ -158,6 +158,11 @@ services:
         source: {{uaa_ca_file}}
         target: /etc/core/certificates/uaa_ca.pem
 {% endif %}
+{% if core_custom_ca_bundle_path %}
+      - type: bind
+        source: {{core_custom_ca_bundle_path}}
+        target: /etc/pki/tls/certs/ca-bundle.crt
+{% endif %}
     networks:
       harbor:
 {% if with_notary %}

--- a/make/photon/prepare/utils/configs.py
+++ b/make/photon/prepare/utils/configs.py
@@ -53,23 +53,21 @@ def validate(conf: dict, **kwargs):
             raise Exception(
                 "Error: no provider configurations are provided for provider %s" % storage_provider_name)
     # ca_bundle validate
-    if conf.get('registry_custom_ca_bundle_path'):
-        registry_custom_ca_bundle_path = conf.get('registry_custom_ca_bundle_path') or ''
-        if registry_custom_ca_bundle_path.startswith('/data/'):
-            ca_bundle_host_path = registry_custom_ca_bundle_path
-        else:
-            ca_bundle_host_path = os.path.join(host_root_dir, registry_custom_ca_bundle_path.lstrip('/'))
-        try:
-            uid = os.stat(ca_bundle_host_path).st_uid
-            st_mode = os.stat(ca_bundle_host_path).st_mode
-        except Exception as e:
-            logging.error(e)
-            raise Exception('Can not get file info')
-        err_msg = 'Cert File {} should be owned by user with uid 10000 or readable by others'.format(registry_custom_ca_bundle_path)
-        if uid == DEFAULT_UID and not owner_can_read(st_mode):
-            raise Exception(err_msg)
-        if uid != DEFAULT_UID and not other_can_read(st_mode):
-            raise Exception(err_msg)
+    for conf_key in ('registry_custom_ca_bundle_path', 'core_custom_ca_bundle_path'):
+        if conf.get(conf_key):
+            custom_ca_bundle_path = conf.get(conf_key) or ''
+            ca_bundle_host_path = os.path.join(host_root_dir, custom_ca_bundle_path.strip('/'))
+            try:
+                uid = os.stat(ca_bundle_host_path).st_uid
+                st_mode = os.stat(ca_bundle_host_path).st_mode
+            except Exception as e:
+                logging.error(e)
+                raise Exception('Can not get file info')
+            err_msg = 'Cert File {} should be owned by user with uid 10000 or readable by others'.format(custom_ca_bundle_path)
+            if uid == DEFAULT_UID and not owner_can_read(st_mode):
+                raise Exception(err_msg)
+            if uid != DEFAULT_UID and not other_can_read(st_mode):
+                raise Exception(err_msg)
 
     # Redis validate
     redis_host = conf.get("redis_host")
@@ -325,8 +323,11 @@ def parse_yaml_config(config_file_path, with_notary, with_clair, with_chartmuseu
     # UAA configs
     config_dict['uaa'] = configs.get('uaa') or {}
 
-    config_dict['registry_username'] = REGISTRY_USER_NAME
-    config_dict['registry_password'] = generate_random_string(32)
+    # Core configs
+    core_config = configs.get('core') or {}
+
+    config_dict['core_custom_ca_bundle_path'] = core_config.get('ca_bundle') or ''
+
     return config_dict
 
 

--- a/make/photon/prepare/utils/docker_compose.py
+++ b/make/photon/prepare/utils/docker_compose.py
@@ -53,6 +53,11 @@ def prepare_docker_compose(configs, with_clair, with_notary, with_chartmuseum):
     if uaa_config.get('ca_file'):
         rendering_variables['uaa_ca_file'] = uaa_config['ca_file']
 
+    # for core ca
+    core_ca_bundle = configs.get('core') or {}
+    if core_ca_bundle = configs.get('core_ca_file'):
+        rendering_variables['core_custom_ca_bundle_path'] = configs['core_custom_ca_bundle_path']
+
     # for log
     log_ep_host = configs.get('log_ep_host')
     if log_ep_host:


### PR DESCRIPTION
Based on https://github.com/goharbor/harbor/pull/10020
We have a need to be able to use ldaps for authentication services against an internal LDAP server that uses an internal PKI. The harbor code utilises golang crypto/tls, which utilises system installed CA bundle for RootCAs when not set. This patch adds that support, as well as a small bug fix for path joining against host_root_dir utilised by prepare.

Bugfix for correctly mounting core ca