### PR TITLE
Allow to turn off XSRF checking via the enable_xsrf harbor.yaml option

### DIFF
--- a/make/photon/prepare/templates/core/app.conf.jinja
+++ b/make/photon/prepare/templates/core/app.conf.jinja
@@ -4,6 +4,6 @@ enablegzip = true
 
 [dev]
 httpport = 8080
-EnableXSRF = true
+EnableXSRF = {{enable_xsrf}}
 XSRFKey = {{xsrf_key}}
 XSRFExpire = 3600

--- a/make/photon/prepare/utils/configs.py
+++ b/make/photon/prepare/utils/configs.py
@@ -233,6 +233,9 @@ def parse_yaml_config(config_file_path, with_notary, with_clair, with_trivy, wit
       config_dict[proxy_component + '_https_proxy'] = proxy_config.get('https_proxy') or ''
       config_dict[proxy_component + '_no_proxy'] = ','.join(all_no_proxy)
 
+    # Core configs
+    config_dict['enable_xsrf'] = configs.get('enable_xsrf') or 'true'
+
     # Clair configs, optional
     clair_configs = configs.get("clair") or {}
     config_dict['clair_db'] = 'postgres'

--- a/make/photon/prepare/utils/core.py
+++ b/make/photon/prepare/utils/core.py
@@ -39,7 +39,8 @@ def prepare_core(config_dict, with_notary, with_clair, with_trivy, with_chartmus
         core_conf,
         uid=DEFAULT_UID,
         gid=DEFAULT_GID,
-        xsrf_key=generate_random_string(40))
+        xsrf_key=generate_random_string(40),
+        **config_dict)
 
 
 def copy_core_config(core_templates_path, core_config_path):


### PR DESCRIPTION
In order to mitigate https://github.com/goharbor/harbor/issues/10780, it is required to manually the `EnableXSRF` option in Core service app.conf file.

However, when running harbor via docker-compose, there is no option to disable XSRF protection in the `harbor.yml` file.
This PR adds a new configuration key in the `harbor.yml` to set the intended value for the `EnableXSRF` core config.

Below an example of `harbor.yml` file setting `EnableXSRF = false`

```yaml
---

enable_xsrf: false

chart:
  absolute_url: disabled
clair:
  updaters_interval: 12
data_volume: /var/lib/harbor
database:
  max_idle_conns: 50
  max_open_conns: 100
  password: <db-password>
harbor_admin_password: <admin-password>
hostname: <registry-hostname>
http:
  port: 80
https:
  certificate: /etc/ssl/harbor/registry.crt
  port: 443
  private_key: /etc/ssl/harbor/registry.key
jobservice:
  max_job_workers: 10
log:
  level: info
  local:
    location: /var/log/harbor
    rotate_count: 50
    rotate_size: 200M
notification:
  webhook_job_max_retry: 10

_version: 1.9.0