### PR TITLE
Revise the GC job flow

### DIFF
--- a/api/v2.0/legacy_swagger.yaml
+++ b/api/v2.0/legacy_swagger.yaml
@@ -5676,6 +5676,9 @@ definitions:
       job_kind:
         type: string
         description: the job kind of gc job.
+      job_parameters:
+        type: string
+        description: the job parameters of gc job.
       schedule:
         $ref: '#/definitions/AdminJobScheduleObj'
       job_status:
@@ -5695,6 +5698,9 @@ definitions:
     properties:
       schedule:
         $ref: '#/definitions/AdminJobScheduleObj'
+      parameters:
+        type: string
+        description: The parameters of admin job
   AdminJobScheduleObj:
     type: object
     properties:

--- a/make/migrations/postgresql/0030_2.0.0_schema.up.sql
+++ b/make/migrations/postgresql/0030_2.0.0_schema.up.sql
@@ -1,3 +1,4 @@
+ALTER TABLE admin_job ADD COLUMN job_parameters varchar(255) Default '';
 ALTER TABLE artifact ADD COLUMN repository_id int;
 ALTER TABLE artifact ADD COLUMN media_type varchar(255);
 ALTER TABLE artifact ADD COLUMN manifest_media_type varchar(255);

--- a/src/common/dao/admin_job.go
+++ b/src/common/dao/admin_job.go
@@ -28,10 +28,10 @@ func AddAdminJob(job *models.AdminJob) (int64, error) {
 	if len(job.Status) == 0 {
 		job.Status = models.JobPending
 	}
-	sql := "insert into admin_job (job_name, job_kind, status, job_uuid, cron_str, creation_time, update_time) values (?, ?, ?, ?, ?, ?, ?) RETURNING id"
+	sql := "insert into admin_job (job_name, job_parameters, job_kind, status, job_uuid, cron_str, creation_time, update_time) values (?, ?, ?, ?, ?, ?, ?, ?) RETURNING id"
 	var id int64
 	now := time.Now()
-	err := o.Raw(sql, job.Name, job.Kind, job.Status, job.UUID, job.Cron, now, now).QueryRow(&id)
+	err := o.Raw(sql, job.Name, job.Parameters, job.Kind, job.Status, job.UUID, job.Cron, now, now).QueryRow(&id)
 	if err != nil {
 		return 0, err
 	}

--- a/src/common/dao/admin_job_test.go
+++ b/src/common/dao/admin_job_test.go
@@ -44,8 +44,9 @@ func (suite *AdminJobSuite) SetupSuite() {
 	}
 
 	job0 := &models.AdminJob{
-		Name: "GC",
-		Kind: "testKind",
+		Name:       "GC",
+		Kind:       "testKind",
+		Parameters: "{test:test}",
 	}
 
 	suite.ids = make([]int64, 0)
@@ -77,6 +78,7 @@ func (suite *AdminJobSuite) TestAdminJobBase() {
 	require.Nil(suite.T(), err)
 	suite.Equal(job1.ID, suite.job0.ID)
 	suite.Equal(job1.Name, suite.job0.Name)
+	suite.Equal(job1.Parameters, suite.job0.Parameters)
 
 	// set uuid
 	err = SetAdminJobUUID(suite.job0.ID, "f5ef34f4cb3588d663176132")

--- a/src/common/models/adminjob.go
+++ b/src/common/models/adminjob.go
@@ -29,6 +29,7 @@ type AdminJob struct {
 	ID           int64     `orm:"pk;auto;column(id)" json:"id"`
 	Name         string    `orm:"column(job_name)"  json:"job_name"`
 	Kind         string    `orm:"column(job_kind)"  json:"job_kind"`
+	Parameters   string    `orm:"column(job_parameters)"  json:"job_parameters"`
 	Cron         string    `orm:"column(cron_str)"  json:"cron_str"`
 	Status       string    `orm:"column(status)"  json:"job_status"`
 	UUID         string    `orm:"column(job_uuid)" json:"-"`

--- a/src/core/api/admin_job.go
+++ b/src/core/api/admin_job.go
@@ -133,7 +133,7 @@ func (aj *AJAPI) list(name string) {
 
 // getSchedule gets admin job schedule ...
 func (aj *AJAPI) getSchedule(name string) {
-	adminJobSchedule := models.AdminJobSchedule{}
+	result := models.AdminJobRep{}
 
 	jobs, err := dao.GetAdminJobs(&common_models.AdminJobQuery{
 		Name: name,
@@ -154,10 +154,11 @@ func (aj *AJAPI) getSchedule(name string) {
 			aj.SendInternalServerError(fmt.Errorf("failed to convert admin job response: %v", err))
 			return
 		}
-		adminJobSchedule.Schedule = adminJobRep.Schedule
+		result.Schedule = adminJobRep.Schedule
+		result.Parameters = adminJobRep.Parameters
 	}
 
-	aj.Data["json"] = adminJobSchedule
+	aj.Data["json"] = result
 	aj.ServeJSON()
 }
 
@@ -285,9 +286,10 @@ func (aj *AJAPI) submit(ajr *models.AdminJobReq) {
 	}
 
 	id, err := dao.AddAdminJob(&common_models.AdminJob{
-		Name: ajr.Name,
-		Kind: ajr.JobKind(),
-		Cron: ajr.CronString(),
+		Name:       ajr.Name,
+		Kind:       ajr.JobKind(),
+		Cron:       ajr.CronString(),
+		Parameters: ajr.ParamString(),
 	})
 	if err != nil {
 		aj.SendInternalServerError(err)
@@ -345,6 +347,7 @@ func convertToAdminJobRep(job *common_models.AdminJob) (models.AdminJobRep, erro
 		Name:         job.Name,
 		Kind:         job.Kind,
 		Status:       job.Status,
+		Parameters:   job.Parameters,
 		CreationTime: job.CreationTime,
 		UpdateTime:   job.UpdateTime,
 	}

--- a/src/core/api/models/admin_job.go
+++ b/src/core/api/models/admin_job.go
@@ -73,6 +73,7 @@ type AdminJobRep struct {
 	ID           int64     `json:"id"`
 	Name         string    `json:"job_name"`
 	Kind         string    `json:"job_kind"`
+	Parameters   string    `json:"job_parameters"`
 	Status       string    `json:"job_status"`
 	UUID         string    `json:"-"`
 	Deleted      bool      `json:"deleted"`
@@ -144,6 +145,16 @@ func (ar *AdminJobReq) JobKind() string {
 // CronString ...
 func (ar *AdminJobReq) CronString() string {
 	str, err := json.Marshal(ar.Schedule)
+	if err != nil {
+		log.Debugf("failed to marshal json error, %v", err)
+		return ""
+	}
+	return string(str)
+}
+
+// ParamString ...
+func (ar *AdminJobReq) ParamString() string {
+	str, err := json.Marshal(ar.Parameters)
 	if err != nil {
 		log.Debugf("failed to marshal json error, %v", err)
 		return ""

--- a/src/core/api/models/admin_job_test.go
+++ b/src/core/api/models/admin_job_test.go
@@ -138,6 +138,19 @@ func TestCronString(t *testing.T) {
 	assert.True(t, strings.EqualFold(cronStr, "{\"type\":\"Daily\",\"Cron\":\"20 3 0 * * *\"}"))
 }
 
+func TestParamString(t *testing.T) {
+	adminJobPara := make(map[string]interface{})
+	adminJobPara["key1"] = "value1"
+	adminJobPara["key2"] = true
+	adminJobPara["key3"] = 88
+
+	adminjob := &AdminJobReq{
+		Parameters: adminJobPara,
+	}
+	paramStr := adminjob.ParamString()
+	assert.True(t, strings.EqualFold(paramStr, "{\"key1\":\"value1\",\"key2\":true,\"key3\":88}"))
+}
+
 func TestConvertSchedule(t *testing.T) {
 	schedule1 := "{\"type\":\"Daily\",\"cron\":\"20 3 0 * * *\"}"
 	converted1, err1 := ConvertSchedule(schedule1)

--- a/src/core/api/reg_gc.go
+++ b/src/core/api/reg_gc.go
@@ -48,12 +48,18 @@ func (gc *GCAPI) Prepare() {
 //  "schedule": {
 //    "type": "Daily",
 //    "cron": "0 0 0 * * *"
+//  },
+//  "parameters": {
+//    "delete_untagged": true
 //  }
 //	}
 // create a manual trigger for GC
 // 	{
 //  "schedule": {
 //    "type": "Manual"
+//  },
+//  "parameters": {
+//    "delete_untagged": true
 //  }
 //	}
 func (gc *GCAPI) Post() {
@@ -64,9 +70,7 @@ func (gc *GCAPI) Post() {
 		return
 	}
 	ajr.Name = common_job.ImageGC
-	ajr.Parameters = map[string]interface{}{
-		"redis_url_reg": os.Getenv("_REDIS_URL_REG"),
-	}
+	ajr.Parameters["redis_url_reg"] = os.Getenv("_REDIS_URL_REG")
 	gc.submit(&ajr)
 	gc.Redirect(http.StatusCreated, strconv.FormatInt(ajr.ID, 10))
 }
@@ -77,6 +81,9 @@ func (gc *GCAPI) Post() {
 //  "schedule": {
 //    "type": "None",
 //    "cron": ""
+//  },
+//  "parameters": {
+//    "delete_untagged": true
 //  }
 //	}
 func (gc *GCAPI) Put() {
@@ -87,9 +94,7 @@ func (gc *GCAPI) Put() {
 		return
 	}
 	ajr.Name = common_job.ImageGC
-	ajr.Parameters = map[string]interface{}{
-		"redis_url_reg": os.Getenv("_REDIS_URL_REG"),
-	}
+	ajr.Parameters["redis_url_reg"] = os.Getenv("_REDIS_URL_REG")
 	gc.updateSchedule(ajr)
 }
 

--- a/src/core/api/reg_gc_test.go
+++ b/src/core/api/reg_gc_test.go
@@ -7,10 +7,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var adminJob001 apilib.AdminJobReq
-
 func TestGCPost(t *testing.T) {
 
+	adminJob001 := apilib.AdminJobReq{
+		Parameters: map[string]interface{}{"delete_untagged": false},
+	}
 	assert := assert.New(t)
 	apiTest := newHarborAPI()
 

--- a/src/jobservice/job/impl/default_context.go
+++ b/src/jobservice/job/impl/default_context.go
@@ -17,6 +17,8 @@ package impl
 import (
 	"context"
 	"errors"
+	o "github.com/astaxie/beego/orm"
+	"github.com/goharbor/harbor/src/internal/orm"
 	"github.com/goharbor/harbor/src/jobservice/job"
 	"github.com/goharbor/harbor/src/jobservice/logger"
 )
@@ -49,7 +51,8 @@ func (dc *DefaultContext) Build(t job.Tracker) (job.Context, error) {
 	}
 
 	jContext := &DefaultContext{
-		sysContext: dc.sysContext,
+		// TODO support DB transaction
+		sysContext: orm.NewContext(dc.sysContext, o.NewOrm()),
 		tracker:    t,
 		properties: make(map[string]interface{}),
 	}

--- a/src/jobservice/job/impl/gc/garbage_collection_test.go
+++ b/src/jobservice/job/impl/gc/garbage_collection_test.go
@@ -1,0 +1,21 @@
+package gc
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestMaxFails(t *testing.T) {
+	rep := &GarbageCollector{}
+	assert.Equal(t, uint(1), rep.MaxFails())
+}
+
+func TestShouldRetry(t *testing.T) {
+	rep := &GarbageCollector{}
+	assert.False(t, rep.ShouldRetry())
+}
+
+func TestValidate(t *testing.T) {
+	rep := &GarbageCollector{}
+	assert.Nil(t, rep.Validate(nil))
+}

--- a/src/jobservice/job/impl/gc/util.go
+++ b/src/jobservice/job/impl/gc/util.go
@@ -1,0 +1,56 @@
+package gc
+
+import (
+	"fmt"
+	"github.com/garyburd/redigo/redis"
+	"github.com/goharbor/harbor/src/pkg/registry"
+)
+
+// delKeys ...
+func delKeys(con redis.Conn, pattern string) error {
+	iter := 0
+	keys := make([]string, 0)
+	for {
+		arr, err := redis.Values(con.Do("SCAN", iter, "MATCH", pattern))
+		if err != nil {
+			return fmt.Errorf("error retrieving '%s' keys", pattern)
+		}
+		iter, err = redis.Int(arr[0], nil)
+		if err != nil {
+			return fmt.Errorf("unexpected type for Int, got type %T", err)
+		}
+		k, err := redis.Strings(arr[1], nil)
+		if err != nil {
+			return fmt.Errorf("converts an array command reply to a []string %v", err)
+		}
+		keys = append(keys, k...)
+
+		if iter == 0 {
+			break
+		}
+	}
+	for _, key := range keys {
+		_, err := con.Do("DEL", key)
+		if err != nil {
+			return fmt.Errorf("failed to clean registry cache %v", err)
+		}
+	}
+	return nil
+}
+
+// deleteManifest calls the registry API to remove manifest
+func deleteManifest(repository, digest string) error {
+	exist, _, err := registry.Cli.ManifestExist(repository, digest)
+	if err != nil {
+		return err
+	}
+	// it could be happened at remove manifest success but fail to delete harbor DB.
+	// when the GC job executes again, the manifest should not exist.
+	if !exist {
+		return nil
+	}
+	if err := registry.Cli.DeleteManifest(repository, digest); err != nil {
+		return err
+	}
+	return nil
+}

--- a/src/jobservice/runner/redis_test.go
+++ b/src/jobservice/runner/redis_test.go
@@ -15,6 +15,7 @@ package runner
 
 import (
 	"context"
+	common_dao "github.com/goharbor/harbor/src/common/dao"
 	"os"
 	"sync"
 	"testing"
@@ -52,6 +53,7 @@ type RedisRunnerTestSuite struct {
 
 // TestRedisRunnerTestSuite is entry of go test
 func TestRedisRunnerTestSuite(t *testing.T) {
+	common_dao.PrepareTestForPostgresSQL()
 	suite.Run(t, new(RedisRunnerTestSuite))
 }
 

--- a/src/jobservice/worker/cworker/c_worker_test.go
+++ b/src/jobservice/worker/cworker/c_worker_test.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	common_dao "github.com/goharbor/harbor/src/common/dao"
 	"github.com/goharbor/harbor/src/jobservice/common/utils"
 	"github.com/goharbor/harbor/src/jobservice/env"
 	"github.com/goharbor/harbor/src/jobservice/job"
@@ -50,6 +51,7 @@ type CWorkerTestSuite struct {
 func (suite *CWorkerTestSuite) SetupSuite() {
 	suite.namespace = tests.GiveMeTestNamespace()
 	suite.pool = tests.GiveMeRedisPool()
+	common_dao.PrepareTestForPostgresSQL()
 
 	// Append node ID
 	vCtx := context.WithValue(context.Background(), utils.NodeID, utils.GenerateNodeID())

--- a/src/pkg/artifactrash/dao/dao.go
+++ b/src/pkg/artifactrash/dao/dao.go
@@ -17,6 +17,8 @@ type DAO interface {
 	Delete(ctx context.Context, id int64) (err error)
 	// Filter lists the artifact that needs to be cleaned
 	Filter(ctx context.Context) (arts []model.ArtifactTrash, err error)
+	// Flush clean the trash table
+	Flush(ctx context.Context) (err error)
 }
 
 // New returns an instance of the default DAO
@@ -75,4 +77,21 @@ func (d *dao) Filter(ctx context.Context) (arts []model.ArtifactTrash, err error
 		return deletedAfs, err
 	}
 	return deletedAfs, nil
+}
+
+// Flush ...
+func (d *dao) Flush(ctx context.Context) (err error) {
+	ormer, err := orm.FromContext(ctx)
+	if err != nil {
+		return err
+	}
+	sql := `DELETE * FROM artifact_trash`
+	if err != nil {
+		return err
+	}
+	_, err = ormer.Raw(sql).Exec()
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/src/pkg/artifactrash/dao/dao_test.go
+++ b/src/pkg/artifactrash/dao/dao_test.go
@@ -89,3 +89,27 @@ func (d *daoTestSuite) TestFilter() {
 	d.Require().NotNil(err)
 	d.Require().Equal(afs[0].Digest, "1234")
 }
+
+func (d *daoTestSuite) TestFlush() {
+	_, err := d.dao.Create(d.ctx, &model.ArtifactTrash{
+		ManifestMediaType: v1.MediaTypeImageManifest,
+		RepositoryName:    "hello-world",
+		Digest:            "abcd",
+	})
+	d.Require().Nil(err)
+	_, err = d.dao.Create(d.ctx, &model.ArtifactTrash{
+		ManifestMediaType: v1.MediaTypeImageManifest,
+		RepositoryName:    "hello-world2",
+		Digest:            "efgh",
+	})
+	d.Require().Nil(err)
+	_, err = d.dao.Create(d.ctx, &model.ArtifactTrash{
+		ManifestMediaType: v1.MediaTypeImageManifest,
+		RepositoryName:    "hello-world3",
+		Digest:            "ijkl",
+	})
+	d.Require().Nil(err)
+
+	err = d.dao.Flush(d.ctx)
+	d.Require().Nil(err)
+}

--- a/src/pkg/artifactrash/manager.go
+++ b/src/pkg/artifactrash/manager.go
@@ -33,6 +33,8 @@ type Manager interface {
 	Delete(ctx context.Context, id int64) (err error)
 	// Filter ...
 	Filter(ctx context.Context) (arts []model.ArtifactTrash, err error)
+	// Flush clean the trash table
+	Flush(ctx context.Context) (err error)
 }
 
 // NewManager returns an instance of the default manager
@@ -56,4 +58,8 @@ func (m *manager) Delete(ctx context.Context, id int64) error {
 }
 func (m *manager) Filter(ctx context.Context) (arts []model.ArtifactTrash, err error) {
 	return m.dao.Filter(ctx)
+}
+
+func (m *manager) Flush(ctx context.Context) (err error) {
+	return m.dao.Flush(ctx)
 }

--- a/src/pkg/artifactrash/manager_test.go
+++ b/src/pkg/artifactrash/manager_test.go
@@ -24,6 +24,10 @@ func (f *fakeDao) Filter(ctx context.Context) (arts []model.ArtifactTrash, err e
 	args := f.Called()
 	return args.Get(0).([]model.ArtifactTrash), args.Error(1)
 }
+func (f *fakeDao) Flush(ctx context.Context) (err error) {
+	args := f.Called()
+	return args.Error(0)
+}
 
 type managerTestSuite struct {
 	suite.Suite
@@ -68,4 +72,11 @@ func (m *managerTestSuite) TestFilter() {
 	arts, err := m.mgr.Filter(nil)
 	m.Require().Nil(err)
 	m.Equal(len(arts), 1)
+}
+
+func (m *managerTestSuite) TestFlush() {
+	m.dao.On("Flush", mock.Anything).Return(nil)
+	err := m.mgr.Flush(nil)
+	m.Require().Nil(err)
+	m.dao.AssertExpectations(m.T())
 }

--- a/src/testing/apitests/apilib/admin_job_req.go
+++ b/src/testing/apitests/apilib/admin_job_req.go
@@ -24,9 +24,11 @@ package apilib
 
 // AdminJobReq holds request information for admin job
 type AdminJobReq struct {
-	Schedule *ScheduleParam `json:"schedule,omitempty"`
-	Status   string         `json:"status,omitempty"`
-	ID       int64          `json:"id,omitempty"`
+	Schedule   *ScheduleParam         `json:"schedule,omitempty"`
+	Name       string                 `json:"name"`
+	Status     string                 `json:"status,omitempty"`
+	ID         int64                  `json:"id,omitempty"`
+	Parameters map[string]interface{} `json:"parameters"`
 }
 
 // ScheduleParam ...

--- a/src/testing/pkg/artifactrash/manager.go
+++ b/src/testing/pkg/artifactrash/manager.go
@@ -45,3 +45,9 @@ func (f *FakeManager) Filter(ctx context.Context) (arts []model.ArtifactTrash, e
 	args := f.Called()
 	return args.Get(0).([]model.ArtifactTrash), args.Error(1)
 }
+
+// Flush ...
+func (f *FakeManager) Flush(ctx context.Context) (err error) {
+	args := f.Called()
+	return args.Error(0)
+}


### PR DESCRIPTION
1, set harbor to readonly
2, select the candidate artifacts from Harbor DB.
3, call registry API(--delete-untagged=false) to delete manifest bases on the results of #2
4, clean keys of redis DB of registry, clean artifact trash and untagged from DB.
5, roll back readonly.

Signed-off-by: wang yan <wangyan@vmware.com>