### PR TITLE
Use the repository name of artifact model

### DIFF
--- a/make/migrations/postgresql/0030_2.0.0_schema.up.sql
+++ b/make/migrations/postgresql/0030_2.0.0_schema.up.sql
@@ -56,9 +56,6 @@ WHERE ordered_art.seq=1;
 
 ALTER TABLE artifact DROP COLUMN tag;
 
-/*TODO: remove this after insert the repository_name when create artifact*/
-ALTER TABLE artifact ALTER COLUMN repository_name DROP NOT NULL;
-
 /*remove the duplicate artifact rows*/
 DELETE FROM artifact
 WHERE id NOT IN (

--- a/src/api/artifact/abstractor/abstractor.go
+++ b/src/api/artifact/abstractor/abstractor.go
@@ -25,7 +25,6 @@ import (
 	"github.com/goharbor/harbor/src/api/artifact/abstractor/resolver"
 	ierror "github.com/goharbor/harbor/src/internal/error"
 	"github.com/goharbor/harbor/src/pkg/artifact"
-	"github.com/goharbor/harbor/src/pkg/repository"
 	"github.com/opencontainers/image-spec/specs-go/v1"
 )
 
@@ -43,24 +42,18 @@ type Abstractor interface {
 // NewAbstractor returns an instance of the default abstractor
 func NewAbstractor() Abstractor {
 	return &abstractor{
-		repoMgr:     repository.Mgr,
 		blobFetcher: blob.Fcher,
 	}
 }
 
 type abstractor struct {
-	repoMgr     repository.Manager
 	blobFetcher blob.Fetcher
 }
 
 // TODO add white list for supported artifact type
 func (a *abstractor) AbstractMetadata(ctx context.Context, artifact *artifact.Artifact) error {
-	repository, err := a.repoMgr.Get(ctx, artifact.RepositoryID)
-	if err != nil {
-		return err
-	}
 	// read manifest content
-	manifestMediaType, content, err := a.blobFetcher.FetchManifest(repository.Name, artifact.Digest)
+	manifestMediaType, content, err := a.blobFetcher.FetchManifest(artifact.RepositoryName, artifact.Digest)
 	if err != nil {
 		return err
 	}

--- a/src/api/artifact/abstractor/abstractor_test.go
+++ b/src/api/artifact/abstractor/abstractor_test.go
@@ -18,12 +18,10 @@ import (
 	"github.com/docker/distribution/manifest/schema1"
 	"github.com/docker/distribution/manifest/schema2"
 	"github.com/goharbor/harbor/src/api/artifact/abstractor/resolver"
-	"github.com/goharbor/harbor/src/common/models"
 	ierror "github.com/goharbor/harbor/src/internal/error"
 	"github.com/goharbor/harbor/src/pkg/artifact"
 	"github.com/goharbor/harbor/src/testing/api/artifact/abstractor/blob"
 	tresolver "github.com/goharbor/harbor/src/testing/api/artifact/abstractor/resolver"
-	"github.com/goharbor/harbor/src/testing/pkg/repository"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/suite"
 	"testing"
@@ -203,16 +201,13 @@ type abstractorTestSuite struct {
 	suite.Suite
 	abstractor Abstractor
 	fetcher    *blob.FakeFetcher
-	repoMgr    *repository.FakeManager
 	resolver   *tresolver.FakeResolver
 }
 
 func (a *abstractorTestSuite) SetupTest() {
 	a.fetcher = &blob.FakeFetcher{}
-	a.repoMgr = &repository.FakeManager{}
 	a.resolver = &tresolver.FakeResolver{}
 	a.abstractor = &abstractor{
-		repoMgr:     a.repoMgr,
 		blobFetcher: a.fetcher,
 	}
 }
@@ -220,7 +215,6 @@ func (a *abstractorTestSuite) SetupTest() {
 // docker manifest v1
 func (a *abstractorTestSuite) TestAbstractMetadataOfV1Manifest() {
 	resolver.Register(a.resolver, schema1.MediaTypeSignedManifest)
-	a.repoMgr.On("Get").Return(&models.RepoRecord{}, nil)
 	a.fetcher.On("FetchManifest").Return(schema1.MediaTypeSignedManifest, []byte(v1Manifest), nil)
 	a.resolver.On("ArtifactType").Return(fakeArtifactType)
 	a.resolver.On("ResolveMetadata").Return(nil)
@@ -238,7 +232,6 @@ func (a *abstractorTestSuite) TestAbstractMetadataOfV1Manifest() {
 // docker manifest v2
 func (a *abstractorTestSuite) TestAbstractMetadataOfV2Manifest() {
 	resolver.Register(a.resolver, schema2.MediaTypeImageConfig)
-	a.repoMgr.On("Get").Return(&models.RepoRecord{}, nil)
 	a.fetcher.On("FetchManifest").Return(schema2.MediaTypeManifest, []byte(v2Manifest), nil)
 	a.resolver.On("ArtifactType").Return(fakeArtifactType)
 	a.resolver.On("ResolveMetadata").Return(nil)
@@ -257,7 +250,6 @@ func (a *abstractorTestSuite) TestAbstractMetadataOfV2Manifest() {
 // OCI index
 func (a *abstractorTestSuite) TestAbstractMetadataOfIndex() {
 	resolver.Register(a.resolver, v1.MediaTypeImageIndex)
-	a.repoMgr.On("Get").Return(&models.RepoRecord{}, nil)
 	a.fetcher.On("FetchManifest").Return(v1.MediaTypeImageIndex, []byte(index), nil)
 	a.resolver.On("ArtifactType").Return(fakeArtifactType)
 	a.resolver.On("ResolveMetadata").Return(nil)
@@ -275,7 +267,6 @@ func (a *abstractorTestSuite) TestAbstractMetadataOfIndex() {
 
 // OCI index
 func (a *abstractorTestSuite) TestAbstractMetadataOfUnsupported() {
-	a.repoMgr.On("Get").Return(&models.RepoRecord{}, nil)
 	a.fetcher.On("FetchManifest").Return("unsupported-manifest", []byte{}, nil)
 	artifact := &artifact.Artifact{
 		ID: 1,

--- a/src/api/artifact/abstractor/resolver/chart/chart_test.go
+++ b/src/api/artifact/abstractor/resolver/chart/chart_test.go
@@ -15,13 +15,11 @@
 package chart
 
 import (
-	"github.com/goharbor/harbor/src/common/models"
 	ierror "github.com/goharbor/harbor/src/internal/error"
 	"github.com/goharbor/harbor/src/pkg/artifact"
 	chartserver "github.com/goharbor/harbor/src/pkg/chart"
 	"github.com/goharbor/harbor/src/testing/api/artifact/abstractor/blob"
 	"github.com/goharbor/harbor/src/testing/pkg/chart"
-	"github.com/goharbor/harbor/src/testing/pkg/repository"
 	"github.com/stretchr/testify/suite"
 	"k8s.io/helm/pkg/chartutil"
 	"testing"
@@ -30,17 +28,14 @@ import (
 type resolverTestSuite struct {
 	suite.Suite
 	resolver    *resolver
-	repoMgr     *repository.FakeManager
 	blobFetcher *blob.FakeFetcher
 	chartOptr   *chart.FakeOpertaor
 }
 
 func (r *resolverTestSuite) SetupTest() {
-	r.repoMgr = &repository.FakeManager{}
 	r.blobFetcher = &blob.FakeFetcher{}
 	r.chartOptr = &chart.FakeOpertaor{}
 	r.resolver = &resolver{
-		repoMgr:       r.repoMgr,
 		blobFetcher:   r.blobFetcher,
 		chartOperator: r.chartOptr,
 	}
@@ -92,11 +87,9 @@ func (r *resolverTestSuite) TestResolveMetadata() {
   "appVersion": "1.8.2"
 }`
 	artifact := &artifact.Artifact{}
-	r.repoMgr.On("Get").Return(&models.RepoRecord{}, nil)
 	r.blobFetcher.On("FetchLayer").Return([]byte(config), nil)
 	err := r.resolver.ResolveMetadata(nil, []byte(content), artifact)
 	r.Require().Nil(err)
-	r.repoMgr.AssertExpectations(r.T())
 	r.blobFetcher.AssertExpectations(r.T())
 	r.Assert().Equal("1.1.2", artifact.ExtraAttrs["version"].(string))
 	r.Assert().Equal("1.8.2", artifact.ExtraAttrs["appVersion"].(string))
@@ -158,7 +151,6 @@ func (r *resolverTestSuite) TestResolveAddition() {
 	}
 
 	artifact := &artifact.Artifact{}
-	r.repoMgr.On("Get").Return(&models.RepoRecord{}, nil)
 	r.blobFetcher.On("FetchManifest").Return("", []byte(chartManifest), nil)
 	r.blobFetcher.On("FetchLayer").Return([]byte(chartYaml), nil)
 	r.chartOptr.On("GetDetails").Return(chartDetails, nil)

--- a/src/api/artifact/abstractor/resolver/cnab/cnab_test.go
+++ b/src/api/artifact/abstractor/resolver/cnab/cnab_test.go
@@ -15,12 +15,10 @@
 package cnab
 
 import (
-	"github.com/goharbor/harbor/src/common/models"
 	ierror "github.com/goharbor/harbor/src/internal/error"
 	"github.com/goharbor/harbor/src/pkg/artifact"
 	"github.com/goharbor/harbor/src/testing/api/artifact/abstractor/blob"
 	testingartifact "github.com/goharbor/harbor/src/testing/pkg/artifact"
-	"github.com/goharbor/harbor/src/testing/pkg/repository"
 	"github.com/stretchr/testify/suite"
 	"testing"
 )
@@ -28,17 +26,14 @@ import (
 type resolverTestSuite struct {
 	suite.Suite
 	resolver    *resolver
-	repoMgr     *repository.FakeManager
 	artMgr      *testingartifact.FakeManager
 	blobFetcher *blob.FakeFetcher
 }
 
 func (r *resolverTestSuite) SetupTest() {
-	r.repoMgr = &repository.FakeManager{}
 	r.artMgr = &testingartifact.FakeManager{}
 	r.blobFetcher = &blob.FakeFetcher{}
 	r.resolver = &resolver{
-		repoMgr:     r.repoMgr,
 		argMgr:      r.artMgr,
 		blobFetcher: r.blobFetcher,
 	}
@@ -115,7 +110,6 @@ func (r *resolverTestSuite) TestResolveMetadata() {
 }`
 	art := &artifact.Artifact{}
 	r.artMgr.On("GetByDigest").Return(&artifact.Artifact{ID: 1}, nil)
-	r.repoMgr.On("Get").Return(&models.RepoRecord{}, nil)
 	r.blobFetcher.On("FetchManifest").Return("", []byte(manifest), nil)
 	r.blobFetcher.On("FetchLayer").Return([]byte(config), nil)
 	err := r.resolver.ResolveMetadata(nil, []byte(index), art)

--- a/src/api/artifact/abstractor/resolver/image/index.go
+++ b/src/api/artifact/abstractor/resolver/image/index.go
@@ -58,7 +58,7 @@ func (i *indexResolver) ResolveMetadata(ctx context.Context, manifest []byte, ar
 	for _, mani := range index.Manifests {
 		digest := mani.Digest.String()
 		// make sure the child artifact exist
-		ar, err := i.artMgr.GetByDigest(ctx, art.RepositoryID, digest)
+		ar, err := i.artMgr.GetByDigest(ctx, art.RepositoryName, digest)
 		if err != nil {
 			return err
 		}

--- a/src/api/artifact/abstractor/resolver/image/manifest_v2_test.go
+++ b/src/api/artifact/abstractor/resolver/image/manifest_v2_test.go
@@ -15,11 +15,9 @@
 package image
 
 import (
-	"github.com/goharbor/harbor/src/common/models"
 	ierror "github.com/goharbor/harbor/src/internal/error"
 	"github.com/goharbor/harbor/src/pkg/artifact"
 	"github.com/goharbor/harbor/src/testing/api/artifact/abstractor/blob"
-	"github.com/goharbor/harbor/src/testing/pkg/repository"
 	"github.com/stretchr/testify/suite"
 	"testing"
 )
@@ -123,15 +121,12 @@ var (
 type manifestV2ResolverTestSuite struct {
 	suite.Suite
 	resolver    *manifestV2Resolver
-	repoMgr     *repository.FakeManager
 	blobFetcher *blob.FakeFetcher
 }
 
 func (m *manifestV2ResolverTestSuite) SetupTest() {
-	m.repoMgr = &repository.FakeManager{}
 	m.blobFetcher = &blob.FakeFetcher{}
 	m.resolver = &manifestV2Resolver{
-		repoMgr:     m.repoMgr,
 		blobFetcher: m.blobFetcher,
 	}
 
@@ -139,11 +134,9 @@ func (m *manifestV2ResolverTestSuite) SetupTest() {
 
 func (m *manifestV2ResolverTestSuite) TestResolveMetadata() {
 	artifact := &artifact.Artifact{}
-	m.repoMgr.On("Get").Return(&models.RepoRecord{}, nil)
 	m.blobFetcher.On("FetchLayer").Return([]byte(config), nil)
 	err := m.resolver.ResolveMetadata(nil, []byte(manifest), artifact)
 	m.Require().Nil(err)
-	m.repoMgr.AssertExpectations(m.T())
 	m.blobFetcher.AssertExpectations(m.T())
 	m.Assert().Equal("amd64", artifact.ExtraAttrs["architecture"].(string))
 	m.Assert().Equal("linux", artifact.ExtraAttrs["os"].(string))
@@ -156,7 +149,6 @@ func (m *manifestV2ResolverTestSuite) TestResolveAddition() {
 
 	// build history
 	artifact := &artifact.Artifact{}
-	m.repoMgr.On("Get").Return(&models.RepoRecord{}, nil)
 	m.blobFetcher.On("FetchManifest").Return("", []byte(manifest), nil)
 	m.blobFetcher.On("FetchLayer").Return([]byte(config), nil)
 	addition, err := m.resolver.ResolveAddition(nil, artifact, AdditionTypeBuildHistory)

--- a/src/pkg/artifact/dao/dao.go
+++ b/src/pkg/artifact/dao/dao.go
@@ -32,8 +32,8 @@ type DAO interface {
 	List(ctx context.Context, query *q.Query) (artifacts []*Artifact, err error)
 	// Get the artifact specified by ID
 	Get(ctx context.Context, id int64) (*Artifact, error)
-	// GetByDigest returns the artifact specified by repository ID and digest
-	GetByDigest(ctx context.Context, repositoryID int64, digest string) (artifact *Artifact, err error)
+	// GetByDigest returns the artifact specified by repository and digest
+	GetByDigest(ctx context.Context, repository, digest string) (artifact *Artifact, err error)
 	// Create the artifact
 	Create(ctx context.Context, artifact *Artifact) (id int64, err error)
 	// Delete the artifact specified by ID
@@ -118,11 +118,11 @@ func (d *dao) Get(ctx context.Context, id int64) (*Artifact, error) {
 	return artifact, nil
 }
 
-func (d *dao) GetByDigest(ctx context.Context, repositoryID int64, digest string) (*Artifact, error) {
+func (d *dao) GetByDigest(ctx context.Context, repository, digest string) (*Artifact, error) {
 	qs, err := orm.QuerySetter(ctx, &Artifact{}, &q.Query{
 		Keywords: map[string]interface{}{
-			"RepositoryID": repositoryID,
-			"Digest":       digest,
+			"RepositoryName": repository,
+			"Digest":         digest,
 		},
 	})
 	if err != nil {
@@ -134,7 +134,7 @@ func (d *dao) GetByDigest(ctx context.Context, repositoryID int64, digest string
 	}
 	if len(artifacts) == 0 {
 		return nil, ierror.New(nil).WithCode(ierror.NotFoundCode).
-			WithMessage("artifact %s under the repository %d not found", digest, repositoryID)
+			WithMessage("artifact %s@%s not found", repository, digest)
 	}
 	return artifacts[0], nil
 }

--- a/src/pkg/artifact/dao/dao_test.go
+++ b/src/pkg/artifact/dao/dao_test.go
@@ -57,6 +57,7 @@ func (d *daoTestSuite) SetupTest() {
 		ManifestMediaType: v1.MediaTypeImageIndex,
 		ProjectID:         1,
 		RepositoryID:      1,
+		RepositoryName:    "library/hello-world",
 		Digest:            "parent_digest",
 		PushTime:          now,
 		PullTime:          now,
@@ -72,6 +73,7 @@ func (d *daoTestSuite) SetupTest() {
 		ManifestMediaType: v1.MediaTypeImageManifest,
 		ProjectID:         1,
 		RepositoryID:      1,
+		RepositoryName:    "library/hello-world",
 		Digest:            "child_digest_01",
 		Size:              1024,
 		PushTime:          now,
@@ -88,6 +90,7 @@ func (d *daoTestSuite) SetupTest() {
 		ManifestMediaType: v1.MediaTypeImageManifest,
 		ProjectID:         1,
 		RepositoryID:      1,
+		RepositoryName:    "library/hello-world",
 		Digest:            "child_digest_02",
 		Size:              1024,
 		PushTime:          now,
@@ -324,12 +327,12 @@ func (d *daoTestSuite) TestGet() {
 
 func (d *daoTestSuite) TestGetByDigest() {
 	// get the non-exist artifact
-	_, err := d.dao.GetByDigest(d.ctx, 1, "non_existing_digest")
+	_, err := d.dao.GetByDigest(d.ctx, "library/hello-world", "non_existing_digest")
 	d.Require().NotNil(err)
 	d.True(ierror.IsErr(err, ierror.NotFoundCode))
 
 	// get the exist artifact
-	artifact, err := d.dao.GetByDigest(d.ctx, 1, "child_digest_02")
+	artifact, err := d.dao.GetByDigest(d.ctx, "library/hello-world", "child_digest_02")
 	d.Require().Nil(err)
 	d.Require().NotNil(artifact)
 	d.Equal(d.childArt02ID, artifact.ID)

--- a/src/pkg/artifact/dao/model.go
+++ b/src/pkg/artifact/dao/model.go
@@ -33,6 +33,7 @@ type Artifact struct {
 	ManifestMediaType string    `orm:"column(manifest_media_type)"` // the media type of manifest/index
 	ProjectID         int64     `orm:"column(project_id)"`          // needed for quota
 	RepositoryID      int64     `orm:"column(repository_id)"`
+	RepositoryName    string    `orm:"column(repository_name)"`
 	Digest            string    `orm:"column(digest)"`
 	Size              int64     `orm:"column(size)"`
 	PushTime          time.Time `orm:"column(push_time)"`

--- a/src/pkg/artifact/manager.go
+++ b/src/pkg/artifact/manager.go
@@ -37,8 +37,8 @@ type Manager interface {
 	List(ctx context.Context, query *q.Query) (artifacts []*Artifact, err error)
 	// Get the artifact specified by the ID
 	Get(ctx context.Context, id int64) (artifact *Artifact, err error)
-	// GetByDigest returns the artifact specified by repository ID and digest
-	GetByDigest(ctx context.Context, repositoryID int64, digest string) (artifact *Artifact, err error)
+	// GetByDigest returns the artifact specified by repository and digest
+	GetByDigest(ctx context.Context, repository, digest string) (artifact *Artifact, err error)
 	// Create the artifact. If the artifact is an index, make sure all the artifacts it references
 	// already exist
 	Create(ctx context.Context, artifact *Artifact) (id int64, err error)
@@ -94,8 +94,8 @@ func (m *manager) Get(ctx context.Context, id int64) (*Artifact, error) {
 	return m.assemble(ctx, art)
 }
 
-func (m *manager) GetByDigest(ctx context.Context, repositoryID int64, digest string) (*Artifact, error) {
-	art, err := m.dao.GetByDigest(ctx, repositoryID, digest)
+func (m *manager) GetByDigest(ctx context.Context, repository, digest string) (*Artifact, error) {
+	art, err := m.dao.GetByDigest(ctx, repository, digest)
 	if err != nil {
 		return nil, err
 	}

--- a/src/pkg/artifact/manager_test.go
+++ b/src/pkg/artifact/manager_test.go
@@ -40,7 +40,7 @@ func (f *fakeDao) Get(ctx context.Context, id int64) (*dao.Artifact, error) {
 	args := f.Called()
 	return args.Get(0).(*dao.Artifact), args.Error(1)
 }
-func (f *fakeDao) GetByDigest(ctx context.Context, repositoryID int64, digest string) (*dao.Artifact, error) {
+func (f *fakeDao) GetByDigest(ctx context.Context, repository, digest string) (*dao.Artifact, error) {
 	args := f.Called()
 	return args.Get(0).(*dao.Artifact), args.Error(1)
 }
@@ -195,7 +195,7 @@ func (m *managerTestSuite) TestGetByDigest() {
 	}
 	m.dao.On("GetByDigest", mock.Anything).Return(art, nil)
 	m.dao.On("ListReferences").Return([]*dao.ArtifactReference{}, nil)
-	artifact, err := m.mgr.GetByDigest(nil, 1, "sha256:418fb88ec412e340cdbef913b8ca1bbe8f9e8dc705f9617414c1f2c8db980180")
+	artifact, err := m.mgr.GetByDigest(nil, "library/hello-world", "sha256:418fb88ec412e340cdbef913b8ca1bbe8f9e8dc705f9617414c1f2c8db980180")
 	m.Require().Nil(err)
 	m.Require().NotNil(artifact)
 	m.Equal(art.ID, artifact.ID)

--- a/src/pkg/artifact/model.go
+++ b/src/pkg/artifact/model.go
@@ -33,6 +33,7 @@ type Artifact struct {
 	ManifestMediaType string                 `json:"manifest_media_type"` // the media type of manifest/index
 	ProjectID         int64                  `json:"project_id"`
 	RepositoryID      int64                  `json:"repository_id"`
+	RepositoryName    string                 `json:"repository_name"`
 	Digest            string                 `json:"digest"`
 	Size              int64                  `json:"size"`
 	PushTime          time.Time              `json:"push_time"`
@@ -40,8 +41,6 @@ type Artifact struct {
 	ExtraAttrs        map[string]interface{} `json:"extra_attrs"` // only contains the simple attributes specific for the different artifact type, most of them should come from the config layer
 	Annotations       map[string]string      `json:"annotations"`
 	References        []*Reference           `json:"references"` // child artifacts referenced by the parent artifact if the artifact is an index
-
-	RepositoryName string `json:"-"` // repository name, eg: library/photon
 }
 
 // From converts the database level artifact to the business level object
@@ -52,6 +51,7 @@ func (a *Artifact) From(art *dao.Artifact) {
 	a.ManifestMediaType = art.ManifestMediaType
 	a.ProjectID = art.ProjectID
 	a.RepositoryID = art.RepositoryID
+	a.RepositoryName = art.RepositoryName
 	a.Digest = art.Digest
 	a.Size = art.Size
 	a.PushTime = art.PushTime
@@ -79,6 +79,7 @@ func (a *Artifact) To() *dao.Artifact {
 		ManifestMediaType: a.ManifestMediaType,
 		ProjectID:         a.ProjectID,
 		RepositoryID:      a.RepositoryID,
+		RepositoryName:    a.RepositoryName,
 		Digest:            a.Digest,
 		Size:              a.Size,
 		PushTime:          a.PushTime,

--- a/src/pkg/blob/dao/dao_test.go
+++ b/src/pkg/blob/dao/dao_test.go
@@ -173,7 +173,7 @@ func (suite *DaoTestSuite) TestFindBlobsShouldUnassociatedWithProject() {
 		artifact1 := suite.DigestString()
 		artifact2 := suite.DigestString()
 
-		sql := `INSERT INTO artifact ("type", media_type, manifest_media_type, digest, project_id, repository_id) VALUES ('image', 'media_type', 'manifest_media_type', ?, ?, ?)`
+		sql := `INSERT INTO artifact ("type", media_type, manifest_media_type, digest, project_id, repository_id, repository_name) VALUES ('image', 'media_type', 'manifest_media_type', ?, ?, ?, 'library/hello-world')`
 		suite.ExecSQL(sql, artifact1, projectID, 10)
 		suite.ExecSQL(sql, artifact2, projectID, 10)
 

--- a/src/pkg/blob/manager_test.go
+++ b/src/pkg/blob/manager_test.go
@@ -92,7 +92,7 @@ func (suite *ManagerTestSuite) TestCleanupAssociationsForProject() {
 		artifact1 := suite.DigestString()
 		artifact2 := suite.DigestString()
 
-		sql := `INSERT INTO artifact ("type", media_type, manifest_media_type, digest, project_id, repository_id) VALUES ('image', 'media_type', 'manifest_media_type', ?, ?, ?)`
+		sql := `INSERT INTO artifact ("type", media_type, manifest_media_type, digest, project_id, repository_id, repository_name) VALUES ('image', 'media_type', 'manifest_media_type', ?, ?, ?, 'library/hello-world')`
 		suite.ExecSQL(sql, artifact1, projectID, 10)
 		suite.ExecSQL(sql, artifact2, projectID, 10)
 

--- a/src/server/middleware/immutable/pushmf_test.go
+++ b/src/server/middleware/immutable/pushmf_test.go
@@ -110,15 +110,16 @@ func (suite *HandlerSuite) addProject(projectName string) int64 {
 	return projectID
 }
 
-func (suite *HandlerSuite) addArt(ctx context.Context, pid, repositoryID int64, dgt string) int64 {
+func (suite *HandlerSuite) addArt(ctx context.Context, pid, repositoryID int64, repositoryName, dgt string) int64 {
 	af := &artifact.Artifact{
-		Type:         "Docker-Image",
-		ProjectID:    pid,
-		RepositoryID: repositoryID,
-		Digest:       dgt,
-		Size:         1024,
-		PushTime:     time.Now(),
-		PullTime:     time.Now(),
+		Type:           "Docker-Image",
+		ProjectID:      pid,
+		RepositoryID:   repositoryID,
+		RepositoryName: repositoryName,
+		Digest:         dgt,
+		Size:           1024,
+		PushTime:       time.Now(),
+		PullTime:       time.Now(),
 	}
 	afid, err := artifact.Mgr.Create(ctx, af)
 	suite.Nil(err, fmt.Sprintf("Add artifact failed for %d", repositoryID))
@@ -185,7 +186,7 @@ func (suite *HandlerSuite) TestPutDeleteManifestCreated() {
 	projectID := suite.addProject(projectName)
 	immuRuleID := suite.addImmutableRule(projectID)
 	repoID := suite.addRepo(ctx, projectID, repoName)
-	afID := suite.addArt(ctx, projectID, repoID, dgt)
+	afID := suite.addArt(ctx, projectID, repoID, repoName, dgt)
 	tagID := suite.addTags(ctx, repoID, afID, "release-1.10")
 
 	defer func() {

--- a/src/server/registry/manifest.go
+++ b/src/server/registry/manifest.go
@@ -70,7 +70,7 @@ func putManifest(w http.ResponseWriter, req *http.Request) {
 	reference := router.Param(req.Context(), ":reference")
 
 	// make sure the repository exist before pushing the manifest
-	_, repositoryID, err := repository.Ctl.Ensure(req.Context(), repo)
+	_, _, err := repository.Ctl.Ensure(req.Context(), repo)
 	if err != nil {
 		serror.SendError(w, err)
 		return
@@ -98,7 +98,7 @@ func putManifest(w http.ResponseWriter, req *http.Request) {
 		tags = append(tags, reference)
 	}
 
-	_, _, err = artifact.Ctl.Ensure(req.Context(), repositoryID, dgt, tags...)
+	_, _, err = artifact.Ctl.Ensure(req.Context(), repo, dgt, tags...)
 	if err != nil {
 		serror.SendError(w, err)
 		return

--- a/src/testing/api/artifact/controller.go
+++ b/src/testing/api/artifact/controller.go
@@ -29,7 +29,7 @@ type FakeController struct {
 }
 
 // Ensure ...
-func (f *FakeController) Ensure(ctx context.Context, repositoryID int64, digest string, tags ...string) (bool, int64, error) {
+func (f *FakeController) Ensure(ctx context.Context, repository, digest string, tags ...string) (bool, int64, error) {
 	args := f.Called()
 	return args.Bool(0), int64(args.Int(1)), args.Error(2)
 }
@@ -77,7 +77,7 @@ func (f *FakeController) Delete(ctx context.Context, id int64) (err error) {
 }
 
 // Copy ...
-func (f *FakeController) Copy(ctx context.Context, srcArtID, dstRepoID int64) (int64, error) {
+func (f *FakeController) Copy(ctx context.Context, srcRepo, ref, dstRepo string) (int64, error) {
 	args := f.Called()
 	return int64(args.Int(0)), args.Error(1)
 }

--- a/src/testing/pkg/artifact/manager.go
+++ b/src/testing/pkg/artifact/manager.go
@@ -54,7 +54,7 @@ func (f *FakeManager) Get(ctx context.Context, id int64) (*artifact.Artifact, er
 }
 
 // GetByDigest ...
-func (f *FakeManager) GetByDigest(ctx context.Context, repositoryID int64, digest string) (*artifact.Artifact, error) {
+func (f *FakeManager) GetByDigest(ctx context.Context, repository, digest string) (*artifact.Artifact, error) {
 	args := f.Called()
 	var art *artifact.Artifact
 	if args.Get(0) != nil {


### PR DESCRIPTION
As we store the repository name in the artifact table, we can use it direclty in the code to reduce the database query

Signed-off-by: Wenkai Yin <yinw@vmware.com>