### PR TITLE
Fix image links

### DIFF
--- a/docs/1.10/working-with-projects/create-projects/_index.md
+++ b/docs/1.10/working-with-projects/create-projects/_index.md
@@ -24,17 +24,17 @@ Log in to Harbor with a Harbor administrator or project administrator account.
 
     If you set the project to **Public**, any user can pull images from this project. If you leave the project set to **Private**, only users who are members of the project can pull images. You can toggle projects from public to private, or the reverse, at any moment after you create the project.
 
-    ![create project](../../../img/new-create-project.png)
+    ![create project](../../img/new-create-project.png)
 
 5. Click **OK**.
 
 After the project is created, you can browse repositories, members, logs, replication and configuration using the navigation tab.
 
-![browse project](../../../img/new-browse-project.png)
+![browse project](../../img/new-browse-project.png)
 
 There are two views to show repositories, list view and card view, you can switch between them by clicking the corresponding icon.
 
-![browse repositories](../../../img/browse-project-repositories.png)
+![browse repositories](../../img/browse-project-repositories.png)
 
 Project properties can be changed by clicking "Configuration".
 
@@ -42,13 +42,13 @@ Project properties can be changed by clicking "Configuration".
 
 * To prevent un-signed images under the project from being pulled, select the `Enable content trust` checkbox. For more information about content trust, see [Implementing Content Trust](../project-configuration/implementing-content-trust.md).
 
-![browse project](../../../img/project-configuration.png)
+![browse project](../../img/project-configuration.png)
 
 
 ## Searching Projects and Repositories
 Entering a keyword in the search field at the top lists all matching projects and repositories. The search result includes both public and private repositories you have access to.
 
-![browse project](../../../img/new-search.png)
+![browse project](../../img/new-search.png)
 
 ## What to Do Next
 


### PR DESCRIPTION
This PR fixes image links broken due to misnaming a Markdown file.