### PR TITLE
Remove docs folder from CI runs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,6 +18,8 @@ env:
 on:
   pull_request:
   push:
+    paths-ignore:
+    - 'docs/**'
 
 jobs:
   UTTEST:


### PR DESCRIPTION
This will remove the docs folder from triggering CI runs.

Signed-off-by: jonasrosland <jrosland@vmware.com>