### PR TITLE
Add "Docker-Distribution-Api-Version" header for the 401 response of registry API

### DIFF
--- a/src/server/middleware/v2auth/auth.go
+++ b/src/server/middleware/v2auth/auth.go
@@ -130,6 +130,8 @@ func Middleware() func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 			if err := checker.check(req); err != nil {
+				// the header is needed for "docker manifest" commands: https://github.com/docker/cli/issues/989
+				rw.Header().Set("Docker-Distribution-Api-Version", "registry/2.0")
 				serror.SendError(rw, ierror.UnauthorizedError(err).WithMessage(err.Error()))
 				return
 			}


### PR DESCRIPTION
This is needed for "docker manifest" commands: https://github.com/docker/cli/issues/989

Signed-off-by: Wenkai Yin <yinw@vmware.com>