### PR TITLE
CLI Secret should handle /v2/* API

### DIFF
--- a/src/core/filter/security.go
+++ b/src/core/filter/security.go
@@ -209,6 +209,7 @@ type oidcCliReqCtxModifier struct{}
 func (oc *oidcCliReqCtxModifier) Modify(ctx *beegoctx.Context) bool {
 	path := ctx.Request.URL.Path
 	if path != "/service/token" &&
+		!strings.HasPrefix(path, "/v2") &&
 		!strings.HasPrefix(path, "/chartrepo/") &&
 		!strings.HasPrefix(path, fmt.Sprintf("/api/%s/chartrepo/", api.APIVersion)) {
 		log.Debug("OIDC CLI modifier only handles request by docker CLI or helm CLI")


### PR DESCRIPTION
As we swtich to basic auth for /v2/* API
The CLI secret should handle /v2/* API so that OIDC user can use the
secret to do push/pull
This commit makes such change.

Signed-off-by: Daniel Jiang <jiangd@vmware.com>