### PR TITLE
feat(artifact): add Walk method to artifact controller

### DIFF
--- a/src/pkg/artifact/manager.go
+++ b/src/pkg/artifact/manager.go
@@ -158,15 +158,15 @@ func (m *manager) assemble(ctx context.Context, art *dao.Artifact) (*Artifact, e
 	artifact := &Artifact{}
 	// convert from database object
 	artifact.From(art)
+
 	// populate the references
-	references, err := m.ListReferences(ctx, &q.Query{
-		Keywords: map[string]interface{}{
-			"ParentID": artifact.ID,
-		},
-	})
-	if err != nil {
-		return nil, err
+	if artifact.HasChildren() {
+		references, err := m.ListReferences(ctx, q.New(q.KeyWords{"ParentID": artifact.ID}))
+		if err != nil {
+			return nil, err
+		}
+		artifact.References = references
 	}
-	artifact.References = references
+
 	return artifact, nil
 }

--- a/src/pkg/artifact/manager_test.go
+++ b/src/pkg/artifact/manager_test.go
@@ -16,12 +16,14 @@ package artifact
 
 import (
 	"context"
-	"github.com/goharbor/harbor/src/pkg/artifact/dao"
-	"github.com/goharbor/harbor/src/pkg/q"
-	"github.com/stretchr/testify/mock"
-	"github.com/stretchr/testify/suite"
 	"testing"
 	"time"
+
+	"github.com/goharbor/harbor/src/pkg/artifact/dao"
+	"github.com/goharbor/harbor/src/pkg/q"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
 )
 
 type fakeDao struct {
@@ -98,7 +100,7 @@ func (m *managerTestSuite) TestAssemble() {
 		ID:                1,
 		Type:              "IMAGE",
 		MediaType:         "application/vnd.oci.image.config.v1+json",
-		ManifestMediaType: "application/vnd.oci.image.manifest.v1+json",
+		ManifestMediaType: v1.MediaTypeImageIndex,
 		ProjectID:         1,
 		RepositoryID:      1,
 		Digest:            "sha256:418fb88ec412e340cdbef913b8ca1bbe8f9e8dc705f9617414c1f2c8db980180",
@@ -159,7 +161,7 @@ func (m *managerTestSuite) TestGet() {
 		ID:                1,
 		Type:              "IMAGE",
 		MediaType:         "application/vnd.oci.image.config.v1+json",
-		ManifestMediaType: "application/vnd.oci.image.manifest.v1+json",
+		ManifestMediaType: v1.MediaTypeImageIndex,
 		ProjectID:         1,
 		RepositoryID:      1,
 		Digest:            "sha256:418fb88ec412e340cdbef913b8ca1bbe8f9e8dc705f9617414c1f2c8db980180",

--- a/src/pkg/artifact/model.go
+++ b/src/pkg/artifact/model.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"time"
 
+	"github.com/docker/distribution/manifest/manifestlist"
 	"github.com/goharbor/harbor/src/common/utils/log"
 	"github.com/goharbor/harbor/src/pkg/artifact/dao"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
@@ -41,6 +42,12 @@ type Artifact struct {
 	ExtraAttrs        map[string]interface{} `json:"extra_attrs"` // only contains the simple attributes specific for the different artifact type, most of them should come from the config layer
 	Annotations       map[string]string      `json:"annotations"`
 	References        []*Reference           `json:"references"` // child artifacts referenced by the parent artifact if the artifact is an index
+}
+
+// HasChildren returns true when artifact has children artifacts, most times that means the artifact is Image Index.
+func (a *Artifact) HasChildren() bool {
+	return a.ManifestMediaType == v1.MediaTypeImageIndex ||
+		a.ManifestMediaType == manifestlist.MediaTypeManifestList
 }
 
 // From converts the database level artifact to the business level object

--- a/src/pkg/artifact/model_test.go
+++ b/src/pkg/artifact/model_test.go
@@ -18,7 +18,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/docker/distribution/manifest/manifestlist"
 	"github.com/goharbor/harbor/src/pkg/artifact/dao"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
@@ -92,6 +94,17 @@ func (m *modelTestSuite) TestArtifactTo() {
 	assert.Equal(t, art.PullTime, dbArt.PullTime)
 	assert.Equal(t, `{"attr1":"value1"}`, dbArt.ExtraAttrs)
 	assert.Equal(t, `{"anno1":"value1"}`, dbArt.Annotations)
+}
+
+func (m *modelTestSuite) TestHasChildren() {
+	art1 := Artifact{ManifestMediaType: v1.MediaTypeImageIndex}
+	m.True(art1.HasChildren())
+
+	art2 := Artifact{ManifestMediaType: manifestlist.MediaTypeManifestList}
+	m.True(art2.HasChildren())
+
+	art3 := Artifact{ManifestMediaType: v1.MediaTypeImageManifest}
+	m.False(art3.HasChildren())
 }
 
 func TestModel(t *testing.T) {

--- a/src/testing/api/artifact/controller.go
+++ b/src/testing/api/artifact/controller.go
@@ -16,11 +16,12 @@ package artifact
 
 import (
 	"context"
+	"time"
+
 	"github.com/goharbor/harbor/src/api/artifact"
 	"github.com/goharbor/harbor/src/api/artifact/abstractor/resolver"
 	"github.com/goharbor/harbor/src/pkg/q"
 	"github.com/stretchr/testify/mock"
-	"time"
 )
 
 // FakeController is a fake artifact controller that implement src/api/artifact.Controller interface
@@ -106,6 +107,12 @@ func (f *FakeController) AddLabel(ctx context.Context, artifactID int64, labelID
 
 // RemoveLabel ...
 func (f *FakeController) RemoveLabel(ctx context.Context, artifactID int64, labelID int64) error {
+	args := f.Called()
+	return args.Error(0)
+}
+
+// Walk ...
+func (f *FakeController) Walk(ctx context.Context, root *artifact.Artifact, workFn func(*artifact.Artifact) error, option *artifact.Option) error {
 	args := f.Called()
 	return args.Error(0)
 }


### PR DESCRIPTION
Add Walk method to artifact controller which walks the artifact tree rooted at root, calling walkFn for each artifact in the tree, including root.

Signed-off-by: He Weiwei <hweiwei@vmware.com>