### PR TITLE
fix[js]:fix ut case faulure

### DIFF
--- a/src/jobservice/runner/redis.go
+++ b/src/jobservice/runner/redis.go
@@ -18,12 +18,10 @@ import (
 	"fmt"
 	"runtime"
 
-	"github.com/goharbor/harbor/src/jobservice/errs"
-
 	"github.com/gocraft/work"
 	"github.com/goharbor/harbor/src/jobservice/env"
+	"github.com/goharbor/harbor/src/jobservice/errs"
 	"github.com/goharbor/harbor/src/jobservice/job"
-	"github.com/goharbor/harbor/src/jobservice/job/impl"
 	"github.com/goharbor/harbor/src/jobservice/lcm"
 	"github.com/goharbor/harbor/src/jobservice/logger"
 	"github.com/goharbor/harbor/src/jobservice/period"
@@ -160,9 +158,6 @@ func (rj *RedisJob) Run(j *work.Job) (err error) {
 	}
 
 	// Build job context
-	if rj.context.JobContext == nil {
-		rj.context.JobContext = impl.NewDefaultContext(rj.context.SystemContext)
-	}
 	if execContext, err = rj.context.JobContext.Build(tracker); err != nil {
 		return
 	}

--- a/src/jobservice/runner/redis_test.go
+++ b/src/jobservice/runner/redis_test.go
@@ -15,25 +15,22 @@ package runner
 
 import (
 	"context"
-	common_dao "github.com/goharbor/harbor/src/common/dao"
 	"os"
 	"sync"
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
-
-	"github.com/goharbor/harbor/src/jobservice/job"
-	"github.com/goharbor/harbor/src/jobservice/logger/backend"
-
 	"github.com/gocraft/work"
-
+	common_dao "github.com/goharbor/harbor/src/common/dao"
 	"github.com/goharbor/harbor/src/jobservice/config"
-	"github.com/goharbor/harbor/src/jobservice/tests"
-
 	"github.com/goharbor/harbor/src/jobservice/env"
+	"github.com/goharbor/harbor/src/jobservice/job"
+	"github.com/goharbor/harbor/src/jobservice/job/impl"
 	"github.com/goharbor/harbor/src/jobservice/lcm"
+	"github.com/goharbor/harbor/src/jobservice/logger/backend"
+	"github.com/goharbor/harbor/src/jobservice/tests"
 	"github.com/gomodule/redigo/redis"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
@@ -66,6 +63,7 @@ func (suite *RedisRunnerTestSuite) SetupSuite() {
 		SystemContext: ctx,
 		WG:            new(sync.WaitGroup),
 		ErrorChan:     make(chan error, 1),
+		JobContext:    impl.NewDefaultContext(ctx),
 	}
 
 	suite.namespace = tests.GiveMeTestNamespace()

--- a/src/jobservice/runtime/bootstrap.go
+++ b/src/jobservice/runtime/bootstrap.go
@@ -30,6 +30,7 @@ import (
 	"github.com/goharbor/harbor/src/jobservice/env"
 	"github.com/goharbor/harbor/src/jobservice/hook"
 	"github.com/goharbor/harbor/src/jobservice/job"
+	"github.com/goharbor/harbor/src/jobservice/job/impl"
 	"github.com/goharbor/harbor/src/jobservice/job/impl/gc"
 	"github.com/goharbor/harbor/src/jobservice/job/impl/notification"
 	"github.com/goharbor/harbor/src/jobservice/job/impl/replication"
@@ -85,6 +86,10 @@ func (bs *Bootstrap) LoadAndRun(ctx context.Context, cancel context.CancelFunc) 
 		if err != nil {
 			return errors.Errorf("initialize job context error: %s", err)
 		}
+	}
+	// Make sure the job context is created
+	if rootContext.JobContext == nil {
+		rootContext.JobContext = impl.NewDefaultContext(ctx)
 	}
 
 	// Alliance to config


### PR DESCRIPTION
- refactor default context creation to avoid data race
- refactor the timer interval in c_worker UT cases to avoid receiving signals at the same time

Signed-off-by: Steven Zou <szou@vmware.com>