### PR TITLE
Persistent the URLs and annotations of artifact references in database

### DIFF
--- a/make/migrations/postgresql/0030_2.0.0_schema.up.sql
+++ b/make/migrations/postgresql/0030_2.0.0_schema.up.sql
@@ -105,7 +105,10 @@ CREATE TABLE artifact_reference
   id          SERIAL PRIMARY KEY NOT NULL,
   parent_id   int NOT NULL,
   child_id    int NOT NULL,
+  child_digest varchar(255) NOT NULL ,
   platform    varchar(255),
+  urls        varchar(1024),
+  annotations jsonb,
   FOREIGN KEY (parent_id) REFERENCES artifact(id),
   FOREIGN KEY (child_id) REFERENCES artifact(id),
   CONSTRAINT  unique_reference UNIQUE (parent_id, child_id)

--- a/src/api/artifact/abstractor/resolver/cnab/cnab.go
+++ b/src/api/artifact/abstractor/resolver/cnab/cnab.go
@@ -67,8 +67,11 @@ func (r *resolver) ResolveMetadata(ctx context.Context, manifest []byte, art *ar
 			return err
 		}
 		art.References = append(art.References, &artifact.Reference{
-			ChildID:  ar.ID,
-			Platform: mani.Platform,
+			ChildID:     ar.ID,
+			ChildDigest: digest,
+			Platform:    mani.Platform,
+			URLs:        mani.URLs,
+			Annotations: mani.Annotations,
 		})
 		// try to get the digest of the manifest that the config layer is referenced by
 		if mani.Annotations != nil &&

--- a/src/api/artifact/abstractor/resolver/image/index.go
+++ b/src/api/artifact/abstractor/resolver/image/index.go
@@ -63,8 +63,11 @@ func (i *indexResolver) ResolveMetadata(ctx context.Context, manifest []byte, ar
 			return err
 		}
 		art.References = append(art.References, &artifact.Reference{
-			ChildID:  ar.ID,
-			Platform: mani.Platform,
+			ChildID:     ar.ID,
+			ChildDigest: digest,
+			Platform:    mani.Platform,
+			URLs:        mani.URLs,
+			Annotations: mani.Annotations,
 		})
 	}
 	return nil

--- a/src/pkg/artifact/dao/model.go
+++ b/src/pkg/artifact/dao/model.go
@@ -49,10 +49,13 @@ func (a *Artifact) TableName() string {
 
 // ArtifactReference records the child artifact referenced by parent artifact
 type ArtifactReference struct {
-	ID       int64  `orm:"pk;auto;column(id)"`
-	ParentID int64  `orm:"column(parent_id)"`
-	ChildID  int64  `orm:"column(child_id)"`
-	Platform string `orm:"column(platform)"` // json string
+	ID          int64  `orm:"pk;auto;column(id)"`
+	ParentID    int64  `orm:"column(parent_id)"`
+	ChildID     int64  `orm:"column(child_id)"`
+	ChildDigest string `orm:"column(child_digest)"`
+	Platform    string `orm:"column(platform)"` // json string
+	URLs        string `orm:"column(urls)"`     // json string
+	Annotations string `orm:"column(annotations);type(jsonb)"`
 }
 
 // TableName for artifact reference

--- a/src/pkg/artifact/manager.go
+++ b/src/pkg/artifact/manager.go
@@ -135,11 +135,6 @@ func (m *manager) ListReferences(ctx context.Context, query *q.Query) ([]*Refere
 	for _, reference := range references {
 		ref := &Reference{}
 		ref.From(reference)
-		art, err := m.dao.Get(ctx, reference.ChildID)
-		if err != nil {
-			return nil, err
-		}
-		ref.ChildDigest = art.Digest
 		refs = append(refs, ref)
 	}
 	return refs, nil

--- a/src/pkg/artifact/manager_test.go
+++ b/src/pkg/artifact/manager_test.go
@@ -122,9 +122,6 @@ func (m *managerTestSuite) TestAssemble() {
 			ChildID:  3,
 		},
 	}, nil)
-	m.dao.On("Get").Return(&dao.Artifact{
-		Digest: "digest",
-	}, nil)
 	artifact, err := m.mgr.assemble(nil, art)
 	m.Require().Nil(err)
 	m.dao.AssertExpectations(m.T())
@@ -244,15 +241,10 @@ func (m *managerTestSuite) TestListReferences() {
 			ChildID:  2,
 		},
 	}, nil)
-	m.dao.On("Get").Return(&dao.Artifact{
-		ID:     1,
-		Digest: "digest",
-	}, nil)
 	references, err := m.mgr.ListReferences(nil, nil)
 	m.Require().Nil(err)
 	m.Require().Len(references, 1)
 	m.Equal(int64(1), references[0].ID)
-	m.Equal("digest", references[0].ChildDigest)
 }
 
 func (m *managerTestSuite) TestDeleteReference() {


### PR DESCRIPTION
Persistent the URLs and annotations of artifact references in database

Signed-off-by: Wenkai Yin <yinw@vmware.com>