### PR TITLE
Remove the "x-go-type" for artifact definition in swagger

### DIFF
--- a/api/v2.0/swagger.yaml
+++ b/api/v2.0/swagger.yaml
@@ -763,10 +763,6 @@ definitions:
         description: The update time of the repository
   Artifact:
     type: object
-    x-go-type:
-      import:
-        package: "github.com/goharbor/harbor/src/server/v2.0/handler/model"
-      type: "Artifact"
     properties:
       id:
         type: integer
@@ -897,6 +893,13 @@ definitions:
         description: The digest of the child artifact
       platform:
         $ref: '#/definitions/Platform'
+      annotations:
+        $ref: '#/definitions/Annotations'
+      urls:
+        type: array
+        description: The download URLs
+        items:
+          type: string
   Platform:
     type: object
     properties:
@@ -948,9 +951,6 @@ definitions:
         type: string
         format: date-time
         description: The update time of the label
-      deleted:
-        type: boolean
-        description: Whether the label is deleted or not
   ScanOverview:
     type: object
     description: 'The scan overview attached in the metadata of tag'

--- a/src/api/artifact/model.go
+++ b/src/api/artifact/model.go
@@ -16,6 +16,7 @@ package artifact
 
 import (
 	"fmt"
+	"github.com/goharbor/harbor/src/server/v2.0/models"
 
 	"github.com/goharbor/harbor/src/api/tag"
 	cmodels "github.com/goharbor/harbor/src/common/models"
@@ -47,6 +48,14 @@ func (artifact *Artifact) SetAdditionLink(addition, version string) {
 type AdditionLink struct {
 	HREF     string `json:"href"`
 	Absolute bool   `json:"absolute"` // specify the href is an absolute URL or not
+}
+
+// ToSwagger converts the addition link to the swagger model
+func (a *AdditionLink) ToSwagger() models.AdditionLink {
+	return models.AdditionLink{
+		Absolute: a.Absolute,
+		Href:     a.HREF,
+	}
 }
 
 // Option is used to specify the properties returned when listing/getting artifacts

--- a/src/api/tag/model.go
+++ b/src/api/tag/model.go
@@ -1,8 +1,10 @@
 package tag
 
 import (
+	"github.com/go-openapi/strfmt"
 	"github.com/goharbor/harbor/src/pkg/signature"
 	"github.com/goharbor/harbor/src/pkg/tag/model/tag"
+	"github.com/goharbor/harbor/src/server/v2.0/models"
 )
 
 // Tag is the overall view of tag
@@ -10,6 +12,20 @@ type Tag struct {
 	tag.Tag
 	Immutable bool `json:"immutable"`
 	Signed    bool `json:"signed"`
+}
+
+// ToSwagger converts the tag to the swagger model
+func (t *Tag) ToSwagger() *models.Tag {
+	return &models.Tag{
+		ArtifactID:   t.ArtifactID,
+		ID:           t.ID,
+		Name:         t.Name,
+		PullTime:     strfmt.DateTime(t.PullTime),
+		PushTime:     strfmt.DateTime(t.PushTime),
+		RepositoryID: t.RepositoryID,
+		Immutable:    t.Immutable,
+		Signed:       t.Signed,
+	}
 }
 
 // Option is used to specify the properties returned when listing/getting tags

--- a/src/common/models/label.go
+++ b/src/common/models/label.go
@@ -16,6 +16,8 @@ package models
 
 import (
 	"fmt"
+	"github.com/go-openapi/strfmt"
+	"github.com/goharbor/harbor/src/server/v2.0/models"
 	"time"
 
 	"github.com/astaxie/beego/validation"
@@ -34,6 +36,20 @@ type Label struct {
 	CreationTime time.Time `orm:"column(creation_time);auto_now_add" json:"creation_time"`
 	UpdateTime   time.Time `orm:"column(update_time);auto_now" json:"update_time"`
 	Deleted      bool      `orm:"column(deleted)" json:"deleted"`
+}
+
+// ToSwagger converts the label to the swagger model
+func (l *Label) ToSwagger() *models.Label {
+	return &models.Label{
+		Color:        l.Color,
+		CreationTime: strfmt.DateTime(l.CreationTime),
+		Description:  l.Description,
+		ID:           l.ID,
+		Name:         l.Name,
+		ProjectID:    l.ProjectID,
+		Scope:        l.Scope,
+		UpdateTime:   strfmt.DateTime(l.UpdateTime),
+	}
 }
 
 // TableName ...

--- a/src/pkg/artifact/model.go
+++ b/src/pkg/artifact/model.go
@@ -16,6 +16,7 @@ package artifact
 
 import (
 	"encoding/json"
+	"github.com/goharbor/harbor/src/server/v2.0/models"
 	"time"
 
 	"github.com/docker/distribution/manifest/manifestlist"
@@ -174,6 +175,27 @@ func (r *Reference) To() *dao.ArtifactReference {
 			log.Errorf("failed to marshal the annotations of reference: %v", err)
 		}
 		ref.Annotations = string(annotations)
+	}
+	return ref
+}
+
+// ToSwagger converts the reference to the swagger model
+func (r *Reference) ToSwagger() *models.Reference {
+	ref := &models.Reference{
+		ChildDigest: r.ChildDigest,
+		ChildID:     r.ChildID,
+		ParentID:    r.ParentID,
+		Annotations: r.Annotations,
+		Urls:        r.URLs,
+	}
+	if r.Platform != nil {
+		ref.Platform = &models.Platform{
+			Architecture: r.Platform.Architecture,
+			Os:           r.Platform.OS,
+			OsFeatures:   r.Platform.OSFeatures,
+			OsVersion:    r.Platform.OSVersion,
+			Variant:      r.Platform.Variant,
+		}
 	}
 	return ref
 }

--- a/src/portal/src/app/project/repository/artifact-list-page/artifact-list/artifact-list-tab/artifact-list-tab.component.spec.ts
+++ b/src/portal/src/app/project/repository/artifact-list-page/artifact-list/artifact-list-tab/artifact-list-tab.component.spec.ts
@@ -118,8 +118,7 @@ describe("ArtifactListTabComponent (inline template)", () => {
           "scope": "g",
           "project_id": 0,
           "creation_time": "2020-01-13T05:44:00.580198Z",
-          "update_time": "2020-01-13T05:44:00.580198Z",
-          "deleted": false
+          "update_time": "2020-01-13T05:44:00.580198Z"
         },
         {
           "id": 6,
@@ -129,8 +128,7 @@ describe("ArtifactListTabComponent (inline template)", () => {
           "scope": "g",
           "project_id": 0,
           "creation_time": "2020-01-13T08:27:19.279123Z",
-          "update_time": "2020-01-13T08:27:19.279123Z",
-          "deleted": false
+          "update_time": "2020-01-13T08:27:19.279123Z"
         }
       ],
       "push_time": "2020-01-07T03:33:41.162319Z",
@@ -176,8 +174,7 @@ describe("ArtifactListTabComponent (inline template)", () => {
           "scope": "g",
           "project_id": 0,
           "creation_time": "2020-01-13T05:44:00.580198Z",
-          "update_time": "2020-01-13T05:44:00.580198Z",
-          "deleted": false
+          "update_time": "2020-01-13T05:44:00.580198Z"
         },
         {
           "id": 6,
@@ -187,8 +184,7 @@ describe("ArtifactListTabComponent (inline template)", () => {
           "scope": "g",
           "project_id": 0,
           "creation_time": "2020-01-13T08:27:19.279123Z",
-          "update_time": "2020-01-13T08:27:19.279123Z",
-          "deleted": false
+          "update_time": "2020-01-13T08:27:19.279123Z"
         }
       ],
       "push_time": "2020-01-07T03:33:41.162319Z",

--- a/src/server/v2.0/handler/model/artifact.go
+++ b/src/server/v2.0/handler/model/artifact.go
@@ -14,10 +14,48 @@
 
 package model
 
-import "github.com/goharbor/harbor/src/api/artifact"
+import (
+	"github.com/go-openapi/strfmt"
+	"github.com/goharbor/harbor/src/api/artifact"
+	"github.com/goharbor/harbor/src/server/v2.0/models"
+)
 
 // Artifact model
 type Artifact struct {
 	artifact.Artifact
 	ScanOverview map[string]interface{} `json:"scan_overview"`
+}
+
+// ToSwagger converts the artifact to the swagger model
+func (a *Artifact) ToSwagger() *models.Artifact {
+	art := &models.Artifact{
+		ID:                a.ID,
+		Type:              a.Type,
+		MediaType:         a.MediaType,
+		ManifestMediaType: a.ManifestMediaType,
+		ProjectID:         a.ProjectID,
+		RepositoryID:      a.RepositoryID,
+		Digest:            a.Digest,
+		Size:              a.Size,
+		PullTime:          strfmt.DateTime(a.PullTime),
+		PushTime:          strfmt.DateTime(a.PushTime),
+		ExtraAttrs:        a.ExtraAttrs,
+		Annotations:       a.Annotations,
+	}
+	for _, reference := range a.References {
+		art.References = append(art.References, reference.ToSwagger())
+	}
+	for _, tag := range a.Tags {
+		art.Tags = append(art.Tags, tag.ToSwagger())
+	}
+	for addition, link := range a.AdditionLinks {
+		if art.AdditionLinks == nil {
+			art.AdditionLinks = make(map[string]models.AdditionLink)
+		}
+		art.AdditionLinks[addition] = link.ToSwagger()
+	}
+	for _, label := range a.Labels {
+		art.Labels = append(art.Labels, label.ToSwagger())
+	}
+	return art
 }


### PR DESCRIPTION
Using "x-go-type" may cause the inconsistence between the swagger definition and the real data model

Signed-off-by: Wenkai Yin <yinw@vmware.com>