### PR TITLE
skip configuration update in readonly mode

### DIFF
--- a/src/core/middlewares/middlewares.go
+++ b/src/core/middlewares/middlewares.go
@@ -41,6 +41,8 @@ var (
 
 	// readonlySkippers skip the post request when harbor sets to readonly.
 	readonlySkippers = []middleware.Skipper{
+		middleware.MethodAndPathSkipper(http.MethodPut, match("^/api/v2.0/configurations")),
+		middleware.MethodAndPathSkipper(http.MethodPut, match("^/api/internal/configurations")),
 		middleware.MethodAndPathSkipper(http.MethodPost, match("^/c/login")),
 		middleware.MethodAndPathSkipper(http.MethodPost, match("^/c/userExists")),
 		middleware.MethodAndPathSkipper(http.MethodPost, match("^/c/oidc/onboard")),


### PR DESCRIPTION
Admin must have a way to switch off the readonly by call configuration api,
either internal or external.

Signed-off-by: wang yan <wangyan@vmware.com>