### PR TITLE
Only set "Www-Authenticate" header for registry API

### DIFF
--- a/src/server/error/error.go
+++ b/src/server/error/error.go
@@ -58,9 +58,6 @@ func SendError(w http.ResponseWriter, err error) {
 		// only log the error whose status code < 500 when debugging to avoid log flooding
 		log.Debug(errPayload)
 	}
-	if statusCode == http.StatusUnauthorized {
-		w.Header().Set("Www-Authenticate", `Basic realm="harbor"`)
-	}
 	w.WriteHeader(statusCode)
 	fmt.Fprintln(w, errPayload)
 }

--- a/src/server/error/error_test.go
+++ b/src/server/error/error_test.go
@@ -31,7 +31,6 @@ func TestSendError(t *testing.T) {
 	SendError(rw, err)
 	assert.Equal(t, http.StatusUnauthorized, rw.Code)
 	assert.Equal(t, `{"errors":[{"code":"UNAUTHORIZED","message":"unauthorized"}]}`+"\n", rw.Body.String())
-	assert.Equal(t, `Basic realm="harbor"`, rw.Header().Get("Www-Authenticate"))
 
 	// internal server error
 	rw = httptest.NewRecorder()

--- a/src/server/middleware/v2auth/auth.go
+++ b/src/server/middleware/v2auth/auth.go
@@ -132,6 +132,7 @@ func Middleware() func(http.Handler) http.Handler {
 			if err := checker.check(req); err != nil {
 				// the header is needed for "docker manifest" commands: https://github.com/docker/cli/issues/989
 				rw.Header().Set("Docker-Distribution-Api-Version", "registry/2.0")
+				rw.Header().Set("Www-Authenticate", `Basic realm="harbor"`)
 				serror.SendError(rw, ierror.UnauthorizedError(err).WithMessage(err.Error()))
 				return
 			}


### PR DESCRIPTION
If "Www-Authenticate" header is set for Harbor management API, the browser will show a basic auth dialog when get 401 error, this commit moves the header to the registry APIs

Signed-off-by: Wenkai Yin <yinw@vmware.com>