### PR TITLE
fix Conformance testing failure

### DIFF
--- a/src/internal/error/errors.go
+++ b/src/internal/error/errors.go
@@ -96,6 +96,8 @@ const (
 	PROJECTPOLICYVIOLATION = "PROJECTPOLICYVIOLATION"
 	// ViolateForeignKeyConstraintCode is the error code for violating foreign key constraint error
 	ViolateForeignKeyConstraintCode = "VIOLATE_FOREIGN_KEY_CONSTRAINT"
+	// DIGESTINVALID ...
+	DIGESTINVALID = "DIGEST_INVALID"
 )
 
 // New ...

--- a/src/server/error/error.go
+++ b/src/server/error/error.go
@@ -29,6 +29,7 @@ import (
 var (
 	codeMap = map[string]int{
 		ierror.BadRequestCode:                  http.StatusBadRequest,
+		ierror.DIGESTINVALID:                   http.StatusBadRequest,
 		ierror.UnAuthorizedCode:                http.StatusUnauthorized,
 		ierror.ForbiddenCode:                   http.StatusForbidden,
 		ierror.DENIED:                          http.StatusForbidden,

--- a/src/server/middleware/immutable/pushmf.go
+++ b/src/server/middleware/immutable/pushmf.go
@@ -6,6 +6,7 @@ import (
 	"github.com/goharbor/harbor/src/api/artifact"
 	"github.com/goharbor/harbor/src/api/tag"
 	common_util "github.com/goharbor/harbor/src/common/utils"
+	"github.com/goharbor/harbor/src/common/utils/log"
 	internal_errors "github.com/goharbor/harbor/src/internal/error"
 	serror "github.com/goharbor/harbor/src/server/error"
 	"github.com/goharbor/harbor/src/server/middleware"
@@ -46,10 +47,8 @@ func handlePush(req *http.Request) error {
 		TagOption: &tag.Option{WithImmutableStatus: true},
 	})
 	if err != nil {
-		if internal_errors.IsErr(err, internal_errors.NotFoundCode) {
-			return nil
-		}
-		return err
+		log.Debugf("failed to list artifact, %v", err.Error())
+		return nil
 	}
 
 	_, repoName := common_util.ParseRepository(art.Repository)

--- a/src/server/registry/catalog.go
+++ b/src/server/registry/catalog.go
@@ -52,7 +52,7 @@ func (r *repositoryHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) 
 		}
 	}
 
-	var repoNames []string
+	repoNames := make([]string, 0)
 	// get all repositories
 	// ToDo filter out the untagged repos
 	repoRecords, err := r.repoCtl.List(req.Context(), nil)

--- a/src/server/registry/manifest_test.go
+++ b/src/server/registry/manifest_test.go
@@ -15,6 +15,9 @@
 package registry
 
 import (
+	"context"
+	beegocontext "github.com/astaxie/beego/context"
+	"github.com/goharbor/harbor/src/server/router"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -99,7 +102,7 @@ func (m *manifestTestSuite) TestDeleteManifest() {
 
 	mock.OnAnything(m.artCtl, "GetByReference").Return(nil, ierror.New(nil).WithCode(ierror.NotFoundCode))
 	deleteManifest(w, req)
-	m.Equal(http.StatusNotFound, w.Code)
+	m.Equal(http.StatusBadRequest, w.Code)
 
 	// reset the mock
 	m.SetupTest()
@@ -116,7 +119,10 @@ func (m *manifestTestSuite) TestDeleteManifest() {
 		}
 		w.WriteHeader(http.StatusOK)
 	})
-	req = httptest.NewRequest(http.MethodDelete, "/v2/library/hello-world/manifests/latest", nil)
+	req = httptest.NewRequest(http.MethodDelete, "/v2/library/hello-world/manifests/sha256:418fb88ec412e340cdbef913b8ca1bbe8f9e8dc705f9617414c1f2c8db980180", nil)
+	input := &beegocontext.BeegoInput{}
+	input.SetParam(":reference", "sha527:418fb88ec412e340cdbef913b8ca1bbe8f9e8dc705f9617414c1f2c8db980180")
+	*req = *(req.WithContext(context.WithValue(req.Context(), router.ContextKeyInput{}, input)))
 	w = &httptest.ResponseRecorder{}
 	mock.OnAnything(m.artCtl, "GetByReference").Return(&artifact.Artifact{}, nil)
 	mock.OnAnything(m.artCtl, "Delete").Return(nil)

--- a/src/server/registry/tag.go
+++ b/src/server/registry/tag.go
@@ -70,7 +70,7 @@ func (t *tagHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		}
 	}
 
-	var tagNames []string
+	tagNames := make([]string, 0)
 
 	t.repositoryName = router.Param(req.Context(), ":splat")
 	repository, err := t.repoCtl.GetByName(req.Context(), t.repositoryName)

--- a/src/server/router/router.go
+++ b/src/server/router/router.go
@@ -23,7 +23,8 @@ import (
 	"path/filepath"
 )
 
-type contextKeyInput struct{}
+// ContextKeyInput ...
+type ContextKeyInput struct{}
 
 // NewRoute creates a new route
 func NewRoute() *Route {
@@ -83,7 +84,7 @@ func (r *Route) Handler(handler http.Handler) {
 	middlewares = append(middlewares, r.middlewares...)
 	filterFunc := beego.FilterFunc(func(ctx *beegocontext.Context) {
 		ctx.Request = ctx.Request.WithContext(
-			context.WithValue(ctx.Request.Context(), contextKeyInput{}, ctx.Input))
+			context.WithValue(ctx.Request.Context(), ContextKeyInput{}, ctx.Input))
 		// TODO remove the WithMiddlewares?
 		middleware.WithMiddlewares(handler, middlewares...).
 			ServeHTTP(ctx.ResponseWriter, ctx.Request)
@@ -123,7 +124,7 @@ func Param(ctx context.Context, key string) string {
 	if ctx == nil {
 		return ""
 	}
-	input, ok := ctx.Value(contextKeyInput{}).(*beegocontext.BeegoInput)
+	input, ok := ctx.Value(ContextKeyInput{}).(*beegocontext.BeegoInput)
 	if !ok {
 		return ""
 	}

--- a/src/server/router/router_test.go
+++ b/src/server/router/router_test.go
@@ -65,13 +65,13 @@ func (r *routerTestSuite) TestParam() {
 	r.Empty(value)
 
 	// context contains wrong type input
-	value = Param(context.WithValue(context.Background(), contextKeyInput{}, &Route{}), "key")
+	value = Param(context.WithValue(context.Background(), ContextKeyInput{}, &Route{}), "key")
 	r.Empty(value)
 
 	// success
 	input := &beegocontext.BeegoInput{}
 	input.SetParam("key", "value")
-	value = Param(context.WithValue(context.Background(), contextKeyInput{}, input), "key")
+	value = Param(context.WithValue(context.Background(), ContextKeyInput{}, input), "key")
 	r.Equal("value", value)
 }
 


### PR DESCRIPTION
1, Return DIGEST_INVALID error in delete manifest instead of NOT_FOUND
2, Disable return 500 in immutable middleware
3, Return empty array in catalog and tags API instead of null

Signed-off-by: wang yan <wangyan@vmware.com>