### PR TITLE
add no expriation limited robot account

### DIFF
--- a/src/pkg/robot/controller.go
+++ b/src/pkg/robot/controller.go
@@ -86,10 +86,14 @@ func (d *DefaultAPIController) CreateRobotAccount(robotReq *model.RobotCreate) (
 		ProjectID: robotReq.ProjectID,
 		Access:    robotReq.Access,
 		StandardClaims: jwt.StandardClaims{
-			IssuedAt:  time.Now().UTC().Unix(),
-			ExpiresAt: robotReq.ExpiresAt,
-			Issuer:    opt.Issuer,
+			IssuedAt: time.Now().UTC().Unix(),
+			Issuer:   opt.Issuer,
 		},
+	}
+	// "-1" means the robot account is a permanent account, no expiration time set.
+	// 	The ExpiresAt claim is optional, so if it's not set, it will still be considered a valid claim
+	if robot.ExpiresAt != -1 {
+		rClaims.ExpiresAt = robotReq.ExpiresAt
 	}
 	tk, err := token.New(opt, rClaims)
 	if err != nil {

--- a/src/pkg/robot/controller_test.go
+++ b/src/pkg/robot/controller_test.go
@@ -79,7 +79,7 @@ func (s *ControllerTestSuite) TestRobotAccount() {
 	robot2 := &model.RobotCreate{
 		Name:        "robot2",
 		Description: "TestCreateRobotAccount",
-		ExpiresAt:   expiresAt,
+		ExpiresAt:   -1,
 		ProjectID:   int64(1),
 		Access:      policies,
 	}

--- a/src/pkg/robot/model/robot.go
+++ b/src/pkg/robot/model/robot.go
@@ -68,8 +68,8 @@ func (rq *RobotCreate) Valid(v *validation.Validation) {
 	if utils.IsContainIllegalChar(rq.Name, []string{",", "~", "#", "$", "%"}) {
 		v.SetError("name", "robot name contains illegal characters")
 	}
-	if rq.ExpiresAt < 0 {
-		v.SetError("expires_at", "expiration time must be a positive integer if set")
+	if rq.ExpiresAt < -1 {
+		v.SetError("expires_at", "expiration time must be a positive integer or -1 if set")
 	}
 }
 


### PR DESCRIPTION
"-1" means the robot account is a permanent account, no expiration time set.
The ExpiresAt claim is optional, so if it's not set, it will still be considered a valid claim

Signed-off-by: wang yan <wangyan@vmware.com>