### PR TITLE
feat(replication) sort the adapters shown on UI

### DIFF
--- a/src/replication/adapter/adapter.go
+++ b/src/replication/adapter/adapter.go
@@ -113,7 +113,7 @@ func HasFactory(t model.RegistryType) bool {
 // ListRegisteredAdapterTypes lists the registered Adapter type
 func ListRegisteredAdapterTypes() []model.RegistryType {
 	types := []model.RegistryType{}
-	for t := range registryKeys {
+	for _, t := range registryKeys {
 		types = append(types, model.RegistryType(t))
 	}
 	return types

--- a/src/replication/adapter/adapter.go
+++ b/src/replication/adapter/adapter.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"sort"
 
 	"github.com/docker/distribution"
 	"github.com/goharbor/harbor/src/replication/model"
@@ -30,6 +31,7 @@ const (
 )
 
 var registry = map[model.RegistryType]Factory{}
+var registryKeys = []string{}
 var adapterInfoMap = map[model.RegistryType]*model.AdapterPattern{}
 
 // Factory creates a specific Adapter according to the params
@@ -84,6 +86,8 @@ func RegisterFactory(t model.RegistryType, factory Factory) error {
 		return fmt.Errorf("adapter factory for %s already exists", t)
 	}
 	registry[t] = factory
+	registryKeys = append(registryKeys, string(t))
+	sort.Strings(registryKeys)
 	adapterInfo := factory.AdapterPattern()
 	if adapterInfo != nil {
 		adapterInfoMap[t] = adapterInfo
@@ -109,8 +113,8 @@ func HasFactory(t model.RegistryType) bool {
 // ListRegisteredAdapterTypes lists the registered Adapter type
 func ListRegisteredAdapterTypes() []model.RegistryType {
 	types := []model.RegistryType{}
-	for t := range registry {
-		types = append(types, t)
+	for t := range registryKeys {
+		types = append(types, model.RegistryType(t))
 	}
 	return types
 }

--- a/src/replication/adapter/adapter_test.go
+++ b/src/replication/adapter/adapter_test.go
@@ -57,6 +57,7 @@ func TestGetFactory(t *testing.T) {
 
 func TestListRegisteredAdapterTypes(t *testing.T) {
 	registry = map[model.RegistryType]Factory{}
+	registryKeys = []string{}
 	// not register, got nothing
 	types := ListRegisteredAdapterTypes()
 	assert.Equal(t, 0, len(types))
@@ -67,4 +68,18 @@ func TestListRegisteredAdapterTypes(t *testing.T) {
 	types = ListRegisteredAdapterTypes()
 	require.Equal(t, 1, len(types))
 	assert.Equal(t, model.RegistryType("harbor"), types[0])
+}
+
+func TestListRegisteredAdapterTypesOrder(t *testing.T) {
+	registry = map[model.RegistryType]Factory{}
+	registryKeys = []string{}
+	require.Nil(t, RegisterFactory("a", new(fakedFactory)))
+	require.Nil(t, RegisterFactory("c", new(fakedFactory)))
+	require.Nil(t, RegisterFactory("b", new(fakedFactory)))
+
+	types := ListRegisteredAdapterTypes()
+	require.Equal(t, 3, len(types))
+	require.Equal(t, model.RegistryType("a"), types[0])
+	require.Equal(t, model.RegistryType("b"), types[1])
+	require.Equal(t, model.RegistryType("c"), types[2])
 }


### PR DESCRIPTION
fix #10322 
The replication adapters should have a fixed order shown on UI

Signed-off-by: Ziming Zhang <zziming@vmware.com>