### PR TITLE
enhance(replication) update healthy status immediately

### DIFF
--- a/src/core/api/registry.go
+++ b/src/core/api/registry.go
@@ -223,6 +223,7 @@ func (t *RegistryAPI) Post() {
 		return
 	}
 
+	r.Status = model.Healthy
 	id, err := t.manager.Add(r)
 	if err != nil {
 		log.Errorf("Add registry '%s' error: %v", r.URL, err)
@@ -309,6 +310,7 @@ func (t *RegistryAPI) Put() {
 		return
 	}
 
+	r.Status = model.Healthy
 	if err := t.manager.Update(r); err != nil {
 		log.Errorf("Update registry %d error: %v", id, err)
 		t.SendInternalServerError(err)


### PR DESCRIPTION
fix #10077 
update healthy status immediately after added or update, as it has already done check when request api.

Signed-off-by: Ziming Zhang <zziming@vmware.com>