### PR TITLE
Add API for query supported event types and notify types

### DIFF
--- a/api/v2.0/swagger.yaml
+++ b/api/v2.0/swagger.yaml
@@ -565,6 +565,23 @@ paths:
           $ref: '#/responses/401'
         '500':
           $ref: '#/responses/500'
+  /projects/{project_id}/webhook/events:
+    get:
+      summary: Get supported event types and notify types.
+      description: Get supportted event types and notify types.
+      tags:
+        - notification
+      parameters:
+        - $ref: '#/parameters/projectId'
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/SupportedWebhookEventTypes'
+        '401':
+          $ref: '#/responses/401'
+        '403':
+          $ref: '#/responses/403'
 parameters:
   query:
     name: q
@@ -583,6 +600,12 @@ parameters:
     name: project_name
     in: path
     description: The name of the project
+    required: true
+    type: string
+  projectId:
+    name: project_id
+    in: path
+    description: The ID of the project
     required: true
     type: string
   repositoryName:
@@ -1012,3 +1035,23 @@ definitions:
       op_time:
         type: string
         description: The time when this operation is triggered.
+  SupportedWebhookEventTypes:
+    type: object
+    description: Supportted webhook event types and notify types.
+    properties:
+      event_type:
+        type: array
+        items:
+          $ref: '#/definitions/EventType'
+      notify_type:
+        type: array
+        items:
+          $ref: '#/definitions/NotifyType'
+  EventType:
+    type: string
+    description: Webhook supportted event type.
+    example: 'pullImage'
+  NotifyType:
+    type: string
+    description: Webhook supportted notify type.
+    example: 'http'

--- a/make/migrations/postgresql/0030_2.0.0_schema.up.sql
+++ b/make/migrations/postgresql/0030_2.0.0_schema.up.sql
@@ -208,3 +208,9 @@ BEGIN
       END IF;
     END LOOP;
 END $$;
+
+/*remove the constraint for project_id in table 'notification_policy'*/
+ALTER TABLE notification_policy DROP CONSTRAINT unique_project_id;
+
+/*add the unique constraint for name in table 'notification_policy'*/
+ALTER TABLE notification_policy ADD UNIQUE (name);

--- a/src/server/v2.0/route/legacy.go
+++ b/src/server/v2.0/route/legacy.go
@@ -77,6 +77,7 @@ func registerLegacyRoutes() {
 	beego.Router("/api/"+version+"/projects/:pid([0-9]+)/webhook/policies/:id([0-9]+)", &api.NotificationPolicyAPI{})
 	beego.Router("/api/"+version+"/projects/:pid([0-9]+)/webhook/policies/test", &api.NotificationPolicyAPI{}, "post:Test")
 	beego.Router("/api/"+version+"/projects/:pid([0-9]+)/webhook/lasttrigger", &api.NotificationPolicyAPI{}, "get:ListGroupByEventType")
+	beego.Router("/api/"+version+"/projects/:pid([0-9]+)/webhook/events", &api.NotificationPolicyAPI{}, "get:GetSupportedEventTypes")
 	beego.Router("/api/"+version+"/projects/:pid([0-9]+)/webhook/jobs/", &api.NotificationJobAPI{}, "get:List")
 
 	beego.Router("/api/"+version+"/projects/:pid([0-9]+)/immutabletagrules", &api.ImmutableTagRuleAPI{}, "get:List;post:Post")


### PR DESCRIPTION
Add API for query supported event types and notify types; 
Return policy name in last trigger info; 
Remove project_id unique constraint in table notification_policy

Signed-off-by: guanxiatao <guanxiatao@corp.netease.com>