### PR TITLE
Escapse the repository name in the link header returned in response

### DIFF
--- a/src/pkg/q/builder.go
+++ b/src/pkg/q/builder.go
@@ -17,7 +17,6 @@ package q
 import (
 	"fmt"
 	ierror "github.com/goharbor/harbor/src/internal/error"
-	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -39,15 +38,6 @@ func Build(q string, pageNumber, pageSize int64) (*Query, error) {
 	if len(q) == 0 {
 		return query, nil
 	}
-	// unescape the query string
-	// when the query string is returned in the link header, they are all escaped
-	qs, err := url.QueryUnescape(q)
-	if err != nil {
-		return nil, ierror.New(err).
-			WithCode(ierror.BadRequestCode).
-			WithMessage("invalid query string: %s", q)
-	}
-	q = qs
 	params := strings.Split(q, ",")
 	for _, param := range params {
 		strs := strings.SplitN(param, "=", 2)

--- a/src/pkg/q/builder_test.go
+++ b/src/pkg/q/builder_test.go
@@ -262,12 +262,4 @@ func TestBuild(t *testing.T) {
 	assert.Equal(t, int64(1), query.PageNumber)
 	assert.Equal(t, int64(10), query.PageSize)
 	assert.Equal(t, "v", query.Keywords["k"].(string))
-
-	// contains escaped characters
-	q = `k%3Dv`
-	query, err = Build(q, 1, 10)
-	require.Nil(t, err)
-	assert.Equal(t, int64(1), query.PageNumber)
-	assert.Equal(t, int64(10), query.PageSize)
-	assert.Equal(t, "v", query.Keywords["k"].(string))
 }

--- a/src/server/v2.0/handler/base_test.go
+++ b/src/server/v2.0/handler/base_test.go
@@ -81,6 +81,16 @@ func (b *baseHandlerTestSuite) TestLinks() {
 	b.Equal("http://localhost/api/artifacts?page=1&page_size=1", links[0].URL)
 	b.Equal("next", links[1].Rel)
 	b.Equal("http://localhost/api/artifacts?page=3&page_size=1", links[1].URL)
+
+	// path and query contain escaped characters
+	url, err = url.Parse("http://localhost/api/library%252Fhello-world/artifacts?page=2&page_size=1&q=a%3D~b")
+	b.Require().Nil(err)
+	links = b.base.Links(nil, url, 3, 2, 1)
+	b.Require().Len(links, 2)
+	b.Equal("prev", links[0].Rel)
+	b.Equal("http://localhost/api/library/hello-world/artifacts?page=1&page_size=1&q=a=~b", links[0].URL)
+	b.Equal("next", links[1].Rel)
+	b.Equal("http://localhost/api/library/hello-world/artifacts?page=3&page_size=1&q=a=~b", links[1].URL)
 }
 
 func TestBaseHandler(t *testing.T) {


### PR DESCRIPTION
Escapse the repository name in the link header returned in response

Signed-off-by: Wenkai Yin <yinw@vmware.com>