### PR TITLE
Repair the count usage during the upgrading 

### DIFF
--- a/src/migration/migration.go
+++ b/src/migration/migration.go
@@ -66,9 +66,6 @@ func Migrate(database *models.Database) error {
 		return err
 	}
 
-	// update quota
-	// TODO
-
 	return nil
 }
 


### PR DESCRIPTION
As the count quota is against artifact rather than tag in 2.0, the count usage should be recalculated

Signed-off-by: Wenkai Yin <yinw@vmware.com>