### PR TITLE
Updating the redirects in the old page stubs to point to new site.

### DIFF
--- a/docs/compile_guide.md
+++ b/docs/compile_guide.md
@@ -1,3 +1,3 @@
-This content has moved. For the Harbor 1.10 docs, please go to https://github.com/goharbor/harbor/blob/master/docs/1.10/. 
+This content has moved. For the Harbor 1.10 docs, please go to https://goharbor.io/docs/1.10/.  
 
 For older versions of the docs, please select the appropriate `release-1.xx.x` branch and go to the `docs` folder.

--- a/docs/compile_guide.md
+++ b/docs/compile_guide.md
@@ -1,3 +1,3 @@
-This content has moved. For the Harbor 1.10 docs, please go to https://goharbor.io/docs/1.10/.  
+This content has moved. From Harbor v1.10 onwards, all documentation is located at https://goharbor.io/docs/. Use the drop-down menu to select the documentation for the appropriate release.
 
-For older versions of the docs, please select the appropriate `release-1.xx.x` branch and go to the `docs` folder.
+For Harbor v1.9 and older versions of the documentation, select the appropriate `release-1.xx.x` branch and go to the `docs` folder.

--- a/docs/configure_https.md
+++ b/docs/configure_https.md
@@ -1,3 +1,3 @@
-This content has moved. For the Harbor 1.10 docs, please go to https://github.com/goharbor/harbor/blob/master/docs/1.10/. 
+This content has moved. For the Harbor 1.10 docs, please go to https://goharbor.io/docs/1.10/.  
 
 For older versions of the docs, please select the appropriate `release-1.xx.x` branch and go to the `docs` folder.

--- a/docs/configure_https.md
+++ b/docs/configure_https.md
@@ -1,3 +1,3 @@
-This content has moved. For the Harbor 1.10 docs, please go to https://goharbor.io/docs/1.10/.  
+This content has moved. From Harbor v1.10 onwards, all documentation is located at https://goharbor.io/docs/. Use the drop-down menu to select the documentation for the appropriate release.
 
-For older versions of the docs, please select the appropriate `release-1.xx.x` branch and go to the `docs` folder.
+For Harbor v1.9 and older versions of the documentation, select the appropriate `release-1.xx.x` branch and go to the `docs` folder.

--- a/docs/configure_swagger.md
+++ b/docs/configure_swagger.md
@@ -1,3 +1,3 @@
-This content has moved. For the Harbor 1.10 docs, please go to https://github.com/goharbor/harbor/blob/master/docs/1.10/. 
+This content has moved. For the Harbor 1.10 docs, please go to https://goharbor.io/docs/1.10/.  
 
 For older versions of the docs, please select the appropriate `release-1.xx.x` branch and go to the `docs` folder.

--- a/docs/configure_swagger.md
+++ b/docs/configure_swagger.md
@@ -1,3 +1,3 @@
-This content has moved. For the Harbor 1.10 docs, please go to https://goharbor.io/docs/1.10/.  
+This content has moved. From Harbor v1.10 onwards, all documentation is located at https://goharbor.io/docs/. Use the drop-down menu to select the documentation for the appropriate release.
 
-For older versions of the docs, please select the appropriate `release-1.xx.x` branch and go to the `docs` folder.
+For Harbor v1.9 and older versions of the documentation, select the appropriate `release-1.xx.x` branch and go to the `docs` folder.

--- a/docs/configure_user_settings.md
+++ b/docs/configure_user_settings.md
@@ -1,3 +1,3 @@
-This content has moved. For the Harbor 1.10 docs, please go to https://github.com/goharbor/harbor/blob/master/docs/1.10/. 
+This content has moved. For the Harbor 1.10 docs, please go to https://goharbor.io/docs/1.10/.  
 
 For older versions of the docs, please select the appropriate `release-1.xx.x` branch and go to the `docs` folder.

--- a/docs/configure_user_settings.md
+++ b/docs/configure_user_settings.md
@@ -1,3 +1,3 @@
-This content has moved. For the Harbor 1.10 docs, please go to https://goharbor.io/docs/1.10/.  
+This content has moved. From Harbor v1.10 onwards, all documentation is located at https://goharbor.io/docs/. Use the drop-down menu to select the documentation for the appropriate release.
 
-For older versions of the docs, please select the appropriate `release-1.xx.x` branch and go to the `docs` folder.
+For Harbor v1.9 and older versions of the documentation, select the appropriate `release-1.xx.x` branch and go to the `docs` folder.

--- a/docs/customize_look&feel_guide.md
+++ b/docs/customize_look&feel_guide.md
@@ -1,3 +1,3 @@
-This content has moved. For the Harbor 1.10 docs, please go to https://github.com/goharbor/harbor/blob/master/docs/1.10/. 
+This content has moved. For the Harbor 1.10 docs, please go to https://goharbor.io/docs/1.10/.  
 
 For older versions of the docs, please select the appropriate `release-1.xx.x` branch and go to the `docs` folder.

--- a/docs/customize_look&feel_guide.md
+++ b/docs/customize_look&feel_guide.md
@@ -1,3 +1,3 @@
-This content has moved. For the Harbor 1.10 docs, please go to https://goharbor.io/docs/1.10/.  
+This content has moved. From Harbor v1.10 onwards, all documentation is located at https://goharbor.io/docs/. Use the drop-down menu to select the documentation for the appropriate release.
 
-For older versions of the docs, please select the appropriate `release-1.xx.x` branch and go to the `docs` folder.
+For Harbor v1.9 and older versions of the documentation, select the appropriate `release-1.xx.x` branch and go to the `docs` folder.

--- a/docs/customize_token_service.md
+++ b/docs/customize_token_service.md
@@ -1,3 +1,3 @@
-This content has moved. For the Harbor 1.10 docs, please go to https://github.com/goharbor/harbor/blob/master/docs/1.10/. 
+This content has moved. For the Harbor 1.10 docs, please go to https://goharbor.io/docs/1.10/.  
 
 For older versions of the docs, please select the appropriate `release-1.xx.x` branch and go to the `docs` folder.

--- a/docs/customize_token_service.md
+++ b/docs/customize_token_service.md
@@ -1,3 +1,3 @@
-This content has moved. For the Harbor 1.10 docs, please go to https://goharbor.io/docs/1.10/.  
+This content has moved. From Harbor v1.10 onwards, all documentation is located at https://goharbor.io/docs/. Use the drop-down menu to select the documentation for the appropriate release.
 
-For older versions of the docs, please select the appropriate `release-1.xx.x` branch and go to the `docs` folder.
+For Harbor v1.9 and older versions of the documentation, select the appropriate `release-1.xx.x` branch and go to the `docs` folder.

--- a/docs/demo_server.md
+++ b/docs/demo_server.md
@@ -1,3 +1,3 @@
-This content has moved. For the Harbor 1.10 docs, please go to https://github.com/goharbor/harbor/blob/master/docs/1.10/. 
+This content has moved. For the Harbor 1.10 docs, please go to https://goharbor.io/docs/1.10/.  
 
 For older versions of the docs, please select the appropriate `release-1.xx.x` branch and go to the `docs` folder.

--- a/docs/demo_server.md
+++ b/docs/demo_server.md
@@ -1,3 +1,3 @@
-This content has moved. For the Harbor 1.10 docs, please go to https://goharbor.io/docs/1.10/.  
+This content has moved. From Harbor v1.10 onwards, all documentation is located at https://goharbor.io/docs/. Use the drop-down menu to select the documentation for the appropriate release.
 
-For older versions of the docs, please select the appropriate `release-1.xx.x` branch and go to the `docs` folder.
+For Harbor v1.9 and older versions of the documentation, select the appropriate `release-1.xx.x` branch and go to the `docs` folder.

--- a/docs/developer_guide_i18n.md
+++ b/docs/developer_guide_i18n.md
@@ -1,3 +1,3 @@
-This content has moved. For the Harbor 1.10 docs, please go to https://github.com/goharbor/harbor/blob/master/docs/1.10/. 
+This content has moved. For the Harbor 1.10 docs, please go to https://goharbor.io/docs/1.10/.  
 
 For older versions of the docs, please select the appropriate `release-1.xx.x` branch and go to the `docs` folder.

--- a/docs/developer_guide_i18n.md
+++ b/docs/developer_guide_i18n.md
@@ -1,3 +1,3 @@
-This content has moved. For the Harbor 1.10 docs, please go to https://goharbor.io/docs/1.10/.  
+This content has moved. From Harbor v1.10 onwards, all documentation is located at https://goharbor.io/docs/. Use the drop-down menu to select the documentation for the appropriate release.
 
-For older versions of the docs, please select the appropriate `release-1.xx.x` branch and go to the `docs` folder.
+For Harbor v1.9 and older versions of the documentation, select the appropriate `release-1.xx.x` branch and go to the `docs` folder.

--- a/docs/harbor_compatibility_list.md
+++ b/docs/harbor_compatibility_list.md
@@ -1,3 +1,3 @@
-This content has moved. For the Harbor 1.10 docs, please go to https://github.com/goharbor/harbor/blob/master/docs/1.10/. 
+This content has moved. For the Harbor 1.10 docs, please go to https://goharbor.io/docs/1.10/.  
 
 For older versions of the docs, please select the appropriate `release-1.xx.x` branch and go to the `docs` folder.

--- a/docs/harbor_compatibility_list.md
+++ b/docs/harbor_compatibility_list.md
@@ -1,3 +1,3 @@
-This content has moved. For the Harbor 1.10 docs, please go to https://goharbor.io/docs/1.10/.  
+This content has moved. From Harbor v1.10 onwards, all documentation is located at https://goharbor.io/docs/. Use the drop-down menu to select the documentation for the appropriate release.
 
-For older versions of the docs, please select the appropriate `release-1.xx.x` branch and go to the `docs` folder.
+For Harbor v1.9 and older versions of the documentation, select the appropriate `release-1.xx.x` branch and go to the `docs` folder.

--- a/docs/import_vulnerability_data.md
+++ b/docs/import_vulnerability_data.md
@@ -1,3 +1,3 @@
-This content has moved. For the Harbor 1.10 docs, please go to https://github.com/goharbor/harbor/blob/master/docs/1.10/. 
+This content has moved. For the Harbor 1.10 docs, please go to https://goharbor.io/docs/1.10/.  
 
 For older versions of the docs, please select the appropriate `release-1.xx.x` branch and go to the `docs` folder.

--- a/docs/import_vulnerability_data.md
+++ b/docs/import_vulnerability_data.md
@@ -1,3 +1,3 @@
-This content has moved. For the Harbor 1.10 docs, please go to https://goharbor.io/docs/1.10/.  
+This content has moved. From Harbor v1.10 onwards, all documentation is located at https://goharbor.io/docs/. Use the drop-down menu to select the documentation for the appropriate release.
 
-For older versions of the docs, please select the appropriate `release-1.xx.x` branch and go to the `docs` folder.
+For Harbor v1.9 and older versions of the documentation, select the appropriate `release-1.xx.x` branch and go to the `docs` folder.

--- a/docs/installation_guide.md
+++ b/docs/installation_guide.md
@@ -1,3 +1,3 @@
-This content has moved. For the Harbor 1.10 docs, please go to https://github.com/goharbor/harbor/blob/master/docs/1.10/. 
+This content has moved. For the Harbor 1.10 docs, please go to https://goharbor.io/docs/1.10/.  
 
 For older versions of the docs, please select the appropriate `release-1.xx.x` branch and go to the `docs` folder.

--- a/docs/installation_guide.md
+++ b/docs/installation_guide.md
@@ -1,3 +1,3 @@
-This content has moved. For the Harbor 1.10 docs, please go to https://goharbor.io/docs/1.10/.  
+This content has moved. From Harbor v1.10 onwards, all documentation is located at https://goharbor.io/docs/. Use the drop-down menu to select the documentation for the appropriate release.
 
-For older versions of the docs, please select the appropriate `release-1.xx.x` branch and go to the `docs` folder.
+For Harbor v1.9 and older versions of the documentation, select the appropriate `release-1.xx.x` branch and go to the `docs` folder.

--- a/docs/kubernetes_deployment.md
+++ b/docs/kubernetes_deployment.md
@@ -1,4 +1,4 @@
-This content has moved. For the Harbor 1.10 docs, please go to https://goharbor.io/docs/1.10/.  
+This content has moved. From Harbor v1.10 onwards, all documentation is located at https://goharbor.io/docs/. Use the drop-down menu to select the documentation for the appropriate release.
 
-For older versions of the docs, please select the appropriate `release-1.xx.x` branch and go to the `docs` folder.
+For Harbor v1.9 and older versions of the documentation, select the appropriate `release-1.xx.x` branch and go to the `docs` folder.
 

--- a/docs/kubernetes_deployment.md
+++ b/docs/kubernetes_deployment.md
@@ -1,4 +1,4 @@
-This content has moved. For the Harbor 1.10 docs, please go to https://github.com/goharbor/harbor/blob/master/docs/1.10/. 
+This content has moved. For the Harbor 1.10 docs, please go to https://goharbor.io/docs/1.10/.  
 
 For older versions of the docs, please select the appropriate `release-1.xx.x` branch and go to the `docs` folder.
 

--- a/docs/manage_role_by_ldap_group.md
+++ b/docs/manage_role_by_ldap_group.md
@@ -1,3 +1,3 @@
-This content has moved. For the Harbor 1.10 docs, please go to https://github.com/goharbor/harbor/blob/master/docs/1.10/. 
+This content has moved. For the Harbor 1.10 docs, please go to https://goharbor.io/docs/1.10/.  
 
 For older versions of the docs, please select the appropriate `release-1.xx.x` branch and go to the `docs` folder.

--- a/docs/manage_role_by_ldap_group.md
+++ b/docs/manage_role_by_ldap_group.md
@@ -1,3 +1,3 @@
-This content has moved. For the Harbor 1.10 docs, please go to https://goharbor.io/docs/1.10/.  
+This content has moved. From Harbor v1.10 onwards, all documentation is located at https://goharbor.io/docs/. Use the drop-down menu to select the documentation for the appropriate release.
 
-For older versions of the docs, please select the appropriate `release-1.xx.x` branch and go to the `docs` folder.
+For Harbor v1.9 and older versions of the documentation, select the appropriate `release-1.xx.x` branch and go to the `docs` folder.

--- a/docs/migration_guide.md
+++ b/docs/migration_guide.md
@@ -1,3 +1,3 @@
-This content has moved. For the Harbor 1.10 docs, please go to https://github.com/goharbor/harbor/blob/master/docs/1.10/. 
+This content has moved. For the Harbor 1.10 docs, please go to https://goharbor.io/docs/1.10/.  
 
 For older versions of the docs, please select the appropriate `release-1.xx.x` branch and go to the `docs` folder.

--- a/docs/migration_guide.md
+++ b/docs/migration_guide.md
@@ -1,3 +1,3 @@
-This content has moved. For the Harbor 1.10 docs, please go to https://goharbor.io/docs/1.10/.  
+This content has moved. From Harbor v1.10 onwards, all documentation is located at https://goharbor.io/docs/. Use the drop-down menu to select the documentation for the appropriate release.
 
-For older versions of the docs, please select the appropriate `release-1.xx.x` branch and go to the `docs` folder.
+For Harbor v1.9 and older versions of the documentation, select the appropriate `release-1.xx.x` branch and go to the `docs` folder.

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -1,3 +1,3 @@
-This content has moved. For the Harbor 1.10 docs, please go to https://github.com/goharbor/harbor/blob/master/docs/1.10/. 
+This content has moved. For the Harbor 1.10 docs, please go to https://goharbor.io/docs/1.10/.  
 
 For older versions of the docs, please select the appropriate `release-1.xx.x` branch and go to the `docs` folder.

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -1,3 +1,3 @@
-This content has moved. For the Harbor 1.10 docs, please go to https://goharbor.io/docs/1.10/.  
+This content has moved. From Harbor v1.10 onwards, all documentation is located at https://goharbor.io/docs/. Use the drop-down menu to select the documentation for the appropriate release.
 
-For older versions of the docs, please select the appropriate `release-1.xx.x` branch and go to the `docs` folder.
+For Harbor v1.9 and older versions of the documentation, select the appropriate `release-1.xx.x` branch and go to the `docs` folder.

--- a/docs/registry_landscape.md
+++ b/docs/registry_landscape.md
@@ -1,3 +1,3 @@
-This content has moved. For the Harbor 1.10 docs, please go to https://github.com/goharbor/harbor/blob/master/docs/1.10/. 
+This content has moved. For the Harbor 1.10 docs, please go to https://goharbor.io/docs/1.10/.  
 
 For older versions of the docs, please select the appropriate `release-1.xx.x` branch and go to the `docs` folder.

--- a/docs/registry_landscape.md
+++ b/docs/registry_landscape.md
@@ -1,3 +1,3 @@
-This content has moved. For the Harbor 1.10 docs, please go to https://goharbor.io/docs/1.10/.  
+This content has moved. From Harbor v1.10 onwards, all documentation is located at https://goharbor.io/docs/. Use the drop-down menu to select the documentation for the appropriate release.
 
-For older versions of the docs, please select the appropriate `release-1.xx.x` branch and go to the `docs` folder.
+For Harbor v1.9 and older versions of the documentation, select the appropriate `release-1.xx.x` branch and go to the `docs` folder.

--- a/docs/ui_contribution_get_started.md
+++ b/docs/ui_contribution_get_started.md
@@ -1,3 +1,3 @@
-This content has moved. For the Harbor 1.10 docs, please go to https://github.com/goharbor/harbor/blob/master/docs/1.10/. 
+This content has moved. For the Harbor 1.10 docs, please go to https://goharbor.io/docs/1.10/.  
 
 For older versions of the docs, please select the appropriate `release-1.xx.x` branch and go to the `docs` folder.

--- a/docs/ui_contribution_get_started.md
+++ b/docs/ui_contribution_get_started.md
@@ -1,3 +1,3 @@
-This content has moved. For the Harbor 1.10 docs, please go to https://goharbor.io/docs/1.10/.  
+This content has moved. From Harbor v1.10 onwards, all documentation is located at https://goharbor.io/docs/. Use the drop-down menu to select the documentation for the appropriate release.
 
-For older versions of the docs, please select the appropriate `release-1.xx.x` branch and go to the `docs` folder.
+For Harbor v1.9 and older versions of the documentation, select the appropriate `release-1.xx.x` branch and go to the `docs` folder.

--- a/docs/upgradetest.md
+++ b/docs/upgradetest.md
@@ -1,3 +1,3 @@
-This content has moved. For the Harbor 1.10 docs, please go to https://github.com/goharbor/harbor/blob/master/docs/1.10/. 
+This content has moved. For the Harbor 1.10 docs, please go to https://goharbor.io/docs/1.10/.  
 
 For older versions of the docs, please select the appropriate `release-1.xx.x` branch and go to the `docs` folder.

--- a/docs/upgradetest.md
+++ b/docs/upgradetest.md
@@ -1,3 +1,3 @@
-This content has moved. For the Harbor 1.10 docs, please go to https://goharbor.io/docs/1.10/.  
+This content has moved. From Harbor v1.10 onwards, all documentation is located at https://goharbor.io/docs/. Use the drop-down menu to select the documentation for the appropriate release.
 
-For older versions of the docs, please select the appropriate `release-1.xx.x` branch and go to the `docs` folder.
+For Harbor v1.9 and older versions of the documentation, select the appropriate `release-1.xx.x` branch and go to the `docs` folder.

--- a/docs/use_make.md
+++ b/docs/use_make.md
@@ -1,3 +1,3 @@
-This content has moved. For the Harbor 1.10 docs, please go to https://github.com/goharbor/harbor/blob/master/docs/1.10/. 
+This content has moved. For the Harbor 1.10 docs, please go to https://goharbor.io/docs/1.10/.  
 
 For older versions of the docs, please select the appropriate `release-1.xx.x` branch and go to the `docs` folder.

--- a/docs/use_make.md
+++ b/docs/use_make.md
@@ -1,3 +1,3 @@
-This content has moved. For the Harbor 1.10 docs, please go to https://goharbor.io/docs/1.10/.  
+This content has moved. From Harbor v1.10 onwards, all documentation is located at https://goharbor.io/docs/. Use the drop-down menu to select the documentation for the appropriate release.
 
-For older versions of the docs, please select the appropriate `release-1.xx.x` branch and go to the `docs` folder.
+For Harbor v1.9 and older versions of the documentation, select the appropriate `release-1.xx.x` branch and go to the `docs` folder.

--- a/docs/use_notary.md
+++ b/docs/use_notary.md
@@ -1,3 +1,3 @@
-This content has moved. For the Harbor 1.10 docs, please go to https://github.com/goharbor/harbor/blob/master/docs/1.10/. 
+This content has moved. For the Harbor 1.10 docs, please go to https://goharbor.io/docs/1.10/.  
 
 For older versions of the docs, please select the appropriate `release-1.xx.x` branch and go to the `docs` folder.

--- a/docs/use_notary.md
+++ b/docs/use_notary.md
@@ -1,3 +1,3 @@
-This content has moved. For the Harbor 1.10 docs, please go to https://goharbor.io/docs/1.10/.  
+This content has moved. From Harbor v1.10 onwards, all documentation is located at https://goharbor.io/docs/. Use the drop-down menu to select the documentation for the appropriate release.
 
-For older versions of the docs, please select the appropriate `release-1.xx.x` branch and go to the `docs` folder.
+For Harbor v1.9 and older versions of the documentation, select the appropriate `release-1.xx.x` branch and go to the `docs` folder.

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -1,3 +1,3 @@
-This content has moved. For the Harbor 1.10 docs, please go to https://github.com/goharbor/harbor/blob/master/docs/1.10/. 
+This content has moved. For the Harbor 1.10 docs, please go to https://goharbor.io/docs/1.10/.  
 
 For older versions of the docs, please select the appropriate `release-1.xx.x` branch and go to the `docs` folder.

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -1,3 +1,3 @@
-This content has moved. For the Harbor 1.10 docs, please go to https://goharbor.io/docs/1.10/.  
+This content has moved. From Harbor v1.10 onwards, all documentation is located at https://goharbor.io/docs/. Use the drop-down menu to select the documentation for the appropriate release.
 
-For older versions of the docs, please select the appropriate `release-1.xx.x` branch and go to the `docs` folder.
+For Harbor v1.9 and older versions of the documentation, select the appropriate `release-1.xx.x` branch and go to the `docs` folder.


### PR DESCRIPTION
All of the old stub pages should now point to the new docs site.

@michmike @jonasrosland @lucperkins is this OK? Thanks!