### PR TITLE
Replicate tag deletion between Harbor instances

### DIFF
--- a/src/api/event/handler/init.go
+++ b/src/api/event/handler/init.go
@@ -29,6 +29,7 @@ func init() {
 	notifier.Subscribe(event.TopicPushArtifact, &replication.Handler{})
 	notifier.Subscribe(event.TopicDeleteArtifact, &replication.Handler{})
 	notifier.Subscribe(event.TopicCreateTag, &replication.Handler{})
+	notifier.Subscribe(event.TopicDeleteTag, &replication.Handler{})
 
 	// audit logs
 	notifier.Subscribe(event.TopicPushArtifact, &auditlog.Handler{})

--- a/src/replication/adapter/adapter.go
+++ b/src/replication/adapter/adapter.go
@@ -51,17 +51,17 @@ type Adapter interface {
 	HealthCheck() (model.HealthStatus, error)
 }
 
-// ImageRegistry defines the capabilities that an image registry should have
-type ImageRegistry interface {
-	FetchImages(filters []*model.Filter) ([]*model.Resource, error)
+// ArtifactRegistry defines the capabilities that an artifact registry should have
+type ArtifactRegistry interface {
+	FetchArtifacts(filters []*model.Filter) ([]*model.Resource, error)
 	ManifestExist(repository, reference string) (exist bool, digest string, err error)
 	PullManifest(repository, reference string, accepttedMediaTypes ...string) (manifest distribution.Manifest, digest string, err error)
 	PushManifest(repository, reference, mediaType string, payload []byte) (string, error)
-	// the "reference" can be "tag" or "digest", the function needs to handle both
-	DeleteManifest(repository, reference string) error
+	DeleteManifest(repository, reference string) error // the "reference" can be "tag" or "digest", the function needs to handle both
 	BlobExist(repository, digest string) (exist bool, err error)
 	PullBlob(repository, digest string) (size int64, blob io.ReadCloser, err error)
 	PushBlob(repository, digest string, size int64, blob io.Reader) error
+	DeleteTag(repository, tag string) error
 }
 
 // ChartRegistry defines the capabilities that a chart registry should have

--- a/src/replication/adapter/aliacr/adapter.go
+++ b/src/replication/adapter/aliacr/adapter.go
@@ -99,6 +99,11 @@ func (f *factory) AdapterPattern() *model.AdapterPattern {
 	return getAdapterInfo()
 }
 
+var (
+	_ adp.Adapter          = (*adapter)(nil)
+	_ adp.ArtifactRegistry = (*adapter)(nil)
+)
+
 // adapter for to aliyun docker registry
 type adapter struct {
 	*native.Adapter
@@ -183,7 +188,7 @@ func (a *adapter) listNamespaces(c *cr.Client) (namespaces []string, err error) 
 		namespaces = append(namespaces, ns.Namespace)
 	}
 
-	log.Debugf("FetchImages.listNamespaces: %#v\n", namespaces)
+	log.Debugf("FetchArtifacts.listNamespaces: %#v\n", namespaces)
 
 	return
 }
@@ -202,9 +207,9 @@ func (a *adapter) listCandidateNamespaces(c *cr.Client, namespacePattern string)
 	return a.listNamespaces(c)
 }
 
-// FetchImages AliACR not support /v2/_catalog of Registry, we'll list all resources via Aliyun's API
-func (a *adapter) FetchImages(filters []*model.Filter) (resources []*model.Resource, err error) {
-	log.Debugf("FetchImages.filters: %#v\n", filters)
+// FetchArtifacts AliACR not support /v2/_catalog of Registry, we'll list all resources via Aliyun's API
+func (a *adapter) FetchArtifacts(filters []*model.Filter) (resources []*model.Resource, err error) {
+	log.Debugf("FetchArtifacts.filters: %#v\n", filters)
 
 	var client *cr.Client
 	client, err = cr.NewClientWithAccessKey(a.region, a.registry.Credential.AccessKey, a.registry.Credential.AccessSecret)
@@ -265,7 +270,7 @@ func (a *adapter) FetchImages(filters []*model.Filter) (resources []*model.Resou
 			}
 		}
 	}
-	log.Debugf("FetchImages.repositories: %#v\n", repositories)
+	log.Debugf("FetchArtifacts.repositories: %#v\n", repositories)
 
 	var rawResources = make([]*model.Resource, len(repositories))
 	runner := utils.NewLimitedConcurrentRunner(adp.MaxConcurrency)
@@ -316,7 +321,7 @@ func (a *adapter) FetchImages(filters []*model.Filter) (resources []*model.Resou
 	runner.Wait()
 
 	if runner.IsCancelled() {
-		return nil, fmt.Errorf("FetchImages error when collect tags for repos")
+		return nil, fmt.Errorf("FetchArtifacts error when collect tags for repos")
 	}
 
 	for _, r := range rawResources {

--- a/src/replication/adapter/aliacr/adapter_test.go
+++ b/src/replication/adapter/aliacr/adapter_test.go
@@ -118,11 +118,11 @@ func BenchmarkGetRegion(b *testing.B) {
 	}
 }
 
-func Test_adapter_FetchImages(t *testing.T) {
+func Test_adapter_FetchArtifacts(t *testing.T) {
 	a, s := getMockAdapter(t, true, true)
 	defer s.Close()
 	var filters = []*model.Filter{}
-	var resources, err = a.FetchImages(filters)
+	var resources, err = a.FetchArtifacts(filters)
 	assert.NotNil(t, err)
 	assert.Nil(t, resources)
 }

--- a/src/replication/adapter/awsecr/adapter.go
+++ b/src/replication/adapter/awsecr/adapter.go
@@ -81,6 +81,11 @@ func (f *factory) AdapterPattern() *model.AdapterPattern {
 	return getAdapterInfo()
 }
 
+var (
+	_ adp.Adapter          = (*adapter)(nil)
+	_ adp.ArtifactRegistry = (*adapter)(nil)
+)
+
 type adapter struct {
 	*native.Adapter
 	registry      *model.Registry

--- a/src/replication/adapter/awsecr/adapter_test.go
+++ b/src/replication/adapter/awsecr/adapter_test.go
@@ -196,7 +196,7 @@ func TestAdapter_PrepareForPush(t *testing.T) {
 func TestAdapter_FetchImages(t *testing.T) {
 	a, s := getMockAdapter(t, true, true)
 	defer s.Close()
-	resources, err := a.FetchImages([]*model.Filter{
+	resources, err := a.FetchArtifacts([]*model.Filter{
 		{
 			Type:  model.FilterTypeName,
 			Value: "*",

--- a/src/replication/adapter/azurecr/adapter.go
+++ b/src/replication/adapter/azurecr/adapter.go
@@ -38,8 +38,10 @@ type adapter struct {
 	*native.Adapter
 }
 
-// Ensure '*adapter' implements interface 'Adapter'.
-var _ adp.Adapter = (*adapter)(nil)
+var (
+	_ adp.Adapter          = (*adapter)(nil)
+	_ adp.ArtifactRegistry = (*adapter)(nil)
+)
 
 // Info returns information of the registry
 func (a *adapter) Info() (*model.RegistryInfo, error) {

--- a/src/replication/adapter/dockerhub/adapter.go
+++ b/src/replication/adapter/dockerhub/adapter.go
@@ -55,6 +55,11 @@ func (f *factory) AdapterPattern() *model.AdapterPattern {
 	return getAdapterInfo()
 }
 
+var (
+	_ adp.Adapter          = (*adapter)(nil)
+	_ adp.ArtifactRegistry = (*adapter)(nil)
+)
+
 type adapter struct {
 	*native.Adapter
 	registry *model.Registry
@@ -232,8 +237,8 @@ func (a *adapter) getNamespace(namespace string) (*model.Namespace, error) {
 	}, nil
 }
 
-// FetchImages fetches images
-func (a *adapter) FetchImages(filters []*model.Filter) ([]*model.Resource, error) {
+// FetchArtifacts fetches images
+func (a *adapter) FetchArtifacts(filters []*model.Filter) ([]*model.Resource, error) {
 	var repos []Repo
 	nameFilter, err := a.getStringFilterValue(model.FilterTypeName, filters)
 	if err != nil {
@@ -339,7 +344,7 @@ func (a *adapter) FetchImages(filters []*model.Filter) ([]*model.Resource, error
 	runner.Wait()
 
 	if runner.IsCancelled() {
-		return nil, fmt.Errorf("FetchImages error when collect tags for repos")
+		return nil, fmt.Errorf("FetchArtifacts error when collect tags for repos")
 	}
 
 	var resources []*model.Resource

--- a/src/replication/adapter/dockerhub/adapter_test.go
+++ b/src/replication/adapter/dockerhub/adapter_test.go
@@ -66,10 +66,10 @@ func TestListNamespaces(t *testing.T) {
 	}
 }
 
-func TestFetchImages(t *testing.T) {
+func TestFetchArtifacts(t *testing.T) {
 	ad := getAdapter(t)
 	adapter := ad.(*adapter)
-	_, err := adapter.FetchImages([]*model.Filter{
+	_, err := adapter.FetchArtifacts([]*model.Filter{
 		{
 			Type:  model.FilterTypeName,
 			Value: "goharbor/harbor-core",

--- a/src/replication/adapter/gitlab/adapter.go
+++ b/src/replication/adapter/gitlab/adapter.go
@@ -30,6 +30,11 @@ func (f *factory) AdapterPattern() *model.AdapterPattern {
 	return nil
 }
 
+var (
+	_ adp.Adapter          = (*adapter)(nil)
+	_ adp.ArtifactRegistry = (*adapter)(nil)
+)
+
 type adapter struct {
 	*native.Adapter
 	registry        *model.Registry
@@ -71,8 +76,8 @@ func (a *adapter) Info() (info *model.RegistryInfo, err error) {
 	}, nil
 }
 
-// FetchImages fetches images
-func (a *adapter) FetchImages(filters []*model.Filter) ([]*model.Resource, error) {
+// FetchArtifacts fetches images
+func (a *adapter) FetchArtifacts(filters []*model.Filter) ([]*model.Resource, error) {
 	var resources []*model.Resource
 	var projects []*Project
 	var err error

--- a/src/replication/adapter/googlegcr/adapter.go
+++ b/src/replication/adapter/googlegcr/adapter.go
@@ -49,6 +49,11 @@ func (f *factory) AdapterPattern() *model.AdapterPattern {
 	return getAdapterInfo()
 }
 
+var (
+	_ adp.Adapter          = (*adapter)(nil)
+	_ adp.ArtifactRegistry = (*adapter)(nil)
+)
+
 type adapter struct {
 	*native.Adapter
 	registry *model.Registry

--- a/src/replication/adapter/googlegcr/adapter_test.go
+++ b/src/replication/adapter/googlegcr/adapter_test.go
@@ -142,7 +142,7 @@ func TestAdapter_PrepareForPush(t *testing.T) {
 func TestAdapter_FetchImages(t *testing.T) {
 	a, s := getMockAdapter(t, true, true)
 	defer s.Close()
-	resources, err := a.FetchImages([]*model.Filter{
+	resources, err := a.FetchArtifacts([]*model.Filter{
 		{
 			Type:  model.FilterTypeName,
 			Value: "*",

--- a/src/replication/adapter/harbor/adapter.go
+++ b/src/replication/adapter/harbor/adapter.go
@@ -54,6 +54,12 @@ func (f *factory) AdapterPattern() *model.AdapterPattern {
 	return nil
 }
 
+var (
+	_ adp.Adapter          = (*adapter)(nil)
+	_ adp.ArtifactRegistry = (*adapter)(nil)
+	_ adp.ChartRegistry    = (*adapter)(nil)
+)
+
 type adapter struct {
 	*native.Adapter
 	registry *model.Registry

--- a/src/replication/adapter/harbor/image_registry.go
+++ b/src/replication/adapter/harbor/image_registry.go
@@ -28,7 +28,7 @@ import (
 	"strings"
 )
 
-func (a *adapter) FetchImages(filters []*model.Filter) ([]*model.Resource, error) {
+func (a *adapter) FetchArtifacts(filters []*model.Filter) ([]*model.Resource, error) {
 	projects, err := a.listProjects(filters)
 	if err != nil {
 		return nil, err
@@ -78,7 +78,7 @@ func (a *adapter) FetchImages(filters []*model.Filter) ([]*model.Resource, error
 		runner.Wait()
 
 		if runner.IsCancelled() {
-			return nil, fmt.Errorf("FetchImages error when collect tags for repos")
+			return nil, fmt.Errorf("FetchArtifacts error when collect tags for repos")
 		}
 
 		for _, r := range rawResources {
@@ -167,4 +167,11 @@ func (a *adapter) listArtifacts(repository string, filters []*model.Filter) ([]*
 		arts = append(arts, art)
 	}
 	return filter.DoFilterArtifacts(arts, filters)
+}
+
+func (a *adapter) DeleteTag(repository, tag string) error {
+	project, repository := utils.ParseRepository(repository)
+	url := fmt.Sprintf("%s/api/%s/projects/%s/repositories/%s/artifacts/%s/tags/%s",
+		a.getURL(), api.APIVersion, project, repository, tag, tag)
+	return a.client.Delete(url)
 }

--- a/src/replication/adapter/harbor/image_registry_test.go
+++ b/src/replication/adapter/harbor/image_registry_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestFetchImages(t *testing.T) {
+func TestFetchArtifacts(t *testing.T) {
 	server := test.NewServer([]*test.RequestHandlerMapping{
 		{
 			Method:  http.MethodGet,
@@ -80,7 +80,7 @@ func TestFetchImages(t *testing.T) {
 	adapter, err := newAdapter(registry)
 	require.Nil(t, err)
 	// nil filter
-	resources, err := adapter.FetchImages(nil)
+	resources, err := adapter.FetchArtifacts(nil)
 	require.Nil(t, err)
 	assert.Equal(t, 1, len(resources))
 	assert.Equal(t, model.ResourceTypeArtifact, resources[0].Type)
@@ -99,7 +99,7 @@ func TestFetchImages(t *testing.T) {
 			Value: "1.0",
 		},
 	}
-	resources, err = adapter.FetchImages(filters)
+	resources, err = adapter.FetchArtifacts(filters)
 	require.Nil(t, err)
 	assert.Equal(t, 1, len(resources))
 	assert.Equal(t, model.ResourceTypeArtifact, resources[0].Type)

--- a/src/replication/adapter/helmhub/adapter.go
+++ b/src/replication/adapter/helmhub/adapter.go
@@ -53,6 +53,11 @@ func (f *factory) AdapterPattern() *model.AdapterPattern {
 	}
 }
 
+var (
+	_ adp.Adapter       = (*adapter)(nil)
+	_ adp.ChartRegistry = (*adapter)(nil)
+)
+
 type adapter struct {
 	registry *model.Registry
 	client   *Client

--- a/src/replication/adapter/huawei/huawei_adapter.go
+++ b/src/replication/adapter/huawei/huawei_adapter.go
@@ -40,6 +40,11 @@ func (f *factory) AdapterPattern() *model.AdapterPattern {
 	return nil
 }
 
+var (
+	_ adp.Adapter          = (*adapter)(nil)
+	_ adp.ArtifactRegistry = (*adapter)(nil)
+)
+
 // Adapter is for images replications between harbor and Huawei image repository(SWR)
 type adapter struct {
 	*native.Adapter

--- a/src/replication/adapter/huawei/image_registry.go
+++ b/src/replication/adapter/huawei/image_registry.go
@@ -10,8 +10,8 @@ import (
 	"github.com/goharbor/harbor/src/replication/model"
 )
 
-// FetchImages gets resources from Huawei SWR
-func (a *adapter) FetchImages(filters []*model.Filter) ([]*model.Resource, error) {
+// FetchArtifacts gets resources from Huawei SWR
+func (a *adapter) FetchArtifacts(filters []*model.Filter) ([]*model.Resource, error) {
 
 	resources := []*model.Resource{}
 

--- a/src/replication/adapter/huawei/image_registry_test.go
+++ b/src/replication/adapter/huawei/image_registry_test.go
@@ -28,8 +28,8 @@ func init() {
 	HWAdapter = *adp.(*adapter)
 }
 
-func TestAdapter_FetchImages(t *testing.T) {
-	resources, err := HWAdapter.FetchImages(nil)
+func TestAdapter_FetchArtifacts(t *testing.T) {
+	resources, err := HWAdapter.FetchArtifacts(nil)
 	if err != nil {
 		if strings.HasPrefix(err.Error(), "[401]") {
 			t.Log("huawei ak/sk is not available", err.Error())

--- a/src/replication/adapter/jfrog/adapter.go
+++ b/src/replication/adapter/jfrog/adapter.go
@@ -43,6 +43,11 @@ func (f *factory) AdapterPattern() *model.AdapterPattern {
 	return nil
 }
 
+var (
+	_ adp.Adapter          = (*adapter)(nil)
+	_ adp.ArtifactRegistry = (*adapter)(nil)
+)
+
 // Adapter is for images replications between harbor and jfrog artifactory image repository
 type adapter struct {
 	*native.Adapter

--- a/src/replication/adapter/native/adapter.go
+++ b/src/replication/adapter/native/adapter.go
@@ -15,6 +15,7 @@
 package native
 
 import (
+	"errors"
 	"fmt"
 	"github.com/goharbor/harbor/src/common/utils"
 	"github.com/goharbor/harbor/src/common/utils/log"
@@ -48,6 +49,11 @@ func (f *factory) Create(r *model.Registry) (adp.Adapter, error) {
 func (f *factory) AdapterPattern() *model.AdapterPattern {
 	return nil
 }
+
+var (
+	_ adp.Adapter          = (*Adapter)(nil)
+	_ adp.ArtifactRegistry = (*Adapter)(nil)
+)
 
 // Adapter implements an adapter for Docker registry. It can be used to all registries
 // that implement the registry V2 API
@@ -123,8 +129,8 @@ func (a *Adapter) HealthCheck() (model.HealthStatus, error) {
 	return model.Healthy, nil
 }
 
-// FetchImages ...
-func (a *Adapter) FetchImages(filters []*model.Filter) ([]*model.Resource, error) {
+// FetchArtifacts ...
+func (a *Adapter) FetchArtifacts(filters []*model.Filter) ([]*model.Resource, error) {
 	repositories, err := a.listRepositories(filters)
 	if err != nil {
 		return nil, err
@@ -165,7 +171,7 @@ func (a *Adapter) FetchImages(filters []*model.Filter) ([]*model.Resource, error
 	runner.Wait()
 
 	if runner.IsCancelled() {
-		return nil, fmt.Errorf("FetchImages error when collect tags for repos")
+		return nil, fmt.Errorf("FetchArtifacts error when collect tags for repos")
 	}
 
 	var resources []*model.Resource
@@ -234,4 +240,9 @@ func (a *Adapter) PingSimple() error {
 		return nil
 	}
 	return err
+}
+
+// DeleteTag isn't supported for docker registry
+func (a *Adapter) DeleteTag(repository, tag string) error {
+	return errors.New("the tag deletion isn't supported")
 }

--- a/src/replication/adapter/native/adapter_test.go
+++ b/src/replication/adapter/native/adapter_test.go
@@ -82,7 +82,7 @@ func mockNativeRegistry() (mock *httptest.Server) {
 		},
 	)
 }
-func Test_native_FetchImages(t *testing.T) {
+func Test_native_FetchArtifacts(t *testing.T) {
 	var mock = mockNativeRegistry()
 	defer mock.Close()
 	fmt.Println("mockNativeRegistry URL: ", mock.URL)
@@ -343,7 +343,7 @@ func Test_native_FetchImages(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var resources, err = adapter.FetchImages(tt.filters)
+			var resources, err = adapter.FetchArtifacts(tt.filters)
 			if tt.wantErr {
 				require.Len(t, resources, 0)
 				require.NotNil(t, err)

--- a/src/replication/adapter/quayio/adapter.go
+++ b/src/replication/adapter/quayio/adapter.go
@@ -18,6 +18,11 @@ import (
 	"github.com/goharbor/harbor/src/replication/util"
 )
 
+var (
+	_ adp.Adapter          = (*adapter)(nil)
+	_ adp.ArtifactRegistry = (*adapter)(nil)
+)
+
 type adapter struct {
 	*native.Adapter
 	registry *model.Registry

--- a/src/replication/event/event.go
+++ b/src/replication/event/event.go
@@ -20,6 +20,7 @@ import "github.com/goharbor/harbor/src/replication/model"
 const (
 	EventTypeArtifactPush   = "artifact_push"
 	EventTypeArtifactDelete = "artifact_delete"
+	EventTypeTagDelete      = "tag_delete"
 	EventTypeChartUpload    = "chart_upload"
 	EventTypeChartDelete    = "chart_delete"
 )

--- a/src/replication/event/handler.go
+++ b/src/replication/event/handler.go
@@ -57,7 +57,7 @@ func (h *handler) Handle(event *Event) error {
 	var policies []*model.Policy
 	var err error
 	switch event.Type {
-	case EventTypeArtifactPush, EventTypeChartUpload,
+	case EventTypeArtifactPush, EventTypeChartUpload, EventTypeTagDelete,
 		EventTypeArtifactDelete, EventTypeChartDelete:
 		policies, err = h.getRelatedPolicies(event.Resource)
 	default:

--- a/src/replication/filter/resource.go
+++ b/src/replication/filter/resource.go
@@ -52,6 +52,7 @@ func DoFilterResources(resources []*model.Resource, filters []*model.Filter) ([]
 			Registry:     resource.Registry,
 			ExtendedInfo: resource.ExtendedInfo,
 			Deleted:      resource.Deleted,
+			IsDeleteTag:  resource.IsDeleteTag,
 			Override:     resource.Override,
 		})
 	}

--- a/src/replication/model/resource.go
+++ b/src/replication/model/resource.go
@@ -37,6 +37,8 @@ type Resource struct {
 	ExtendedInfo map[string]interface{} `json:"extended_info"`
 	// Indicate if the resource is a deleted resource
 	Deleted bool `json:"deleted"`
+	// indicate the resource is a tag deletion
+	IsDeleteTag bool `json:"is_delete_tag"`
 	// indicate whether the resource can be overridden
 	Override bool `json:"override"`
 }

--- a/src/replication/operation/flow/stage_test.go
+++ b/src/replication/operation/flow/stage_test.go
@@ -59,7 +59,7 @@ func (f *fakedAdapter) PrepareForPush([]*model.Resource) error {
 func (f *fakedAdapter) HealthCheck() (model.HealthStatus, error) {
 	return model.Healthy, nil
 }
-func (f *fakedAdapter) FetchImages(filters []*model.Filter) ([]*model.Resource, error) {
+func (f *fakedAdapter) FetchArtifacts(filters []*model.Filter) ([]*model.Resource, error) {
 	return []*model.Resource{
 		{
 			Type: model.ResourceTypeImage,
@@ -93,6 +93,9 @@ func (f *fakedAdapter) PullBlob(repository, digest string) (size int64, blob io.
 	return 0, nil, nil
 }
 func (f *fakedAdapter) PushBlob(repository, digest string, size int64, blob io.Reader) error {
+	return nil
+}
+func (f *fakedAdapter) DeleteTag(repository, tag string) error {
 	return nil
 }
 func (f *fakedAdapter) FetchCharts(filters []*model.Filter) ([]*model.Resource, error) {

--- a/src/replication/transfer/image/transfer_test.go
+++ b/src/replication/transfer/image/transfer_test.go
@@ -31,7 +31,7 @@ import (
 
 type fakeRegistry struct{}
 
-func (f *fakeRegistry) FetchImages([]*model.Filter) ([]*model.Resource, error) {
+func (f *fakeRegistry) FetchArtifacts([]*model.Filter) ([]*model.Resource, error) {
 	return nil, nil
 }
 
@@ -90,6 +90,9 @@ func (f *fakeRegistry) PullBlob(repository, digest string) (size int64, blob io.
 	return 1, r, nil
 }
 func (f *fakeRegistry) PushBlob(repository, digest string, size int64, blob io.Reader) error {
+	return nil
+}
+func (f *fakeRegistry) DeleteTag(repository, tag string) error {
 	return nil
 }
 


### PR DESCRIPTION
This commit introduces the tag deletion as a new capability for registry adapters, and currently only Harbor supports it

Signed-off-by: Wenkai Yin <yinw@vmware.com>