### PR TITLE
Update a few docs with correct images and formatting

### DIFF
--- a/docs/1.10/administration/configuring-replication/create-replication-endpoints.md
+++ b/docs/1.10/administration/configuring-replication/create-replication-endpoints.md
@@ -8,6 +8,7 @@ To replicate image repositories from one instance of Harbor to another Harbor or
 1. Go to **Registries** and click the **+ New Endpoint** button.
 
    ![New replication endpoint](../../../img/replication-endpoint1.png)
+
 1. For **Provider**, use the drop-down menu to select the type of registry to set up as a replication endpoint.
 
    The endpoint can be another Harbor instance, or a non-Harbor registry. Currently, the following non-Harbor registries are supported:
@@ -30,17 +31,20 @@ To replicate image repositories from one instance of Harbor to another Harbor or
 1. Enter the full URL of the registry to set up as a replication endpoint.
 
    For example, to replicate to another Harbor instance, enter https://harbor_instance_address:443. The registry must exist and be running before you create the endpoint.
+
 1. Enter the Access ID and Access Secret for the endpoint registry instance.
 
-    Use an account that has the appropriate privileges on that registry, or an account that has write permission on the corresponding project in a Harbor registry.
+   Use an account that has the appropriate privileges on that registry, or an account that has write permission on the corresponding project in a Harbor registry.
 
-    {{< note >}}
-    - AWS ECR adapters should use access keys, not a username and password. The access key should have sufficient permissions, such as storage permission.
-    - Google GCR adapters should use the entire JSON key generated in the service account. The namespace should start with the project ID.
-    {{< /note >}}
+   {{< note >}}
+   - AWS ECR adapters should use access keys, not a username and password. The access key should have sufficient permissions, such as storage permission.
+   - Google GCR adapters should use the entire JSON key generated in the service account. The namespace should start with the project ID.
+   {{< /note >}}
+
 1. Optionally, select the **Verify Remote Cert** check box.
 
-    Deselect the check box if the remote registry uses a self-signed or untrusted certificate.
+   Deselect the check box if the remote registry uses a self-signed or untrusted certificate.
+
 1. Click **Test Connection**.
 1. When you have successfully tested the connection, click **OK**.
 

--- a/docs/1.10/administration/configuring-replication/create-replication-rules.md
+++ b/docs/1.10/administration/configuring-replication/create-replication-rules.md
@@ -22,9 +22,9 @@ A replication endpoint must exist before you create a replication rule. To creat
    * **Tag**: Replicate resources with a given tag by entering a tag name or fragment.
    * **Label**: Replicate resources with a given label by using the drop-down menu to select from the available labels.
    * **Resource**: Replicate images, charts, or both.
-   
+
    The name filter and tag filters support the following patterns:
-   
+
    * **\***: Matches any sequence of non-separator characters `/`.
    * **\*\***: Matches any sequence of characters, including path separators `/`.
    * **?**: Matches any single non-separator character `/`.
@@ -33,9 +33,9 @@ A replication endpoint must exist before you create a replication rule. To creat
    * **\*\***: Matches any sequence of characters, including path separators `/`.
    * **?**: Matches any single non-separator character `/`.
    * **{alt1,...}**: Matches a sequence of characters if one of the comma-separated alternatives matches.
-   
+
    **NOTE:** You must add `library` if you want to replicate the official images of Docker Hub. For example, `library/hello-world` matches the official hello-world images.  
-   
+
    Pattern | String(Match or not)
    ---------- | -------
    `library/*`      | `library/hello-world`(Y)<br> `library/my/hello-world`(N)
@@ -53,9 +53,9 @@ A replication endpoint must exist before you create a replication rule. To creat
    * **Scheduled**: Replicate the resources periodically by defining a cron job. **Note**: Deletion operations are not replicated. 
    * **Event Based**: When a new resource is pushed to the project, or an image is retagged, it is replicated to the remote registry immediately. If you select the **Delete remote resources when locally deleted**, if you delete an image, it is automatically deleted from the replication target.
 
-    {{< note >}}
-    You can filter images for replication based on the labels that are applied to the images. However, changing a label on an image does not trigger replication. Event-based replication is limited to pushing, retagging, and deleting images.
-    {{< /note >}}
+   {{< note >}}
+   You can filter images for replication based on the labels that are applied to the images. However, changing a label on an image does not trigger replication. Event-based replication is limited to pushing, retagging, and deleting images.
+   {{< /note >}}
 
    ![Trigger mode](../../../img/replication-rule5.png)
       

--- a/docs/1.10/working-with-projects/project-configuration/_index.md
+++ b/docs/1.10/working-with-projects/project-configuration/_index.md
@@ -11,13 +11,13 @@ After the initial creation of a project, you can configure or reconfigure its pr
 1. To make all repositories under the project accessible to everyone, select the `Public` checkbox, or deselect this checkbox to make the project private.
 1. To prevent un-signed images under the project from being pulled, select the `Enable content trust` checkbox.
 
-![browse project](../../../img/project-configuration.png)
+![browse project](../../img/project-configuration.png)
 
 ## Searching projects and repositories
 
 Enter a keyword in the search field at the top to list all matching projects and repositories. The search result includes both public and private repositories you have access to.  
 
-![browse project](../../../img/new-search.png)
+![browse project](../../img/new-search.png)
 
 ## Configure Vulnerability Settings in Projects
 
@@ -28,16 +28,16 @@ You can configure projects so that images with vulnerabilities cannot be run, an
 1. Select the **Configuration** tab.
 1. To prevent vulnerable images under the project from being pulled, select the **Prevent vulnerable images from running** checkbox.
 
-   ![Prevent vulnerable images from running](../../../img/prevent-vulnerable-images.png)
+   ![Prevent vulnerable images from running](../../img/prevent-vulnerable-images.png)
 
 1. Select the severity level of vulnerabilities to prevent images from running.
 
-   ![Set vulnerability threshold](../../../img/set-vulnerability-threshold.png)
+   ![Set vulnerability threshold](../../img/set-vulnerability-threshold.png)
    
    Images cannot be pulled if their level is equal to or higher than the selected level of severity. Harbor does not prevent images with a vulnerability severity of `negligible` from running.
 1. To activate an immediate vulnerability scan on new images that are pushed to the project, select the **Automatically scan images on push** check box.
 
-   ![Automatically scan images on push](../../../img/scan-on-push.png)
+   ![Automatically scan images on push](../../img/scan-on-push.png)
 
 ## Build history
 
@@ -45,4 +45,4 @@ Build history makes it easy to see the contents of a container image, find the c
 
 In Harbor portal, enter your project, select the repository, click on the link of tag name you'd like to see its build history, the detail page will be opened. Then switch to `Build History` tab, you can see the build history information.
 
-![build history](../../../img/build-history.png)
+![build history](../../img/build-history.png)

--- a/docs/1.10/working-with-projects/project-configuration/create-robot-accounts.md
+++ b/docs/1.10/working-with-projects/project-configuration/create-robot-accounts.md
@@ -26,15 +26,15 @@ You can create robot accounts to run automated operations. Robot accounts have t
 1. Click **Save**.
 1. In the confirmation window, click **Export to File** to download the access token as a JSON file, or click the clipboard icon to copy its contents to the clipboard.
 
-    ![copy_robot_account_token](../../../img/copy-robot-account-token.png)
+   ![copy_robot_account_token](../../../img/copy-robot-account-token.png)
 
-    {{< important >}}
-    Harbor does not store robot account tokens, so you must either download the token JSON or copy and paste its contents into a text file. There is no way to get the token from Harbor after you have created the robot account.
-    {{< /important >}}
+   {{< important >}}
+   Harbor does not store robot account tokens, so you must either download the token JSON or copy and paste its contents into a text file. There is no way to get the token from Harbor after you have created the robot account.
+   {{< /important >}}
 
-    The new robot account appears as `robot$account_name` in the list of robot accounts. The `robot$` prefix makes it easily distinguishable from a normal Harbor user account.
+   The new robot account appears as `robot$account_name` in the list of robot accounts. The `robot$` prefix makes it easily distinguishable from a normal Harbor user account.
 
-    ![New robot account](../../../img/new-robot-account.png)
+   ![New robot account](../../../img/new-robot-account.png)
 
 1. To delete or disable a robot account, select the account in the list, and select **Disable account** or **Delete** from the Action drop-down menu.
 

--- a/docs/1.10/working-with-projects/using-api-explorer/_index.md
+++ b/docs/1.10/working-with-projects/using-api-explorer/_index.md
@@ -6,9 +6,7 @@ weight: 100
 Harbor integrated swagger UI from 1.8. That means all APIs can be invoked through the Harbor interface. You can navigate to the API Explorer in two ways. 
 
 1. Log in to Harbor and click the "API EXPLORER" button. All APIs will be invoked with the current user's authorization.                         
-![navigation bar](../../../img/api-explorer-btn.png)
-
+![navigation bar](../../img/api-explorer-btn.png)
 
 2. Navigate to the Swagger page by using the IP address of your Harbor instance and adding the router "devcenter". For example: https://10.192.111.118/devcenter. Then click the **Authorize** button to give basic authentication to all APIs. All APIs will be invoked with the authorized user's authorization. 
-![authentication](../../../img/authorize.png)
-
+![authentication](../../img/authorize.png)


### PR DESCRIPTION
A few docs pages still had wrong links for images, and some wonky formatting.

We should run a Markdown linter on the docs in the near future to make sure everything looks proper.

Signed-off-by: jonasrosland <jrosland@vmware.com>