### PR TITLE
Fix bug when scanner is unhealthy

### DIFF
--- a/src/controller/scanner/base_controller.go
+++ b/src/controller/scanner/base_controller.go
@@ -242,7 +242,7 @@ func (bc *basicController) GetRegistrationByProject(projectID int64, options ...
 		}
 	}
 
-	return registration, err
+	return registration, nil
 }
 
 // Ping ...


### PR DESCRIPTION
The function GetRegistrationByProject should not return err when Ping
return err.  The return value 'registration' has 'Health' field which
shows the scanner health status.

Resolves: #11051
See also: #9788, #9807

Signed-off-by: qinshaoxuan <qinshaoxuan@baidu.com>