### PR TITLE
Filter the pulling manifest request from replication service

### DIFF
--- a/src/pkg/registry/client.go
+++ b/src/pkg/registry/client.go
@@ -55,6 +55,11 @@ var (
 	}
 )
 
+// const definition
+const (
+	UserAgent = "harbor-registry-client"
+)
+
 // Client defines the methods that a registry client should implements
 type Client interface {
 	// Ping the base API endpoint "/v2/"
@@ -503,6 +508,7 @@ func (c *client) do(req *http.Request) (*http.Response, error) {
 			return nil, err
 		}
 	}
+	req.Header.Set(http.CanonicalHeaderKey("User-Agent"), UserAgent)
 	resp, err := c.client.Do(req)
 	if err != nil {
 		return nil, err

--- a/src/server/registry/manifest.go
+++ b/src/server/registry/manifest.go
@@ -22,6 +22,7 @@ import (
 	"github.com/goharbor/harbor/src/internal"
 	ierror "github.com/goharbor/harbor/src/internal/error"
 	"github.com/goharbor/harbor/src/pkg/notification"
+	"github.com/goharbor/harbor/src/pkg/registry"
 	serror "github.com/goharbor/harbor/src/server/error"
 	"github.com/goharbor/harbor/src/server/router"
 	"github.com/opencontainers/go-digest"
@@ -48,20 +49,20 @@ func getManifest(w http.ResponseWriter, req *http.Request) {
 
 	recorder := internal.NewResponseRecorder(w)
 	proxy.ServeHTTP(recorder, req)
-	// fire event
-	if recorder.Success() {
-		// TODO don't fire event for the pulling from replication
-		e := &metadata.PullArtifactEventMetadata{
-			Ctx:      req.Context(),
-			Artifact: &artifact.Artifact,
-		}
-		// TODO provide a util function to determine whether the reference is tag or not
-		// the reference is tag
-		if _, err = digest.Parse(reference); err != nil {
-			e.Tag = reference
-		}
-		notification.AddEvent(req.Context(), e)
+	// fire event, ignore the HEAD request and pulling request from replication service
+	if !recorder.Success() || req.Method == http.MethodHead ||
+		req.UserAgent() == registry.UserAgent {
+		return
 	}
+	e := &metadata.PullArtifactEventMetadata{
+		Ctx:      req.Context(),
+		Artifact: &artifact.Artifact,
+	}
+	// the reference is tag
+	if _, err = digest.Parse(reference); err != nil {
+		e.Tag = reference
+	}
+	notification.AddEvent(req.Context(), e)
 }
 
 // just delete the artifact from database


### PR DESCRIPTION
Filter the pulling manifest request from replication service so that the audit log will not record the pulling action

Signed-off-by: Wenkai Yin <yinw@vmware.com>