### PR TITLE
fix(scan): assign repository pull access policy to robot account when scan artifact

### DIFF
--- a/src/api/scan/base_controller.go
+++ b/src/api/scan/base_controller.go
@@ -523,7 +523,10 @@ func (bc *basicController) makeRobotAccount(projectID int64, repository string) 
 		Name:        UUID,
 		Description: "for scan",
 		ProjectID:   projectID,
-		Access:      []*types.Policy{{Resource: resource, Action: rbac.ActionScannerPull}},
+		Access: []*types.Policy{
+			{Resource: resource, Action: rbac.ActionPull},
+			{Resource: resource, Action: rbac.ActionScannerPull},
+		},
 	}
 
 	rb, err := bc.rc.CreateRobotAccount(robotReq)

--- a/src/api/scan/base_controller_test.go
+++ b/src/api/scan/base_controller_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/goharbor/harbor/src/api/artifact"
 	"github.com/goharbor/harbor/src/common"
 	cj "github.com/goharbor/harbor/src/common/job"
-	cjm "github.com/goharbor/harbor/src/common/job/models"
 	jm "github.com/goharbor/harbor/src/common/job/models"
 	"github.com/goharbor/harbor/src/common/rbac"
 	"github.com/goharbor/harbor/src/jobservice/job"
@@ -168,10 +167,10 @@ func (suite *ControllerTestSuite) SetupSuite() {
 	rc := &MockRobotController{}
 
 	resource := fmt.Sprintf("/project/%d/repository", suite.artifact.ProjectID)
-	access := []*types.Policy{{
-		Resource: types.Resource(resource),
-		Action:   rbac.ActionScannerPull,
-	}}
+	access := []*types.Policy{
+		{Resource: types.Resource(resource), Action: rbac.ActionPull},
+		{Resource: types.Resource(resource), Action: rbac.ActionScannerPull},
+	}
 
 	rname := "the-uuid-123"
 	account := &model.RobotCreate{
@@ -322,7 +321,7 @@ type MockJobServiceClient struct {
 }
 
 // SubmitJob ...
-func (mjc *MockJobServiceClient) SubmitJob(jData *cjm.JobData) (string, error) {
+func (mjc *MockJobServiceClient) SubmitJob(jData *jm.JobData) (string, error) {
 	args := mjc.Called(jData)
 
 	return args.String(0), args.Error(1)


### PR DESCRIPTION
The v2auth middleware will check whether the requestor  has the pull or
push permissions for the repository, and forbid the request when the
requestor does not have the permission.  We need to assign repository
pulling permission to the robot account for the scanner, otherwise
scanner will be failed to pull the artifact.

Signed-off-by: He Weiwei <hweiwei@vmware.com>