### PR TITLE
Remove the project manager from context

### DIFF
--- a/src/core/api/base.go
+++ b/src/core/api/base.go
@@ -28,7 +28,6 @@ import (
 	"github.com/goharbor/harbor/src/common/utils"
 	"github.com/goharbor/harbor/src/common/utils/log"
 	"github.com/goharbor/harbor/src/core/config"
-	"github.com/goharbor/harbor/src/core/filter"
 	"github.com/goharbor/harbor/src/core/promgr"
 	internal_errors "github.com/goharbor/harbor/src/internal/error"
 	"github.com/goharbor/harbor/src/pkg/project"
@@ -75,14 +74,7 @@ func (b *BaseController) Prepare() {
 		return
 	}
 	b.SecurityCtx = ctx
-
-	pm, err := filter.GetProjectManager(b.Ctx.Request)
-	if err != nil {
-		log.Errorf("failed to get project manager: %v", err)
-		b.SendInternalServerError(errors.New(""))
-		return
-	}
-	b.ProjectMgr = pm
+	b.ProjectMgr = config.GlobalProjectMgr
 }
 
 // RequireAuthenticated returns true when the request is authenticated

--- a/src/core/api/retention.go
+++ b/src/core/api/retention.go
@@ -4,11 +4,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/goharbor/harbor/src/core/config"
 	"net/http"
 	"strconv"
 
 	"github.com/goharbor/harbor/src/common/rbac"
-	"github.com/goharbor/harbor/src/core/filter"
 	"github.com/goharbor/harbor/src/core/promgr"
 	"github.com/goharbor/harbor/src/pkg/retention"
 	"github.com/goharbor/harbor/src/pkg/retention/policy"
@@ -28,13 +28,7 @@ func (r *RetentionAPI) Prepare() {
 		r.SendUnAuthorizedError(errors.New("UnAuthorized"))
 		return
 	}
-	pm, e := filter.GetProjectManager(r.Ctx.Request)
-	if e != nil {
-		r.SendInternalServerError(e)
-		return
-	}
-	r.pm = pm
-
+	r.pm = config.GlobalProjectMgr
 }
 
 // GetMetadatas Get Metadatas

--- a/src/core/service/token/creator.go
+++ b/src/core/service/token/creator.go
@@ -26,7 +26,6 @@ import (
 	"github.com/goharbor/harbor/src/common/security"
 	"github.com/goharbor/harbor/src/common/utils/log"
 	"github.com/goharbor/harbor/src/core/config"
-	"github.com/goharbor/harbor/src/core/filter"
 	"github.com/goharbor/harbor/src/core/promgr"
 )
 
@@ -208,10 +207,7 @@ func (g generalCreator) Create(r *http.Request) (*models.Token, error) {
 		return nil, fmt.Errorf("failed to  get security context from request")
 	}
 
-	pm, err := filter.GetProjectManager(r)
-	if err != nil {
-		return nil, fmt.Errorf("failed to  get project manager from request")
-	}
+	pm := config.GlobalProjectMgr
 
 	// for docker login
 	if !ctx.IsAuthenticated() {


### PR DESCRIPTION
Remove the project manager introduced when integrated with Admiral from the context

Signed-off-by: Wenkai Yin <yinw@vmware.com>