### PR TITLE
Increase the length the columns (src_resource, dst_resource)of replication_task

### DIFF
--- a/make/migrations/postgresql/0030_2.0.0_schema.up.sql
+++ b/make/migrations/postgresql/0030_2.0.0_schema.up.sql
@@ -200,3 +200,6 @@ ALTER TABLE notification_policy DROP CONSTRAINT unique_project_id;
 
 /*add the unique constraint for name in table 'notification_policy'*/
 ALTER TABLE notification_policy ADD UNIQUE (name);
+
+ALTER TABLE replication_task ALTER COLUMN src_resource TYPE varchar(512);
+ALTER TABLE replication_task ALTER COLUMN dst_resource TYPE varchar(512);


### PR DESCRIPTION
Fixes #10786 by increaseing the length of src_resource and dst_resource to 256

Signed-off-by: Wenkai Yin <yinw@vmware.com>