### PR TITLE
Move the webhook event API definition to legacy_swagger.yaml

### DIFF
--- a/api/v2.0/legacy_swagger.yaml
+++ b/api/v2.0/legacy_swagger.yaml
@@ -3471,6 +3471,30 @@ paths:
           description: User have no permission to list webhook jobs of the project.
         '500':
           description: Unexpected internal errors.
+  '/projects/{project_id}/webhook/events':
+    get:
+      summary: Get supported event types and notify types.
+      description: Get supportted event types and notify types.
+      tags:
+        - Products
+      parameters:
+        - name: project_id
+          in: path
+          type: integer
+          format: int64
+          required: true
+          description: Relevant project ID.
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/SupportedWebhookEventTypes'
+        '401':
+          description: User need to log in first.
+        '403':
+          description: User have no permission to list webhook jobs of the project.
+        '500':
+          description: Unexpected internal errors.
   '/projects/{project_id}/immutabletagrules':
     get:
       summary: List all immutable tag rules of current project
@@ -6658,3 +6682,23 @@ definitions:
           'Success': 5
           'Error': 2,
           'Running': 3
+  SupportedWebhookEventTypes:
+    type: object
+    description: Supportted webhook event types and notify types.
+    properties:
+      event_type:
+        type: array
+        items:
+          $ref: '#/definitions/EventType'
+      notify_type:
+        type: array
+        items:
+          $ref: '#/definitions/NotifyType'
+  EventType:
+    type: string
+    description: Webhook supportted event type.
+    example: 'pullImage'
+  NotifyType:
+    type: string
+    description: Webhook supportted notify type.
+    example: 'http'

--- a/api/v2.0/swagger.yaml
+++ b/api/v2.0/swagger.yaml
@@ -552,24 +552,6 @@ paths:
           $ref: '#/responses/401'
         '500':
           $ref: '#/responses/500'
-  # TODO replace project_id with project_name
-  /projects/{project_id}/webhook/events:
-    get:
-      summary: Get supported event types and notify types.
-      description: Get supportted event types and notify types.
-      tags:
-        - notification
-      parameters:
-        - $ref: '#/parameters/projectId'
-      responses:
-        '200':
-          description: Success
-          schema:
-            $ref: '#/definitions/SupportedWebhookEventTypes'
-        '401':
-          $ref: '#/responses/401'
-        '403':
-          $ref: '#/responses/403'
   /projects/{project_name}/logs:
     get:
       summary: Get recent logs of the projects
@@ -1060,23 +1042,3 @@ definitions:
       op_time:
         type: string
         description: The time when this operation is triggered.
-  SupportedWebhookEventTypes:
-    type: object
-    description: Supportted webhook event types and notify types.
-    properties:
-      event_type:
-        type: array
-        items:
-          $ref: '#/definitions/EventType'
-      notify_type:
-        type: array
-        items:
-          $ref: '#/definitions/NotifyType'
-  EventType:
-    type: string
-    description: Webhook supportted event type.
-    example: 'pullImage'
-  NotifyType:
-    type: string
-    description: Webhook supportted notify type.
-    example: 'http'


### PR DESCRIPTION
The API definition is put on the wrong swagger file introduced by PR #11029 by mistake

Signed-off-by: Wenkai Yin <yinw@vmware.com>