### PR TITLE
Unescape tags query when to list artifact

### DIFF
--- a/src/pkg/q/builder.go
+++ b/src/pkg/q/builder.go
@@ -16,7 +16,9 @@ package q
 
 import (
 	"fmt"
+	"github.com/goharbor/harbor/src/common/utils/log"
 	ierror "github.com/goharbor/harbor/src/internal/error"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -37,6 +39,12 @@ func Build(q string, pageNumber, pageSize int64) (*Query, error) {
 	}
 	if len(q) == 0 {
 		return query, nil
+	}
+	// try to escaped the 'q=tags%3Dnil' when to filter tags.
+	if unescapedQuery, err := url.QueryUnescape(q); err == nil {
+		q = unescapedQuery
+	} else {
+		log.Errorf("failed to unescape the query %s: %v", q, err)
 	}
 	params := strings.Split(q, ",")
 	for _, param := range params {

--- a/src/pkg/q/builder_test.go
+++ b/src/pkg/q/builder_test.go
@@ -262,4 +262,11 @@ func TestBuild(t *testing.T) {
 	assert.Equal(t, int64(1), query.PageNumber)
 	assert.Equal(t, int64(10), query.PageSize)
 	assert.Equal(t, "v", query.Keywords["k"].(string))
+
+	q = `q=tags%3Dnil`
+	query, err = Build(q, 1, 10)
+	require.Nil(t, err)
+	assert.Equal(t, int64(1), query.PageNumber)
+	assert.Equal(t, int64(10), query.PageSize)
+	assert.Equal(t, "tags=nil", query.Keywords["q"].(string))
 }

--- a/src/server/v2.0/handler/base_test.go
+++ b/src/server/v2.0/handler/base_test.go
@@ -53,6 +53,18 @@ func (b *baseHandlerTestSuite) TestBuildQuery() {
 	b.Equal(int64(1), q.PageNumber)
 	b.Equal(int64(10), q.PageSize)
 	b.NotNil(q.Keywords)
+
+	var (
+		qs1       = "q=a%3Db"
+		pn1 int64 = 1
+		ps1 int64 = 10
+	)
+	q, err = b.base.BuildQuery(nil, &qs1, &pn1, &ps1)
+	b.Require().Nil(err)
+	b.Require().NotNil(q)
+	b.Equal(int64(1), q.PageNumber)
+	b.Equal(int64(10), q.PageSize)
+	b.Equal(q.Keywords["q"], "a=b")
 }
 
 func (b *baseHandlerTestSuite) TestLinks() {


### PR DESCRIPTION
The query string is encoded by UI, and we have to unescape the "=" in "q=tag=nil",
otherwise, the query doesn't work, and returns 400

Signed-off-by: wang yan <wangyan@vmware.com>