### PR TITLE
posixGroup support

### DIFF
--- a/tests/ldap_test.ldif
+++ b/tests/ldap_test.ldif
@@ -773,5 +773,28 @@ uidnumber: 6003
 userpassword: {MD5}wb68DeX0CyENafzUADNn9A==
 memberof: cn=harbor_admin,ou=groups,dc=example,dc=com
 
+dn: cn=brian,ou=people,dc=example,dc=com
+cn: brian
+gidnumber: 10000
+givenname: brian
+homedirectory: /home/brian
+loginshell: /bin/bash
+mail: brian@example.com
+objectclass: top
+objectclass: posixAccount
+objectclass: shadowAccount
+objectclass: inetOrgPerson
+objectclass: organizationalPerson
+objectclass: person
+sn: brian
+uid: brian
+uidnumber: 6004
+userpassword: {MD5}wb68DeX0CyENafzUADNn9A==
 
-
+# Group Entry harbor_users_posix
+dn: cn=harbor_users_posix,ou=groups,dc=example,dc=com
+cn: harbor_users_posix
+description: harbor users posix
+memberUid: brian
+objectClass: top
+objectClass: posixGroup


### PR DESCRIPTION
ldap groups with objectclass posixGroup has a different behaviour, by default they don't create any reference records in the user object, in order to make them work, we have to query the groups themselves and push the group DNs into the `GroupDNList` slice separately 