### PR TITLE
Add "_self" suffix for repository API to avoid conflict

### DIFF
--- a/api/v2.0/swagger.yaml
+++ b/api/v2.0/swagger.yaml
@@ -54,7 +54,11 @@ paths:
           $ref: '#/responses/404'
         '500':
           $ref: '#/responses/500'
-  /projects/{project_name}/repositories/{repository_name}:
+  # the _self suffix here is used to avoid the conflict of repository name and URL path
+  # e.g. the repository name can be "library/artifacts", we cannot distinguish the URL
+  # "GET /projects/{project_name}/repositories/library/artifacts" is getting repository
+  # or listing artifacts
+  /projects/{project_name}/repositories/{repository_name}/_self:
     get:
       summary: Get repository
       description: Get the repository specified by name

--- a/src/server/middleware/path/path.go
+++ b/src/server/middleware/path/path.go
@@ -25,9 +25,9 @@ import (
 
 var (
 	defaultRegexps = []*regexp.Regexp{
+		regexp.MustCompile(`^/api/` + api.APIVersion + `/projects/.*/repositories/(.*)/_self/?$`),
 		regexp.MustCompile(`^/api/` + api.APIVersion + `/projects/.*/repositories/(.*)/artifacts/?$`),
 		regexp.MustCompile(`^/api/` + api.APIVersion + `/projects/.*/repositories/(.*)/artifacts/.*$`),
-		regexp.MustCompile(`^/api/` + api.APIVersion + `/projects/.*/repositories/(.*)/?$`),
 	}
 )
 

--- a/src/server/middleware/path/path_test.go
+++ b/src/server/middleware/path/path_test.go
@@ -55,9 +55,9 @@ func Test_escape(t *testing.T) {
 			"/api/v2.0/projects/library/repositories",
 		},
 		{
-			"/api/v2.0/projects/library/repositories/hello/mariadb",
-			args{regexp.MustCompile(`^/api/v2.0/projects/.*/repositories/(.*)`), "/api/v2.0/projects/library/repositories/hello/mariadb"},
-			"/api/v2.0/projects/library/repositories/hello%2Fmariadb",
+			"/api/v2.0/projects/library/repositories/hello/mariadb/_self",
+			args{regexp.MustCompile(`^/api/v2.0/projects/.*/repositories/(.*)/_self`), "/api/v2.0/projects/library/repositories/hello/mariadb/_self"},
+			"/api/v2.0/projects/library/repositories/hello%2Fmariadb/_self",
 		},
 	}
 	for _, tt := range tests {
@@ -70,11 +70,11 @@ func Test_escape(t *testing.T) {
 }
 
 func TestEscapeMiddleware(t *testing.T) {
-	r := httptest.NewRequest(http.MethodGet, "/api/v2.0/projects/library/repositories/hello/mariadb", nil)
+	r := httptest.NewRequest(http.MethodGet, "/api/v2.0/projects/library/repositories/hello/mariadb/_self", nil)
 	w := httptest.NewRecorder()
 
 	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/api/v2.0/projects/library/repositories/hello%2Fmariadb" {
+		if r.URL.Path != "/api/v2.0/projects/library/repositories/hello%2Fmariadb/_self" {
 			t.Errorf("escape middleware failed")
 		}
 		w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
Add "_self" suffix for repository API to avoid conflict

Signed-off-by: Wenkai Yin <yinw@vmware.com>