### PR TITLE
Update the URL checking logic of auth proxy security generator

### DIFF
--- a/src/server/middleware/security/auth_proxy.go
+++ b/src/server/middleware/security/auth_proxy.go
@@ -38,7 +38,7 @@ func (a *authProxy) Generate(req *http.Request) security.Context {
 		return nil
 	}
 	// only support docker login
-	if req.URL.Path != "/service/token" {
+	if !strings.HasPrefix(req.URL.Path, "/v2") {
 		return nil
 	}
 	proxyUserName, proxyPwd, ok := req.BasicAuth()

--- a/src/server/middleware/security/auth_proxy_test.go
+++ b/src/server/middleware/security/auth_proxy_test.go
@@ -60,7 +60,7 @@ func TestAuthProxy(t *testing.T) {
 	})
 
 	// No onboard
-	req, err := http.NewRequest(http.MethodGet, "http://127.0.0.1/service/token", nil)
+	req, err := http.NewRequest(http.MethodGet, "http://127.0.0.1/v2", nil)
 	require.Nil(t, err)
 	req = req.WithContext(internal.WithAuthMode(req.Context(), common.HTTPAuth))
 	req.SetBasicAuth("tokenreview$administrator@vsphere.local", "reviEwt0k3n")


### PR DESCRIPTION
As we don't support bearer token in Harbor 2.0, the URL checking logic in auth proxy security generator should be updated

Signed-off-by: Wenkai Yin <yinw@vmware.com>