### PR TITLE
Handle empty orlist in orm query

### DIFF
--- a/src/lib/orm/query.go
+++ b/src/lib/orm/query.go
@@ -66,7 +66,7 @@ func QuerySetter(ctx context.Context, model interface{}, query *q.Query, ignored
 
 		// or list
 		ol, ok := v.(*q.OrList)
-		if ok {
+		if ok && len(ol.Values) > 0 {
 			qs = qs.Filter(k+"__in", ol.Values...)
 			continue
 		}


### PR DESCRIPTION
Fixes #11267
When caller parse an empty orlist to orm lib, it will parse the empty vaule to beego orm.
But beego will panic if the query string is empty.

Signed-off-by: wang yan <wangyan@vmware.com>