### PR TITLE
Support replicate images with media type application/vnd.docker.distribution.manifest.v1+json

### DIFF
--- a/src/pkg/registry/client.go
+++ b/src/pkg/registry/client.go
@@ -53,6 +53,7 @@ var (
 		v1.MediaTypeImageManifest,
 		schema2.MediaTypeManifest,
 		schema1.MediaTypeSignedManifest,
+		schema1.MediaTypeManifest,
 	}
 )
 
@@ -473,7 +474,7 @@ func (c *client) Copy(srcRepo, srcRef, dstRepo, dstRef string, override bool) er
 		// manifest or index
 		case v1.MediaTypeImageIndex, manifestlist.MediaTypeManifestList,
 			v1.MediaTypeImageManifest, schema2.MediaTypeManifest,
-			schema1.MediaTypeSignedManifest:
+			schema1.MediaTypeSignedManifest, schema1.MediaTypeManifest:
 			if err = c.Copy(srcRepo, digest, dstRepo, digest, false); err != nil {
 				return err
 			}

--- a/src/replication/transfer/image/transfer.go
+++ b/src/replication/transfer/image/transfer.go
@@ -230,7 +230,7 @@ func (t *transfer) copyContent(content distribution.Descriptor, srcRepo, dstRepo
 	// the contents it contains are a few manifests/indexes
 	case v1.MediaTypeImageIndex, manifestlist.MediaTypeManifestList,
 		v1.MediaTypeImageManifest, schema2.MediaTypeManifest,
-		schema1.MediaTypeSignedManifest:
+		schema1.MediaTypeSignedManifest, schema1.MediaTypeManifest:
 		// as using digest as the reference, so set the override to true directly
 		return t.copyArtifact(srcRepo, digest, dstRepo, digest, true)
 	// handle foreign layer


### PR DESCRIPTION
Fixes #11272, support replicate images with media type application/vnd.docker.distribution.manifest.v1+json

Signed-off-by: Wenkai Yin <yinw@vmware.com>