### PR TITLE
append pull permission for push policy

### DIFF
--- a/src/common/security/robot/robot.go
+++ b/src/common/security/robot/robot.go
@@ -1,6 +1,7 @@
 package robot
 
 import (
+	"github.com/goharbor/harbor/src/common/rbac"
 	"github.com/goharbor/harbor/src/pkg/permission/types"
 )
 
@@ -40,8 +41,11 @@ func filterPolicies(namespace types.Namespace, policies []*types.Policy) []*type
 	for _, policy := range policies {
 		if types.ResourceAllowedInNamespace(policy.Resource, namespace) {
 			results = append(results, policy)
+			// give the PUSH action a pull access
+			if policy.Action == rbac.ActionPush {
+				results = append(results, &types.Policy{Resource: policy.Resource, Action: rbac.ActionPull})
+			}
 		}
 	}
-
 	return results
 }

--- a/src/common/security/robot/robot_test.go
+++ b/src/common/security/robot/robot_test.go
@@ -44,12 +44,12 @@ func TestGetPolicies(t *testing.T) {
 
 func TestNewRobot(t *testing.T) {
 	policies := []*types.Policy{
-		{Resource: "/project/1/repository", Action: "pull"},
+		{Resource: "/project/1/repository", Action: "push"},
 		{Resource: "/project/1/repository", Action: "scanner-pull"},
 		{Resource: "/project/library/repository", Action: "pull"},
 		{Resource: "/project/library/repository", Action: "push"},
 	}
 
 	robot := NewRobot("test", rbac.NewProjectNamespace(1), policies)
-	assert.Len(t, robot.GetPolicies(), 2)
+	assert.Len(t, robot.GetPolicies(), 3)
 }

--- a/tests/apitests/python/library/artifact.py
+++ b/tests/apitests/python/library/artifact.py
@@ -82,6 +82,7 @@ class Artifact(base.Base, object):
             if (timeout_count == 0):
                 break
             artifact = self.get_reference_info(project_name, repo_name, reference, **kwargs)
+            print "artifact", artifact
             scan_status = artifact[0].scan_overview['application/vnd.scanner.adapter.vuln.report.harbor+json; version=1.0']["scan_status"]
             if scan_status == expected_scan_status:
                 return


### PR DESCRIPTION
Fixes #11225
As registry changes to basic auth, the push action lost the pull permission.
Add it in the robot security context.

Signed-off-by: wang yan <wangyan@vmware.com>