### PR TITLE
give the username to anonymous when to pull public resource without a…

### DIFF
--- a/src/controller/event/topic.go
+++ b/src/controller/event/topic.go
@@ -168,6 +168,13 @@ func (p *PullArtifactEvent) ResolveToAuditLog() (*model.AuditLog, error) {
 			p.Artifact.RepositoryName, p.Tags[0])
 	}
 
+	// for pull public resource
+	if p.Operator == "" {
+		auditLog.Username = "anonymous"
+	} else {
+		auditLog.Username = p.Operator
+	}
+
 	return auditLog, nil
 }
 


### PR DESCRIPTION
…uthN

For pull a public resource, there is no need to login, give the access name to anonymous in the audit logs

Signed-off-by: wang yan <wangyan@vmware.com>