### PR TITLE
Fix bugs of replication

### DIFF
--- a/src/common/api/base.go
+++ b/src/common/api/base.go
@@ -193,12 +193,11 @@ func (b *BaseAPI) ParseAndHandleError(text string, err error) {
 	if err == nil {
 		return
 	}
-	log.Errorf("%s: %v", text, err)
 	if e, ok := err.(*commonhttp.Error); ok {
-		b.RenderError(e.Code, e.Message)
+		b.RenderError(e.Code, fmt.Sprintf("%s: %s", text, e.Message))
 		return
 	}
-	b.SendInternalServerError(errors.New(""))
+	b.SendInternalServerError(fmt.Errorf("%s: %v", text, err))
 }
 
 // SendUnAuthorizedError sends unauthorized error to the client.
@@ -226,7 +225,7 @@ func (b *BaseAPI) SendBadRequestError(err error) {
 // When you send an internal server error  to the client, you expect user to check the log
 // to find out the root cause.
 func (b *BaseAPI) SendInternalServerError(err error) {
-	b.RenderError(http.StatusInternalServerError, http.StatusText(http.StatusInternalServerError))
+	b.RenderError(http.StatusInternalServerError, err.Error())
 }
 
 // SendForbiddenError sends forbidden error to the client.

--- a/src/core/api/registry.go
+++ b/src/core/api/registry.go
@@ -416,7 +416,7 @@ func (t *RegistryAPI) GetInfo() {
 	}
 	info, err := adp.Info()
 	if err != nil {
-		t.SendInternalServerError(fmt.Errorf("failed to get registry info %d: %v", id, err))
+		t.ParseAndHandleError(fmt.Sprintf("failed to get registry info %d", id), err)
 		return
 	}
 	// currently, only the local Harbor registry supports the event based trigger, append it here

--- a/src/jobservice/job/impl/replication/scheduler.go
+++ b/src/jobservice/job/impl/replication/scheduler.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/goharbor/harbor/src/common/api"
 	common_http "github.com/goharbor/harbor/src/common/http"
 	"github.com/goharbor/harbor/src/common/http/modifier/auth"
 	"github.com/goharbor/harbor/src/jobservice/job"
@@ -56,7 +57,7 @@ func (s *Scheduler) Run(ctx job.Context, params job.Parameters) error {
 	logger := ctx.GetLogger()
 
 	url := params["url"].(string)
-	url = fmt.Sprintf("%s/api/replication/executions?trigger=%s", url, model.TriggerTypeScheduled)
+	url = fmt.Sprintf("%s/api/%s/replication/executions?trigger=%s", url, api.APIVersion, model.TriggerTypeScheduled)
 	policyID := (int64)(params["policy_id"].(float64))
 	cred := auth.NewSecretAuthorizer(os.Getenv("JOBSERVICE_SECRET"))
 	client := common_http.NewClient(&http.Client{

--- a/src/replication/policy/scheduler/scheduler.go
+++ b/src/replication/policy/scheduler/scheduler.go
@@ -16,7 +16,7 @@ package scheduler
 
 import (
 	"fmt"
-	"net/http"
+	"strings"
 	"time"
 
 	commonHttp "github.com/goharbor/harbor/src/common/http"
@@ -104,7 +104,8 @@ func (s *scheduler) Unschedule(policyID int64) error {
 		if err = s.jobservice.PostAction(sj.JobID, job.JobActionStop); err != nil {
 			// if the job specified by jobID is not found in jobservice, just delete
 			// the record from database
-			if e, ok := err.(*commonHttp.Error); !ok || e.Code != http.StatusNotFound {
+			if e, ok := err.(*commonHttp.Error); !ok ||
+				!strings.Contains(e.Message, "no valid periodic job policy found") {
 				return err
 			}
 			log.Debugf("the stop action for schedule job %s submitted to the jobservice", sj.JobID)


### PR DESCRIPTION
1. In Harbor 2.0, the replication isn't supported between instances with different versions, this commit returns the 404 error when trying to get the registry info whose version is different with the current one
2. Bump up the version of API used in replicatoin scheduler job
3. Check the error message to determine whether the job exists or not in jobservice when unschedule a job

Signed-off-by: Wenkai Yin <yinw@vmware.com>