### PR TITLE
Iterate the link header when listing artifact

### DIFF
--- a/src/replication/adapter/harbor/image_registry.go
+++ b/src/replication/adapter/harbor/image_registry.go
@@ -149,7 +149,7 @@ func (a *adapter) listArtifacts(repository string, filters []*model.Filter) ([]*
 	url := fmt.Sprintf("%s/api/%s/projects/%s/repositories/%s/artifacts?with_label=true",
 		a.getURL(), api.APIVersion, project, repository)
 	artifacts := []*artifact.Artifact{}
-	if err := a.client.Get(url, &artifacts); err != nil {
+	if err := a.client.GetAndIteratePagination(url, &artifacts); err != nil {
 		return nil, err
 	}
 	var arts []*model.Artifact


### PR DESCRIPTION
Fixes #11315
When specify no pagination in listing artifact request, the go-swagger will set the default value for them, so we need to iterate the link header to get all of artifacts

Signed-off-by: Wenkai Yin <yinw@vmware.com>