### PR TITLE
Add "order by" clause to avoid the duplicat rows

### DIFF
--- a/src/pkg/artifact/dao/dao.go
+++ b/src/pkg/artifact/dao/dao.go
@@ -97,6 +97,7 @@ func (d *dao) List(ctx context.Context, query *q.Query) ([]*Artifact, error) {
 	if err != nil {
 		return nil, err
 	}
+	qs = qs.OrderBy("-PushTime", "ID")
 	if _, err = qs.All(&artifacts); err != nil {
 		return nil, err
 	}

--- a/src/pkg/repository/dao/dao.go
+++ b/src/pkg/repository/dao/dao.go
@@ -68,6 +68,7 @@ func (d *dao) List(ctx context.Context, query *q.Query) ([]*models.RepoRecord, e
 	if err != nil {
 		return nil, err
 	}
+	qs = qs.OrderBy("-CreationTime", "RepositoryID")
 	if _, err = qs.All(&repositories); err != nil {
 		return nil, err
 	}

--- a/src/pkg/tag/dao/dao.go
+++ b/src/pkg/tag/dao/dao.go
@@ -71,6 +71,7 @@ func (d *dao) List(ctx context.Context, query *q.Query) ([]*tag.Tag, error) {
 	if err != nil {
 		return nil, err
 	}
+	qs = qs.OrderBy("-PushTime", "ID")
 	if _, err = qs.All(&tags); err != nil {
 		return nil, err
 	}

--- a/tests/apitests/python/test_create_delete_tag.py
+++ b/tests/apitests/python/test_create_delete_tag.py
@@ -80,8 +80,8 @@ class TestProjects(unittest.TestCase):
         artifact = self.artifact.get_reference_info(TestProjects.project_name, self.repo_name, tag, **TestProjects.USER_CLIENT)
 
         #6. Verify the image(IA) contains tag named 1.0;
-        self.assertEqual(artifact[0].tags[0].name, tag)
-        self.assertEqual(artifact[0].tags[1].name, "1.0")
+        self.assertEqual(artifact[0].tags[0].name, "1.0")
+        self.assertEqual(artifact[0].tags[1].name, tag)
 
         #7. Delete the tag(1.0) from image(IA);
         self.artifact.delete_tag(TestProjects.project_name, self.repo_name, tag, "1.0",**TestProjects.USER_CLIENT)


### PR DESCRIPTION
Add "order by" clause to avoid the duplicat rows: https://www.postgresql.org/docs/9.6/queries-limit.html

Signed-off-by: Wenkai Yin <yinw@vmware.com>