### PR TITLE
Not checking for registry credentials in v2auth

### DIFF
--- a/src/server/middleware/v2auth/auth.go
+++ b/src/server/middleware/v2auth/auth.go
@@ -36,10 +36,6 @@ type reqChecker struct {
 }
 
 func (rc *reqChecker) check(req *http.Request) error {
-	if rc.hasRegistryCred(req) {
-		// TODO: May consider implement a local authorizer for registry, more details see #10602
-		return nil
-	}
 	securityCtx, ok := security.FromContext(req.Context())
 	if !ok {
 		return fmt.Errorf("the security context got from request is nil")
@@ -86,12 +82,6 @@ func (rc *reqChecker) projectID(name string) (int64, error) {
 		return 0, fmt.Errorf("project not found, name: %s", name)
 	}
 	return p.ProjectID, nil
-}
-
-func (rc *reqChecker) hasRegistryCred(req *http.Request) bool {
-	u, p, ok := req.BasicAuth()
-	regUser, regPass := config.RegistryCredential()
-	return ok && u == regUser && p == regPass
 }
 
 func getAction(req *http.Request) rbac.Action {

--- a/src/server/middleware/v2auth/auth_test.go
+++ b/src/server/middleware/v2auth/auth_test.go
@@ -153,27 +153,16 @@ func TestMiddleware(t *testing.T) {
 
 	ctx1 := lib.WithArtifactInfo(baseCtx, ar1)
 	ctx2 := lib.WithArtifactInfo(baseCtx, ar2)
-	ctx2x := lib.WithArtifactInfo(context.Background(), ar2) // no securityCtx
 	ctx3 := lib.WithArtifactInfo(baseCtx, ar3)
 	ctx4 := lib.WithArtifactInfo(baseCtx, ar4)
 	ctx5 := lib.WithArtifactInfo(baseCtx, ar5)
 	req1a, _ := http.NewRequest(http.MethodGet, "/v2/project_1/hello-world/manifest/v1", nil)
 	req1b, _ := http.NewRequest(http.MethodDelete, "/v2/project_1/hello-world/manifest/v1", nil)
 	req2, _ := http.NewRequest(http.MethodGet, "/v2/library/ubuntu/manifest/14.04", nil)
-	req2x, _ := http.NewRequest(http.MethodGet, "/v2/library/ubuntu/manifest/14.04", nil)
 	req3, _ := http.NewRequest(http.MethodGet, "/v2/_catalog", nil)
 	req4, _ := http.NewRequest(http.MethodPost, "/v2/project_1/ubuntu/blobs/uploads/mount=?mount=sha256:08e4a417ff4e3913d8723a05cc34055db01c2fd165b588e049c5bad16ce6094f&from=project_2/ubuntu", nil)
 	req5, _ := http.NewRequest(http.MethodPost, "/v2/project_1/ubuntu/blobs/uploads/mount=?mount=sha256:08e4a417ff4e3913d8723a05cc34055db01c2fd165b588e049c5bad16ce6094f&from=project_3/ubuntu", nil)
 	req6, _ := http.NewRequest(http.MethodPost, "/v2/project_1/ubuntu/blobs/uploads/mount=?mount=sha256:08e4a417ff4e3913d8723a05cc34055db01c2fd165b588e049c5bad16ce6094f&from=project_0/ubuntu", nil)
-
-	os.Setenv("REGISTRY_CREDENTIAL_USERNAME", "testuser")
-	os.Setenv("REGISTRY_CREDENTIAL_PASSWORD", "testpassword")
-	defer func() {
-		os.Unsetenv("REGISTRY_CREDENTIAL_USERNAME")
-		os.Unsetenv("REGISTRY_CREDENTIAL_PASSWORD")
-	}()
-
-	req2x.SetBasicAuth("testuser", "testpassword")
 
 	cases := []struct {
 		input  *http.Request
@@ -190,10 +179,6 @@ func TestMiddleware(t *testing.T) {
 		{
 			input:  req2.WithContext(ctx2),
 			status: http.StatusUnauthorized,
-		},
-		{
-			input:  req2x.WithContext(ctx2x),
-			status: http.StatusOK,
 		},
 		{
 			input:  req3.WithContext(baseCtx),


### PR DESCRIPTION
That was added to support core process sending request to `/v2/xxx`.
It's no longer needed after reworking the flow.
This commit removes this.

Fixes #10602, as it's not a case we need to support for now.

Signed-off-by: Daniel Jiang <jiangd@vmware.com>