### PR TITLE
fix(scan): add scanner name as prefix for name of the robot when submit scan job

### DIFF
--- a/src/controller/scan/base_controller.go
+++ b/src/controller/scan/base_controller.go
@@ -509,7 +509,7 @@ func (bc *basicController) GetStats(requester string) (*all.Stats, error) {
 }
 
 // makeRobotAccount creates a robot account based on the arguments for scanning.
-func (bc *basicController) makeRobotAccount(projectID int64, repository string) (*model.Robot, error) {
+func (bc *basicController) makeRobotAccount(projectID int64, repository string, registration *scanner.Registration) (*model.Robot, error) {
 	// Use uuid as name to avoid duplicated entries.
 	UUID, err := bc.uuid()
 	if err != nil {
@@ -518,7 +518,7 @@ func (bc *basicController) makeRobotAccount(projectID int64, repository string) 
 
 	resource := rbac.NewProjectNamespace(projectID).Resource(rbac.ResourceRepository)
 	robotReq := &model.RobotCreate{
-		Name:        UUID,
+		Name:        fmt.Sprintf("%s-%s", registration.Name, UUID),
 		Description: "for scan",
 		ProjectID:   projectID,
 		Access: []*types.Policy{
@@ -549,7 +549,7 @@ func (bc *basicController) launchScanJob(trackID string, artifact *ar.Artifact, 
 		return "", errors.Wrap(err, "scan controller: launch scan job")
 	}
 
-	robot, err := bc.makeRobotAccount(artifact.ProjectID, artifact.RepositoryName)
+	robot, err := bc.makeRobotAccount(artifact.ProjectID, artifact.RepositoryName, registration)
 	if err != nil {
 		return "", errors.Wrap(err, "scan controller: launch scan job")
 	}

--- a/src/controller/scan/base_controller_test.go
+++ b/src/controller/scan/base_controller_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/goharbor/harbor/src/common"
 	cj "github.com/goharbor/harbor/src/common/job"
 	jm "github.com/goharbor/harbor/src/common/job/models"
 	"github.com/goharbor/harbor/src/common/rbac"
@@ -173,7 +172,7 @@ func (suite *ControllerTestSuite) SetupSuite() {
 		{Resource: types.Resource(resource), Action: rbac.ActionScannerPull},
 	}
 
-	rname := "the-uuid-123"
+	rname := fmt.Sprintf("%s-%s", suite.registration.Name, "the-uuid-123")
 	account := &model.RobotCreate{
 		Name:        rname,
 		Description: "for scan",
@@ -182,7 +181,7 @@ func (suite *ControllerTestSuite) SetupSuite() {
 	}
 	rc.On("CreateRobotAccount", account).Return(&model.Robot{
 		ID:          1,
-		Name:        common.RobotPrefix + rname,
+		Name:        rname,
 		Token:       "robot-account",
 		Description: "for scan",
 		ProjectID:   suite.artifact.ProjectID,
@@ -192,7 +191,7 @@ func (suite *ControllerTestSuite) SetupSuite() {
 	req := &v1.ScanRequest{
 		Registry: &v1.Registry{
 			URL:           "https://core.com",
-			Authorization: "Basic " + base64.StdEncoding.EncodeToString([]byte(common.RobotPrefix+"the-uuid-123:robot-account")),
+			Authorization: "Basic " + base64.StdEncoding.EncodeToString([]byte(rname+":robot-account")),
 		},
 		Artifact: &v1.Artifact{
 			NamespaceID: suite.artifact.ProjectID,


### PR DESCRIPTION
Scanner name and uuid splited by `-` not `:` because of `:` is the separator of the basic auth.

Closes #11198

Signed-off-by: He Weiwei <hweiwei@vmware.com>