### PR TITLE
Fix merge scan summary

### DIFF
--- a/src/controller/scan/base_controller_test.go
+++ b/src/controller/scan/base_controller_test.go
@@ -53,8 +53,9 @@ type ControllerTestSuite struct {
 	artifact     *artifact.Artifact
 	rawReport    string
 
-	ar artifact.Controller
-	c  Controller
+	reportMgr *reporttesting.Manager
+	ar        artifact.Controller
+	c         Controller
 }
 
 // TestController is the entry point of ControllerTestSuite.
@@ -163,6 +164,7 @@ func (suite *ControllerTestSuite) SetupSuite() {
 	mgr.On("Get", "rp-uuid-001").Return(reports[0], nil)
 	mgr.On("UpdateReportData", "rp-uuid-001", suite.rawReport, (int64)(10000)).Return(nil)
 	mgr.On("UpdateStatus", "the-uuid-123", "Success", (int64)(10000)).Return(nil)
+	suite.reportMgr = mgr
 
 	rc := &MockRobotController{}
 
@@ -286,6 +288,60 @@ func (suite *ControllerTestSuite) TestScanControllerGetScanLog() {
 		success = len(bytes) > 0
 		return
 	})
+}
+
+func (suite *ControllerTestSuite) TestScanControllerGetMultiScanLog() {
+	{
+		// Both success
+		suite.reportMgr.On("Get", "rp-uuid-002").Return(&scan.Report{
+			ID:               12,
+			UUID:             "rp-uuid-002",
+			Digest:           "digest-code",
+			RegistrationUUID: "uuid001",
+			MimeType:         "application/vnd.scanner.adapter.vuln.report.harbor+json; version=1.0",
+			Status:           "Success",
+			StatusCode:       3,
+			TrackID:          "the-uuid-124",
+			JobID:            "the-job-id",
+			StatusRevision:   time.Now().Unix(),
+			Report:           suite.rawReport,
+			StartTime:        time.Now(),
+			EndTime:          time.Now().Add(2 * time.Second),
+		}, nil).Once()
+
+		bytes, err := suite.c.GetScanLog(base64.StdEncoding.EncodeToString([]byte("rp-uuid-001|rp-uuid-002")))
+		suite.Nil(err)
+		suite.NotEmpty(bytes)
+		suite.Contains(string(bytes), "Logs of report rp-uuid-001")
+		suite.Contains(string(bytes), "Logs of report rp-uuid-002")
+	}
+
+	{
+		// One successfully, one failed
+		suite.reportMgr.On("Get", "rp-uuid-002").Return(nil, fmt.Errorf("error")).Once()
+		bytes, err := suite.c.GetScanLog(base64.StdEncoding.EncodeToString([]byte("rp-uuid-001|rp-uuid-002")))
+		suite.Nil(err)
+		suite.NotEmpty(bytes)
+		suite.NotContains(string(bytes), "Logs of report rp-uuid-001")
+	}
+
+	{
+		// Both failed
+		suite.reportMgr.On("Get", "rp-uuid-002").Return(nil, fmt.Errorf("error")).Once()
+		suite.reportMgr.On("Get", "rp-uuid-003").Return(nil, fmt.Errorf("error")).Once()
+		bytes, err := suite.c.GetScanLog(base64.StdEncoding.EncodeToString([]byte("rp-uuid-002|rp-uuid-003")))
+		suite.Error(err)
+		suite.Empty(bytes)
+	}
+
+	{
+		// Both empty
+		suite.reportMgr.On("Get", "rp-uuid-002").Return(nil, nil).Once()
+		suite.reportMgr.On("Get", "rp-uuid-003").Return(nil, nil).Once()
+		bytes, err := suite.c.GetScanLog(base64.StdEncoding.EncodeToString([]byte("rp-uuid-002|rp-uuid-003")))
+		suite.Nil(err)
+		suite.Empty(bytes)
+	}
 }
 
 // TestScanControllerHandleJobHooks ...

--- a/src/pkg/scan/vuln/summary_test.go
+++ b/src/pkg/scan/vuln/summary_test.go
@@ -1,0 +1,149 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vuln
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/goharbor/harbor/src/jobservice/job"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_mergeReportID(t *testing.T) {
+	type args struct {
+		r1 string
+		r2 string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{"1|2", args{"1", "2"}, base64.StdEncoding.EncodeToString([]byte("1|2"))},
+		{"1|2|3", args{base64.StdEncoding.EncodeToString([]byte("1|2")), "3"}, base64.StdEncoding.EncodeToString([]byte("1|2|3"))},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := mergeReportID(tt.args.r1, tt.args.r2); got != tt.want {
+				t.Errorf("mergeReportID() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_mergeSeverity(t *testing.T) {
+	type args struct {
+		s1 Severity
+		s2 Severity
+	}
+	tests := []struct {
+		name string
+		args args
+		want Severity
+	}{
+		{"empty string and none", args{Severity(""), None}, None},
+		{"none and empty string", args{None, Severity("")}, None},
+		{"none and low", args{None, Low}, Low},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := mergeSeverity(tt.args.s1, tt.args.s2); got != tt.want {
+				t.Errorf("mergeSeverity() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_mergeScanStatus(t *testing.T) {
+	errorStatus := job.ErrorStatus.String()
+	runningStatus := job.RunningStatus.String()
+	successStatus := job.SuccessStatus.String()
+
+	type args struct {
+		s1 string
+		s2 string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{"running and error", args{runningStatus, errorStatus}, runningStatus},
+		{"running and success", args{runningStatus, successStatus}, runningStatus},
+		{"running and running", args{runningStatus, runningStatus}, runningStatus},
+		{"success and error", args{successStatus, errorStatus}, successStatus},
+		{"success and success", args{successStatus, successStatus}, successStatus},
+		{"error and error", args{errorStatus, errorStatus}, errorStatus},
+		{"error and empty string", args{errorStatus, ""}, errorStatus},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := mergeScanStatus(tt.args.s1, tt.args.s2); got != tt.want {
+				t.Errorf("mergeScanStatus() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMergeVulnerabilitySummary(t *testing.T) {
+	assert := assert.New(t)
+	v1 := VulnerabilitySummary{
+		Total:   1,
+		Fixable: 1,
+		Summary: map[Severity]int{Low: 1},
+	}
+
+	r := v1.Merge(&VulnerabilitySummary{
+		Total:   1,
+		Fixable: 1,
+		Summary: map[Severity]int{Low: 1, High: 1},
+	})
+
+	assert.Equal(2, r.Total)
+	assert.Equal(2, r.Fixable)
+	assert.Len(r.Summary, 2)
+	assert.Equal(2, r.Summary[Low])
+	assert.Equal(1, r.Summary[High])
+}
+
+func TestMergeNativeReportSummary(t *testing.T) {
+	assert := assert.New(t)
+	errorStatus := job.ErrorStatus.String()
+	runningStatus := job.RunningStatus.String()
+
+	v1 := VulnerabilitySummary{
+		Total:   1,
+		Fixable: 1,
+		Summary: map[Severity]int{Low: 1},
+	}
+
+	n1 := NativeReportSummary{
+		ScanStatus: runningStatus,
+		Severity:   Low,
+		TotalCount: 1,
+		Summary:    &v1,
+	}
+
+	r := n1.Merge(&NativeReportSummary{
+		ScanStatus: errorStatus,
+		Severity:   Severity(""),
+		TotalCount: 1,
+	})
+
+	assert.Equal(runningStatus, r.ScanStatus)
+	assert.Equal(Low, r.Severity)
+	assert.Equal(v1, *r.Summary)
+}

--- a/src/portal/src/i18n/lang/en-us-lang.json
+++ b/src/portal/src/i18n/lang/en-us-lang.json
@@ -992,7 +992,7 @@
         "CHART": {
             "SCANNING_TIME": "Scan completed time:",
             "SCANNING_PERCENT": "Scan completed percent:",
-            "SCANNING_PERCENT_EXPLAIN": "(Scan completed percentage is calculated as # of successfully scanned images / total number of images referenced within the image index not including the index file itself and the images that do not support being scanned.)",
+            "SCANNING_PERCENT_EXPLAIN": "Scan completed percentage is calculated as # of successfully scanned images / total number of images referenced within the image index.",
             "TOOLTIPS_TITLE": "{{totalVulnerability}} of {{totalPackages}} {{package}} have known {{vulnerability}}.",
             "TOOLTIPS_TITLE_SINGULAR": "{{totalVulnerability}} of {{totalPackages}} {{package}} has known {{vulnerability}}.",
             "TOOLTIPS_TITLE_ZERO": "No recognizable vulnerability found"

--- a/src/portal/src/i18n/lang/es-es-lang.json
+++ b/src/portal/src/i18n/lang/es-es-lang.json
@@ -991,7 +991,7 @@
         "CHART": {
             "SCANNING_TIME": "Scan completed time:",
             "SCANNING_PERCENT": "Scan completed percent:",
-            "SCANNING_PERCENT_EXPLAIN": "(Scan completed percentage is calculated as # of successfully scanned images / total number of images referenced within the image index not including the index file itself and the images that do not support being scanned.)",
+            "SCANNING_PERCENT_EXPLAIN": "Scan completed percentage is calculated as # of successfully scanned images / total number of images referenced within the image index.",
             "TOOLTIPS_TITLE": "{{totalVulnerability}} of {{totalPackages}} {{package}} have known {{vulnerability}}.",
             "TOOLTIPS_TITLE_SINGULAR": "{{totalVulnerability}} of {{totalPackages}} {{package}} has known {{vulnerability}}.",
             "TOOLTIPS_TITLE_ZERO": "No recognizable vulnerability found"

--- a/src/portal/src/i18n/lang/fr-fr-lang.json
+++ b/src/portal/src/i18n/lang/fr-fr-lang.json
@@ -964,7 +964,7 @@
         "CHART": {
             "SCANNING_TIME": "Temps d'analyse complète :",
             "SCANNING_PERCENT": "Scan completed percent:",
-            "SCANNING_PERCENT_EXPLAIN": "(Scan completed percentage is calculated as # of successfully scanned images / total number of images referenced within the image index not including the index file itself and the images that do not support being scanned.)",
+            "SCANNING_PERCENT_EXPLAIN": "Scan completed percentage is calculated as # of successfully scanned images / total number of images referenced within the image index.",
             "TOOLTIPS_TITLE": "{{totalVulnerability}} de {{totalPackages}} {{package}} ont des {{vulnerability}} connues.",
             "TOOLTIPS_TITLE_SINGULAR": "{{totalVulnerability}} de {{totalPackages}} {{package}} a des {{vulnerability}} connues.",
             "TOOLTIPS_TITLE_ZERO": "No recognizable vulnerability found"

--- a/src/portal/src/i18n/lang/pt-br-lang.json
+++ b/src/portal/src/i18n/lang/pt-br-lang.json
@@ -987,7 +987,7 @@
         "CHART": {
             "SCANNING_TIME": "Tempo de conclusão da análise:",
             "SCANNING_PERCENT": "Scan completed percent:",
-            "SCANNING_PERCENT_EXPLAIN": "(Scan completed percentage is calculated as # of successfully scanned images / total number of images referenced within the image index not including the index file itself and the images that do not support being scanned.)",
+            "SCANNING_PERCENT_EXPLAIN": "Scan completed percentage is calculated as # of successfully scanned images / total number of images referenced within the image index.",
             "TOOLTIPS_TITLE": "{{totalVulnerability}} de {{totalPackages}} {{package}} possuem {{vulnerability}}.",
             "TOOLTIPS_TITLE_SINGULAR": "{{totalVulnerability}} de {{totalPackages}} {{package}} possuem {{vulnerability}}.",
             "TOOLTIPS_TITLE_ZERO": "No recognizable vulnerability found"

--- a/src/portal/src/i18n/lang/tr-tr-lang.json
+++ b/src/portal/src/i18n/lang/tr-tr-lang.json
@@ -992,7 +992,7 @@
         "CHART": {
             "SCANNING_TIME": "Tarama tamamlanma zamanı:",
             "SCANNING_PERCENT": "Scan completed percent:",
-            "SCANNING_PERCENT_EXPLAIN": "(Scan completed percentage is calculated as # of successfully scanned images / total number of images referenced within the image index not including the index file itself and the images that do not support being scanned.)",
+            "SCANNING_PERCENT_EXPLAIN": "Scan completed percentage is calculated as # of successfully scanned images / total number of images referenced within the image index.",
             "TOOLTIPS_TITLE": "{{totalVulnerability}} 'nın {{totalPackages}} {{package}} bilinen {{vulnerability}}.",
             "TOOLTIPS_TITLE_SINGULAR": "{{totalVulnerability}} 'nın {{totalPackages}} {{package}} bilinen {{vulnerability}}.",
             "TOOLTIPS_TITLE_ZERO": "No recognizable vulnerability found"

--- a/src/portal/src/i18n/lang/zh-cn-lang.json
+++ b/src/portal/src/i18n/lang/zh-cn-lang.json
@@ -991,7 +991,7 @@
         "CHART": {
             "SCANNING_TIME": "扫描完成时间:",
             "SCANNING_PERCENT": "扫描完成度:",
-            "SCANNING_PERCENT_EXPLAIN": "（扫描完成度是扫描成功的镜像数与总共需要扫描的镜像数的比值。总共需要的扫描的镜像不包含 Index 本身和不支持扫描的镜像。）",
+            "SCANNING_PERCENT_EXPLAIN": "扫描完成度是扫描成功的镜像数与总共需要扫描的镜像数的比值，总共需要的扫描的镜像不包含 Index 。",
             "TOOLTIPS_TITLE": "{{totalPackages}}个{{package}}中的{{totalVulnerability}}个含有{{vulnerability}}。",
             "TOOLTIPS_TITLE_SINGULAR": "{{totalPackages}}个{{package}}中的{{totalVulnerability}}个含有{{vulnerability}}。",
             "TOOLTIPS_TITLE_ZERO": "没有发现可识别的漏洞"


### PR DESCRIPTION
1. Fix ScanStatus when merge NativeReportSummary

      -  Running and success status is high priority when merge ScanStatus of
    NativeReportSummary, otherwise chose the bigger status.
      -  Merge scan logs of referenced artifacts when get the scan logs of
    image index.

2. Fix the annotation for the scan completed percent in scan overview