### PR TITLE
Add "_self" suffix after reposiotry name for all APIs that contain repository

### DIFF
--- a/api/v2.0/swagger.yaml
+++ b/api/v2.0/swagger.yaml
@@ -16,6 +16,10 @@ consumes:
 securityDefinitions:
   basicAuth:
     type: basic
+# the "_self" suffix in the paths is used to avoid the conflict of repository name and URL path
+# e.g. the repository name can be "library/artifacts", we cannot distinguish the URL
+# "GET /projects/{project_name}/repositories/library/artifacts" is getting repository
+# or listing artifacts
 paths:
   /projects/{project_name}/repositories:
     get:
@@ -54,10 +58,6 @@ paths:
           $ref: '#/responses/404'
         '500':
           $ref: '#/responses/500'
-  # the _self suffix here is used to avoid the conflict of repository name and URL path
-  # e.g. the repository name can be "library/artifacts", we cannot distinguish the URL
-  # "GET /projects/{project_name}/repositories/library/artifacts" is getting repository
-  # or listing artifacts
   /projects/{project_name}/repositories/{repository_name}/_self:
     get:
       summary: Get repository
@@ -136,7 +136,7 @@ paths:
           $ref: '#/responses/404'
         '500':
           $ref: '#/responses/500'
-  /projects/{project_name}/repositories/{repository_name}/artifacts:
+  /projects/{project_name}/repositories/{repository_name}/_self/artifacts:
     get:
       summary: List artifacts
       description: List artifacts under the specific project and repository. Except the basic properties, the other supported queries in "q" includes "tags=*" to list only tagged artifacts, "tags=nil" to list only untagged artifacts, "tags=~v" to list artifacts whose tag fuzzy matches "v", "labels=(id1, id2)" to list artifacts that both labels with id1 and id2 are added to
@@ -234,7 +234,7 @@ paths:
           $ref: '#/responses/409'
         '500':
           $ref: '#/responses/500'
-  /projects/{project_name}/repositories/{repository_name}/artifacts/{reference}:
+  /projects/{project_name}/repositories/{repository_name}/_self/artifacts/{reference}:
     get:
       summary: Get the specific artifact
       description: Get the artifact specified by the reference under the project and repository. The reference can be digest or tag.
@@ -316,7 +316,7 @@ paths:
           $ref: '#/responses/404'
         '500':
           $ref: '#/responses/500'
-  /projects/{project_name}/repositories/{repository_name}/artifacts/{reference}/scan:
+  /projects/{project_name}/repositories/{repository_name}/_self/artifacts/{reference}/scan:
     post:
       summary: Scan the artifact
       description: Scan the specified artifact
@@ -339,7 +339,7 @@ paths:
           $ref: '#/responses/404'
         '500':
           $ref: '#/responses/500'
-  /projects/{project_name}/repositories/{repository_name}/artifacts/{reference}/scan/{report_id}/log:
+  /projects/{project_name}/repositories/{repository_name}/_self/artifacts/{reference}/scan/{report_id}/log:
     get:
       summary: Get the log of the scan report
       description: Get the log of the scan report
@@ -371,7 +371,7 @@ paths:
           $ref: '#/responses/404'
         '500':
           $ref: '#/responses/500'
-  /projects/{project_name}/repositories/{repository_name}/artifacts/{reference}/tags:
+  /projects/{project_name}/repositories/{repository_name}/_self/artifacts/{reference}/tags:
     post:
       summary: Create tag
       description: Create a tag for the specified artifact
@@ -404,7 +404,7 @@ paths:
           $ref: '#/responses/409'
         '500':
           $ref: '#/responses/500'
-  /projects/{project_name}/repositories/{repository_name}/artifacts/{reference}/tags/{tag_name}:
+  /projects/{project_name}/repositories/{repository_name}/_self/artifacts/{reference}/tags/{tag_name}:
     delete:
       summary: Delete tag
       description: Delete the tag of the specified artifact
@@ -428,7 +428,7 @@ paths:
           $ref: '#/responses/404'
         '500':
           $ref: '#/responses/500'
-  /projects/{project_name}/repositories/{repository_name}/artifacts/{reference}/additions/{addition}:
+  /projects/{project_name}/repositories/{repository_name}/_self/artifacts/{reference}/additions/{addition}:
     get:
       summary: Get the addition of the specific artifact
       description: Get the addition of the artifact specified by the reference under the project and repository.
@@ -465,7 +465,7 @@ paths:
           $ref: '#/responses/404'
         '500':
           $ref: '#/responses/500'
-  /projects/{project_name}/repositories/{repository_name}/artifacts/{reference}/labels:
+  /projects/{project_name}/repositories/{repository_name}/_self/artifacts/{reference}/labels:
     post:
       summary: Add label to artifact
       description: Add label to the specified artiact.
@@ -498,7 +498,7 @@ paths:
           $ref: '#/responses/409'
         '500':
           $ref: '#/responses/500'
-  /projects/{project_name}/repositories/{repository_name}/artifacts/{reference}/labels/{label_id}:
+  /projects/{project_name}/repositories/{repository_name}/_self/artifacts/{reference}/labels/{label_id}:
     delete:
       summary: Remove label from artifact
       description: Remove the label from the specified artiact.
@@ -529,7 +529,7 @@ paths:
           $ref: '#/responses/409'
         '500':
           $ref: '#/responses/500'
-  /projects/{project_name}/repositories/{repository_name}/tags:
+  /projects/{project_name}/repositories/{repository_name}/_self/tags:
     get:
       summary: List tags
       description: List tags under the specific project and repository.

--- a/src/controller/artifact/model.go
+++ b/src/controller/artifact/model.go
@@ -39,7 +39,7 @@ func (artifact *Artifact) SetAdditionLink(addition, version string) {
 	}
 
 	projectName, repo := utils.ParseRepository(artifact.RepositoryName)
-	href := fmt.Sprintf("/api/%s/projects/%s/repositories/%s/artifacts/%s/additions/%s", version, projectName, repo, artifact.Digest, addition)
+	href := fmt.Sprintf("/api/%s/projects/%s/repositories/%s/_self/artifacts/%s/additions/%s", version, projectName, repo, artifact.Digest, addition)
 
 	artifact.AdditionLinks[addition] = &AdditionLink{HREF: href, Absolute: false}
 }

--- a/src/pkg/clients/core/image.go
+++ b/src/pkg/clients/core/image.go
@@ -16,11 +16,13 @@ package core
 
 import (
 	"fmt"
+	"github.com/goharbor/harbor/src/common/api"
 	modelsv2 "github.com/goharbor/harbor/src/controller/artifact"
 )
 
 func (c *client) ListAllArtifacts(project, repository string) ([]*modelsv2.Artifact, error) {
-	url := c.buildURL(fmt.Sprintf("/api/v2.0/projects/%s/repositories/%s/artifacts", project, repository)) // should query only tag
+	url := c.buildURL(fmt.Sprintf("/api/%s/projects/%s/repositories/%s/_self/artifacts",
+		api.APIVersion, project, repository)) // should query only tag
 	var arts []*modelsv2.Artifact
 	if err := c.httpclient.GetAndIteratePagination(url, &arts); err != nil {
 		return nil, err
@@ -30,7 +32,8 @@ func (c *client) ListAllArtifacts(project, repository string) ([]*modelsv2.Artif
 
 func (c *client) DeleteArtifact(project, repository, digest string) error {
 	// /projects/{project_name}/repositories/{repository_name}/artifacts/{reference}
-	url := c.buildURL(fmt.Sprintf("/api/v2.0/projects/%s/repositories/%s/artifacts/%s", project, repository, digest))
+	url := c.buildURL(fmt.Sprintf("/api/%s/projects/%s/repositories/%s/_self/artifacts/%s",
+		api.APIVersion, project, repository, digest))
 	return c.httpclient.Delete(url)
 }
 

--- a/src/replication/adapter/harbor/image_registry.go
+++ b/src/replication/adapter/harbor/image_registry.go
@@ -146,7 +146,7 @@ func (a *adapter) listRepositories(project *project, filters []*model.Filter) ([
 
 func (a *adapter) listArtifacts(repository string, filters []*model.Filter) ([]*model.Artifact, error) {
 	project, repository := utils.ParseRepository(repository)
-	url := fmt.Sprintf("%s/api/%s/projects/%s/repositories/%s/artifacts?with_label=true",
+	url := fmt.Sprintf("%s/api/%s/projects/%s/repositories/%s/_self/artifacts?with_label=true",
 		a.getURL(), api.APIVersion, project, repository)
 	artifacts := []*artifact.Artifact{}
 	if err := a.client.GetAndIteratePagination(url, &artifacts); err != nil {

--- a/src/replication/adapter/harbor/image_registry_test.go
+++ b/src/replication/adapter/harbor/image_registry_test.go
@@ -28,7 +28,7 @@ func TestFetchArtifacts(t *testing.T) {
 	server := test.NewServer([]*test.RequestHandlerMapping{
 		{
 			Method:  http.MethodGet,
-			Pattern: "/api/v2.0/projects/library/repositories/hello-world/artifacts",
+			Pattern: "/api/v2.0/projects/library/repositories/hello-world/_self/artifacts",
 			Handler: func(w http.ResponseWriter, r *http.Request) {
 				data := `[
   {

--- a/src/server/middleware/path/path.go
+++ b/src/server/middleware/path/path.go
@@ -26,8 +26,7 @@ import (
 var (
 	defaultRegexps = []*regexp.Regexp{
 		regexp.MustCompile(`^/api/` + api.APIVersion + `/projects/.*/repositories/(.*)/_self/?$`),
-		regexp.MustCompile(`^/api/` + api.APIVersion + `/projects/.*/repositories/(.*)/artifacts/?$`),
-		regexp.MustCompile(`^/api/` + api.APIVersion + `/projects/.*/repositories/(.*)/artifacts/.*$`),
+		regexp.MustCompile(`^/api/` + api.APIVersion + `/projects/.*/repositories/(.*)/_self/.*$`),
 	}
 )
 


### PR DESCRIPTION
Add "_self" suffix for all APIs that contain repository to avoid path conflict

Signed-off-by: Wenkai Yin <yinw@vmware.com>