### PR TITLE
fix(log): correct file and line when use logger

### DIFF
--- a/src/lib/log/context_test.go
+++ b/src/lib/log/context_test.go
@@ -1,0 +1,84 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import (
+	"context"
+	"testing"
+)
+
+func TestGetLogger(t *testing.T) {
+	var (
+		expectedLevel = ErrorLevel.string()
+		expectLine    = "context_test.go:32"
+		expectMsg     = "message"
+	)
+
+	buf := enter()
+	defer exit()
+
+	G(context.TODO()).Errorf("%s", message)
+
+	str := buf.String()
+	if !contains(t, str, expectedLevel, expectLine, expectMsg) {
+		t.Errorf("unexpected message: %s, expected level: %s, expected line: %s, expected message: %s", str, expectedLevel, expectLine, expectMsg)
+	}
+}
+
+func TestGetLoggerWithFields(t *testing.T) {
+	var (
+		expectedLevel = ErrorLevel.string()
+		expectLine    = "context_test.go:50"
+		expectMsg     = "message"
+	)
+
+	buf := enter()
+	defer exit()
+
+	G(context.TODO()).WithFields(Fields{"action": "test"}).Errorf("%s", message)
+
+	str := buf.String()
+	if !contains(t, str, expectedLevel, expectLine, expectMsg) {
+		t.Errorf("unexpected message: %s, expected level: %s, expected line: %s, expected message: %s", str, expectedLevel, expectLine, expectMsg)
+	}
+
+	if !contains(t, str, expectedLevel, expectLine, `action="test"`) {
+		t.Errorf("unexpected message: %s, expected level: %s, expected line: %s, expected message: %s", str, expectedLevel, expectLine, expectMsg)
+	}
+}
+
+func TestWithLogger(t *testing.T) {
+	var (
+		expectedLevel = ErrorLevel.string()
+		expectLine    = "context_test.go:74"
+		expectMsg     = "message"
+	)
+
+	buf := enter()
+	defer exit()
+
+	ctx := WithLogger(context.TODO(), L.WithFields(Fields{"action": "test"}))
+
+	G(ctx).WithFields(Fields{"action": "test"}).Errorf("%s", message)
+
+	str := buf.String()
+	if !contains(t, str, expectedLevel, expectLine, expectMsg) {
+		t.Errorf("unexpected message: %s, expected level: %s, expected line: %s, expected message: %s", str, expectedLevel, expectLine, expectMsg)
+	}
+
+	if !contains(t, str, expectedLevel, expectLine, `action="test"`) {
+		t.Errorf("unexpected message: %s, expected level: %s, expected line: %s, expected message: %s", str, expectedLevel, expectLine, expectMsg)
+	}
+}

--- a/src/lib/log/logger.go
+++ b/src/lib/log/logger.go
@@ -25,7 +25,8 @@ import (
 	"time"
 )
 
-var logger = New(os.Stdout, NewTextFormatter(), WarningLevel, 4)
+// NOTE: the default depth for the logger is 3 so that we can get the correct file and line when use the logger to log message
+var logger = New(os.Stdout, NewTextFormatter(), WarningLevel, 3)
 
 const srcSeparator = "harbor" + string(os.PathSeparator) + "src"
 
@@ -277,52 +278,52 @@ func (l *Logger) getLine() string {
 
 // Debug ...
 func Debug(v ...interface{}) {
-	logger.Debug(v...)
+	logger.WithDepth(4).Debug(v...)
 }
 
 // Debugf ...
 func Debugf(format string, v ...interface{}) {
-	logger.Debugf(format, v...)
+	logger.WithDepth(4).Debugf(format, v...)
 }
 
 // Info ...
 func Info(v ...interface{}) {
-	logger.Info(v...)
+	logger.WithDepth(4).Info(v...)
 }
 
 // Infof ...
 func Infof(format string, v ...interface{}) {
-	logger.Infof(format, v...)
+	logger.WithDepth(4).Infof(format, v...)
 }
 
 // Warning  ...
 func Warning(v ...interface{}) {
-	logger.Warning(v...)
+	logger.WithDepth(4).Warning(v...)
 }
 
 // Warningf ...
 func Warningf(format string, v ...interface{}) {
-	logger.Warningf(format, v...)
+	logger.WithDepth(4).Warningf(format, v...)
 }
 
 // Error ...
 func Error(v ...interface{}) {
-	logger.Error(v...)
+	logger.WithDepth(4).Error(v...)
 }
 
 // Errorf ...
 func Errorf(format string, v ...interface{}) {
-	logger.Errorf(format, v...)
+	logger.WithDepth(4).Errorf(format, v...)
 }
 
 // Fatal ...
 func Fatal(v ...interface{}) {
-	logger.Fatal(v...)
+	logger.WithDepth(4).Fatal(v...)
 }
 
 // Fatalf ...
 func Fatalf(format string, v ...interface{}) {
-	logger.Fatalf(format, v...)
+	logger.WithDepth(4).Fatalf(format, v...)
 }
 
 func line(callDepth int) string {

--- a/src/lib/log/logger_test.go
+++ b/src/lib/log/logger_test.go
@@ -201,6 +201,24 @@ func TestErrorf(t *testing.T) {
 	}
 }
 
+func TestDefaultLoggerErrorf(t *testing.T) {
+	var (
+		expectedLevel = ErrorLevel.string()
+		expectLine    = "logger_test.go:214"
+		expectMsg     = "message"
+	)
+
+	buf := enter()
+	defer exit()
+
+	DefaultLogger().Errorf("%s", message)
+
+	str := buf.String()
+	if !contains(t, str, expectedLevel, expectLine, expectMsg) {
+		t.Errorf("unexpected message: %s, expected level: %s, expected line: %s, expected message: %s", str, expectedLevel, expectLine, expectMsg)
+	}
+}
+
 func enter() *bytes.Buffer {
 	b := make([]byte, 0, 32)
 	buf := bytes.NewBuffer(b)


### PR DESCRIPTION
1. When use the helper functions of log pkg, the depth is 4 to get the
correct file and line.
2. Whe use the default logger of log pkg, the depth is 3 to get the
correct file and line.

Closes #11391

Signed-off-by: He Weiwei <hweiwei@vmware.com>