### PR TITLE
fix(prepare): not accpet items of false value in external_redis

### DIFF
--- a/make/photon/prepare/utils/configs.py
+++ b/make/photon/prepare/utils/configs.py
@@ -402,8 +402,17 @@ def get_redis_configs(external_redis=None, with_clair=True, with_trivy=True):
     >>> get_redis_configs()['trivy_redis_url']
     'redis://redis:6379/5'
 
+    >>> get_redis_configs({'host': 'localhost', 'password': ''})['redis_password']
+    ''
+    >>> get_redis_configs({'host': 'localhost', 'password': None})['redis_password']
+    ''
+    >>> get_redis_configs({'host': 'localhost', 'password': None})['redis_url_reg']
+    'redis://localhost:6379/1'
+
     >>> get_redis_configs({'host': 'localhost', 'password': 'pass'})['external_redis']
     True
+    >>> get_redis_configs({'host': 'localhost', 'password': 'pass'})['redis_password']
+    'pass'
     >>> get_redis_configs({'host': 'localhost', 'password': 'pass'})['redis_url_reg']
     'redis://anonymous:pass@localhost:6379/1'
     >>> get_redis_configs({'host': 'localhost', 'password': 'pass'})['redis_url_js']
@@ -418,6 +427,7 @@ def get_redis_configs(external_redis=None, with_clair=True, with_trivy=True):
     >>> 'trivy_redis_url' not in get_redis_configs(with_trivy=False)
     True
     """
+    external_redis = external_redis or {}
 
     configs = dict(external_redis=bool(external_redis))
 
@@ -435,7 +445,7 @@ def get_redis_configs(external_redis=None, with_clair=True, with_trivy=True):
     }
 
     # overwriting existing keys by external_redis
-    redis.update(external_redis or {})
+    redis.update({key: value for (key, value) in external_redis.items() if value})
 
     configs['redis_host'] = redis['host']
     configs['redis_port'] = redis['port']


### PR DESCRIPTION
Item in yaml without value will be as None in python, which will make
the password of redis as `None` in `get_redis_configs`. This fix will
not accept items of `false value` in `external_redis` configurations.

Closes #11367

Signed-off-by: He Weiwei <hweiwei@vmware.com>