### PR TITLE
Add trace information into internal error

### DIFF
--- a/src/lib/errors/const.go
+++ b/src/lib/errors/const.go
@@ -1,0 +1,66 @@
+package errors
+
+const (
+	// NotFoundCode is code for the error of no object found
+	NotFoundCode = "NOT_FOUND"
+	// ConflictCode ...
+	ConflictCode = "CONFLICT"
+	// UnAuthorizedCode ...
+	UnAuthorizedCode = "UNAUTHORIZED"
+	// BadRequestCode ...
+	BadRequestCode = "BAD_REQUEST"
+	// ForbiddenCode ...
+	ForbiddenCode = "FORBIDDEN"
+	// PreconditionCode ...
+	PreconditionCode = "PRECONDITION"
+	// GeneralCode ...
+	GeneralCode = "UNKNOWN"
+	// DENIED it's used by middleware(readonly, vul and content trust) and returned to docker client to index the request is denied.
+	DENIED = "DENIED"
+	// PROJECTPOLICYVIOLATION ...
+	PROJECTPOLICYVIOLATION = "PROJECTPOLICYVIOLATION"
+	// ViolateForeignKeyConstraintCode is the error code for violating foreign key constraint error
+	ViolateForeignKeyConstraintCode = "VIOLATE_FOREIGN_KEY_CONSTRAINT"
+	// DIGESTINVALID ...
+	DIGESTINVALID = "DIGEST_INVALID"
+)
+
+// NotFoundError is error for the case of object not found
+func NotFoundError(err error) *Error {
+	return New(err).WithCode(NotFoundCode).WithMessage("resource not found")
+}
+
+// ConflictError is error for the case of object conflict
+func ConflictError(err error) *Error {
+	return New(err).WithCode(ConflictCode).WithMessage("resource conflict")
+}
+
+// DeniedError is error for the case of denied
+func DeniedError(err error) *Error {
+	return New(err).WithCode(DENIED).WithMessage("denied")
+}
+
+// UnauthorizedError is error for the case of unauthorized accessing
+func UnauthorizedError(err error) *Error {
+	return New(err).WithCode(UnAuthorizedCode).WithMessage("unauthorized")
+}
+
+// BadRequestError is error for the case of bad request
+func BadRequestError(err error) *Error {
+	return New(err).WithCode(BadRequestCode).WithMessage("bad request")
+}
+
+// ForbiddenError is error for the case of forbidden
+func ForbiddenError(err error) *Error {
+	return New(err).WithCode(ForbiddenCode).WithMessage("forbidden")
+}
+
+// PreconditionFailedError is error for the case of precondition failed
+func PreconditionFailedError(err error) *Error {
+	return New(err).WithCode(PreconditionCode).WithMessage("precondition failed")
+}
+
+// UnknownError ...
+func UnknownError(err error) *Error {
+	return New(err).WithCode(GeneralCode).WithMessage("unknown")
+}

--- a/src/lib/errors/stack.go
+++ b/src/lib/errors/stack.go
@@ -1,0 +1,48 @@
+package errors
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+)
+
+const maxDeepth = 50
+
+type stack []uintptr
+
+func (s *stack) frames() StackFrames {
+	var stackFrames StackFrames
+	frames := runtime.CallersFrames(*s)
+	for {
+		frame, next := frames.Next()
+		// filter out runtime
+		if !strings.Contains(frame.File, "runtime/") {
+			stackFrames = append(stackFrames, frame)
+		}
+		if !next {
+			break
+		}
+	}
+	return stackFrames
+}
+
+// newStack ...
+func newStack() *stack {
+	var pcs [maxDeepth]uintptr
+	n := runtime.Callers(3, pcs[:])
+	var st stack = pcs[0:n]
+	return &st
+}
+
+// StackFrames ...
+// ToDo we can define an Harbor frame to customize trace message, but it depends on requirement
+type StackFrames []runtime.Frame
+
+// Output: <File>:<Line>, <Method>
+func (frames StackFrames) format() string {
+	var msg string
+	for _, frame := range frames {
+		msg = msg + fmt.Sprintf("\n%v:%v, %v", frame.File, frame.Line, frame.Function)
+	}
+	return msg
+}

--- a/src/lib/errors/stack_test.go
+++ b/src/lib/errors/stack_test.go
@@ -1,0 +1,30 @@
+package errors
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type stackTestSuite struct {
+	suite.Suite
+}
+
+func (c *stackTestSuite) SetupTest() {}
+
+func (c *stackTestSuite) TestFrame() {
+	stack := newStack()
+	frames := stack.frames()
+	c.Equal(len(frames), 4)
+	fmt.Println(frames.format())
+}
+
+func (c *stackTestSuite) TestFormat() {
+	stack := newStack()
+	frames := stack.frames()
+	c.Contains(frames[len(frames)-1].Function, "testing.tRunner")
+}
+
+func TestStackTestSuite(t *testing.T) {
+	suite.Run(t, &stackTestSuite{})
+}

--- a/src/lib/log/logger.go
+++ b/src/lib/log/logger.go
@@ -330,6 +330,7 @@ func line(callDepth int) string {
 	_, file, line, ok := runtime.Caller(callDepth)
 	if !ok {
 		file = "???"
+
 		line = 0
 	}
 	l := strings.SplitN(file, srcSeparator, 2)


### PR DESCRIPTION
Fixes #10839
Add a StackTrace func in to Error, and log it when Harbor gets a internal

Signed-off-by: wang yan <wangyan@vmware.com>