### PR TITLE
fix(swagger): make json as default response

### DIFF
--- a/api/v2.0/swagger.yaml
+++ b/api/v2.0/swagger.yaml
@@ -10,7 +10,6 @@ schemes:
 basePath: /api/v2.0
 produces:
   - application/json
-  - text/plain
 consumes:
   - application/json
 securityDefinitions:


### PR DESCRIPTION
Remove `text/plain` from produces to make `application/json` as default response.

Signed-off-by: He Weiwei <hweiwei@vmware.com>