### PR TITLE
Update the logic of copy artifact

### DIFF
--- a/api/v2.0/swagger.yaml
+++ b/api/v2.0/swagger.yaml
@@ -229,8 +229,6 @@ paths:
           $ref: '#/responses/403'
         '404':
           $ref: '#/responses/404'
-        '409':
-          $ref: '#/responses/409'
         '500':
           $ref: '#/responses/500'
   /projects/{project_name}/repositories/{repository_name}/artifacts/{reference}:

--- a/src/controller/artifact/controller.go
+++ b/src/controller/artifact/controller.go
@@ -118,8 +118,6 @@ func NewController() Controller {
 	}
 }
 
-// TODO concurrency summary
-
 type controller struct {
 	tagCtl       tag.Controller
 	repoMgr      repository.Manager
@@ -415,33 +413,17 @@ func (c *controller) copyDeeply(ctx context.Context, srcRepo, reference, dstRepo
 	digest := srcArt.Digest
 
 	// check the existence of artifact in the destination repository
-	if isRoot {
-		// for the root artifact, check the existence by calling "Count()"
-		// which finds the artifact based on all parent artifacts to avoid
-		// the issue: https://github.com/goharbor/harbor/issues/11222
-		n, err := c.artMgr.Count(ctx, &q.Query{
-			Keywords: map[string]interface{}{
-				"RepositoryName": dstRepo,
-				"Digest":         digest,
-			},
-		})
-		if err != nil {
-			return 0, err
-		}
-		if n > 0 {
-			return 0, errors.New(nil).WithCode(errors.ConflictCode).
-				WithMessage("the artifact %s@%s already exists", dstRepo, digest)
-		}
-	} else {
-		// for the child artifact, check the existence by calling "GetByReference" directly
-		dstArt, err := c.GetByReference(ctx, dstRepo, digest, option)
-		if err == nil {
-			// the child artifact already under the destination repository, skip
+	dstArt, err := c.GetByReference(ctx, dstRepo, digest, option)
+	if err == nil {
+		// the child artifact already exists under the destination repository, skip
+		if !isRoot {
 			return dstArt.ID, nil
 		}
-		if !errors.IsErr(err, errors.NotFoundCode) {
-			return 0, err
-		}
+		// the root parent already exists, goto next step to copy tags
+		goto tags
+	}
+	if !errors.IsErr(err, errors.NotFoundCode) {
+		return 0, err
 	}
 
 	// the artifact doesn't exist under the destination repository, continue to copy
@@ -457,6 +439,7 @@ func (c *controller) copyDeeply(ctx context.Context, srcRepo, reference, dstRepo
 		return 0, err
 	}
 
+tags:
 	// only copy the tags of outermost artifact
 	var tags []string
 	for _, tag := range srcArt.Tags {


### PR DESCRIPTION
1. Copy artifact will not return 409 anymore.
2. Make sure the tags of source artifact exist in the target artifact

Signed-off-by: Wenkai Yin <yinw@vmware.com>