### PR TITLE
Get digest in content trust middleware

### DIFF
--- a/src/server/middleware/contenttrust/contenttrust.go
+++ b/src/server/middleware/contenttrust/contenttrust.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/goharbor/harbor/src/common/rbac"
 	"github.com/goharbor/harbor/src/common/security"
+	"github.com/goharbor/harbor/src/controller/artifact"
 	"github.com/goharbor/harbor/src/controller/project"
 	"github.com/goharbor/harbor/src/jobservice/logger"
 	"github.com/goharbor/harbor/src/lib"
@@ -30,12 +31,16 @@ func Middleware() func(http.Handler) http.Handler {
 	return middleware.BeforeRequest(func(r *http.Request) error {
 		ctx := r.Context()
 		none := lib.ArtifactInfo{}
-		if err := middleware.EnsureArtifactDigest(ctx); err != nil {
-			return err
-		}
 		af := lib.GetArtifactInfo(ctx)
 		if af == none {
 			return fmt.Errorf("artifactinfo middleware required before this middleware")
+		}
+		if len(af.Digest) == 0 {
+			art, err := artifact.Ctl.GetByReference(ctx, af.Repository, af.Reference, nil)
+			if err != nil {
+				return err
+			}
+			af.Digest = art.Digest
 		}
 		pro, err := project.Ctl.GetByName(ctx, af.ProjectName)
 		if err != nil {

--- a/src/server/middleware/patterns.go
+++ b/src/server/middleware/patterns.go
@@ -1,15 +1,10 @@
 package middleware
 
 import (
-	"context"
 	"fmt"
-	"net/http"
-	"net/http/httptest"
 	"regexp"
 
 	"github.com/docker/distribution/reference"
-	"github.com/goharbor/harbor/src/controller/artifact"
-	"github.com/goharbor/harbor/src/lib"
 	"github.com/opencontainers/go-digest"
 )
 
@@ -34,31 +29,3 @@ var (
 	// V2CatalogURLRe is the regular expression for mathing the request to v2 handler to list catalog
 	V2CatalogURLRe = regexp.MustCompile(`^/v2/_catalog$`)
 )
-
-// EnsureArtifactDigest get artifactInfo from context and set the digest for artifact that has project name repository and reference
-func EnsureArtifactDigest(ctx context.Context) error {
-	info := lib.GetArtifactInfo(ctx)
-	none := lib.ArtifactInfo{}
-
-	if info == none {
-		return fmt.Errorf("no artifact info in context")
-	}
-	if len(info.Digest) > 0 {
-		return nil
-	}
-	af, err := artifact.Ctl.GetByReference(ctx, info.Repository, info.Reference, nil)
-	if err != nil || af == nil {
-		return fmt.Errorf("failed to get artifact for populating digest, error: %v", err)
-	}
-	info.Digest = af.Digest
-	return nil
-}
-
-// CopyResp ...
-func CopyResp(rec *httptest.ResponseRecorder, rw http.ResponseWriter) {
-	for k, v := range rec.Header() {
-		rw.Header()[k] = v
-	}
-	rw.WriteHeader(rec.Result().StatusCode)
-	rw.Write(rec.Body.Bytes())
-}


### PR DESCRIPTION
This commit removes the EnsureArtifactDigest as its implementation is
problematic: the artifactinfo in context is immutable.
When the content trust middleware needs the digest it will retrieve it
via artifact controller.

Signed-off-by: Daniel Jiang <jiangd@vmware.com>