### PR TITLE
fix artifact trash filter issue

### DIFF
--- a/src/pkg/artifactrash/dao/dao.go
+++ b/src/pkg/artifactrash/dao/dao.go
@@ -63,7 +63,7 @@ func (d *dao) Delete(ctx context.Context, id int64) (err error) {
 	return nil
 }
 
-// Filter ...
+// Filter the results are: all of records in artifact_trash excludes the records in artifact with same repo and digest.
 func (d *dao) Filter(ctx context.Context) (arts []model.ArtifactTrash, err error) {
 	var deletedAfs []model.ArtifactTrash
 	ormer, err := orm.FromContext(ctx)
@@ -71,12 +71,13 @@ func (d *dao) Filter(ctx context.Context) (arts []model.ArtifactTrash, err error
 		return deletedAfs, err
 	}
 
-	sql := `SELECT * FROM artifact_trash where artifact_trash.digest NOT IN (select digest from artifact)`
+	sql := `SELECT aft.* FROM artifact_trash AS aft LEFT JOIN artifact af ON (aft.repository_name=af.repository_name AND aft.digest=af.digest) WHERE (af.digest IS NULL AND af.repository_name IS NULL)`
 
 	_, err = ormer.Raw(sql).QueryRows(&deletedAfs)
 	if err != nil {
 		return deletedAfs, err
 	}
+
 	return deletedAfs, nil
 }
 

--- a/src/pkg/artifactrash/dao/dao_test.go
+++ b/src/pkg/artifactrash/dao/dao_test.go
@@ -87,6 +87,70 @@ func (d *daoTestSuite) TestFilter() {
 	afs, err := d.dao.Filter(d.ctx)
 	d.Require().Nil(err)
 	d.Require().Equal(afs[0].Digest, "1234")
+
+	// clean it in GC
+	err = d.dao.Flush(d.ctx)
+	d.Require().Nil(err)
+
+	// push hello-world to projecta
+	art1 := &artdao.Artifact{
+		Type:              "image",
+		ManifestMediaType: v1.MediaTypeImageManifest,
+		ProjectID:         11,
+		RepositoryID:      11,
+		RepositoryName:    "projectA/hello-world",
+		Digest:            "sha256:hello-world",
+	}
+	_, err = d.afDao.Create(d.ctx, art1)
+	d.Require().Nil(err)
+
+	// push hello-world to projectb
+	art2 := &artdao.Artifact{
+		Type:              "image",
+		ManifestMediaType: v1.MediaTypeImageManifest,
+		ProjectID:         12,
+		RepositoryID:      12,
+		RepositoryName:    "projectB/hello-world",
+		Digest:            "sha256:hello-world",
+	}
+	_, err = d.afDao.Create(d.ctx, art2)
+	d.Require().Nil(err)
+
+	// remove hello-world to projectA
+	err = d.afDao.Delete(d.ctx, art1.ID)
+	d.Require().Nil(err)
+
+	aft2 := &model.ArtifactTrash{
+		ManifestMediaType: v1.MediaTypeImageManifest,
+		RepositoryName:    "projectA/hello-world",
+		Digest:            "sha256:hello-world",
+	}
+	_, err = d.dao.Create(d.ctx, aft2)
+	d.Require().Nil(err)
+
+	// filter results should contain projectA hello-world
+	afs1, err := d.dao.Filter(d.ctx)
+	d.Require().Nil(err)
+	d.Require().Equal(afs1[0].Digest, "sha256:hello-world")
+	d.Require().Equal(afs1[0].RepositoryName, "projectA/hello-world")
+
+	// push hello-world again to projecta
+	art3 := &artdao.Artifact{
+		Type:              "image",
+		ManifestMediaType: v1.MediaTypeImageManifest,
+		ProjectID:         11,
+		RepositoryID:      13,
+		RepositoryName:    "projectA/hello-world",
+		Digest:            "sha256:hello-world",
+	}
+	_, err = d.afDao.Create(d.ctx, art3)
+	d.Require().Nil(err)
+
+	// filter results should contain nothing
+	afs2, err := d.dao.Filter(d.ctx)
+	d.Require().Nil(err)
+	d.Require().Equal(0, len(afs2))
+
 }
 
 func (d *daoTestSuite) TestFlush() {


### PR DESCRIPTION
fixes #11533

GC jobs will use the filter results to call registry API to delete manifest.

In the current imple, the filter function in some case does not return the deleted artifact as it's using digest as the filter condition.

Like: If one artifact is deleted, but there is another project/repo has a image with same digest with the deleted one, filter func will
not mark the deleted artifact as candidate. It results in, GC job does not call API to remove the manifest.

To fix it, update the filter to use both digest and repository name to filter candidate.

Signed-off-by: wang yan <wangyan@vmware.com>