### PR TITLE
replace pkg errors with lib errors

### DIFF
--- a/src/chartserver/client.go
+++ b/src/chartserver/client.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	commonhttp "github.com/goharbor/harbor/src/common/http"
-	"github.com/pkg/errors"
+	"github.com/goharbor/harbor/src/lib/errors"
 )
 
 const (

--- a/src/chartserver/handler_manipulation.go
+++ b/src/chartserver/handler_manipulation.go
@@ -10,11 +10,11 @@ import (
 
 	"github.com/ghodss/yaml"
 	commonhttp "github.com/goharbor/harbor/src/common/http"
+	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/lib/log"
 	"github.com/goharbor/harbor/src/replication"
 	rep_event "github.com/goharbor/harbor/src/replication/event"
 	"github.com/goharbor/harbor/src/replication/model"
-	"github.com/pkg/errors"
 	helm_repo "k8s.io/helm/pkg/repo"
 )
 

--- a/src/chartserver/handler_utility.go
+++ b/src/chartserver/handler_utility.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/pkg/errors"
+	"github.com/goharbor/harbor/src/lib/errors"
 	"k8s.io/helm/cmd/helm/search"
 
 	"github.com/goharbor/harbor/src/core/config"

--- a/src/common/dao/group/usergroup.go
+++ b/src/common/dao/group/usergroup.go
@@ -22,8 +22,8 @@ import (
 	"github.com/goharbor/harbor/src/common"
 	"github.com/goharbor/harbor/src/common/dao"
 	"github.com/goharbor/harbor/src/common/models"
+	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/lib/log"
-	"github.com/pkg/errors"
 )
 
 // ErrGroupNameDup ...

--- a/src/common/dao/notification/notification_job.go
+++ b/src/common/dao/notification/notification_job.go
@@ -6,8 +6,8 @@ import (
 	"github.com/astaxie/beego/orm"
 	"github.com/goharbor/harbor/src/common/dao"
 	"github.com/goharbor/harbor/src/common/models"
+	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/lib/log"
-	"github.com/pkg/errors"
 )
 
 // UpdateNotificationJob update notification job

--- a/src/common/dao/notification/notification_policy.go
+++ b/src/common/dao/notification/notification_policy.go
@@ -4,7 +4,7 @@ import (
 	"github.com/astaxie/beego/orm"
 	"github.com/goharbor/harbor/src/common/dao"
 	"github.com/goharbor/harbor/src/common/models"
-	"github.com/pkg/errors"
+	"github.com/goharbor/harbor/src/lib/errors"
 )
 
 // GetNotificationPolicy return notification policy by id

--- a/src/common/dao/oidc_user.go
+++ b/src/common/dao/oidc_user.go
@@ -21,8 +21,8 @@ import (
 
 	"github.com/astaxie/beego/orm"
 	"github.com/goharbor/harbor/src/common/models"
+	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/lib/log"
-	"github.com/pkg/errors"
 )
 
 var (

--- a/src/common/utils/oidc/secret.go
+++ b/src/common/utils/oidc/secret.go
@@ -10,8 +10,8 @@ import (
 	"github.com/goharbor/harbor/src/common/models"
 	"github.com/goharbor/harbor/src/common/utils"
 	"github.com/goharbor/harbor/src/core/config"
+	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/lib/log"
-	"github.com/pkg/errors"
 	"sync"
 )
 

--- a/src/controller/event/handler/webhook/scan/delete.go
+++ b/src/controller/event/handler/webhook/scan/delete.go
@@ -20,10 +20,10 @@ import (
 	"github.com/goharbor/harbor/src/controller/artifact"
 	"github.com/goharbor/harbor/src/controller/event"
 	"github.com/goharbor/harbor/src/controller/scan"
+	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/lib/log"
 	"github.com/goharbor/harbor/src/lib/orm"
 	"github.com/goharbor/harbor/src/lib/q"
-	"github.com/pkg/errors"
 )
 
 // DelArtHandler is a handler to listen to the internal delete image event.

--- a/src/controller/event/handler/webhook/scan/scan.go
+++ b/src/controller/event/handler/webhook/scan/scan.go
@@ -26,11 +26,11 @@ import (
 
 	"github.com/goharbor/harbor/src/common/models"
 	"github.com/goharbor/harbor/src/controller/scan"
+	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/lib/log"
 	"github.com/goharbor/harbor/src/pkg/notification"
 	"github.com/goharbor/harbor/src/pkg/project"
 	v1 "github.com/goharbor/harbor/src/pkg/scan/rest/v1"
-	"github.com/pkg/errors"
 )
 
 // Handler preprocess scan artifact event

--- a/src/controller/event/metadata/quota.go
+++ b/src/controller/event/metadata/quota.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/goharbor/harbor/src/common/models"
 	event2 "github.com/goharbor/harbor/src/controller/event"
+	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/pkg/notifier/event"
-	"github.com/pkg/errors"
 )
 
 // QuotaMetaData defines quota related event data

--- a/src/controller/event/metadata/scan.go
+++ b/src/controller/event/metadata/scan.go
@@ -3,9 +3,9 @@ package metadata
 import (
 	"github.com/goharbor/harbor/src/common/models"
 	event2 "github.com/goharbor/harbor/src/controller/event"
+	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/pkg/notifier/event"
 	v1 "github.com/goharbor/harbor/src/pkg/scan/rest/v1"
-	"github.com/pkg/errors"
 	"time"
 )
 

--- a/src/controller/scan/all_handler.go
+++ b/src/controller/scan/all_handler.go
@@ -20,9 +20,9 @@ import (
 	"github.com/goharbor/harbor/src/common/models"
 	"github.com/goharbor/harbor/src/controller/artifact"
 	"github.com/goharbor/harbor/src/controller/repository"
+	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/lib/log"
 	"github.com/goharbor/harbor/src/lib/q"
-	"github.com/pkg/errors"
 )
 
 // HandleCheckIn handles the check in data of the scan all job

--- a/src/controller/scanner/base_controller.go
+++ b/src/controller/scanner/base_controller.go
@@ -17,13 +17,12 @@ package scanner
 import (
 	"github.com/goharbor/harbor/src/core/promgr/metamgr"
 	"github.com/goharbor/harbor/src/jobservice/logger"
-	lerrors "github.com/goharbor/harbor/src/lib/errors"
+	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/lib/log"
 	"github.com/goharbor/harbor/src/lib/q"
 	"github.com/goharbor/harbor/src/pkg/scan/dao/scanner"
 	v1 "github.com/goharbor/harbor/src/pkg/scan/rest/v1"
 	rscanner "github.com/goharbor/harbor/src/pkg/scan/scanner"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -67,7 +66,7 @@ func (bc *basicController) ListRegistrations(query *q.Query) ([]*scanner.Registr
 // CreateRegistration ...
 func (bc *basicController) CreateRegistration(registration *scanner.Registration) (string, error) {
 	if isReservedName(registration.Name) {
-		return "", lerrors.BadRequestError(nil).WithMessage(`name "%s" is reserved, please try a different name`, registration.Name)
+		return "", errors.BadRequestError(nil).WithMessage(`name "%s" is reserved, please try a different name`, registration.Name)
 	}
 
 	// Check if the registration is available
@@ -121,7 +120,7 @@ func (bc *basicController) UpdateRegistration(registration *scanner.Registration
 	}
 
 	if isReservedName(registration.Name) {
-		return lerrors.BadRequestError(nil).WithMessage(`name "%s" is reserved, please try a different name`, registration.Name)
+		return errors.BadRequestError(nil).WithMessage(`name "%s" is reserved, please try a different name`, registration.Name)
 	}
 
 	return bc.manager.Update(registration)

--- a/src/core/api/admin_job.go
+++ b/src/core/api/admin_job.go
@@ -28,8 +28,8 @@ import (
 	"github.com/goharbor/harbor/src/controller/scan"
 	"github.com/goharbor/harbor/src/core/api/models"
 	utils_core "github.com/goharbor/harbor/src/core/utils"
+	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/lib/log"
-	"github.com/pkg/errors"
 )
 
 // AJAPI manages the CRUD of admin job and its schedule, any API wants to handle manual and cron job like ScanAll and GC cloud reuse it.

--- a/src/core/api/notification_policy_test.go
+++ b/src/core/api/notification_policy_test.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/pkg/errors"
+	"github.com/goharbor/harbor/src/lib/errors"
 
 	"github.com/goharbor/harbor/src/common/models"
 	"github.com/goharbor/harbor/src/pkg/notification"

--- a/src/core/api/pro_scanner.go
+++ b/src/core/api/pro_scanner.go
@@ -17,8 +17,8 @@ package api
 import (
 	"github.com/goharbor/harbor/src/common/rbac"
 	"github.com/goharbor/harbor/src/controller/scanner"
+	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/lib/q"
-	"github.com/pkg/errors"
 )
 
 // ProjectScannerAPI provides rest API for managing the project level scanner(s).

--- a/src/core/api/project.go
+++ b/src/core/api/project.go
@@ -34,11 +34,11 @@ import (
 	"github.com/goharbor/harbor/src/controller/event/metadata"
 	"github.com/goharbor/harbor/src/controller/quota"
 	"github.com/goharbor/harbor/src/core/config"
+	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/lib/log"
 	evt "github.com/goharbor/harbor/src/pkg/notifier/event"
 	"github.com/goharbor/harbor/src/pkg/scan/vuln"
 	"github.com/goharbor/harbor/src/pkg/types"
-	"github.com/pkg/errors"
 )
 
 type deletableResp struct {

--- a/src/core/api/quota.go
+++ b/src/core/api/quota.go
@@ -18,10 +18,10 @@ import (
 	"fmt"
 
 	"github.com/goharbor/harbor/src/controller/quota"
+	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/lib/q"
 	"github.com/goharbor/harbor/src/pkg/quota/models"
 	"github.com/goharbor/harbor/src/pkg/types"
-	"github.com/pkg/errors"
 )
 
 // QuotaUpdateRequest struct for the body of put quota API

--- a/src/core/api/robot.go
+++ b/src/core/api/robot.go
@@ -22,10 +22,10 @@ import (
 	"github.com/goharbor/harbor/src/common/dao"
 	"github.com/goharbor/harbor/src/common/models"
 	"github.com/goharbor/harbor/src/common/rbac"
+	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/lib/q"
 	"github.com/goharbor/harbor/src/pkg/robot"
 	"github.com/goharbor/harbor/src/pkg/robot/model"
-	"github.com/pkg/errors"
 )
 
 // RobotAPI ...

--- a/src/core/api/scan_all.go
+++ b/src/core/api/scan_all.go
@@ -12,9 +12,9 @@ import (
 	"github.com/goharbor/harbor/src/controller/scanner"
 	"github.com/goharbor/harbor/src/core/api/models"
 	"github.com/goharbor/harbor/src/jobservice/job"
+	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/lib/q"
 	"github.com/goharbor/harbor/src/pkg/scan/all"
-	"github.com/pkg/errors"
 )
 
 // ScanAllAPI handles request of scan all images...

--- a/src/core/controllers/oidc.go
+++ b/src/core/controllers/oidc.go
@@ -28,8 +28,8 @@ import (
 	"github.com/goharbor/harbor/src/common/utils/oidc"
 	"github.com/goharbor/harbor/src/core/api"
 	"github.com/goharbor/harbor/src/core/config"
+	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/lib/log"
-	"github.com/pkg/errors"
 )
 
 const tokenKey = "oidc_token"

--- a/src/core/service/notifications/jobs/handler.go
+++ b/src/core/service/notifications/jobs/handler.go
@@ -25,6 +25,7 @@ import (
 	"github.com/goharbor/harbor/src/controller/event/metadata"
 	"github.com/goharbor/harbor/src/controller/scan"
 	jjob "github.com/goharbor/harbor/src/jobservice/job"
+	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/lib/log"
 	"github.com/goharbor/harbor/src/pkg/notification"
 	"github.com/goharbor/harbor/src/pkg/notifier/event"
@@ -33,7 +34,6 @@ import (
 	"github.com/goharbor/harbor/src/replication"
 	"github.com/goharbor/harbor/src/replication/operation/hook"
 	"github.com/goharbor/harbor/src/replication/policy/scheduler"
-	"github.com/pkg/errors"
 )
 
 var statusMap = map[string]string{

--- a/src/go.mod
+++ b/src/go.mod
@@ -60,7 +60,6 @@ require (
 	github.com/opencontainers/go-digest v1.0.0-rc1
 	github.com/opencontainers/image-spec v1.0.1
 	github.com/opentracing/opentracing-go v1.1.0 // indirect
-	github.com/pkg/errors v0.9.1
 	github.com/pquerna/cachecontrol v0.0.0-20180517163645-1555304b9b35 // indirect
 	github.com/robfig/cron v1.0.0
 	github.com/shiena/ansicolor v0.0.0-20151119151921-a422bbe96644 // indirect

--- a/src/jobservice/api/handler.go
+++ b/src/jobservice/api/handler.go
@@ -30,7 +30,7 @@ import (
 	"github.com/goharbor/harbor/src/jobservice/errs"
 	"github.com/goharbor/harbor/src/jobservice/job"
 	"github.com/goharbor/harbor/src/jobservice/logger"
-	"github.com/pkg/errors"
+	"github.com/goharbor/harbor/src/lib/errors"
 	"strconv"
 )
 

--- a/src/jobservice/api/router.go
+++ b/src/jobservice/api/router.go
@@ -16,7 +16,7 @@ package api
 
 import (
 	"fmt"
-	"github.com/pkg/errors"
+	"github.com/goharbor/harbor/src/lib/errors"
 	"net/http"
 
 	"github.com/goharbor/harbor/src/jobservice/errs"

--- a/src/jobservice/common/rds/utils.go
+++ b/src/jobservice/common/rds/utils.go
@@ -5,8 +5,8 @@ import (
 	"time"
 
 	"github.com/goharbor/harbor/src/jobservice/common/utils"
+	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/gomodule/redigo/redis"
-	"github.com/pkg/errors"
 )
 
 // ErrNoElements is a pre defined error to describe the case that no elements got

--- a/src/jobservice/common/utils/utils.go
+++ b/src/jobservice/common/utils/utils.go
@@ -20,7 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/gocraft/work"
-	"github.com/pkg/errors"
+	"github.com/goharbor/harbor/src/lib/errors"
 	"io"
 	"net"
 	"net/url"

--- a/src/jobservice/core/controller.go
+++ b/src/jobservice/core/controller.go
@@ -17,7 +17,7 @@ package core
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
+	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/robfig/cron"
 
 	"github.com/goharbor/harbor/src/jobservice/common/query"

--- a/src/jobservice/hook/hook_agent.go
+++ b/src/jobservice/hook/hook_agent.go
@@ -25,8 +25,8 @@ import (
 	"github.com/goharbor/harbor/src/jobservice/env"
 	"github.com/goharbor/harbor/src/jobservice/job"
 	"github.com/goharbor/harbor/src/jobservice/logger"
+	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/gomodule/redigo/redis"
-	"github.com/pkg/errors"
 )
 
 const (

--- a/src/jobservice/hook/hook_agent_test.go
+++ b/src/jobservice/hook/hook_agent_test.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/goharbor/harbor/src/jobservice/common/utils"
 
-	"github.com/pkg/errors"
+	"github.com/goharbor/harbor/src/lib/errors"
 
 	"github.com/goharbor/harbor/src/jobservice/common/rds"
 	"github.com/goharbor/harbor/src/jobservice/job"

--- a/src/jobservice/job/models.go
+++ b/src/jobservice/job/models.go
@@ -16,7 +16,7 @@ package job
 
 import (
 	"github.com/goharbor/harbor/src/jobservice/common/utils"
-	"github.com/pkg/errors"
+	"github.com/goharbor/harbor/src/lib/errors"
 )
 
 // Parameters for job execution.

--- a/src/jobservice/job/tracker.go
+++ b/src/jobservice/job/tracker.go
@@ -27,8 +27,8 @@ import (
 	"github.com/goharbor/harbor/src/jobservice/common/utils"
 	"github.com/goharbor/harbor/src/jobservice/errs"
 	"github.com/goharbor/harbor/src/jobservice/logger"
+	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/gomodule/redigo/redis"
-	"github.com/pkg/errors"
 )
 
 const (

--- a/src/jobservice/lcm/controller.go
+++ b/src/jobservice/lcm/controller.go
@@ -29,8 +29,8 @@ import (
 	"github.com/goharbor/harbor/src/jobservice/env"
 	"github.com/goharbor/harbor/src/jobservice/job"
 	"github.com/goharbor/harbor/src/jobservice/logger"
+	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/gomodule/redigo/redis"
-	"github.com/pkg/errors"
 )
 
 const (

--- a/src/jobservice/mgt/manager.go
+++ b/src/jobservice/mgt/manager.go
@@ -28,8 +28,8 @@ import (
 	"github.com/goharbor/harbor/src/jobservice/job"
 	"github.com/goharbor/harbor/src/jobservice/logger"
 	"github.com/goharbor/harbor/src/jobservice/period"
+	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/gomodule/redigo/redis"
-	"github.com/pkg/errors"
 )
 
 // Manager defies the related operations to handle the management of job stats.

--- a/src/jobservice/migration/manager.go
+++ b/src/jobservice/migration/manager.go
@@ -21,7 +21,7 @@ import (
 	"github.com/gomodule/redigo/redis"
 
 	"github.com/goharbor/harbor/src/jobservice/logger"
-	"github.com/pkg/errors"
+	"github.com/goharbor/harbor/src/lib/errors"
 )
 
 // Manager for managing the related migrators

--- a/src/jobservice/migration/migrator_v180.go
+++ b/src/jobservice/migration/migrator_v180.go
@@ -25,8 +25,8 @@ import (
 	"github.com/goharbor/harbor/src/jobservice/job"
 	"github.com/goharbor/harbor/src/jobservice/logger"
 	"github.com/goharbor/harbor/src/jobservice/period"
+	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/gomodule/redigo/redis"
-	"github.com/pkg/errors"
 )
 
 // PolicyMigrator migrate the cron job policy to new schema

--- a/src/jobservice/period/basic_scheduler.go
+++ b/src/jobservice/period/basic_scheduler.go
@@ -24,8 +24,8 @@ import (
 	"github.com/goharbor/harbor/src/jobservice/job"
 	"github.com/goharbor/harbor/src/jobservice/lcm"
 	"github.com/goharbor/harbor/src/jobservice/logger"
+	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/gomodule/redigo/redis"
-	"github.com/pkg/errors"
 )
 
 // basicScheduler manages the periodic scheduling policies.

--- a/src/jobservice/period/enqueuer_test.go
+++ b/src/jobservice/period/enqueuer_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pkg/errors"
+	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/stretchr/testify/require"
 
 	"github.com/goharbor/harbor/src/jobservice/common/rds"

--- a/src/jobservice/runner/redis.go
+++ b/src/jobservice/runner/redis.go
@@ -25,7 +25,7 @@ import (
 	"github.com/goharbor/harbor/src/jobservice/lcm"
 	"github.com/goharbor/harbor/src/jobservice/logger"
 	"github.com/goharbor/harbor/src/jobservice/period"
-	"github.com/pkg/errors"
+	"github.com/goharbor/harbor/src/lib/errors"
 )
 
 // RedisJob is a job wrapper to wrap the job.Interface to the style which can be recognized by the redis worker.

--- a/src/jobservice/runtime/bootstrap.go
+++ b/src/jobservice/runtime/bootstrap.go
@@ -41,12 +41,12 @@ import (
 	"github.com/goharbor/harbor/src/jobservice/migration"
 	"github.com/goharbor/harbor/src/jobservice/worker"
 	"github.com/goharbor/harbor/src/jobservice/worker/cworker"
+	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/pkg/retention"
 	sc "github.com/goharbor/harbor/src/pkg/scan"
 	"github.com/goharbor/harbor/src/pkg/scan/all"
 	"github.com/goharbor/harbor/src/pkg/scheduler"
 	"github.com/gomodule/redigo/redis"
-	"github.com/pkg/errors"
 )
 
 const (

--- a/src/jobservice/worker/cworker/c_worker.go
+++ b/src/jobservice/worker/cworker/c_worker.go
@@ -29,8 +29,8 @@ import (
 	"github.com/goharbor/harbor/src/jobservice/period"
 	"github.com/goharbor/harbor/src/jobservice/runner"
 	"github.com/goharbor/harbor/src/jobservice/worker"
+	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/gomodule/redigo/redis"
-	"github.com/pkg/errors"
 )
 
 var (

--- a/src/jobservice/worker/cworker/reaper.go
+++ b/src/jobservice/worker/cworker/reaper.go
@@ -25,8 +25,8 @@ import (
 	"github.com/goharbor/harbor/src/jobservice/job"
 	"github.com/goharbor/harbor/src/jobservice/lcm"
 	"github.com/goharbor/harbor/src/jobservice/logger"
+	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/gomodule/redigo/redis"
-	"github.com/pkg/errors"
 )
 
 const (

--- a/src/lib/errors/errors_test.go
+++ b/src/lib/errors/errors_test.go
@@ -16,6 +16,7 @@ package errors
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -126,6 +127,11 @@ func (suite *ErrorTestSuite) TestWithCauseMessage() {
 	cause := errors.New("stdErr")
 	err := New("root").WithCause(cause).WithMessage("With Message")
 	suite.Equal("With Message: stdErr", err.Error())
+}
+
+func (suite *ErrorTestSuite) TestFormat() {
+	err := New("empty job ID")
+	suite.Equal("empty job ID", fmt.Sprintf("%s", err))
 }
 
 func (suite *ErrorTestSuite) TestWrap() {

--- a/src/lib/selector/candidate.go
+++ b/src/lib/selector/candidate.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"github.com/goharbor/harbor/src/lib/log"
 
-	"github.com/pkg/errors"
+	"github.com/goharbor/harbor/src/lib/errors"
 )
 
 const (

--- a/src/lib/selector/selectors/index/index.go
+++ b/src/lib/selector/selectors/index/index.go
@@ -18,8 +18,8 @@ import (
 	"github.com/goharbor/harbor/src/lib/selector"
 	"sync"
 
+	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/lib/selector/selectors/doublestar"
-	"github.com/pkg/errors"
 )
 
 func init() {

--- a/src/pkg/notifier/event/event.go
+++ b/src/pkg/notifier/event/event.go
@@ -2,10 +2,10 @@ package event
 
 import (
 	"github.com/goharbor/harbor/src/common/models"
+	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/lib/log"
 	"github.com/goharbor/harbor/src/pkg/notifier"
 	"github.com/goharbor/harbor/src/pkg/notifier/model"
-	"github.com/pkg/errors"
 )
 
 // Event to publish

--- a/src/pkg/retention/job.go
+++ b/src/pkg/retention/job.go
@@ -25,11 +25,11 @@ import (
 
 	"github.com/goharbor/harbor/src/jobservice/job"
 	"github.com/goharbor/harbor/src/jobservice/logger"
+	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/pkg/retention/dep"
 	"github.com/goharbor/harbor/src/pkg/retention/policy"
 	"github.com/goharbor/harbor/src/pkg/retention/policy/lwp"
 	"github.com/olekukonko/tablewriter"
-	"github.com/pkg/errors"
 )
 
 const (

--- a/src/pkg/retention/launcher.go
+++ b/src/pkg/retention/launcher.go
@@ -29,6 +29,7 @@ import (
 	cmodels "github.com/goharbor/harbor/src/common/models"
 	"github.com/goharbor/harbor/src/common/utils"
 	"github.com/goharbor/harbor/src/core/config"
+	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/lib/log"
 	pq "github.com/goharbor/harbor/src/lib/q"
 	"github.com/goharbor/harbor/src/pkg/project"
@@ -36,7 +37,6 @@ import (
 	"github.com/goharbor/harbor/src/pkg/retention/policy"
 	"github.com/goharbor/harbor/src/pkg/retention/policy/lwp"
 	"github.com/goharbor/harbor/src/pkg/retention/q"
-	"github.com/pkg/errors"
 )
 
 const (

--- a/src/pkg/retention/policy/action/index/index.go
+++ b/src/pkg/retention/policy/action/index/index.go
@@ -17,8 +17,8 @@ package index
 import (
 	"sync"
 
+	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/pkg/retention/policy/action"
-	"github.com/pkg/errors"
 )
 
 // index for keeping the mapping action and its performer

--- a/src/pkg/retention/policy/action/performer_test.go
+++ b/src/pkg/retention/policy/action/performer_test.go
@@ -21,9 +21,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/goharbor/harbor/src/lib/errors"
 	immumodel "github.com/goharbor/harbor/src/pkg/immutabletag/model"
 	"github.com/goharbor/harbor/src/pkg/retention/dep"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"

--- a/src/pkg/retention/policy/alg/index/index.go
+++ b/src/pkg/retention/policy/alg/index/index.go
@@ -17,9 +17,9 @@ package index
 import (
 	"sync"
 
+	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/pkg/retention/policy/alg"
 	"github.com/goharbor/harbor/src/pkg/retention/policy/alg/or"
-	"github.com/pkg/errors"
 )
 
 const (

--- a/src/pkg/retention/policy/alg/or/processor.go
+++ b/src/pkg/retention/policy/alg/or/processor.go
@@ -18,11 +18,11 @@ import (
 	"github.com/goharbor/harbor/src/lib/selector"
 	"sync"
 
+	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/lib/log"
 	"github.com/goharbor/harbor/src/pkg/retention/policy/action"
 	"github.com/goharbor/harbor/src/pkg/retention/policy/alg"
 	"github.com/goharbor/harbor/src/pkg/retention/policy/rule"
-	"github.com/pkg/errors"
 )
 
 // processor to handle the rules with OR mapping ways

--- a/src/pkg/retention/policy/builder.go
+++ b/src/pkg/retention/policy/builder.go
@@ -26,9 +26,9 @@ import (
 
 	"github.com/goharbor/harbor/src/pkg/retention/policy/rule/index"
 
+	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/pkg/retention/policy/alg"
 	"github.com/goharbor/harbor/src/pkg/retention/policy/lwp"
-	"github.com/pkg/errors"
 )
 
 // Builder builds the runnable processor from the raw policy

--- a/src/pkg/retention/policy/builder_test.go
+++ b/src/pkg/retention/policy/builder_test.go
@@ -28,7 +28,7 @@ import (
 
 	"github.com/goharbor/harbor/src/pkg/retention/dep"
 
-	"github.com/pkg/errors"
+	"github.com/goharbor/harbor/src/lib/errors"
 
 	"github.com/goharbor/harbor/src/pkg/retention/policy/alg/or"
 

--- a/src/pkg/retention/policy/lwp/models.go
+++ b/src/pkg/retention/policy/lwp/models.go
@@ -18,8 +18,8 @@ package lwp
 import (
 	"encoding/json"
 
+	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/pkg/retention/policy/rule"
-	"github.com/pkg/errors"
 )
 
 // Metadata contains partial metadata of policy

--- a/src/pkg/retention/policy/rule/index/index.go
+++ b/src/pkg/retention/policy/rule/index/index.go
@@ -17,6 +17,7 @@ package index
 import (
 	"sync"
 
+	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/pkg/retention/policy/action"
 	"github.com/goharbor/harbor/src/pkg/retention/policy/rule"
 	"github.com/goharbor/harbor/src/pkg/retention/policy/rule/always"
@@ -26,7 +27,6 @@ import (
 	"github.com/goharbor/harbor/src/pkg/retention/policy/rule/latestk"
 	"github.com/goharbor/harbor/src/pkg/retention/policy/rule/latestpl"
 	"github.com/goharbor/harbor/src/pkg/retention/policy/rule/latestps"
-	"github.com/pkg/errors"
 )
 
 // index for keeping the mapping between template ID and evaluator

--- a/src/pkg/robot/controller.go
+++ b/src/pkg/robot/controller.go
@@ -5,12 +5,12 @@ import (
 	"github.com/dgrijalva/jwt-go"
 	"github.com/goharbor/harbor/src/common"
 	"github.com/goharbor/harbor/src/core/config"
+	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/lib/log"
 	"github.com/goharbor/harbor/src/lib/q"
 	"github.com/goharbor/harbor/src/pkg/robot/model"
 	"github.com/goharbor/harbor/src/pkg/token"
 	robot_claim "github.com/goharbor/harbor/src/pkg/token/claims/robot"
-	"github.com/pkg/errors"
 	"time"
 )
 

--- a/src/pkg/scan/all/job.go
+++ b/src/pkg/scan/all/job.go
@@ -16,7 +16,7 @@ package all
 
 import (
 	"github.com/goharbor/harbor/src/jobservice/job"
-	"github.com/pkg/errors"
+	"github.com/goharbor/harbor/src/lib/errors"
 )
 
 const (

--- a/src/pkg/scan/dao/scan/report.go
+++ b/src/pkg/scan/dao/scan/report.go
@@ -21,9 +21,9 @@ import (
 
 	"github.com/astaxie/beego/orm"
 	"github.com/goharbor/harbor/src/common/dao"
+	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/lib/log"
 	"github.com/goharbor/harbor/src/lib/q"
-	"github.com/pkg/errors"
 )
 
 func init() {

--- a/src/pkg/scan/dao/scan/report_test.go
+++ b/src/pkg/scan/dao/scan/report_test.go
@@ -19,9 +19,9 @@ import (
 
 	"github.com/goharbor/harbor/src/common/dao"
 	"github.com/goharbor/harbor/src/jobservice/job"
+	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/lib/q"
 	v1 "github.com/goharbor/harbor/src/pkg/scan/rest/v1"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"

--- a/src/pkg/scan/dao/scanner/model.go
+++ b/src/pkg/scan/dao/scanner/model.go
@@ -20,9 +20,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/pkg/scan/rest/auth"
 	v1 "github.com/goharbor/harbor/src/pkg/scan/rest/v1"
-	"github.com/pkg/errors"
 )
 
 const (

--- a/src/pkg/scan/dao/scanner/registration.go
+++ b/src/pkg/scan/dao/scanner/registration.go
@@ -20,9 +20,9 @@ import (
 
 	"github.com/astaxie/beego/orm"
 	"github.com/goharbor/harbor/src/common/dao"
+	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/lib/q"
 	"github.com/goharbor/harbor/src/pkg/types"
-	"github.com/pkg/errors"
 )
 
 func init() {

--- a/src/pkg/scan/init.go
+++ b/src/pkg/scan/init.go
@@ -15,11 +15,11 @@
 package scan
 
 import (
+	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/lib/log"
 	"github.com/goharbor/harbor/src/lib/q"
 	"github.com/goharbor/harbor/src/pkg/scan/dao/scanner"
 	sc "github.com/goharbor/harbor/src/pkg/scan/scanner"
-	"github.com/pkg/errors"
 )
 
 var (

--- a/src/pkg/scan/init_test.go
+++ b/src/pkg/scan/init_test.go
@@ -17,10 +17,10 @@ package scan
 import (
 	"testing"
 
+	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/lib/q"
 	"github.com/goharbor/harbor/src/pkg/scan/dao/scanner"
 	"github.com/goharbor/harbor/src/pkg/scan/scanner/mocks"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/src/pkg/scan/job.go
+++ b/src/pkg/scan/job.go
@@ -32,11 +32,11 @@ import (
 	"github.com/goharbor/harbor/src/common/models"
 	"github.com/goharbor/harbor/src/jobservice/job"
 	"github.com/goharbor/harbor/src/jobservice/logger"
+	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/pkg/robot/model"
 	"github.com/goharbor/harbor/src/pkg/scan/dao/scanner"
 	"github.com/goharbor/harbor/src/pkg/scan/report"
 	v1 "github.com/goharbor/harbor/src/pkg/scan/rest/v1"
-	"github.com/pkg/errors"
 )
 
 const (

--- a/src/pkg/scan/report/report.go
+++ b/src/pkg/scan/report/report.go
@@ -15,9 +15,9 @@
 package report
 
 import (
+	"github.com/goharbor/harbor/src/lib/errors"
 	v1 "github.com/goharbor/harbor/src/pkg/scan/rest/v1"
 	"github.com/goharbor/harbor/src/pkg/scan/vuln"
-	"github.com/pkg/errors"
 )
 
 // Merger is a helper function to merge report together

--- a/src/pkg/scan/report/summary.go
+++ b/src/pkg/scan/report/summary.go
@@ -18,10 +18,10 @@ import (
 	"reflect"
 
 	"github.com/goharbor/harbor/src/jobservice/job"
+	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/pkg/scan/dao/scan"
 	v1 "github.com/goharbor/harbor/src/pkg/scan/rest/v1"
 	"github.com/goharbor/harbor/src/pkg/scan/vuln"
-	"github.com/pkg/errors"
 )
 
 // CVESet defines the CVE whitelist with a hash set way for easy query.

--- a/src/pkg/scan/report/supported_mimes.go
+++ b/src/pkg/scan/report/supported_mimes.go
@@ -18,9 +18,9 @@ import (
 	"encoding/json"
 	"reflect"
 
+	"github.com/goharbor/harbor/src/lib/errors"
 	v1 "github.com/goharbor/harbor/src/pkg/scan/rest/v1"
 	"github.com/goharbor/harbor/src/pkg/scan/vuln"
-	"github.com/pkg/errors"
 )
 
 // SupportedMimes indicates what mime types are supported to render at UI end.

--- a/src/pkg/scan/rest/auth/api_key_auth.go
+++ b/src/pkg/scan/rest/auth/api_key_auth.go
@@ -17,7 +17,7 @@ package auth
 import (
 	"net/http"
 
-	"github.com/pkg/errors"
+	"github.com/goharbor/harbor/src/lib/errors"
 )
 
 // apiKeyAuthorizer authorize by adding a header `X-ScannerAdapter-API-Key` with value "credential"

--- a/src/pkg/scan/rest/auth/auth.go
+++ b/src/pkg/scan/rest/auth/auth.go
@@ -18,7 +18,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/pkg/errors"
+	"github.com/goharbor/harbor/src/lib/errors"
 )
 
 const (

--- a/src/pkg/scan/rest/auth/basic_auth.go
+++ b/src/pkg/scan/rest/auth/basic_auth.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/pkg/errors"
+	"github.com/goharbor/harbor/src/lib/errors"
 )
 
 // basicAuthorizer authorizes the request by adding `Authorization Basic base64(credential)` header

--- a/src/pkg/scan/rest/auth/bearer_auth.go
+++ b/src/pkg/scan/rest/auth/bearer_auth.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/pkg/errors"
+	"github.com/goharbor/harbor/src/lib/errors"
 )
 
 // bearerAuthorizer authorizes the request by adding `Authorization Bearer credential` header

--- a/src/pkg/scan/rest/v1/client.go
+++ b/src/pkg/scan/rest/v1/client.go
@@ -26,8 +26,8 @@ import (
 	"time"
 
 	"github.com/goharbor/harbor/src/jobservice/logger"
+	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/pkg/scan/rest/auth"
-	"github.com/pkg/errors"
 )
 
 const (

--- a/src/pkg/scan/rest/v1/client_pool.go
+++ b/src/pkg/scan/rest/v1/client_pool.go
@@ -22,7 +22,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/pkg/errors"
+	"github.com/goharbor/harbor/src/lib/errors"
 )
 
 const (

--- a/src/pkg/scan/rest/v1/models.go
+++ b/src/pkg/scan/rest/v1/models.go
@@ -18,7 +18,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/pkg/errors"
+	"github.com/goharbor/harbor/src/lib/errors"
 )
 
 // Scanner represents metadata of a Scanner Adapter which allow Harbor to lookup a scanner capable of

--- a/src/pkg/scan/scanner/manager.go
+++ b/src/pkg/scan/scanner/manager.go
@@ -15,10 +15,10 @@
 package scanner
 
 import (
+	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/lib/q"
 	"github.com/goharbor/harbor/src/pkg/scan/dao/scanner"
 	"github.com/google/uuid"
-	"github.com/pkg/errors"
 )
 
 // Manager defines the related scanner API endpoints

--- a/src/pkg/scheduler/scheduler.go
+++ b/src/pkg/scheduler/scheduler.go
@@ -25,9 +25,9 @@ import (
 	"github.com/goharbor/harbor/src/common/job"
 	"github.com/goharbor/harbor/src/common/job/models"
 	"github.com/goharbor/harbor/src/core/config"
+	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/lib/log"
 	"github.com/goharbor/harbor/src/pkg/scheduler/model"
-	"github.com/pkg/errors"
 )
 
 // const definitions

--- a/src/replication/adapter/helmhub/chart_registry.go
+++ b/src/replication/adapter/helmhub/chart_registry.go
@@ -22,9 +22,9 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/lib/log"
 	"github.com/goharbor/harbor/src/replication/model"
-	"github.com/pkg/errors"
 )
 
 func (a *adapter) FetchCharts(filters []*model.Filter) ([]*model.Resource, error) {

--- a/src/replication/adapter/helmhub/client.go
+++ b/src/replication/adapter/helmhub/client.go
@@ -3,9 +3,9 @@ package helmhub
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/replication/model"
 	"github.com/goharbor/harbor/src/replication/util"
-	"github.com/pkg/errors"
 	"io/ioutil"
 	"net/http"
 )

--- a/src/server/error/error_test.go
+++ b/src/server/error/error_test.go
@@ -15,10 +15,10 @@
 package error
 
 import (
+	std_errors "errors"
 	openapi "github.com/go-openapi/errors"
 	commonhttp "github.com/goharbor/harbor/src/common/http"
 	"github.com/goharbor/harbor/src/lib/errors"
-	pkg_errors "github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"net/http"
 	"net/http/httptest"
@@ -75,7 +75,7 @@ func TestAPIError(t *testing.T) {
 	assert.Contains(t, stacktrace, `error.TestAPIError`)
 
 	// common error, common error has no stacktrace
-	e := pkg_errors.New("customized error")
+	e := std_errors.New("customized error")
 	statusCode, payload, stacktrace = apiError(e)
 	assert.Equal(t, http.StatusInternalServerError, statusCode)
 	assert.Equal(t, `{"errors":[{"code":"UNKNOWN","message":"unknown: customized error"}]}`, payload)


### PR DESCRIPTION
Fixes #9704
Decreprated pkg errors, use lib/errors instead as in most cases we have cusomized error code.

Signed-off-by: wang yan <wangyan@vmware.com>