### PR TITLE
feat(job):enable priority option

### DIFF
--- a/src/jobservice/job/priority.go
+++ b/src/jobservice/job/priority.go
@@ -1,0 +1,56 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package job
+
+const (
+	defaultPriority uint = 1000
+)
+
+// PrioritySampler define the job priority generation method
+type PrioritySampler interface {
+	// Priority for the given job.
+	// Job with high priority has the more probabilities to execute.
+	// e.g.:
+	//   always process X jobs before Y jobs if priorityX > priority Y
+	//
+	// Arguments:
+	//   job string: the job type
+	//
+	// Returns:
+	//   uint: the priority value (between 1 and 10000)
+	For(job string) uint
+}
+
+// defaultSampler is default implementation of PrioritySampler
+type defaultSampler struct{}
+
+// For the given job
+func (ps *defaultSampler) For(job string) uint {
+	switch job {
+	// As an example, sample job has the lowest priority
+	case SampleJob:
+		return 1
+		// add more cases here if specified job priority is required
+	// case XXX:
+	//	return 2000
+	default:
+		return defaultPriority
+	}
+}
+
+// Priority returns the default job priority sampler implementation.
+func Priority() PrioritySampler {
+	return &defaultSampler{}
+}

--- a/src/jobservice/job/priority_test.go
+++ b/src/jobservice/job/priority_test.go
@@ -1,0 +1,50 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package job
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+// PrioritySamplerSuite is test suite for PrioritySampler.
+type PrioritySamplerSuite struct {
+	suite.Suite
+
+	sampler *defaultSampler
+}
+
+// TestPrioritySampler is entry point of PrioritySamplerSuite.
+func TestPrioritySampler(t *testing.T) {
+	suite.Run(t, &PrioritySamplerSuite{})
+}
+
+// SetupSuite prepares the testing env
+func (suite *PrioritySamplerSuite) SetupSuite() {
+	suite.sampler = &defaultSampler{}
+}
+
+// Test for method
+func (suite *PrioritySamplerSuite) Test() {
+	p1 := suite.sampler.For(SampleJob)
+	suite.Equal((uint)(1), p1, "Job priority for %s", SampleJob)
+
+	p2 := suite.sampler.For(Retention)
+	suite.Equal(defaultPriority, p2, "Job priority for %s", Retention)
+
+	p3 := suite.sampler.For(Replication)
+	suite.Equal(defaultPriority, p3, "Job priority for %s", Replication)
+}

--- a/src/jobservice/worker/cworker/c_worker.go
+++ b/src/jobservice/worker/cworker/c_worker.go
@@ -412,6 +412,7 @@ func (w *basicWorker) registerJob(name string, j interface{}) (err error) {
 		work.JobOptions{
 			MaxFails:       theJ.MaxFails(),
 			MaxConcurrency: theJ.MaxCurrency(),
+			Priority:       job.Priority().For(name),
 			SkipDead:       true,
 		},
 		// Use generic handler to handle as we do not accept context with this way.


### PR DESCRIPTION
- priority option is supported when doing job registration
- the priority is defined by a unique priority sampler
- the default priority is 1000 (max is 10000)

 Fix issue #11607 

Signed-off-by: Steven Zou <szou@vmware.com>