### PR TITLE
add warning to registry binary name

### DIFF
--- a/make/photon/registry/Dockerfile
+++ b/make/photon/registry/Dockerfile
@@ -4,12 +4,12 @@ FROM ${harbor_base_namespace}/harbor-registry-base:${harbor_base_image_version}
 
 COPY ./make/photon/common/install_cert.sh /home/harbor
 COPY ./make/photon/registry/entrypoint.sh /home/harbor
-COPY ./make/photon/registry/binary/registry /usr/bin
+COPY ./make/photon/registry/binary/registry /usr/bin/registry_DO_NOT_USE_GC
 
 RUN chown -R harbor:harbor /etc/pki/tls/certs \
     && chown harbor:harbor /home/harbor/entrypoint.sh && chmod u+x /home/harbor/entrypoint.sh \
     && chown harbor:harbor /home/harbor/install_cert.sh && chmod u+x /home/harbor/install_cert.sh \
-    && chown harbor:harbor /usr/bin/registry && chmod u+x /usr/bin/registry
+    && chown harbor:harbor /usr/bin/registry_DO_NOT_USE_GC && chmod u+x /usr/bin/registry_DO_NOT_USE_GC
 
 HEALTHCHECK CMD curl --fail -s http://127.0.0.1:5000 || curl -k --fail -s https://127.0.0.1:5443 || exit 1
 

--- a/make/photon/registry/entrypoint.sh
+++ b/make/photon/registry/entrypoint.sh
@@ -10,4 +10,4 @@ set -e
 
 /home/harbor/install_cert.sh
 
-/usr/bin/registry serve /etc/registry/config.yml
+/usr/bin/registry_DO_NOT_USE_GC serve /etc/registry/config.yml

--- a/make/photon/registryctl/Dockerfile
+++ b/make/photon/registryctl/Dockerfile
@@ -3,13 +3,13 @@ ARG harbor_base_namespace
 FROM ${harbor_base_namespace}/harbor-registryctl-base:${harbor_base_image_version}
 
 COPY ./make/photon/common/install_cert.sh /home/harbor
-COPY ./make/photon/registry/binary/registry /usr/bin
+COPY ./make/photon/registry/binary/registry /usr/bin/registry_DO_NOT_USE_GC
 COPY ./make/photon/registryctl/start.sh /home/harbor
 COPY ./make/photon/registryctl/harbor_registryctl /home/harbor
 
 RUN chown -R harbor:harbor /etc/pki/tls/certs \
     && chown harbor:harbor /home/harbor/harbor_registryctl && chmod u+x /home/harbor/harbor_registryctl \
-    && chown harbor:harbor /usr/bin/registry && chmod u+x /usr/bin/registry \
+    && chown harbor:harbor /usr/bin/registry_DO_NOT_USE_GC && chmod u+x /usr/bin/registry_DO_NOT_USE_GC \
     && chown harbor:harbor /home/harbor/start.sh && chmod u+x /home/harbor/start.sh \
     && chown harbor:harbor /home/harbor/install_cert.sh && chmod u+x /home/harbor/install_cert.sh
 

--- a/src/registryctl/api/registry.go
+++ b/src/registryctl/api/registry.go
@@ -38,7 +38,7 @@ type GCResult struct {
 
 // StartGC ...
 func StartGC(w http.ResponseWriter, r *http.Request) {
-	cmd := exec.Command("/bin/bash", "-c", "registry garbage-collect --delete-untagged=false "+regConf)
+	cmd := exec.Command("/bin/bash", "-c", "registry_DO_NOT_USE_GC garbage-collect --delete-untagged=false "+regConf)
 	var outBuf, errBuf bytes.Buffer
 	cmd.Stdout = &outBuf
 	cmd.Stderr = &errBuf


### PR DESCRIPTION
Fixes #11606

As we DO NOT want to user to execute GC in the container, rename it and append the warning message.

Signed-off-by: wang yan <wangyan@vmware.com>