### PR TITLE
fix notification policy ugrade issue

### DIFF
--- a/make/migrations/postgresql/0030_2.0.0_schema.up.sql
+++ b/make/migrations/postgresql/0030_2.0.0_schema.up.sql
@@ -191,6 +191,9 @@ DROP TABLE IF EXISTS access_log;
 /*remove the constraint for project_id in table 'notification_policy'*/
 ALTER TABLE notification_policy DROP CONSTRAINT unique_project_id;
 
+/*the existing policy has no name, to make sure the unique constraint for name works, use the id as name*/
+/*if the name is set via API, it will be force to be changed with new pattern*/
+UPDATE notification_policy SET name=CONCAT('policy_', id);
 /*add the unique constraint for name in table 'notification_policy'*/
 ALTER TABLE notification_policy ADD UNIQUE (name);
 


### PR DESCRIPTION
Fixes #11624
All of the existing policies created v1.10 has no name, it fails the upgrade process.
When to set the unique constraint for policy name, the empty can be seen as duplicated key.

ERROR:  could not create unique index "notification_policy_name_key"
DETAIL:  Key (name)=() is duplicated.

Signed-off-by: wang yan <wangyan@vmware.com>