### PR TITLE
fix: set root password never expire

### DIFF
--- a/make/photon/log/Dockerfile
+++ b/make/photon/log/Dockerfile
@@ -17,6 +17,8 @@ COPY ./make/photon/log/start.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/start.sh /etc/rsyslog.d/ && \
     chown -R 10000:10000 /etc/rsyslog.conf /etc/rsyslog.d/ /run /var/lib/logrotate/
 
+RUN chage -M 99999 root
+
 HEALTHCHECK CMD netstat -ltun|grep 10514
 
 VOLUME /var/log/docker/ /run/ /etc/logrotate.d/


### PR DESCRIPTION
For harbor-log container,
```
root [ / ]# chage -l root
Last password change					: Apr 15, 2020
Password expires					: Jul 14, 2020
Password inactive					: never
Account expires						: never
Minimum number of days between password change		: 0
Maximum number of days between password change		: 90
Number of days of warning before password expires	: 7
```
When run ```sudo -u \#10000 -E  'rsyslogd' '-n'```, after 90 days you build image, it requires password change.
Fix: https://github.com/goharbor/harbor/issues/11633