### PR TITLE
fix(replication) fix replication hang seems when enable internal tls

### DIFF
--- a/src/pkg/registry/client.go
+++ b/src/pkg/registry/client.go
@@ -396,7 +396,7 @@ func (c *client) monolithicBlobUpload(location, digest string, size int64, data 
 	if err != nil {
 		return err
 	}
-	req.ContentLength = size
+	req.ContentLength = -1
 	resp, err := c.do(req)
 	if err != nil {
 		return err


### PR DESCRIPTION
It seems when enable internal tls, transfer some bigger blob, it will hang at 
https://github.com/goharbor/harbor/blob/master/src/pkg/registry/client.go#L390

the root reason is not clear now, it seems set req.ContentLength = -1 can workaround.