### PR TITLE
Allow sys admin to call /c/UserExists

### DIFF
--- a/src/core/controllers/base.go
+++ b/src/core/controllers/base.go
@@ -30,6 +30,7 @@ import (
 	"github.com/goharbor/harbor/src/common"
 	"github.com/goharbor/harbor/src/common/dao"
 	"github.com/goharbor/harbor/src/common/models"
+	"github.com/goharbor/harbor/src/common/security"
 	"github.com/goharbor/harbor/src/common/utils"
 	email_util "github.com/goharbor/harbor/src/common/utils/email"
 	"github.com/goharbor/harbor/src/core/api"
@@ -126,8 +127,10 @@ func (cc *CommonController) UserExists() {
 	if err != nil {
 		log.Errorf("Failed to get the status of self registration flag, error: %v, disabling user existence check", err)
 	}
-	if !flag {
-		cc.CustomAbort(http.StatusPreconditionFailed, "self registration disabled.")
+	securityCtx, ok := security.FromContext(cc.Ctx.Request.Context())
+	isAdmin := ok && securityCtx.IsSysAdmin()
+	if !flag && !isAdmin {
+		cc.CustomAbort(http.StatusPreconditionFailed, "self registration disabled, only sysadmin can check user existence")
 	}
 
 	target := cc.GetString("target")


### PR DESCRIPTION
The commit fix a regression introduced by #11672 which impacts admin
adding new users.
When admin is creating new users, /c/UserExists is called by UI. We must
allow it called by admin when self-registration is turned off.

Signed-off-by: Daniel Jiang <jiangd@vmware.com>