### PR TITLE
fix(retention) fix empty pull time log

### DIFF
--- a/src/pkg/retention/job.go
+++ b/src/pkg/retention/job.go
@@ -213,7 +213,7 @@ func arn(art *selector.Candidate) string {
 }
 
 func t(tm int64) string {
-	if tm == 0 {
+	if tm <= 0 {
 		return ""
 	}
 	return time.Unix(tm, 0).Format("2006/01/02 15:04:05")


### PR DESCRIPTION
fix #11690 
When artifact never been pulled, the time is nil in db, and the value is int64(-62135596800) that shown as "0001/01/01 00:00:00", so just ignore time<=0 can work

Signed-off-by: Ziming Zhang <zziming@vmware.com>