### PR TITLE
Make swagger.yaml work with go-swagger

### DIFF
--- a/docs/build-customize-contribute/swagger.yaml
+++ b/docs/build-customize-contribute/swagger.yaml
@@ -4008,7 +4008,7 @@ paths:
           schema:
             type: array
             items:
-            $ref: '#/definitions/ImmutableTagRule'
+              $ref: '#/definitions/ImmutableTagRule'
         '400':
           description: Illegal format of provided ID value.
         '401':
@@ -4117,7 +4117,6 @@ paths:
         '200':
           description: Get Retention Metadatas successfully.
           schema:
-            type: object
             $ref: '#/definitions/RetentionMetadata'
 
   '/retentions':
@@ -4167,7 +4166,6 @@ paths:
         '200':
           description: Get Retention Policy successfully.
           schema:
-            type: object
             $ref: '#/definitions/RetentionPolicy'
         '401':
           description: User need to log in first.
@@ -4255,7 +4253,6 @@ paths:
           schema:
             type: array
             items:
-              type: object
               $ref: '#/definitions/RetentionExecution'
         '401':
           description: User need to log in first.
@@ -4329,7 +4326,6 @@ paths:
           schema:
             type: array
             items:
-              type: object
               $ref: '#/definitions/RetentionExecutionTask'
         '401':
           description: User need to log in first.
@@ -6273,13 +6269,9 @@ definitions:
         items:
           $ref: '#/definitions/RetentionRule'
       trigger:
-        type: object
-        items:
-          $ref: '#/definitions/RetentionRuleTrigger'
+        $ref: '#/definitions/RetentionRuleTrigger'
       scope:
-        type: object
-        items:
-          $ref: '#/definitions/RetentionPolicyScope'
+        $ref: '#/definitions/RetentionPolicyScope'
 
   RetentionRuleTrigger:
     type: object


### PR DESCRIPTION
I was attempting to build a Go client for Harbor to automate project and user management, and I discovered that the current swagger doc for the management APIs hits at least two issues:

```
The swagger spec at "https://github.com/goharbor/harbor/raw/master/docs/build-customize-contribute/swagger.yaml" is invalid against swagger specification 2.0. see errors :
- definitions.RetentionPolicy.properties.trigger in body must be of type array
- definitions.RetentionPolicy.properties.scope in body must be of type array
```
(`items` is not a valid field on `type:object` -- these should just be a straight `$ref`)

And

```
response body for "" is a collection without an element type (array requires items definition)
```
(missing indent on `/projects/{project_id}/immutabletagrules`)