### PR TITLE
fix(retention) not retry retention job

### DIFF
--- a/src/pkg/retention/job.go
+++ b/src/pkg/retention/job.go
@@ -54,7 +54,7 @@ func (pj *Job) MaxCurrency() uint {
 
 // ShouldRetry indicates job can be retried if failed
 func (pj *Job) ShouldRetry() bool {
-	return true
+	return false
 }
 
 // Validate the parameters


### PR DESCRIPTION
fix #11702
do not retry retention job, as it's usually not necessary, and user can't manually retry easily
Signed-off-by: Ziming Zhang <zziming@vmware.com>