### PR TITLE
[cherry-pick]Fix delete repository event issue

### DIFF
--- a/src/controller/event/handler/webhook/artifact/artifact.go
+++ b/src/controller/event/handler/webhook/artifact/artifact.go
@@ -115,9 +115,10 @@ func (a *Handler) constructArtifactPayload(event *event.ArtifactEvent) (*model.P
 	repoRecord, err := repository.Mgr.GetByName(ctx, repoName)
 	if err != nil {
 		log.Errorf("failed to get repository with name %s: %v", repoName, err)
-		return nil, err
+	} else {
+		// for the delete repository event, it cannot get the repo info here, just let the creation time be empty.
+		payload.EventData.Repository.DateCreated = repoRecord.CreationTime.Unix()
 	}
-	payload.EventData.Repository.DateCreated = repoRecord.CreationTime.Unix()
 
 	var reference string
 	if len(event.Tags) == 0 {


### PR DESCRIPTION
In the delete repository scenario, the repository has already been removed from the DB, the repository cannot be retrived.
Just let the creation time as empty.

Signed-off-by: wang yan <wangyan@vmware.com>