### PR TITLE
[Cherry pick]fix(swagger): enable security in swagger.yaml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -518,7 +518,6 @@ swagger_client:
 	mkdir  -p harborclient/harbor_client
 	mkdir  -p harborclient/harbor_swagger_client
 	mkdir  -p harborclient/harbor_v2_swagger_client
-	sed -i "/type: basic/ a\\security:\n  - basicAuth: []" api/v2.0/swagger.yaml
 	java -jar swagger-codegen-cli.jar generate -i api/swagger.yaml -l python -o harborclient/harbor_client -DpackageName=client
 	java -jar swagger-codegen-cli.jar generate -i api/v2.0/legacy_swagger.yaml -l python -o harborclient/harbor_swagger_client -DpackageName=swagger_client
 	java -jar swagger-codegen-cli.jar generate -i api/v2.0/swagger.yaml -l python -o harborclient/harbor_v2_swagger_client -DpackageName=v2_swagger_client

--- a/api/v2.0/swagger.yaml
+++ b/api/v2.0/swagger.yaml
@@ -13,8 +13,11 @@ produces:
 consumes:
   - application/json
 securityDefinitions:
-  basicAuth:
+  basic:
     type: basic
+security:
+  - basic: []
+  - {}
 paths:
   /projects/{project_name}/repositories:
     get:

--- a/tests/apitests/python/library/base.py
+++ b/tests/apitests/python/library/base.py
@@ -23,7 +23,12 @@ class Credential:
         self.password = password
 
 def _create_client(server, credential, debug, api_type="products"):
-    cfg = swagger_client.Configuration()
+    cfg = None
+    if api_type in ('projectv2', 'artifact', 'repository', 'scan'):
+        cfg = v2_swagger_client.Configuration()
+    else:
+        cfg = swagger_client.Configuration()
+
     cfg.host = server.endpoint
     cfg.verify_ssl = server.verify_ssl
     # support basic auth only for now


### PR DESCRIPTION
1. Enable `security` in the swagger.yaml.
2. Include `basic` auth in `security` to make the generated python
client by `swagger-codegen-cli` work with basic authorization.
3. Include `anonymous` auth in `security` to make APIs of v2.0 generated
by `goswagger` work with `security` middleware.

Closes #11771

Signed-off-by: He Weiwei <hweiwei@vmware.com>