### PR TITLE
[cherry-pick]fix(retention) fix empty pull time log 2.0.0

### DIFF
--- a/src/pkg/retention/dep/client.go
+++ b/src/pkg/retention/dep/client.go
@@ -17,13 +17,11 @@ package dep
 import (
 	"errors"
 	"fmt"
-	"github.com/goharbor/harbor/src/lib/selector"
-	"net/http"
-	"time"
-
 	"github.com/goharbor/harbor/src/common/http/modifier/auth"
 	"github.com/goharbor/harbor/src/jobservice/config"
+	"github.com/goharbor/harbor/src/lib/selector"
 	"github.com/goharbor/harbor/src/pkg/clients/core"
+	"net/http"
 )
 
 // DefaultClient for the retention
@@ -109,8 +107,8 @@ func (bc *basicClient) GetCandidates(repository *selector.Repository) ([]*select
 				labels = append(labels, label.Name)
 			}
 			tags := make([]string, 0)
-			var lastPulledTime time.Time
-			var lastPushedTime time.Time
+			lastPulledTime := art.PullTime
+			lastPushedTime := art.PushTime
 			for _, t := range art.Tags {
 				tags = append(tags, t.Name)
 				if t.PullTime.After(lastPulledTime) {

--- a/src/pkg/retention/job.go
+++ b/src/pkg/retention/job.go
@@ -213,7 +213,7 @@ func arn(art *selector.Candidate) string {
 }
 
 func t(tm int64) string {
-	if tm == 0 {
+	if tm <= 0 {
 		return ""
 	}
 	return time.Unix(tm, 0).Format("2006/01/02 15:04:05")


### PR DESCRIPTION
fix #11690

When artifact never been pulled, the time is nil in db, and the value is int64(-62135596800) that shown as "0001/01/01 00:00:00", so just ignore time<=0 can work