### PR TITLE
fix conformance test ErrorsCodes failure

### DIFF
--- a/src/lib/errors/const.go
+++ b/src/lib/errors/const.go
@@ -23,6 +23,8 @@ const (
 	ViolateForeignKeyConstraintCode = "VIOLATE_FOREIGN_KEY_CONSTRAINT"
 	// DIGESTINVALID ...
 	DIGESTINVALID = "DIGEST_INVALID"
+	// MANIFESTINVALID ...
+	MANIFESTINVALID = "MANIFEST_INVALID"
 )
 
 // NotFoundError is error for the case of object not found

--- a/src/server/error/error.go
+++ b/src/server/error/error.go
@@ -30,6 +30,7 @@ var (
 	codeMap = map[string]int{
 		errors.BadRequestCode:                  http.StatusBadRequest,
 		errors.DIGESTINVALID:                   http.StatusBadRequest,
+		errors.MANIFESTINVALID:                 http.StatusBadRequest,
 		errors.UnAuthorizedCode:                http.StatusUnauthorized,
 		errors.ForbiddenCode:                   http.StatusForbidden,
 		errors.DENIED:                          http.StatusForbidden,

--- a/src/server/middleware/quota/put_manifest.go
+++ b/src/server/middleware/quota/put_manifest.go
@@ -19,6 +19,7 @@ import (
 	"strconv"
 
 	"github.com/goharbor/harbor/src/controller/blob"
+	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/lib/log"
 	"github.com/goharbor/harbor/src/pkg/blob/models"
 	"github.com/goharbor/harbor/src/pkg/types"
@@ -42,7 +43,7 @@ func putManifestResources(r *http.Request, reference, referenceID string) (types
 	manifest, descriptor, err := unmarshalManifest(r)
 	if err != nil {
 		logger.Errorf("unmarshal manifest failed, error: %v", err)
-		return nil, err
+		return nil, errors.Wrap(err, "unmarshal manifest failed").WithCode(errors.MANIFESTINVALID)
 	}
 
 	exist, err := blobController.Exist(r.Context(), descriptor.Digest.String(), blob.IsAssociatedWithProject(projectID))


### PR DESCRIPTION
fixes #11945
When client calls PUT with an invalid digtest, Harbor has to give a 400 instead of 500.

Signed-off-by: wang yan <wangyan@vmware.com>