### PR TITLE
fix conformance issue on deleting manifest

### DIFF
--- a/src/lib/errors/const.go
+++ b/src/lib/errors/const.go
@@ -25,6 +25,8 @@ const (
 	DIGESTINVALID = "DIGEST_INVALID"
 	// MANIFESTINVALID ...
 	MANIFESTINVALID = "MANIFEST_INVALID"
+	// UNSUPPORTED is for digest UNSUPPORTED error
+	UNSUPPORTED = "UNSUPPORTED"
 )
 
 // NotFoundError is error for the case of object not found

--- a/src/server/error/error.go
+++ b/src/server/error/error.go
@@ -31,6 +31,7 @@ var (
 		errors.BadRequestCode:                  http.StatusBadRequest,
 		errors.DIGESTINVALID:                   http.StatusBadRequest,
 		errors.MANIFESTINVALID:                 http.StatusBadRequest,
+		errors.UNSUPPORTED:                     http.StatusBadRequest,
 		errors.UnAuthorizedCode:                http.StatusUnauthorized,
 		errors.ForbiddenCode:                   http.StatusForbidden,
 		errors.DENIED:                          http.StatusForbidden,

--- a/src/server/registry/manifest.go
+++ b/src/server/registry/manifest.go
@@ -74,12 +74,8 @@ func deleteManifest(w http.ResponseWriter, req *http.Request) {
 	// Do not add the logic into GetByReference as it's a shared method for PUT/GET/DELETE/Internal call,
 	// and NOT_FOUND satisfy PUT/GET/Internal call.
 	if _, err := digest.Parse(reference); err != nil {
-		switch err {
-		case digest.ErrDigestInvalidFormat:
-			serror.SendError(w, errors.New(nil).WithCode(errors.DIGESTINVALID).
-				WithMessage(digest.ErrDigestInvalidFormat.Error()))
-			return
-		}
+		serror.SendError(w, errors.Wrapf(err, "unsupported digest %s", reference).WithCode(errors.UNSUPPORTED))
+		return
 	}
 	art, err := artifact.Ctl.GetByReference(req.Context(), repository, reference, nil)
 	if err != nil {

--- a/src/server/registry/manifest_test.go
+++ b/src/server/registry/manifest_test.go
@@ -121,7 +121,7 @@ func (m *manifestTestSuite) TestDeleteManifest() {
 	})
 	req = httptest.NewRequest(http.MethodDelete, "/v2/library/hello-world/manifests/sha256:418fb88ec412e340cdbef913b8ca1bbe8f9e8dc705f9617414c1f2c8db980180", nil)
 	input := &beegocontext.BeegoInput{}
-	input.SetParam(":reference", "sha527:418fb88ec412e340cdbef913b8ca1bbe8f9e8dc705f9617414c1f2c8db980180")
+	input.SetParam(":reference", "sha256:418fb88ec412e340cdbef913b8ca1bbe8f9e8dc705f9617414c1f2c8db980180")
 	*req = *(req.WithContext(context.WithValue(req.Context(), router.ContextKeyInput{}, input)))
 	w = &httptest.ResponseRecorder{}
 	mock.OnAnything(m.artCtl, "GetByReference").Return(&artifact.Artifact{}, nil)


### PR DESCRIPTION
fixes #11949
When to call delete manifest API with a tag as the reference, Harbor should give a unsupported error code.

Reference: Note that a manifest can only be deleted by digest. https://github.com/opencontainers/distribution-spec/blob/master/spec.md#delete-manifest

Signed-off-by: wang yan <wangyan@vmware.com>