### PR TITLE
Fix: chart repo response code inconsistent

### DIFF
--- a/src/core/api/chart_repository.go
+++ b/src/core/api/chart_repository.go
@@ -442,7 +442,7 @@ func (cra *ChartRepositoryAPI) requireNamespace(namespace string) bool {
 
 	// Not existing
 	if !existing {
-		cra.SendBadRequestError(fmt.Errorf("namespace %s is not existing", namespace))
+		cra.handleProjectNotFound(namespace)
 		return false
 	}
 


### PR DESCRIPTION
Response code should consistent whether namespace is existed or not

Signed-off-by: DQ <dengq@vmware.com>