### PR TITLE
fix(jobservice):fix issues of jobservice

### DIFF
--- a/src/jobservice/common/rds/scripts.go
+++ b/src/jobservice/common/rds/scripts.go
@@ -88,8 +88,14 @@ if res then
       end
 
       if ARGV[1] == 'Success' or ARGV[1] == 'Stopped' then
-        -- expire the job stats with shorter interval
+        -- expire the job stats with shorter interval (1 day)
         redis.call('expire', KEYS[1], 86400)
+      elseif ARGV[1] == 'Error' then
+        -- expire the job stats with normal interval (7 days) incase it may be retried again
+        redis.call('expire', KEYS[1], 604800)
+      else
+        -- remove the expire time if existing
+        redis.call('persist', KEYS[1])
       end
     end
     

--- a/src/jobservice/job/tracker_test.go
+++ b/src/jobservice/job/tracker_test.go
@@ -151,9 +151,6 @@ func (suite *TrackerTestSuite) TestTracker() {
 	st, err = t.Status()
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), StoppedStatus, st)
-
-	err = t.Expire()
-	assert.NoError(suite.T(), err)
 }
 
 // TestPeriodicTracker tests tracker of periodic

--- a/src/jobservice/period/basic_scheduler.go
+++ b/src/jobservice/period/basic_scheduler.go
@@ -143,11 +143,6 @@ func (bs *basicScheduler) UnSchedule(policyID string) error {
 		return err
 	}
 
-	// Expire periodic job stats
-	if err := tracker.Expire(); err != nil {
-		logger.Error(err)
-	}
-
 	// Switch the job stats to stopped
 	// Should not block the next clear action
 	err = tracker.Stop()


### PR DESCRIPTION
- never expire the jobs that are not entering the final status (Error, Success or Stopped)
- set different expiration time to the jobs with different status
- never store the `check_in` data in the Redis DB to save space

Signed-off-by: Steven Zou <szou@vmware.com>