### PR TITLE
Update health check script for harbor-db (#12103) - cherrypick to 2.0

### DIFF
--- a/make/photon/db/docker-healthcheck.sh
+++ b/make/photon/db/docker-healthcheck.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 set -eo pipefail
 
-host="$(hostname -i || echo '127.0.0.1')"
+h="$(hostname -i || echo '127.0.0.1')"
+host="${h%%[[:space:]]*}" #remove the trailing space
 user="${POSTGRES_USER:-postgres}"
 db="${POSTGRES_DB:-$POSTGRES_USER}"
 export PGPASSWORD="${POSTGRES_PASSWORD:-}"


### PR DESCRIPTION
This patch remove the trailing space of the hostname introduced by
`hostname -i`.

The trailing space will cause resolution error after this patch is
applied to glibc in photon:
https://github.com/vmware/photon/blob/2.0/SPECS/glibc/glibc-fix-CVE-2019-10739.patch

Signed-off-by: Daniel Jiang <jiangd@vmware.com>