### PR TITLE
fix(jobservice):mismatch status issue when stopping job

### DIFF
--- a/src/jobservice/hook/hook_agent_test.go
+++ b/src/jobservice/hook/hook_agent_test.go
@@ -166,7 +166,8 @@ func (suite *HookAgentTestSuite) TestRetryAndPopMin() {
 func (suite *HookAgentTestSuite) checkStatus() {
 	t := job.NewBasicTrackerWithID(context.TODO(), suite.jid, suite.namespace, suite.pool, nil, list.New())
 	err := t.Load()
-	suite.NoError(err, "load updated job stats")
+	require.NoError(suite.T(), err, "load updated job stats")
+	require.NotNil(suite.T(), t.Job(), "latest job stats")
 	suite.Equal(job.SuccessStatus.String(), t.Job().Info.HookAck.Status, "ack status")
 }
 

--- a/src/jobservice/worker/cworker/c_worker.go
+++ b/src/jobservice/worker/cworker/c_worker.go
@@ -327,7 +327,17 @@ func (w *basicWorker) StopJob(jobID string) error {
 
 	if job.RunningStatus.Compare(job.Status(t.Job().Info.Status)) < 0 {
 		// Job has been in the final states
-		return errors.Errorf("mismatch job status for stopping job: %s, job status %s is behind %s", jobID, t.Job().Info.Status, job.RunningStatus)
+		logger.Warningf("Trying to stop a(n) %s job: ID=%s, Kind=%s", t.Job().Info.Status, jobID, t.Job().Info.JobKind)
+		// Under this situation, the non-periodic job we're trying to stop has already been in the "non-running(stopped)" status.
+		// As the goal of stopping the job running has achieved, we directly return nil here.
+		if t.Job().Info.JobKind != job.KindPeriodic {
+			return nil
+		}
+
+		// For the periodic job, its status should always be "Scheduled".
+		// This case should never happen under the current model. But there might be some legacy job stats data
+		// to cause such inconsistent situation.
+		// Under this situation, let the periodical scheduler to handle and fix the issue.
 	}
 
 	switch t.Job().Info.JobKind {
@@ -338,9 +348,9 @@ func (w *basicWorker) StopJob(jobID string) error {
 		// otherwise, stop it.
 		if err := w.client.DeleteScheduledJob(t.Job().Info.RunAt, jobID); err != nil {
 			// Job is already running?
-			logger.Errorf("scheduled job %s (run at = %d) is not found in the queue to stop, is it already running?", jobID, t.Job().Info.RunAt)
+			logger.Errorf("scheduled job %s (run at = %d) is not found in the queue, is it running?", jobID, t.Job().Info.RunAt)
 		}
-		// Anyway, mark jon stopped
+		// Anyway, mark job stopped
 		return t.Stop()
 	case job.KindPeriodic:
 		return w.scheduler.UnSchedule(jobID)


### PR DESCRIPTION
CHERRY_PICK to 2.0

- returnning nil instead of error when trying to stop a job that has been in the final status(Error/Success/Stopped)
- do enhancements to the periodic job unschedule func
- fix a UT nil ptr issue

Signed-off-by: Steven Zou <szou@vmware.com>