### PR TITLE
fix: prepare script prompts SELinux relabeling of / is not allowed.

### DIFF
--- a/make/prepare
+++ b/make/prepare
@@ -51,6 +51,7 @@ docker run --rm -v $input_dir:/input:z \
                     -v $config_dir:/config:z \
                     -v $secret_dir:/secret:z \
                     -v /:/hostfs:z \
+                    --privileged \
                     goharbor/prepare:dev $@
 
 echo "Clean up the input dir"


### PR DESCRIPTION
The following error would be reported during installation on CoreOS:

```
/run/torcx/bin/docker: Error response from daemon: error setting label on mount source '/': SELinux relabeling of / is not allowed.
```