### PR TITLE
Update "registryctl" to invoke "registry garbage-collect ..." directly

### DIFF
--- a/src/registryctl/api/registry/gc/gc.go
+++ b/src/registryctl/api/registry/gc/gc.go
@@ -40,7 +40,7 @@ type Result struct {
 
 // start ...
 func (h *handler) start(w http.ResponseWriter, r *http.Request) {
-	cmd := exec.Command("/bin/bash", "-c", "registry_DO_NOT_USE_GC garbage-collect --delete-untagged=false "+h.registryConf)
+	cmd := exec.Command("registry_DO_NOT_USE_GC", "garbage-collect", "--delete-untagged=false", h.registryConf)
 	var outBuf, errBuf bytes.Buffer
 	cmd.Stdout = &outBuf
 	cmd.Stderr = &errBuf


### PR DESCRIPTION
This avoid shelling out to "/bin/bash" unnecessarily.