### PR TITLE
Remove unused "sudo" package from most images

### DIFF
--- a/make/photon/chartserver/Dockerfile.base
+++ b/make/photon/chartserver/Dockerfile.base
@@ -1,6 +1,6 @@
 FROM photon:2.0
 
-RUN tdnf install -y shadow sudo >>/dev/null\
+RUN tdnf install -y shadow >>/dev/null\
     && tdnf clean all \
     && groupadd -r -g 10000 chart \
     && useradd --no-log-init -m -g 10000 -u 10000 chart

--- a/make/photon/clair-adapter/Dockerfile.base
+++ b/make/photon/clair-adapter/Dockerfile.base
@@ -1,7 +1,5 @@
 FROM photon:2.0
 
-RUN tdnf install -y sudo >>/dev/null\
-    && tdnf clean all \
-    && mkdir /clair-adapter/ \
+RUN mkdir /clair-adapter/ \
     && groupadd -r -g 10000 clair-adapter \
     && useradd --no-log-init -m -r -g 10000 -u 10000 clair-adapter

--- a/make/photon/clair/Dockerfile.base
+++ b/make/photon/clair/Dockerfile.base
@@ -1,6 +1,6 @@
 FROM photon:2.0
 
-RUN tdnf install -y git shadow sudo rpm xz python-xml >>/dev/null\
+RUN tdnf install -y git shadow rpm xz python-xml >>/dev/null\
     && tdnf clean all \
     && groupadd -r -g 10000 clair \
     && useradd --no-log-init -m -g 10000 -u 10000 clair

--- a/make/photon/core/Dockerfile.base
+++ b/make/photon/core/Dockerfile.base
@@ -1,6 +1,6 @@
 FROM photon:2.0
 
-RUN tdnf install sudo tzdata -y >> /dev/null \
+RUN tdnf install tzdata -y >> /dev/null \
     && tdnf clean all \
     && groupadd -r -g 10000 harbor && useradd --no-log-init -r -m -g 10000 -u 10000 harbor \
     && mkdir /harbor/

--- a/make/photon/jobservice/Dockerfile.base
+++ b/make/photon/jobservice/Dockerfile.base
@@ -1,5 +1,5 @@
 FROM photon:2.0
 
-RUN tdnf install sudo tzdata -y >> /dev/null \
+RUN tdnf install tzdata -y >> /dev/null \
     && tdnf clean all \
     && groupadd -r -g 10000 harbor && useradd --no-log-init -r -m -g 10000 -u 10000 harbor

--- a/make/photon/nginx/Dockerfile.base
+++ b/make/photon/nginx/Dockerfile.base
@@ -1,6 +1,6 @@
 FROM photon:2.0
 
-RUN tdnf install sudo nginx -y >> /dev/null\
+RUN tdnf install nginx -y >> /dev/null\
     && tdnf clean all \
     && groupadd -r -g 10000 nginx && useradd --no-log-init -r -g 10000 -u 10000 nginx \
     && ln -sf /dev/stdout /var/log/nginx/access.log \

--- a/make/photon/notary-server/Dockerfile.base
+++ b/make/photon/notary-server/Dockerfile.base
@@ -1,6 +1,6 @@
 FROM photon:2.0
 
-RUN tdnf install -y shadow sudo \
+RUN tdnf install -y shadow \
     && tdnf clean all \
     && groupadd -r -g 10000 notary \
     && useradd --no-log-init -r -g 10000 -u 10000 notary

--- a/make/photon/notary-signer/Dockerfile.base
+++ b/make/photon/notary-signer/Dockerfile.base
@@ -1,6 +1,6 @@
 FROM photon:2.0
 
-RUN tdnf install -y shadow sudo \
+RUN tdnf install -y shadow \
     && tdnf clean all \
     && groupadd -r -g 10000 notary \
     && useradd --no-log-init -r -g 10000 -u 10000 notary

--- a/make/photon/portal/Dockerfile.base
+++ b/make/photon/portal/Dockerfile.base
@@ -1,6 +1,6 @@
 FROM photon:2.0
 
-RUN tdnf install -y nginx sudo >> /dev/null \
+RUN tdnf install -y nginx >> /dev/null \
     && ln -sf /dev/stdout /var/log/nginx/access.log \
     && ln -sf /dev/stderr /var/log/nginx/error.log \
     && groupadd -r -g 10000 nginx && useradd --no-log-init -r -g 10000 -u 10000 nginx \

--- a/make/photon/redis/Dockerfile.base
+++ b/make/photon/redis/Dockerfile.base
@@ -1,3 +1,3 @@
 FROM photon:2.0
 
-RUN tdnf install -y redis sudo && tdnf clean all
+RUN tdnf install -y redis && tdnf clean all

--- a/make/photon/registry/Dockerfile.base
+++ b/make/photon/registry/Dockerfile.base
@@ -1,6 +1,4 @@
 FROM photon:2.0
 
-RUN tdnf install sudo -y >> /dev/null\
-    && tdnf clean all \
-    && mkdir -p /etc/registry \
+RUN mkdir -p /etc/registry \
     && groupadd -r -g 10000 harbor && useradd --no-log-init -m -g 10000 -u 10000 harbor

--- a/make/photon/registryctl/Dockerfile.base
+++ b/make/photon/registryctl/Dockerfile.base
@@ -1,6 +1,4 @@
 FROM photon:2.0
 
-RUN tdnf install sudo -y >> /dev/null \
-    && tdnf clean all \
-    && groupadd -r -g 10000 harbor && useradd --no-log-init -m -g 10000 -u 10000 harbor \
+RUN groupadd -r -g 10000 harbor && useradd --no-log-init -m -g 10000 -u 10000 harbor \
     && mkdir -p /etc/registry

--- a/make/photon/trivy-adapter/Dockerfile.base
+++ b/make/photon/trivy-adapter/Dockerfile.base
@@ -1,6 +1,6 @@
 FROM photon:2.0
 
-RUN tdnf install -y sudo rpm >> /dev/null \
+RUN tdnf install -y rpm >> /dev/null \
     && tdnf clean all \
     && groupadd -r -g 10000 scanner \
     && useradd --no-log-init -m -r -g 10000 -u 10000 scanner


### PR DESCRIPTION
Notably missing is the "log" image, which still uses sudo.

Relatedly, it might be useful to include `security_opt: [ 'no-new-privileges' ]` in the generated `docker-compose.yml` to avoid the ability of a setuid binary to elevate privileges in the containers.