### PR TITLE
Fix Amazon S3 storage not work

### DIFF
--- a/make/photon/prepare/templates/chartserver/env.jinja
+++ b/make/photon/prepare/templates/chartserver/env.jinja
@@ -25,10 +25,11 @@ DEPTH=1
 
 # Backend storage driver: e.g. "local", "amazon", "google" etc.
 STORAGE={{storage_driver}}
-
+{% if storage_driver == "amazon" %}
+AWS_SDK_LOAD_CONFIG=1
+{% endif %}
 # Storage driver settings
 {{all_storage_driver_configs}}
-
 ## Settings with default values. Just put here for future changes
 DEBUG=false
 LOG_JSON=true


### PR DESCRIPTION
The Chartmuseum S3 client need set an Env variable
Ref: https://github.com/helm/chartmuseum/issues/280

Signed-off-by: DQ <dengq@vmware.com>