### PR TITLE
fix(codecov):add ignore configuration

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -25,3 +25,16 @@ comment:
   layout: "reach,diff,flags,tree"
   behavior: default
   require_changes: no
+
+ignore:
+  - "**/*.md"
+  - "**/*.yml"
+  - "docs"
+  - "api"
+  - "make"
+  - "contrib"
+  - "tests"
+  - "tools"
+  - "src/vendor"
+  - "src/server/v2.0/models/**/*"
+  - "src/server/v2.0/restapi/**/*"


### PR DESCRIPTION
- ignore all md files
- ignore all yaml files
- ignore non source code folders: docs,api,make,contrib,tests,tools
- ignore source code vendor folder: src/vendor
- ignore folders for auto-generated code: "src/server/v2.0/models" and "src/server/v2.0/restapi"

Signed-off-by: Steven Zou <szou@vmware.com>