### PR TITLE
Fix Swagger description of API v2.0 errors

### DIFF
--- a/api/v2.0/swagger.yaml
+++ b/api/v2.0/swagger.yaml
@@ -774,9 +774,12 @@ responses:
 definitions:
   Errors:
     description: The error array that describe the errors got during the handling of request
-    type: array
-    items:
-      $ref: '#/definitions/Error'
+    type: object
+    properties:
+      errors:
+        type: array
+        items:
+          $ref: '#/definitions/Error'
   Error:
     description: a model for all the error response coming from harbor
     type: object


### PR DESCRIPTION
Errors are documented to be an array of errors. However, [`errors.Errors.Error()`](https://github.com/goharbor/harbor/blob/master/src/lib/errors/errors.go#L92) wraps the array inside a JSON object with key `errors`. As a result, the error is returned as the following HTTP response:
```json
{"errors":[{"code":"UNAUTHORIZED","message":"unauthorized"}]}
```
This PR fixes the Swagger description.
