### PR TITLE
fix delete manifest route issue

### DIFF
--- a/src/registryctl/handlers/router.go
+++ b/src/registryctl/handlers/router.go
@@ -33,6 +33,6 @@ func newRouter(conf config.Configuration) http.Handler {
 
 	rootRouter.Path("/api/registry/gc").Methods(http.MethodPost).Handler(gc.NewHandler(conf.RegistryConfig))
 	rootRouter.Path("/api/registry/blob/{reference}").Methods(http.MethodDelete).Handler(blob.NewHandler(conf.StorageDriver))
-	rootRouter.Path("/api/registry/{name}/manifests/{reference}").Methods(http.MethodDelete).Handler(manifest.NewHandler(conf.StorageDriver))
+	rootRouter.Path("/api/registry/{name:.*}/manifests/{reference}").Methods(http.MethodDelete).Handler(manifest.NewHandler(conf.StorageDriver))
 	return rootRouter
 }


### PR DESCRIPTION
The repository name contains blackslash, the mux router has to use the * to match the blackslash. Otherwise the caller(gc job) will get a 404.

Signed-off-by: wang yan <wangyan@vmware.com>