### PR TITLE
support list blobs by update time

### DIFF
--- a/src/pkg/blob/dao/dao.go
+++ b/src/pkg/blob/dao/dao.go
@@ -239,6 +239,10 @@ func (d *dao) ListBlobs(ctx context.Context, params models.ListParams) ([]*model
 		qs = qs.Filter("digest__in", params.BlobDigests)
 	}
 
+	if !params.UpdateTime.IsZero() {
+		qs = qs.Filter("update_time__lte", params.UpdateTime)
+	}
+
 	if params.ArtifactDigest != "" {
 		params.ArtifactDigests = append(params.ArtifactDigests, params.ArtifactDigest)
 	}

--- a/src/pkg/blob/dao/dao_test.go
+++ b/src/pkg/blob/dao/dao_test.go
@@ -20,6 +20,7 @@ import (
 	htesting "github.com/goharbor/harbor/src/testing"
 	"github.com/stretchr/testify/suite"
 	"testing"
+	"time"
 )
 
 type DaoTestSuite struct {
@@ -202,6 +203,18 @@ func (suite *DaoTestSuite) TestListBlobs() {
 	blobs, err = suite.dao.ListBlobs(ctx, models.ListParams{BlobDigests: []string{digest1, digest2}})
 	if suite.Nil(err) {
 		suite.Len(blobs, 2)
+	}
+
+	blobs, err = suite.dao.ListBlobs(ctx, models.ListParams{UpdateTime: time.Now().Add(-time.Hour)})
+	if suite.Nil(err) {
+		suite.Len(blobs, 0)
+	}
+
+	digest3 := suite.DigestString()
+	suite.dao.CreateBlob(ctx, &models.Blob{Digest: digest3, UpdateTime: time.Now().Add(-time.Hour * 2)})
+	blobs, err = suite.dao.ListBlobs(ctx, models.ListParams{UpdateTime: time.Now().Add(-time.Hour)})
+	if suite.Nil(err) {
+		suite.Len(blobs, 1)
 	}
 }
 

--- a/src/pkg/blob/manager_test.go
+++ b/src/pkg/blob/manager_test.go
@@ -19,6 +19,7 @@ import (
 	htesting "github.com/goharbor/harbor/src/testing"
 	"github.com/stretchr/testify/suite"
 	"testing"
+	"time"
 
 	"github.com/goharbor/harbor/src/pkg/blob/models"
 )
@@ -222,6 +223,11 @@ func (suite *ManagerTestSuite) TestList() {
 	blobs, err = Mgr.List(ctx, ListParams{BlobDigests: []string{digest1, digest2}})
 	suite.Nil(err)
 	suite.Len(blobs, 2)
+
+	blobs, err = Mgr.List(ctx, models.ListParams{UpdateTime: time.Now().Add(-time.Hour)})
+	if suite.Nil(err) {
+		suite.Len(blobs, 0)
+	}
 }
 
 func (suite *ManagerTestSuite) TestListByArtifact() {

--- a/src/pkg/blob/models/blob.go
+++ b/src/pkg/blob/models/blob.go
@@ -88,8 +88,9 @@ type ProjectBlob = models.ProjectBlob
 
 // ListParams list params
 type ListParams struct {
-	ArtifactDigest  string   // list blobs which associated with the artifact
-	ArtifactDigests []string // list blobs which associated with these artifacts
-	BlobDigests     []string // list blobs which digest in the digests
-	ProjectID       int64    // list blobs which associated with the project
+	ArtifactDigest  string    // list blobs which associated with the artifact
+	ArtifactDigests []string  // list blobs which associated with these artifacts
+	BlobDigests     []string  // list blobs which digest in the digests
+	ProjectID       int64     // list blobs which associated with the project
+	UpdateTime      time.Time // list blobs which update time less than updatetime
 }


### PR DESCRIPTION
Add support list blob with update time.
As introduces the time window in GC, it wants to list the blobs less than specific time.

Signed-off-by: wang yan <wangyan@vmware.com>