### PR TITLE
fix return value for blob & manifest not found

### DIFF
--- a/src/registryctl/api/base.go
+++ b/src/registryctl/api/base.go
@@ -16,6 +16,7 @@ package api
 
 import (
 	"encoding/json"
+	"github.com/docker/distribution/registry/storage/driver"
 	"github.com/goharbor/harbor/src/lib/errors"
 	lib_http "github.com/goharbor/harbor/src/lib/http"
 	"net/http"
@@ -38,6 +39,9 @@ func HandleBadRequest(w http.ResponseWriter, err error) {
 
 // HandleError ...
 func HandleError(w http.ResponseWriter, err error) {
+	if _, ok := err.(driver.PathNotFoundError); ok {
+		err = errors.New(nil).WithCode(errors.NotFoundCode).WithMessage(err.Error())
+	}
 	lib_http.SendError(w, err)
 }
 

--- a/src/registryctl/api/base_test.go
+++ b/src/registryctl/api/base_test.go
@@ -15,6 +15,7 @@
 package api
 
 import (
+	"github.com/docker/distribution/registry/storage/driver"
 	"github.com/goharbor/harbor/src/lib/errors"
 	"net/http"
 	"net/http/httptest"
@@ -45,6 +46,12 @@ func TestHandleError(t *testing.T) {
 	HandleError(w, errors.New("handle error"))
 	if w.Code != http.StatusInternalServerError {
 		t.Errorf("unexpected status code: %d != %d", w.Code, http.StatusInternalServerError)
+	}
+
+	w = httptest.NewRecorder()
+	HandleError(w, driver.PathNotFoundError{Path: "/blobstore/nonexist"})
+	if w.Code != http.StatusNotFound {
+		t.Errorf("unexpected status code: %d != %d", w.Code, http.StatusNotFound)
 	}
 
 }


### PR DESCRIPTION
When to delete an non exist blob/manifest, the API has to return a 404 instead of 500

Signed-off-by: wang yan <wangyan@vmware.com>