### PR TITLE
Rename master role to maintainer

### DIFF
--- a/api/v2.0/legacy_swagger.yaml
+++ b/api/v2.0/legacy_swagger.yaml
@@ -3858,9 +3858,9 @@ definitions:
       project_admin_count:
         type: integer
         description: The total number of project admin members.
-      master_count:
+      maintainer_count:
         type: integer
-        description: The total number of master members.
+        description: The total number of maintainer members.
       developer_count:
         type: integer
         description: The total number of developer members.
@@ -4592,7 +4592,7 @@ definitions:
     properties:
       role_id:
         type: integer
-        description: 'The role id 1 for projectAdmin, 2 for developer, 3 for guest, 4 for master'
+        description: 'The role id 1 for projectAdmin, 2 for developer, 3 for guest, 4 for maintainer'
       member_user:
         $ref: '#/definitions/UserEntity'
       member_group:
@@ -4602,7 +4602,7 @@ definitions:
     properties:
       role_id:
         type: integer
-        description: 'The role id 1 for projectAdmin, 2 for developer, 3 for guest, 4 for master'
+        description: 'The role id 1 for projectAdmin, 2 for developer, 3 for guest, 4 for maintainer'
   UserEntity:
     type: object
     properties:

--- a/make/migrations/postgresql/0040_2.1.0_schema.up.sql
+++ b/make/migrations/postgresql/0040_2.1.0_schema.up.sql
@@ -1,5 +1,6 @@
 ALTER TABLE project ADD COLUMN IF NOT EXISTS registry_id int;
 ALTER TABLE IF EXISTS cve_whitelist RENAME TO cve_allowlist;
+UPDATE role SET name='maintainer' WHERE name='master';
 
 CREATE TABLE IF NOT EXISTS execution (
     id SERIAL NOT NULL,

--- a/src/common/const.go
+++ b/src/common/const.go
@@ -32,7 +32,7 @@ const (
 	RoleProjectAdmin = 1
 	RoleDeveloper    = 2
 	RoleGuest        = 3
-	RoleMaster       = 4
+	RoleMaintainer   = 4
 	RoleLimitedGuest = 5
 
 	LabelLevelSystem  = "s"

--- a/src/common/dao/project.go
+++ b/src/common/dao/project.go
@@ -256,7 +256,7 @@ func projectQueryConditions(query *models.ProjectQueryParam) (string, []interfac
 				roleID = 2
 			case common.RoleGuest:
 				roleID = 3
-			case common.RoleMaster:
+			case common.RoleMaintainer:
 				roleID = 4
 			case common.RoleLimitedGuest:
 				roleID = 5

--- a/src/common/dao/project/projectmember_test.go
+++ b/src/common/dao/project/projectmember_test.go
@@ -310,7 +310,7 @@ func TestGetTotalOfProjectMembers(t *testing.T) {
 		wantErr bool
 	}{
 		{"Get total of project admin", args{currentProject.ProjectID, []int{common.RoleProjectAdmin}}, 2, false},
-		{"Get total of master", args{currentProject.ProjectID, []int{common.RoleMaster}}, 0, false},
+		{"Get total of maintainer", args{currentProject.ProjectID, []int{common.RoleMaintainer}}, 0, false},
 		{"Get total of developer", args{currentProject.ProjectID, []int{common.RoleDeveloper}}, 0, false},
 		{"Get total of guest", args{currentProject.ProjectID, []int{common.RoleGuest}}, 0, false},
 	}

--- a/src/common/models/project.go
+++ b/src/common/models/project.go
@@ -206,7 +206,7 @@ type ProjectSummary struct {
 	ChartCount uint64 `json:"chart_count"`
 
 	ProjectAdminCount int64 `json:"project_admin_count"`
-	MasterCount       int64 `json:"master_count"`
+	MaintainerCount   int64 `json:"maintainer_count"`
 	DeveloperCount    int64 `json:"developer_count"`
 	GuestCount        int64 `json:"guest_count"`
 	LimitedGuestCount int64 `json:"limited_guest_count"`

--- a/src/common/rbac/project_rbac_role.go
+++ b/src/common/rbac/project_rbac_role.go
@@ -115,7 +115,7 @@ var (
 			{Resource: ResourceArtifactLabel, Action: ActionDelete},
 		},
 
-		"master": {
+		"maintainer": {
 			{Resource: ResourceSelf, Action: ActionRead},
 
 			{Resource: ResourceMember, Action: ActionRead},
@@ -326,8 +326,8 @@ func (role *projectRBACRole) GetRoleName() string {
 	switch role.roleID {
 	case common.RoleProjectAdmin:
 		return "projectAdmin"
-	case common.RoleMaster:
-		return "master"
+	case common.RoleMaintainer:
+		return "maintainer"
 	case common.RoleDeveloper:
 		return "developer"
 	case common.RoleGuest:

--- a/src/core/api/project.go
+++ b/src/core/api/project.go
@@ -626,7 +626,7 @@ func getProjectMemberSummary(ctx context.Context, projectID int64, summary *mode
 		count *int64
 	}{
 		{common.RoleProjectAdmin, &summary.ProjectAdminCount},
-		{common.RoleMaster, &summary.MasterCount},
+		{common.RoleMaintainer, &summary.MaintainerCount},
 		{common.RoleDeveloper, &summary.DeveloperCount},
 		{common.RoleGuest, &summary.GuestCount},
 		{common.RoleLimitedGuest, &summary.LimitedGuestCount},
@@ -657,7 +657,7 @@ func highestRole(roles []int) int {
 	}
 	rolePower := map[int]int{
 		common.RoleProjectAdmin: 50,
-		common.RoleMaster:       40,
+		common.RoleMaintainer:   40,
 		common.RoleDeveloper:    30,
 		common.RoleGuest:        20,
 		common.RoleLimitedGuest: 10,

--- a/src/core/api/project_test.go
+++ b/src/core/api/project_test.go
@@ -494,16 +494,16 @@ func TestHighestRole(t *testing.T) {
 		{
 			[]int{
 				common.RoleDeveloper,
-				common.RoleMaster,
+				common.RoleMaintainer,
 				common.RoleLimitedGuest,
 			},
-			common.RoleMaster,
+			common.RoleMaintainer,
 		},
 		{
 			[]int{
 				common.RoleProjectAdmin,
-				common.RoleMaster,
-				common.RoleMaster,
+				common.RoleMaintainer,
+				common.RoleMaintainer,
 			},
 			common.RoleProjectAdmin,
 		},

--- a/src/core/api/projectmember.go
+++ b/src/core/api/projectmember.go
@@ -292,7 +292,7 @@ func AddProjectMember(projectID int64, request models.MemberReq) (int, error) {
 func isValidRole(role int) bool {
 	switch role {
 	case common.RoleProjectAdmin,
-		common.RoleMaster,
+		common.RoleMaintainer,
 		common.RoleDeveloper,
 		common.RoleGuest,
 		common.RoleLimitedGuest:

--- a/src/core/api/projectmember_test.go
+++ b/src/core/api/projectmember_test.go
@@ -396,7 +396,7 @@ func Test_isValidRole(t *testing.T) {
 		want bool
 	}{
 		{"project admin", args{1}, true},
-		{"master", args{4}, true},
+		{"maintainer", args{4}, true},
 		{"developer", args{2}, true},
 		{"guest", args{3}, true},
 		{"limited guest", args{5}, true},

--- a/src/testing/apitests/apilib/project.go
+++ b/src/testing/apitests/apilib/project.go
@@ -74,7 +74,7 @@ type ProjectSummary struct {
 	ChartCount uint64 `json:"chart_count"`
 
 	ProjectAdminCount int64 `json:"project_admin_count"`
-	MasterCount       int64 `json:"master_count"`
+	MaintainerCount   int64 `json:"maintainer_count"`
 	DeveloperCount    int64 `json:"developer_count"`
 	GuestCount        int64 `json:"guest_count"`
 


### PR DESCRIPTION
This commit rename the var name, text appearance, and swagger of "master" role
to "maintainer" role.
It only covers backend code.

Signed-off-by: Daniel Jiang <jiangd@vmware.com>