### PR TITLE
fix(quota): fix internal server error when delete project

### DIFF
--- a/src/common/quota/driver/project/driver.go
+++ b/src/common/quota/driver/project/driver.go
@@ -50,7 +50,7 @@ func getProjectsBatchFn(ctx context.Context, keys dataloader.Keys) []*dataloader
 		projectIDs = append(projectIDs, id)
 	}
 
-	projects, err := dao.GetProjects(&models.ProjectQueryParam{})
+	projects, err := dao.GetProjects(&models.ProjectQueryParam{ProjectIDs: projectIDs})
 	if err != nil {
 		return handleError(err)
 	}
@@ -154,7 +154,7 @@ func (d *driver) Validate(hardLimits types.ResourceList) error {
 func newDriver() dr.Driver {
 	cfg := config.NewDBCfgManager()
 
-	loader := dataloader.NewBatchedLoader(getProjectsBatchFn)
+	loader := dataloader.NewBatchedLoader(getProjectsBatchFn, dataloader.WithClearCacheOnBatch())
 
 	return &driver{cfg: cfg, loader: loader}
 }

--- a/src/core/api/project.go
+++ b/src/core/api/project.go
@@ -292,11 +292,6 @@ func (p *ProjectAPI) Delete() {
 		return
 	}
 
-	if err = p.ProjectMgr.Delete(p.project.ProjectID); err != nil {
-		p.ParseAndHandleError(fmt.Sprintf("failed to delete project %d", p.project.ProjectID), err)
-		return
-	}
-
 	quotaMgr, err := quota.NewManager("project", strconv.FormatInt(p.project.ProjectID, 10))
 	if err != nil {
 		p.SendInternalServerError(fmt.Errorf("failed to get quota manager: %v", err))
@@ -304,6 +299,11 @@ func (p *ProjectAPI) Delete() {
 	}
 	if err := quotaMgr.DeleteQuota(); err != nil {
 		p.SendInternalServerError(fmt.Errorf("failed to delete quota for project: %v", err))
+		return
+	}
+
+	if err = p.ProjectMgr.Delete(p.project.ProjectID); err != nil {
+		p.ParseAndHandleError(fmt.Sprintf("failed to delete project %d", p.project.ProjectID), err)
 		return
 	}
 


### PR DESCRIPTION
1. Clear cache for projects loader in quota driver of project which will
ensure that load project will raise error after project deleted.
2. Delete quota of the project before the deletion of the project.

Closes #12292

Signed-off-by: He Weiwei <hweiwei@vmware.com>