### PR TITLE
Rename "reuse_sys_cve_whitelist" to "reuse_sys_cve_allowlist"

### DIFF
--- a/make/migrations/postgresql/0040_2.1.0_schema.up.sql
+++ b/make/migrations/postgresql/0040_2.1.0_schema.up.sql
@@ -1,6 +1,7 @@
 ALTER TABLE project ADD COLUMN IF NOT EXISTS registry_id int;
 ALTER TABLE IF EXISTS cve_whitelist RENAME TO cve_allowlist;
 UPDATE role SET name='maintainer' WHERE name='master';
+UPDATE project_metadata SET name='reuse_sys_cve_allowlist' WHERE name='reuse_sys_cve_whitelist';
 
 CREATE TABLE IF NOT EXISTS execution (
     id SERIAL NOT NULL,


### PR DESCRIPTION
Rename "reuse_sys_cve_whitelist" to "reuse_sys_cve_allowlist" in project metadata

Signed-off-by: Wenkai Yin <yinw@vmware.com>