### PR TITLE
Change permissions on /storage to owner harbor

### DIFF
--- a/make/photon/registry/Dockerfile
+++ b/make/photon/registry/Dockerfile
@@ -9,7 +9,8 @@ COPY ./make/photon/registry/binary/registry /usr/bin/registry_DO_NOT_USE_GC
 RUN chown -R harbor:harbor /etc/pki/tls/certs \
     && chown harbor:harbor /home/harbor/entrypoint.sh && chmod u+x /home/harbor/entrypoint.sh \
     && chown harbor:harbor /home/harbor/install_cert.sh && chmod u+x /home/harbor/install_cert.sh \
-    && chown harbor:harbor /usr/bin/registry_DO_NOT_USE_GC && chmod u+x /usr/bin/registry_DO_NOT_USE_GC
+    && chown harbor:harbor /usr/bin/registry_DO_NOT_USE_GC && chmod u+x /usr/bin/registry_DO_NOT_USE_GC \
+    && mkdir /storage && chown harbor:harbor /storage
 
 HEALTHCHECK CMD curl --fail -s http://127.0.0.1:5000 || curl -k --fail -s https://127.0.0.1:5443 || exit 1
 


### PR DESCRIPTION
fixes #12463

By adding the folder `/storage` with the correct permissions to the image a new empty name volume is initialized with the contents of the image so the permissions are correct.