### PR TITLE
fix get manifest return code

### DIFF
--- a/src/server/middleware/repoproxy/proxy.go
+++ b/src/server/middleware/repoproxy/proxy.go
@@ -73,7 +73,11 @@ func handleBlob(w http.ResponseWriter, r *http.Request, next http.Handler) error
 }
 
 func preCheck(ctx context.Context) (art lib.ArtifactInfo, p *models.Project, ctl proxy.Controller, err error) {
+	none := lib.ArtifactInfo{}
 	art = lib.GetArtifactInfo(ctx)
+	if art == none {
+		return none, nil, nil, errors.New("artifactinfo is not found").WithCode(errors.NotFoundCode)
+	}
 	ctl = proxy.ControllerInstance()
 	p, err = project.Ctl.GetByName(ctx, art.ProjectName, project.Metadata(false))
 	return


### PR DESCRIPTION
When to call,
~~~ REQUEST ~~~
GET  /v2/conformance/testrepo/manifests/.INVALID_MANIFEST_NAME

Per OCI distribution spec, it has to return 404, instead of 400 (project name required)

Signed-off-by: wang yan <wangyan@vmware.com>