### PR TITLE
Don't return the error detail back to the client when adding registry

### DIFF
--- a/src/core/api/registry.go
+++ b/src/core/api/registry.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"strconv"
 
-	common_http "github.com/goharbor/harbor/src/common/http"
 	common_models "github.com/goharbor/harbor/src/common/models"
 	"github.com/goharbor/harbor/src/common/utils"
 	"github.com/goharbor/harbor/src/core/api/models"
@@ -111,21 +110,12 @@ func (t *RegistryAPI) Ping() {
 		return
 	}
 
-	status, err := registry.CheckHealthStatus(reg)
-	if err != nil {
-		e, ok := err.(*common_http.Error)
-		if ok && e.Code == http.StatusUnauthorized {
-			t.SendBadRequestError(errors.New("invalid credential"))
-			return
-		}
-		t.SendInternalServerError(fmt.Errorf("failed to check health of registry %s: %v", reg.URL, err))
+	status := t.getHealthStatus(reg)
+	if status != model.Healthy {
+		t.SendBadRequestError(errors.New("the registry is unhealthy"))
 		return
 	}
 
-	if status != model.Healthy {
-		t.SendBadRequestError(errors.New(""))
-		return
-	}
 	return
 }
 
@@ -226,13 +216,9 @@ func (t *RegistryAPI) Post() {
 	// Prevent SSRF security issue #3755
 	r.URL = url.Scheme + "://" + url.Host + url.Path
 
-	status, err := registry.CheckHealthStatus(r)
-	if err != nil {
-		t.SendBadRequestError(fmt.Errorf("health check to registry %s failed: %v", r.URL, err))
-		return
-	}
+	status := t.getHealthStatus(r)
 	if status != model.Healthy {
-		t.SendBadRequestError(fmt.Errorf("registry %s is unhealthy: %s", r.URL, status))
+		t.SendBadRequestError(errors.New("the registry is unhealthy"))
 		return
 	}
 
@@ -245,6 +231,15 @@ func (t *RegistryAPI) Post() {
 	}
 
 	t.Redirect(http.StatusCreated, strconv.FormatInt(id, 10))
+}
+
+func (t *RegistryAPI) getHealthStatus(r *model.Registry) string {
+	status, err := registry.CheckHealthStatus(r)
+	if err != nil {
+		log.Errorf("failed to check the health status of registry %s: %v", r.URL, err)
+		return model.Unhealthy
+	}
+	return string(status)
 }
 
 // Put updates a registry
@@ -313,13 +308,9 @@ func (t *RegistryAPI) Put() {
 		}
 	}
 
-	status, err := registry.CheckHealthStatus(r)
-	if err != nil {
-		t.SendBadRequestError(fmt.Errorf("health check to registry %s failed: %v", r.URL, err))
-		return
-	}
+	status := t.getHealthStatus(r)
 	if status != model.Healthy {
-		t.SendBadRequestError(fmt.Errorf("registry %s is unhealthy: %s", r.URL, status))
+		t.SendBadRequestError(errors.New("the registry is unhealthy"))
 		return
 	}
 


### PR DESCRIPTION
Don't return the error detail back to the client when adding registry to avoid security issue

Signed-off-by: Wenkai Yin <yinw@vmware.com>