### PR TITLE
Fix #12487: Proxy cache create duplicated operation log

### DIFF
--- a/src/controller/proxy/local_test.go
+++ b/src/controller/proxy/local_test.go
@@ -191,8 +191,9 @@ func (lh *localHelperTestSuite) TestManifestExist() {
 	var opt *artifact.Option
 	lh.artCtl.On("GetByReference", ctx, "library/hello-world", dig, opt).Return(ar, nil)
 	art := lib.ArtifactInfo{Repository: "library/hello-world", Digest: dig}
-	exist := lh.local.ManifestExist(ctx, art)
-	lh.Assert().True(exist)
+	a, err := lh.local.GetManifest(ctx, art)
+	lh.Assert().Nil(err)
+	lh.Assert().NotNil(a)
 }
 
 func TestLocalHelperTestSuite(t *testing.T) {

--- a/src/controller/proxy/remote.go
+++ b/src/controller/proxy/remote.go
@@ -17,8 +17,8 @@ package proxy
 import (
 	"fmt"
 	"github.com/docker/distribution"
-	"github.com/goharbor/harbor/src/lib/log"
 	"github.com/goharbor/harbor/src/replication/adapter"
+	"github.com/goharbor/harbor/src/replication/model"
 	"github.com/goharbor/harbor/src/replication/registry"
 	"io"
 )
@@ -28,20 +28,22 @@ type remoteInterface interface {
 	// BlobReader create a reader for remote blob
 	BlobReader(repo, dig string) (int64, io.ReadCloser, error)
 	// Manifest get manifest by reference
-	Manifest(repo string, ref string) (distribution.Manifest, error)
+	Manifest(repo string, ref string) (distribution.Manifest, string, error)
 }
 
 // remoteHelper defines operations related to remote repository under proxy
 type remoteHelper struct {
-	regID    int64
-	registry adapter.ArtifactRegistry
+	regID       int64
+	registry    adapter.ArtifactRegistry
+	registryMgr registry.Manager
 }
 
 // newRemoteHelper create a remoteHelper interface
-func newRemoteHelper(regID int64) (remoteInterface, error) {
-	r := &remoteHelper{regID: regID}
+func newRemoteHelper(regID int64) (*remoteHelper, error) {
+	r := &remoteHelper{
+		regID:       regID,
+		registryMgr: registry.NewDefaultManager()}
 	if err := r.init(); err != nil {
-		log.Errorf("failed to create remoteHelper error %v", err)
 		return nil, err
 	}
 	return r, nil
@@ -52,12 +54,15 @@ func (r *remoteHelper) init() error {
 	if r.registry != nil {
 		return nil
 	}
-	reg, err := registry.NewDefaultManager().Get(r.regID)
+	reg, err := r.registryMgr.Get(r.regID)
 	if err != nil {
 		return err
 	}
 	if reg == nil {
 		return fmt.Errorf("failed to get registry, registryID: %v", r.regID)
+	}
+	if reg.Status != model.Healthy {
+		return fmt.Errorf("current registry is unhealthy, regID:%v, Name:%v, Status: %v", reg.ID, reg.Name, reg.Status)
 	}
 	factory, err := adapter.GetFactory(reg.Type)
 	if err != nil {
@@ -75,7 +80,6 @@ func (r *remoteHelper) BlobReader(repo, dig string) (int64, io.ReadCloser, error
 	return r.registry.PullBlob(repo, dig)
 }
 
-func (r *remoteHelper) Manifest(repo string, ref string) (distribution.Manifest, error) {
-	man, _, err := r.registry.PullManifest(repo, ref)
-	return man, err
+func (r *remoteHelper) Manifest(repo string, ref string) (distribution.Manifest, string, error) {
+	return r.registry.PullManifest(repo, ref)
 }

--- a/src/server/middleware/repoproxy/proxy.go
+++ b/src/server/middleware/repoproxy/proxy.go
@@ -98,7 +98,15 @@ func handleManifest(w http.ResponseWriter, r *http.Request, next http.Handler) e
 	if err != nil {
 		return err
 	}
-	if !canProxy(p) || proxyCtl.UseLocalManifest(ctx, art) {
+	if !canProxy(p) {
+		next.ServeHTTP(w, r)
+		return nil
+	}
+	useLocal, err := proxyCtl.UseLocalManifest(ctx, art)
+	if err != nil {
+		return err
+	}
+	if useLocal {
 		next.ServeHTTP(w, r)
 		return nil
 	}


### PR DESCRIPTION
Change method UseLocalManifest to avoid pull manifest from remote repo frequently

Signed-off-by: stonezdj <stonezdj@gmail.com>