### PR TITLE
add debugging env for GC time window

### DIFF
--- a/src/common/const.go
+++ b/src/common/const.go
@@ -154,6 +154,6 @@ const (
 	CountPerProject       = "count_per_project"
 	StoragePerProject     = "storage_per_project"
 
-	// ForeignLayer
-	ForeignLayer = "application/vnd.docker.image.rootfs.foreign.diff.tar.gzip"
+	// DefaultGCBlobTimeWindow is the reserve blob time window used by GC, default is 2 hours
+	DefaultGCBlobTimeWindow = 2
 )

--- a/src/common/const.go
+++ b/src/common/const.go
@@ -154,6 +154,6 @@ const (
 	CountPerProject       = "count_per_project"
 	StoragePerProject     = "storage_per_project"
 
-	// DefaultGCBlobTimeWindow is the reserve blob time window used by GC, default is 2 hours
-	DefaultGCBlobTimeWindow = 2
+	// DefaultGCTimeWindowHours is the reserve blob time window used by GC, default is 2 hours
+	DefaultGCTimeWindowHours = int64(2)
 )

--- a/src/core/api/reg_gc.go
+++ b/src/core/api/reg_gc.go
@@ -75,7 +75,7 @@ func (gc *GCAPI) Post() {
 	}
 	ajr.Name = common_job.ImageGC
 	ajr.Parameters["redis_url_reg"] = os.Getenv("_REDIS_URL_REG")
-	ajr.Parameters["time_window"] = config.GetGCBlobTimeWindow()
+	ajr.Parameters["time_window"] = config.GetGCTimeWindow()
 	gc.submit(&ajr)
 	gc.Redirect(http.StatusCreated, strconv.FormatInt(ajr.ID, 10))
 }
@@ -103,7 +103,7 @@ func (gc *GCAPI) Put() {
 	}
 	ajr.Name = common_job.ImageGC
 	ajr.Parameters["redis_url_reg"] = os.Getenv("_REDIS_URL_REG")
-	ajr.Parameters["time_window"] = config.GetGCBlobTimeWindow()
+	ajr.Parameters["time_window"] = config.GetGCTimeWindow()
 	gc.updateSchedule(ajr)
 }
 

--- a/src/core/api/reg_gc.go
+++ b/src/core/api/reg_gc.go
@@ -16,6 +16,7 @@ package api
 
 import (
 	"errors"
+	"github.com/goharbor/harbor/src/core/config"
 	"net/http"
 	"os"
 	"strconv"
@@ -74,6 +75,7 @@ func (gc *GCAPI) Post() {
 	}
 	ajr.Name = common_job.ImageGC
 	ajr.Parameters["redis_url_reg"] = os.Getenv("_REDIS_URL_REG")
+	ajr.Parameters["time_window"] = config.GetGCBlobTimeWindow()
 	gc.submit(&ajr)
 	gc.Redirect(http.StatusCreated, strconv.FormatInt(ajr.ID, 10))
 }
@@ -101,6 +103,7 @@ func (gc *GCAPI) Put() {
 	}
 	ajr.Name = common_job.ImageGC
 	ajr.Parameters["redis_url_reg"] = os.Getenv("_REDIS_URL_REG")
+	ajr.Parameters["time_window"] = config.GetGCBlobTimeWindow()
 	gc.updateSchedule(ajr)
 }
 

--- a/src/core/config/config.go
+++ b/src/core/config/config.go
@@ -20,6 +20,7 @@ package config
 import (
 	"errors"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/goharbor/harbor/src/common"
@@ -477,4 +478,16 @@ func GetPermittedRegistryTypesForProxyCache() []string {
 		return []string{}
 	}
 	return strings.Split(types, ",")
+}
+
+// GetGCBlobTimeWindow returns the reserve time window of blob.
+func GetGCBlobTimeWindow() int64 {
+	// the env is for testing/debugging. For production, Do NOT set it.
+	if env, exist := os.LookupEnv("_GC_BLOB_TIME_WINDOW"); exist {
+		timeWindow, err := strconv.ParseInt(env, 10, 64)
+		if err == nil {
+			return timeWindow
+		}
+	}
+	return int64(common.DefaultGCBlobTimeWindow)
 }

--- a/src/core/config/config.go
+++ b/src/core/config/config.go
@@ -480,14 +480,14 @@ func GetPermittedRegistryTypesForProxyCache() []string {
 	return strings.Split(types, ",")
 }
 
-// GetGCBlobTimeWindow returns the reserve time window of blob.
-func GetGCBlobTimeWindow() int64 {
+// GetGCTimeWindow returns the reserve time window of blob.
+func GetGCTimeWindow() int64 {
 	// the env is for testing/debugging. For production, Do NOT set it.
-	if env, exist := os.LookupEnv("_GC_BLOB_TIME_WINDOW"); exist {
+	if env, exist := os.LookupEnv("GC_TIME_WINDOW_HOURS"); exist {
 		timeWindow, err := strconv.ParseInt(env, 10, 64)
 		if err == nil {
 			return timeWindow
 		}
 	}
-	return int64(common.DefaultGCBlobTimeWindow)
+	return common.DefaultGCTimeWindowHours
 }

--- a/src/core/config/config_test.go
+++ b/src/core/config/config_test.go
@@ -59,6 +59,7 @@ func TestConfig(t *testing.T) {
 	defer os.Setenv("TOKEN_PRIVATE_KEY_PATH", oriKeyPath)
 
 	os.Setenv("JOBSERVICE_URL", "http://myjob:8888")
+	os.Setenv("_GC_BLOB_TIME_WINDOW", "0")
 
 	Init()
 
@@ -188,6 +189,8 @@ func TestConfig(t *testing.T) {
 	assert.Equal("http://127.0.0.1:8080", localCoreURL)
 
 	assert.True(NotificationEnable())
+	assert.Equal(int64(0), GetGCBlobTimeWindow())
+
 }
 
 func currPath() string {

--- a/src/core/config/config_test.go
+++ b/src/core/config/config_test.go
@@ -59,7 +59,7 @@ func TestConfig(t *testing.T) {
 	defer os.Setenv("TOKEN_PRIVATE_KEY_PATH", oriKeyPath)
 
 	os.Setenv("JOBSERVICE_URL", "http://myjob:8888")
-	os.Setenv("_GC_BLOB_TIME_WINDOW", "0")
+	os.Setenv("GC_TIME_WINDOW_HOURS", "0")
 
 	Init()
 
@@ -189,7 +189,7 @@ func TestConfig(t *testing.T) {
 	assert.Equal("http://127.0.0.1:8080", localCoreURL)
 
 	assert.True(NotificationEnable())
-	assert.Equal(int64(0), GetGCBlobTimeWindow())
+	assert.Equal(int64(0), GetGCTimeWindow())
 
 }
 

--- a/src/pkg/blob/dao/dao.go
+++ b/src/pkg/blob/dao/dao.go
@@ -391,7 +391,7 @@ func (d *dao) GetBlobsNotRefedByProjectBlob(ctx context.Context, timeWindowHours
 		return noneRefed, err
 	}
 
-	sql := fmt.Sprintf(`SELECT b.id, b.digest, b.content_type, b.status FROM blob AS b LEFT JOIN project_blob pb ON b.id = pb.blob_id WHERE pb.id IS NULL AND b.update_time <= now() - interval '%d hours';`, timeWindowHours)
+	sql := fmt.Sprintf(`SELECT b.id, b.digest, b.content_type, b.status, b.version, b.size FROM blob AS b LEFT JOIN project_blob pb ON b.id = pb.blob_id WHERE pb.id IS NULL AND b.update_time <= now() - interval '%d hours';`, timeWindowHours)
 	_, err = ormer.Raw(sql).QueryRows(&noneRefed)
 	if err != nil {
 		return noneRefed, err

--- a/src/server/middleware/blob/head_blob.go
+++ b/src/server/middleware/blob/head_blob.go
@@ -3,6 +3,7 @@ package blob
 import (
 	"fmt"
 	"github.com/goharbor/harbor/src/controller/blob"
+	"github.com/goharbor/harbor/src/core/config"
 	"github.com/goharbor/harbor/src/lib"
 	"github.com/goharbor/harbor/src/lib/errors"
 	lib_http "github.com/goharbor/harbor/src/lib/http"
@@ -48,7 +49,7 @@ func handleHead(req *http.Request) error {
 	case blob_models.StatusDeleting:
 		now := time.Now().UTC()
 		// if the deleting exceed 2 hours, marks the blob as StatusDeleteFailed and gives a 404, so client can push it again
-		if now.Sub(bb.UpdateTime) > time.Duration(BlobDeleteingTimeWindow)*time.Hour {
+		if now.Sub(bb.UpdateTime) > time.Duration(config.GetGCBlobTimeWindow())*time.Hour {
 			if err := blob.Ctl.Fail(req.Context(), bb); err != nil {
 				log.Errorf("failed to update blob: %s status to StatusDeleteFailed, error:%v", blobInfo.Digest, err)
 				return errors.Wrapf(err, fmt.Sprintf("the request id is: %s", req.Header.Get(requestid.HeaderXRequestID)))

--- a/src/server/middleware/blob/head_blob.go
+++ b/src/server/middleware/blob/head_blob.go
@@ -49,7 +49,7 @@ func handleHead(req *http.Request) error {
 	case blob_models.StatusDeleting:
 		now := time.Now().UTC()
 		// if the deleting exceed 2 hours, marks the blob as StatusDeleteFailed and gives a 404, so client can push it again
-		if now.Sub(bb.UpdateTime) > time.Duration(config.GetGCBlobTimeWindow())*time.Hour {
+		if now.Sub(bb.UpdateTime) > time.Duration(config.GetGCTimeWindow())*time.Hour {
 			if err := blob.Ctl.Fail(req.Context(), bb); err != nil {
 				log.Errorf("failed to update blob: %s status to StatusDeleteFailed, error:%v", blobInfo.Digest, err)
 				return errors.Wrapf(err, fmt.Sprintf("the request id is: %s", req.Header.Get(requestid.HeaderXRequestID)))

--- a/src/server/middleware/blob/util.go
+++ b/src/server/middleware/blob/util.go
@@ -34,7 +34,7 @@ func probeBlob(r *http.Request, digest string) error {
 	case models.StatusDeleting:
 		now := time.Now().UTC()
 		// if the deleting exceed 2 hours, marks the blob as StatusDeleteFailed
-		if now.Sub(bb.UpdateTime) > time.Duration(config.GetGCBlobTimeWindow())*time.Hour {
+		if now.Sub(bb.UpdateTime) > time.Duration(config.GetGCTimeWindow())*time.Hour {
 			if err := blob.Ctl.Fail(r.Context(), bb); err != nil {
 				log.Errorf("failed to update blob: %s status to StatusDeleteFailed, error:%v", bb.Digest, err)
 				return errors.Wrapf(err, fmt.Sprintf("the request id is: %s", r.Header.Get(requestid.HeaderXRequestID)))

--- a/src/server/middleware/blob/util.go
+++ b/src/server/middleware/blob/util.go
@@ -3,6 +3,7 @@ package blob
 import (
 	"fmt"
 	"github.com/goharbor/harbor/src/controller/blob"
+	"github.com/goharbor/harbor/src/core/config"
 	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/lib/log"
 	"github.com/goharbor/harbor/src/pkg/blob/models"
@@ -10,9 +11,6 @@ import (
 	"net/http"
 	"time"
 )
-
-// BlobDeleteingTimeWindow is the time window used in GC to reserve blobs
-const BlobDeleteingTimeWindow = 2
 
 // probeBlob handles config/layer and manifest status in the PUT Blob & Manifest middleware, and update the status before it passed into proxy(distribution).
 func probeBlob(r *http.Request, digest string) error {
@@ -36,7 +34,7 @@ func probeBlob(r *http.Request, digest string) error {
 	case models.StatusDeleting:
 		now := time.Now().UTC()
 		// if the deleting exceed 2 hours, marks the blob as StatusDeleteFailed
-		if now.Sub(bb.UpdateTime) > time.Duration(BlobDeleteingTimeWindow)*time.Hour {
+		if now.Sub(bb.UpdateTime) > time.Duration(config.GetGCBlobTimeWindow())*time.Hour {
 			if err := blob.Ctl.Fail(r.Context(), bb); err != nil {
 				log.Errorf("failed to update blob: %s status to StatusDeleteFailed, error:%v", bb.Digest, err)
 				return errors.Wrapf(err, fmt.Sprintf("the request id is: %s", r.Header.Get(requestid.HeaderXRequestID)))

--- a/tests/apitests/python/library/system.py
+++ b/tests/apitests/python/library/system.py
@@ -93,7 +93,7 @@ class System(base.Base):
     def create_gc_schedule(self, schedule_type, cron = None, expect_status_code = 201, expect_response_body = None, **kwargs):
         client = self._get_client(**kwargs)
 
-        gc_parameters = {'delete_untagged':True, 'time_window':'0'}
+        gc_parameters = {'delete_untagged':True}
 
         gc_schedule = swagger_client.AdminJobScheduleObj()
         gc_schedule.type = schedule_type

--- a/tests/ci/api_common_install.sh
+++ b/tests/ci/api_common_install.sh
@@ -30,7 +30,11 @@ if [ $GITHUB_TOKEN ];
 then
     sed "s/# github_token: xxx/github_token: $GITHUB_TOKEN/" -i make/harbor.yml
 fi
-sudo make install COMPILETAG=compile_golangimage GOBUILDTAGS="include_oss include_gcs" NOTARYFLAG=true CLAIRFLAG=true TRIVYFLAG=true CHARTFLAG=true GEN_TLS=true
+sudo make compile build prepare COMPILETAG=compile_golangimage GOBUILDTAGS="include_oss include_gcs" NOTARYFLAG=true CLAIRFLAG=true TRIVYFLAG=true CHARTFLAG=true GEN_TLS=true
+
+# set the debugging env
+echo "_GC_BLOB_TIME_WINDOW=0" | sudo tee -a ./make/common/config/core/env
+sudo make start
 
 # waiting 5 minutes to start
 for((i=1;i<=30;i++)); do

--- a/tests/ci/api_common_install.sh
+++ b/tests/ci/api_common_install.sh
@@ -33,7 +33,7 @@ fi
 sudo make compile build prepare COMPILETAG=compile_golangimage GOBUILDTAGS="include_oss include_gcs" NOTARYFLAG=true CLAIRFLAG=true TRIVYFLAG=true CHARTFLAG=true GEN_TLS=true
 
 # set the debugging env
-echo "_GC_BLOB_TIME_WINDOW=0" | sudo tee -a ./make/common/config/core/env
+echo "GC_TIME_WINDOW_HOURS=0" | sudo tee -a ./make/common/config/core/env
 sudo make start
 
 # waiting 5 minutes to start


### PR DESCRIPTION
For debugging, the tester/users wants to run GC to delete the removed artifact immediately instead of waitting for two hours, add the env(_GC_BLOB_TIME_WINDOW) to meet this.

Signed-off-by: wang yan <wangyan@vmware.com>