### PR TITLE
Make notary-remove-image-signature more flexible

### DIFF
--- a/tests/robot-cases/Group0-Util/notary-remove-image-signature.expect
+++ b/tests/robot-cases/Group0-Util/notary-remove-image-signature.expect
@@ -1,4 +1,4 @@
-#!/usr/local/bin/expect
+#!/usr/bin/env expect
 
 set HOST [lindex $argv 0]
 set PROJECT [lindex $argv 1]


### PR DESCRIPTION
Instead of explicitly defining the expect path to /usr/local/bin/expect,
use the env command, so the expect executable is searched for and launched
from wherever it is first found.

Signed-off-by: Flávio Ramalho <framalho@suse.com>