### PR TITLE
perf(db): skip tx for get blob, patch/put blob upload apis

### DIFF
--- a/src/core/middlewares/middlewares_test.go
+++ b/src/core/middlewares/middlewares_test.go
@@ -20,28 +20,6 @@ import (
 	"testing"
 )
 
-func Test_fetchBlobAPISkipper(t *testing.T) {
-	type args struct {
-		r *http.Request
-	}
-	tests := []struct {
-		name string
-		args args
-		want bool
-	}{
-		{"fetch blob", args{httptest.NewRequest(http.MethodGet, "/v2/library/photon/blobs/sha256:6e0447537050cf871f9ab6a3fec5715f9c6fff5212f6666993f1fc46b1f717a3", nil)}, true},
-		{"delete blob", args{httptest.NewRequest(http.MethodDelete, "/v2/library/photon/blobs/sha256:6e0447537050cf871f9ab6a3fec5715f9c6fff5212f6666993f1fc46b1f717a3", nil)}, false},
-		{"get manifest", args{httptest.NewRequest(http.MethodDelete, "/v2/library/photon/manifests/sha256:6e0447537050cf871f9ab6a3fec5715f9c6fff5212f6666993f1fc46b1f717a3", nil)}, false},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := fetchBlobAPISkipper(tt.args.r); got != tt.want {
-				t.Errorf("fetchBlobAPISkipper() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
 func Test_readonlySkipper(t *testing.T) {
 	type args struct {
 		r *http.Request

--- a/src/pkg/distribution/distribution.go
+++ b/src/pkg/distribution/distribution.go
@@ -47,7 +47,11 @@ var (
 var (
 	name      = fmt.Sprintf("(?P<name>%s)", ref.NameRegexp)
 	reference = fmt.Sprintf("(?P<reference>((%s)|(%s)))", ref.DigestRegexp, ref.TagRegexp)
+	dgt       = fmt.Sprintf("(?P<digest>%s)", ref.DigestRegexp)
 	sessionID = "(?P<session_id>[a-zA-Z0-9-_.=]+)"
+
+	// BlobURLRegexp regexp which match blob url
+	BlobURLRegexp = regexp.MustCompile(`^/v2/` + name + `/blobs/` + dgt)
 
 	// BlobUploadURLRegexp regexp which match blob upload url
 	BlobUploadURLRegexp = regexp.MustCompile(`^/v2/` + name + `/blobs/uploads/` + sessionID)

--- a/src/server/middleware/blob/put_blob_upload.go
+++ b/src/server/middleware/blob/put_blob_upload.go
@@ -15,11 +15,14 @@
 package blob
 
 import (
-	"github.com/goharbor/harbor/src/lib/log"
-	"github.com/goharbor/harbor/src/pkg/distribution"
-	"github.com/goharbor/harbor/src/server/middleware"
+	"context"
 	"net/http"
 	"strconv"
+
+	"github.com/goharbor/harbor/src/lib/log"
+	"github.com/goharbor/harbor/src/lib/orm"
+	"github.com/goharbor/harbor/src/pkg/distribution"
+	"github.com/goharbor/harbor/src/server/middleware"
 )
 
 // PutBlobUploadMiddleware middleware is to update the blob status according to the different situation before the request passed into proxy(distribution).
@@ -42,36 +45,40 @@ func PutBlobUploadMiddleware() func(http.Handler) http.Handler {
 
 		ctx := r.Context()
 
-		logger := log.G(ctx).WithFields(log.Fields{"middleware": "blob"})
+		h := func(ctx context.Context) error {
+			logger := log.G(ctx).WithFields(log.Fields{"middleware": "blob"})
 
-		size, err := strconv.ParseInt(r.Header.Get("Content-Length"), 10, 64)
-		if err != nil || size == 0 {
-			size, err = blobController.GetAcceptedBlobSize(distribution.ParseSessionID(r.URL.Path))
-		}
-		if err != nil {
-			logger.Errorf("get blob size failed, error: %v", err)
-			return err
+			size, err := strconv.ParseInt(r.Header.Get("Content-Length"), 10, 64)
+			if err != nil || size == 0 {
+				size, err = blobController.GetAcceptedBlobSize(distribution.ParseSessionID(r.URL.Path))
+			}
+			if err != nil {
+				logger.Errorf("get blob size failed, error: %v", err)
+				return err
+			}
+
+			p, err := projectController.GetByName(ctx, distribution.ParseProjectName(r.URL.Path))
+			if err != nil {
+				logger.Errorf("get project failed, error: %v", err)
+				return err
+			}
+
+			digest := w.Header().Get("Docker-Content-Digest")
+			blobID, err := blobController.Ensure(ctx, digest, "application/octet-stream", size)
+			if err != nil {
+				logger.Errorf("ensure blob %s failed, error: %v", digest, err)
+				return err
+			}
+
+			if err := blobController.AssociateWithProjectByID(ctx, blobID, p.ProjectID); err != nil {
+				logger.Errorf("associate blob %s with project %s failed, error: %v", digest, p.Name, err)
+				return err
+			}
+
+			return nil
 		}
 
-		p, err := projectController.GetByName(ctx, distribution.ParseProjectName(r.URL.Path))
-		if err != nil {
-			logger.Errorf("get project failed, error: %v", err)
-			return err
-		}
-
-		digest := w.Header().Get("Docker-Content-Digest")
-		blobID, err := blobController.Ensure(ctx, digest, "application/octet-stream", size)
-		if err != nil {
-			logger.Errorf("ensure blob %s failed, error: %v", digest, err)
-			return err
-		}
-
-		if err := blobController.AssociateWithProjectByID(ctx, blobID, p.ProjectID); err != nil {
-			logger.Errorf("associate blob %s with project %s failed, error: %v", digest, p.Name, err)
-			return err
-		}
-
-		return nil
+		return orm.WithTransaction(h)(ctx)
 	})
 
 	return middleware.Chain(before, after)


### PR DESCRIPTION
1. Skip database transaction middleware for GET Blob and PATCH Blob Upload APIs for there are no database writing operations in them.
2. Skip database transaction middleware for PUT Blob Upload API  and execute database transaction manually in the middlewares in it so that use some short time executions than one long time database transaction execution. Replication use PUT Blob Upload API to upload the whole blob which may spend a long time (minutes level or even more) taking up a database connection if only one database transaction execution in this API.

Signed-off-by: He Weiwei <hweiwei@vmware.com>