### PR TITLE
Enhance: Prolong the timeout of chartclient

### DIFF
--- a/src/chartserver/client.go
+++ b/src/chartserver/client.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	clientTimeout         = 10 * time.Second
+	clientTimeout         = 30 * time.Second
 	maxIdleConnections    = 10
 	idleConnectionTimeout = 30 * time.Second
 )


### PR DESCRIPTION
In some perspectives to reduce the too many charts performence issue

Signed-off-by: DQ <dengq@vmware.com>