### PR TITLE
remove limitation of artifact in the GC job

### DIFF
--- a/src/jobservice/job/impl/gc/garbage_collection.go
+++ b/src/jobservice/job/impl/gc/garbage_collection.go
@@ -184,11 +184,9 @@ func (gc *GarbageCollector) mark(ctx job.Context) error {
 		gc.logger.Errorf("failed to get deleted Artifacts in gc job, with error: %v", err)
 		return err
 	}
-	// no need to execute GC as there is no removed artifacts.
-	// Do this is to handle if user trigger GC job several times, only one job should do the following logic as artifact trash table is flushed.
+	// just log it, the job will continue to execute, the orphan blobs that created in the quota exceeding case can be removed.
 	if len(arts) == 0 {
-		gc.logger.Info("no need to execute GC as there is no removed artifacts.")
-		return nil
+		gc.logger.Warning("no removed artifacts.")
 	}
 	gc.trashedArts = arts
 

--- a/src/jobservice/job/impl/gc/garbage_collection_test.go
+++ b/src/jobservice/job/impl/gc/garbage_collection_test.go
@@ -221,6 +221,28 @@ func (suite *gcTestSuite) TestRun() {
 
 	mock.OnAnything(suite.blobMgr, "CleanupAssociationsForProject").Return(nil)
 
+	mock.OnAnything(suite.blobMgr, "UselessBlobs").Return([]*pkg_blob.Blob{
+		{
+			ID:          1,
+			Digest:      suite.DigestString(),
+			ContentType: schema2.MediaTypeManifest,
+		},
+		{
+			ID:          2,
+			Digest:      suite.DigestString(),
+			ContentType: schema2.MediaTypeLayer,
+		},
+		{
+			ID:          3,
+			Digest:      suite.DigestString(),
+			ContentType: schema2.MediaTypeManifest,
+		},
+	}, nil)
+
+	mock.OnAnything(suite.blobMgr, "UpdateBlobStatus").Return(int64(1), nil)
+
+	mock.OnAnything(suite.blobMgr, "Delete").Return(nil)
+
 	gc := &GarbageCollector{
 		artCtl:            suite.artifactCtl,
 		artrashMgr:        suite.artrashMgr,


### PR DESCRIPTION
To handle the orphan blobs that created in the quota exceeding case deletion, remove the limition of artifact remove.

Signed-off-by: wang yan <wangyan@vmware.com>