### PR TITLE
Refresh the status of execution for every status changing of task

### DIFF
--- a/make/migrations/postgresql/0040_2.1.0_schema.up.sql
+++ b/make/migrations/postgresql/0040_2.1.0_schema.up.sql
@@ -13,6 +13,7 @@ CREATE TABLE IF NOT EXISTS execution (
     extra_attrs JSON,
     start_time timestamp DEFAULT CURRENT_TIMESTAMP,
     end_time timestamp,
+    revision int,
     PRIMARY KEY (id)
 );
 

--- a/src/pkg/task/dao/execution.go
+++ b/src/pkg/task/dao/execution.go
@@ -16,7 +16,10 @@ package dao
 
 import (
 	"context"
+	"fmt"
+	"github.com/goharbor/harbor/src/lib/log"
 
+	"github.com/goharbor/harbor/src/jobservice/job"
 	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/lib/orm"
 	"github.com/goharbor/harbor/src/lib/q"
@@ -36,14 +39,23 @@ type ExecutionDAO interface {
 	Update(ctx context.Context, execution *Execution, props ...string) (err error)
 	// Delete the specified execution
 	Delete(ctx context.Context, id int64) (err error)
+	// GetMetrics returns the task metrics for the specified execution
+	GetMetrics(ctx context.Context, id int64) (metrics *Metrics, err error)
+	// RefreshStatus refreshes the status of the specified execution according to it's tasks. If it's status
+	// is final, update the end time as well
+	RefreshStatus(ctx context.Context, id int64) (err error)
 }
 
 // NewExecutionDAO returns an instance of ExecutionDAO
 func NewExecutionDAO() ExecutionDAO {
-	return &executionDAO{}
+	return &executionDAO{
+		taskDAO: NewTaskDAO(),
+	}
 }
 
-type executionDAO struct{}
+type executionDAO struct {
+	taskDAO TaskDAO
+}
 
 func (e *executionDAO) Count(ctx context.Context, query *q.Query) (int64, error) {
 	if query != nil {
@@ -131,4 +143,152 @@ func (e *executionDAO) Delete(ctx context.Context, id int64) error {
 		return errors.NotFoundError(nil).WithMessage("execution %d not found", id)
 	}
 	return nil
+}
+
+func (e *executionDAO) GetMetrics(ctx context.Context, id int64) (*Metrics, error) {
+	scs, err := e.taskDAO.ListStatusCount(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	metrics := &Metrics{}
+	if len(scs) == 0 {
+		return metrics, nil
+	}
+
+	for _, sc := range scs {
+		switch sc.Status {
+		case job.SuccessStatus.String():
+			metrics.SuccessTaskCount = sc.Count
+		case job.ErrorStatus.String():
+			metrics.ErrorTaskCount = sc.Count
+		case job.PendingStatus.String():
+			metrics.PendingTaskCount = sc.Count
+		case job.RunningStatus.String():
+			metrics.RunningTaskCount = sc.Count
+		case job.ScheduledStatus.String():
+			metrics.ScheduledTaskCount = sc.Count
+		case job.StoppedStatus.String():
+			metrics.StoppedTaskCount = sc.Count
+		default:
+			log.Errorf("unknown task status: %s", sc.Status)
+		}
+	}
+	metrics.TaskCount = metrics.SuccessTaskCount + metrics.ErrorTaskCount +
+		metrics.PendingTaskCount + metrics.RunningTaskCount +
+		metrics.ScheduledTaskCount + metrics.StoppedTaskCount
+	return metrics, nil
+}
+func (e *executionDAO) RefreshStatus(ctx context.Context, id int64) error {
+	// as the status of the execution can be refreshed by multiple operators concurrently
+	// we use the optimistic locking to avoid the conflict and retry 5 times at most
+	for i := 0; i < 5; i++ {
+		retry, err := e.refreshStatus(ctx, id)
+		if err != nil {
+			return err
+		}
+		if !retry {
+			return nil
+		}
+	}
+	return fmt.Errorf("failed to refresh the status of the execution %d after %d retries", id, 5)
+}
+
+func (e *executionDAO) refreshStatus(ctx context.Context, id int64) (bool, error) {
+	execution, err := e.Get(ctx, id)
+	if err != nil {
+		return false, err
+	}
+	metrics, err := e.GetMetrics(ctx, id)
+	if err != nil {
+		return false, err
+	}
+	// no task, return directly
+	if metrics.TaskCount == 0 {
+		return false, nil
+	}
+
+	var status string
+	if metrics.PendingTaskCount > 0 || metrics.RunningTaskCount > 0 || metrics.ScheduledTaskCount > 0 {
+		status = job.RunningStatus.String()
+	} else if metrics.ErrorTaskCount > 0 {
+		status = job.ErrorStatus.String()
+	} else if metrics.StoppedTaskCount > 0 {
+		status = job.StoppedStatus.String()
+	} else if metrics.SuccessTaskCount > 0 {
+		status = job.SuccessStatus.String()
+	}
+
+	ormer, err := orm.FromContext(ctx)
+	if err != nil {
+		return false, err
+	}
+	sql := `update execution set status = ?, revision = revision+1 where id = ? and revision = ?`
+	result, err := ormer.Raw(sql, status, id, execution.Revision).Exec()
+	if err != nil {
+		return false, err
+	}
+	n, err := result.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	// if the count of affected rows is 0, that means the execution is updating by others, retry
+	if n == 0 {
+		return true, nil
+	}
+
+	/* this is another solution to solve the concurrency issue for refreshing the execution status
+	// set a score for each status:
+	// 		pending, running, scheduled - 4
+	// 		error - 3
+	//		stopped - 2
+	//		success - 1
+	// and set the status of record with highest score as the status of execution
+	sql := `with status_score as (
+				select status,
+					case
+						when status='%s' or status='%s' or status='%s' then 4
+						when status='%s' then 3
+						when status='%s' then 2
+						when status='%s' then 1
+						else 0
+					end as score
+				from task
+				where execution_id=?
+				group by status
+			)
+			update execution
+			set status=(
+				select
+					case
+						when max(score)=4 then '%s'
+						when max(score)=3 then '%s'
+						when max(score)=2 then '%s'
+						when max(score)=1 then '%s'
+						when max(score)=0 then ''
+					end as status
+				from status_score)
+			where id = ?`
+	sql = fmt.Sprintf(sql, job.PendingStatus.String(), job.RunningStatus.String(), job.ScheduledStatus.String(),
+		job.ErrorStatus.String(), job.StoppedStatus.String(), job.SuccessStatus.String(),
+		job.RunningStatus.String(), job.ErrorStatus.String(), job.StoppedStatus.String(), job.SuccessStatus.String())
+	if _, err = ormer.Raw(sql, id, id).Exec(); err != nil {
+		return err
+	}
+	*/
+
+	// update the end time if the status is final, otherwise set the end time as NULL, this is useful
+	// for retrying jobs
+	sql = `update execution
+			set end_time = (
+				case
+					when status='%s' or status='%s' or status='%s' then  (
+						select max(end_time)
+						from task
+						where execution_id=?)
+					else NULL
+				end)
+			where id=?`
+	sql = fmt.Sprintf(sql, job.ErrorStatus.String(), job.StoppedStatus.String(), job.SuccessStatus.String())
+	_, err = ormer.Raw(sql, id, id).Exec()
+	return false, err
 }

--- a/src/pkg/task/dao/model.go
+++ b/src/pkg/task/dao/model.go
@@ -39,6 +39,18 @@ type Execution struct {
 	ExtraAttrs    string    `orm:"column(extra_attrs)"` // json string
 	StartTime     time.Time `orm:"column(start_time)"`
 	EndTime       time.Time `orm:"column(end_time)"`
+	Revision      int64     `orm:"column(revision)"`
+}
+
+// Metrics is the task metrics for one execution
+type Metrics struct {
+	TaskCount          int64 `json:"task_count"`
+	SuccessTaskCount   int64 `json:"success_task_count"`
+	ErrorTaskCount     int64 `json:"error_task_count"`
+	PendingTaskCount   int64 `json:"pending_task_count"`
+	RunningTaskCount   int64 `json:"running_task_count"`
+	ScheduledTaskCount int64 `json:"scheduled_task_count"`
+	StoppedTaskCount   int64 `json:"stopped_task_count"`
 }
 
 // Task database model

--- a/src/pkg/task/hook_test.go
+++ b/src/pkg/task/hook_test.go
@@ -64,7 +64,12 @@ func (h *hookHandlerTestSuite) TestHandle() {
 	h.SetupTest()
 
 	// handle status changing
+	h.taskDAO.On("Get", mock.Anything, mock.Anything).Return(&dao.Task{
+		ID:          1,
+		ExecutionID: 1,
+	}, nil)
 	h.taskDAO.On("UpdateStatus", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	h.execDAO.On("RefreshStatus", mock.Anything, mock.Anything).Return(nil)
 	sc = &job.StatusChange{
 		Status: job.SuccessStatus.String(),
 		Metadata: &job.StatsInfo{

--- a/src/pkg/task/mock_execution_dao_test.go
+++ b/src/pkg/task/mock_execution_dao_test.go
@@ -95,6 +95,29 @@ func (_m *mockExecutionDAO) Get(ctx context.Context, id int64) (*dao.Execution, 
 	return r0, r1
 }
 
+// GetMetrics provides a mock function with given fields: ctx, id
+func (_m *mockExecutionDAO) GetMetrics(ctx context.Context, id int64) (*dao.Metrics, error) {
+	ret := _m.Called(ctx, id)
+
+	var r0 *dao.Metrics
+	if rf, ok := ret.Get(0).(func(context.Context, int64) *dao.Metrics); ok {
+		r0 = rf(ctx, id)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*dao.Metrics)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, int64) error); ok {
+		r1 = rf(ctx, id)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // List provides a mock function with given fields: ctx, query
 func (_m *mockExecutionDAO) List(ctx context.Context, query *q.Query) ([]*dao.Execution, error) {
 	ret := _m.Called(ctx, query)
@@ -116,6 +139,20 @@ func (_m *mockExecutionDAO) List(ctx context.Context, query *q.Query) ([]*dao.Ex
 	}
 
 	return r0, r1
+}
+
+// RefreshStatus provides a mock function with given fields: ctx, id
+func (_m *mockExecutionDAO) RefreshStatus(ctx context.Context, id int64) error {
+	ret := _m.Called(ctx, id)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, int64) error); ok {
+		r0 = rf(ctx, id)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
 }
 
 // Update provides a mock function with given fields: ctx, execution, props

--- a/src/pkg/task/model.go
+++ b/src/pkg/task/model.go
@@ -49,25 +49,14 @@ type Execution struct {
 	// 1. After creating the execution, there may be some errors before creating tasks, the
 	// "StatusMessage" can contain the error message
 	// 2. The execution may contain no tasks, "StatusMessage" can be used to explain the case
-	StatusMessage string   `json:"status_message"`
-	Metrics       *Metrics `json:"metrics"`
+	StatusMessage string       `json:"status_message"`
+	Metrics       *dao.Metrics `json:"metrics"`
 	// trigger type: manual/schedule/event
 	Trigger string `json:"trigger"`
 	// the customized attributes for different kinds of consumers
 	ExtraAttrs map[string]interface{} `json:"extra_attrs"`
 	StartTime  time.Time              `json:"start_time"`
 	EndTime    time.Time              `json:"end_time"`
-}
-
-// Metrics for tasks
-type Metrics struct {
-	TaskCount          int64 `json:"task_count"`
-	SuccessTaskCount   int64 `json:"success_task_count"`
-	ErrorTaskCount     int64 `json:"error_task_count"`
-	PendingTaskCount   int64 `json:"pending_task_count"`
-	RunningTaskCount   int64 `json:"running_task_count"`
-	ScheduledTaskCount int64 `json:"scheduled_task_count"`
-	StoppedTaskCount   int64 `json:"stopped_task_count"`
 }
 
 // Task is the unit for running. It stores the jobservice job records and related information

--- a/src/server/handler/job_status_hook.go
+++ b/src/server/handler/job_status_hook.go
@@ -56,7 +56,7 @@ func (j *jobStatusHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if err = j.handler.Handle(r.Context(), taskID, sc); err != nil {
 		// ignore the not found error to avoid the jobservice re-sending the hook
 		if errors.IsNotFoundErr(err) {
-			log.Warningf("got the status change hook for a non existing task %d", taskID)
+			log.Warningf("task %d does not exist, ignore the not found error to avoid subsequent retrying webhooks from jobservice", taskID)
 			return
 		}
 		libhttp.SendError(w, err)


### PR DESCRIPTION
Refresh the status of execution for every status changing of task to support filtering executions by status directly

Signed-off-by: Wenkai Yin <yinw@vmware.com>