### PR TITLE
fix[replicatioin] aliyun acr pull with repo filter

### DIFF
--- a/src/replication/adapter/aliacr/adapter.go
+++ b/src/replication/adapter/aliacr/adapter.go
@@ -256,22 +256,16 @@ func (a *adapter) FetchArtifacts(filters []*model.Filter) (resources []*model.Re
 
 		log.Debugf("\nnamespace: %s \t repositories: %#v\n\n", namespace, repos)
 
-		if _, ok := util.IsSpecificPathComponent(namespacePattern); ok {
-			log.Debugf("specific namespace: %s", repoPattern)
-			repositories = append(repositories, repos...)
-		} else {
-			for _, repo := range repos {
-
-				var ok bool
-				var repoName = filepath.Join(repo.RepoNamespace, repo.RepoName)
-				ok, err = util.Match(repoPattern, repoName)
-				log.Debugf("\n Repository: %s\t repoPattern: %s\t Match: %v\n", repoName, repoPattern, ok)
-				if err != nil {
-					return
-				}
-				if ok {
-					repositories = append(repositories, repo)
-				}
+		for _, repo := range repos {
+			var ok bool
+			var repoName = filepath.Join(repo.RepoNamespace, repo.RepoName)
+			ok, err = util.Match(repoPattern, repoName)
+			log.Debugf("\n Repository: %s\t repoPattern: %s\t Match: %v\n", repoName, repoPattern, ok)
+			if err != nil {
+				return
+			}
+			if ok {
+				repositories = append(repositories, repo)
 			}
 		}
 	}


### PR DESCRIPTION
fix #12621
Aliyun replication adapter can't filter specific repo name, like 'abcde/busybox', it will replicate all images under namespace abcde