### PR TITLE
update time format of audit log

### DIFF
--- a/api/v2.0/swagger.yaml
+++ b/api/v2.0/swagger.yaml
@@ -1672,6 +1672,8 @@ definitions:
         description: The operation against the repository in this log entry.
       op_time:
         type: string
+        format: date-time
+        example: '2006-01-02T15:04:05'
         description: The time when this operation is triggered.
   Metadata:
     type: object

--- a/src/server/v2.0/handler/auditlog.go
+++ b/src/server/v2.0/handler/auditlog.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/go-openapi/runtime/middleware"
+	"github.com/go-openapi/strfmt"
 	"github.com/goharbor/harbor/src/common/rbac"
 	"github.com/goharbor/harbor/src/common/security"
 	"github.com/goharbor/harbor/src/common/security/local"
@@ -78,7 +79,7 @@ func (a *auditlogAPI) ListAuditLogs(ctx context.Context, params auditlog.ListAud
 			ResourceType: log.ResourceType,
 			Username:     log.Username,
 			Operation:    log.Operation,
-			OpTime:       log.OpTime.String(),
+			OpTime:       strfmt.DateTime(log.OpTime),
 		})
 	}
 	return operation.NewListAuditLogsOK().

--- a/src/server/v2.0/handler/project.go
+++ b/src/server/v2.0/handler/project.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"context"
 	"github.com/go-openapi/runtime/middleware"
+	"github.com/go-openapi/strfmt"
 	"github.com/goharbor/harbor/src/common/rbac"
 	"github.com/goharbor/harbor/src/controller/project"
 	"github.com/goharbor/harbor/src/pkg/audit"
@@ -54,7 +55,7 @@ func (a *projectAPI) GetLogs(ctx context.Context, params operation.GetLogsParams
 			ResourceType: log.ResourceType,
 			Username:     log.Username,
 			Operation:    log.Operation,
-			OpTime:       log.OpTime.String(),
+			OpTime:       strfmt.DateTime(log.OpTime),
 		})
 	}
 	return operation.NewGetLogsOK().


### PR DESCRIPTION
use the format: date-time as the format of audit op_time, then it could be rendered by FF and Chrome.

Signed-off-by: wang yan <wangyan@vmware.com>