### PR TITLE
update GC job

### DIFF
--- a/src/jobservice/job/impl/gc/garbage_collection_test.go
+++ b/src/jobservice/job/impl/gc/garbage_collection_test.go
@@ -62,7 +62,6 @@ func (suite *gcTestSuite) TestDeletedArt() {
 	logger := &mockjobservice.MockJobLogger{}
 	ctx.On("GetLogger").Return(logger)
 
-	suite.artrashMgr.On("Flush").Return(nil)
 	suite.artifactCtl.On("List").Return([]*artifact.Artifact{
 		{
 			ID:           1,
@@ -194,7 +193,6 @@ func (suite *gcTestSuite) TestRun() {
 	ctx.On("OPCommand").Return(job.NilCommand, true)
 	mock.OnAnything(ctx, "Get").Return("core url", true)
 
-	suite.artrashMgr.On("Flush").Return(nil)
 	suite.artifactCtl.On("List").Return([]*artifact.Artifact{
 		{
 			ID:           1,
@@ -265,7 +263,6 @@ func (suite *gcTestSuite) TestMark() {
 	logger := &mockjobservice.MockJobLogger{}
 	ctx.On("GetLogger").Return(logger)
 
-	suite.artrashMgr.On("Flush").Return(nil)
 	suite.artifactCtl.On("List").Return([]*artifact.Artifact{
 		{
 			ID:           1,


### PR DESCRIPTION
Remove the artifact trash record after manifest delete success.

Don't use the flush method is because that when all of records are removed, only GC job knows these informations, and they are in the memory. Once the jobservice is crashed and restarted at GC job execution phase, the trash records are lost, then these manifest are become orphan manifests, cannot be removed any more.
Signed-off-by: wang yan <wangyan@vmware.com>