### PR TITLE
fix(swagger): fix the definition of errors

### DIFF
--- a/api/v2.0/swagger.yaml
+++ b/api/v2.0/swagger.yaml
@@ -1349,9 +1349,12 @@ responses:
 definitions:
   Errors:
     description: The error array that describe the errors got during the handling of request
-    type: array
-    items:
-      $ref: '#/definitions/Error'
+    type: object
+    properties:
+      errors:
+        type: array
+        items:
+          $ref: '#/definitions/Error'
   Error:
     description: a model for all the error response coming from harbor
     type: object


### PR DESCRIPTION
When we use harbor swagger generate client,  when api return error, it will return json unmarshal to models.Errors,  after check the swagger yaml, the definition in swagger is not same as api result.

![image](https://user-images.githubusercontent.com/31262637/89252944-ca1dd500-d64d-11ea-978d-346605576fdd.png)


Signed-off-by: chlins <chlins.zhang@gmail.com>