### PR TITLE
chore(images): install shadow package in base images

### DIFF
--- a/make/photon/clair-adapter/Dockerfile.base
+++ b/make/photon/clair-adapter/Dockerfile.base
@@ -1,5 +1,7 @@
 FROM photon:2.0
 
-RUN mkdir /clair-adapter/ \
+RUN tdnf install -y shadow >> /dev/null \
+    && tdnf clean all \
+    && mkdir /clair-adapter/ \
     && groupadd -r -g 10000 clair-adapter \
     && useradd --no-log-init -m -r -g 10000 -u 10000 clair-adapter

--- a/make/photon/core/Dockerfile.base
+++ b/make/photon/core/Dockerfile.base
@@ -1,6 +1,6 @@
 FROM photon:2.0
 
-RUN tdnf install tzdata -y >> /dev/null \
+RUN tdnf install -y tzdata shadow >> /dev/null \
     && tdnf clean all \
     && groupadd -r -g 10000 harbor && useradd --no-log-init -r -m -g 10000 -u 10000 harbor \
     && mkdir /harbor/

--- a/make/photon/jobservice/Dockerfile.base
+++ b/make/photon/jobservice/Dockerfile.base
@@ -1,5 +1,5 @@
 FROM photon:2.0
 
-RUN tdnf install tzdata -y >> /dev/null \
+RUN tdnf install -y tzdata shadow >> /dev/null \
     && tdnf clean all \
     && groupadd -r -g 10000 harbor && useradd --no-log-init -r -m -g 10000 -u 10000 harbor

--- a/make/photon/nginx/Dockerfile.base
+++ b/make/photon/nginx/Dockerfile.base
@@ -1,6 +1,6 @@
 FROM photon:2.0
 
-RUN tdnf install nginx -y >> /dev/null\
+RUN tdnf install -y nginx shadow >> /dev/null \
     && tdnf clean all \
     && groupadd -r -g 10000 nginx && useradd --no-log-init -r -g 10000 -u 10000 nginx \
     && ln -sf /dev/stdout /var/log/nginx/access.log \

--- a/make/photon/notary-server/Dockerfile.base
+++ b/make/photon/notary-server/Dockerfile.base
@@ -1,6 +1,6 @@
 FROM photon:2.0
 
-RUN tdnf install -y shadow \
+RUN tdnf install -y shadow >> /dev/null \
     && tdnf clean all \
     && groupadd -r -g 10000 notary \
     && useradd --no-log-init -r -g 10000 -u 10000 notary

--- a/make/photon/notary-signer/Dockerfile.base
+++ b/make/photon/notary-signer/Dockerfile.base
@@ -1,6 +1,6 @@
 FROM photon:2.0
 
-RUN tdnf install -y shadow \
+RUN tdnf install -y shadow >> /dev/null \
     && tdnf clean all \
     && groupadd -r -g 10000 notary \
     && useradd --no-log-init -r -g 10000 -u 10000 notary

--- a/make/photon/portal/Dockerfile.base
+++ b/make/photon/portal/Dockerfile.base
@@ -1,8 +1,8 @@
 FROM photon:2.0
 
-RUN tdnf install -y nginx >> /dev/null \
+RUN tdnf install -y nginx shadow >> /dev/null \
+    && tdnf clean all \
     && ln -sf /dev/stdout /var/log/nginx/access.log \
     && ln -sf /dev/stderr /var/log/nginx/error.log \
     && groupadd -r -g 10000 nginx && useradd --no-log-init -r -g 10000 -u 10000 nginx \
-    && chown -R nginx:nginx /etc/nginx \
-    && tdnf clean all
+    && chown -R nginx:nginx /etc/nginx

--- a/make/photon/registry/Dockerfile.base
+++ b/make/photon/registry/Dockerfile.base
@@ -1,4 +1,6 @@
 FROM photon:2.0
 
-RUN mkdir -p /etc/registry \
+RUN tdnf install -y shadow >> /dev/null \
+    && tdnf clean all \
+    && mkdir -p /etc/registry \
     && groupadd -r -g 10000 harbor && useradd --no-log-init -m -g 10000 -u 10000 harbor

--- a/make/photon/registryctl/Dockerfile.base
+++ b/make/photon/registryctl/Dockerfile.base
@@ -1,4 +1,6 @@
 FROM photon:2.0
 
-RUN groupadd -r -g 10000 harbor && useradd --no-log-init -m -g 10000 -u 10000 harbor \
+RUN tdnf install -y shadow >> /dev/null \
+    && tdnf clean all \
+    && groupadd -r -g 10000 harbor && useradd --no-log-init -m -g 10000 -u 10000 harbor \
     && mkdir -p /etc/registry

--- a/make/photon/trivy-adapter/Dockerfile.base
+++ b/make/photon/trivy-adapter/Dockerfile.base
@@ -1,6 +1,6 @@
 FROM photon:2.0
 
-RUN tdnf install -y rpm >> /dev/null \
+RUN tdnf install -y rpm shadow >> /dev/null \
     && tdnf clean all \
     && groupadd -r -g 10000 scanner \
     && useradd --no-log-init -m -r -g 10000 -u 10000 scanner


### PR DESCRIPTION
The latest `photon:2.0` does not include `groupadd` and `useradd`
we need to install `shadow` package which includes these commands.

Signed-off-by: He Weiwei <hweiwei@vmware.com>