### PR TITLE
fix gc remove manifest issue

### DIFF
--- a/src/pkg/blob/models/blob.go
+++ b/src/pkg/blob/models/blob.go
@@ -88,8 +88,10 @@ func (b *Blob) IsForeignLayer() bool {
 
 // IsManifest returns true if the blob is manifest layer
 func (b *Blob) IsManifest() bool {
-	return b.ContentType == schema2.MediaTypeManifest || b.ContentType == schema1.MediaTypeManifest ||
-		b.ContentType == v1.MediaTypeImageManifest || b.ContentType == v1.MediaTypeImageIndex || b.ContentType == manifestlist.MediaTypeManifestList
+	return b.ContentType == schema2.MediaTypeManifest ||
+		b.ContentType == schema1.MediaTypeManifest || b.ContentType == schema1.MediaTypeSignedManifest ||
+		b.ContentType == v1.MediaTypeImageManifest || b.ContentType == v1.MediaTypeImageIndex ||
+		b.ContentType == manifestlist.MediaTypeManifestList
 }
 
 // ProjectBlob alias ProjectBlob model


### PR DESCRIPTION
fixes #12720

The GC job doesn't remove the manifest of scheme1.MediaTypeSignedManifest as it's recognized by GC job.

Signed-off-by: wang yan <wangyan@vmware.com>