### PR TITLE
Use a separated database table to store the data version

### DIFF
--- a/make/migrations/postgresql/0040_2.1.0_schema.up.sql
+++ b/make/migrations/postgresql/0040_2.1.0_schema.up.sql
@@ -116,3 +116,15 @@ ALTER TABLE schedule DROP COLUMN IF EXISTS status;
 UPDATE registry SET type = 'quay' WHERE type = 'quay-io';
 
 ALTER TABLE artifact ADD COLUMN icon varchar(255);
+
+CREATE TABLE IF NOT EXISTS data_migrations (
+    version int
+);
+INSERT INTO data_migrations (version) VALUES (
+    CASE
+        /*if the "extra_attrs" isn't null, it means that the deployment upgrades from v2.0*/
+        WHEN (SELECT Count(*) FROM artifact WHERE extra_attrs!='')>0 THEN 30
+        ELSE 0
+    END
+);
+ALTER TABLE schema_migrations DROP COLUMN IF EXISTS data_version;

--- a/src/migration/artifact.go
+++ b/src/migration/artifact.go
@@ -42,7 +42,7 @@ func abstractArtData(ctx context.Context) error {
 			continue
 		}
 		for _, repo := range repos {
-			log.Debugf("abstracting artifact metadata under repository %s ....", repo.Name)
+			log.Infof("abstracting artifact metadata under repository %s ....", repo.Name)
 			arts, err := artifact.Mgr.List(ctx, &q.Query{
 				Keywords: map[string]interface{}{
 					"RepositoryID": repo.RepositoryID,
@@ -62,7 +62,7 @@ func abstractArtData(ctx context.Context) error {
 					continue
 				}
 			}
-			log.Debugf("artifact metadata under repository %s abstracted", repo.Name)
+			log.Infof("artifact metadata under repository %s abstracted", repo.Name)
 		}
 	}
 

--- a/src/migration/migration.go
+++ b/src/migration/migration.go
@@ -86,7 +86,7 @@ func getDataVersion(ctx context.Context) (int, error) {
 		return 0, err
 	}
 	var version int
-	if err = ormer.Raw("select data_version from schema_migrations").QueryRow(&version); err != nil {
+	if err = ormer.Raw("select version from data_migrations").QueryRow(&version); err != nil {
 		return 0, err
 	}
 	return version, nil
@@ -97,6 +97,6 @@ func setDataVersion(ctx context.Context, version int) error {
 	if err != nil {
 		return err
 	}
-	_, err = ormer.Raw("update schema_migrations set data_version=?", version).Exec()
+	_, err = ormer.Raw("update data_migrations set version=?", version).Exec()
 	return err
 }


### PR DESCRIPTION
Use a separated database table to store the data version.
Fixes #12747

Signed-off-by: Wenkai Yin <yinw@vmware.com>