### PR TITLE
remove reset password dialog from sign-in component

### DIFF
--- a/src/portal/src/app/sign-in/sign-in.component.html
+++ b/src/portal/src/app/sign-in/sign-in.component.html
@@ -44,5 +44,4 @@
     </div>
 </clr-main-container>
 <sign-up #signupDialog (userCreation)="handleUserCreation($event)"></sign-up>
-<forgot-password #forgotPwdDialog></forgot-password>
 <about-dialog></about-dialog>


### PR DESCRIPTION
As mentioned in #10712 forgot password should be removed. The
dialog was left in place.
See #12745