### PR TITLE
fix(swagger): format the value of ResourceList as int64

### DIFF
--- a/api/v2.0/legacy_swagger.yaml
+++ b/api/v2.0/legacy_swagger.yaml
@@ -5087,6 +5087,7 @@ definitions:
     type: object
     additionalProperties:
       type: integer
+      format: int64
   QuotaUpdateReq:
     type: object
     properties:


### PR DESCRIPTION
According to the spec of swagger, https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types, the integer type support int64, so we will only format the value of ResourceList as int64 to fix this issue.

Closes #12482

Signed-off-by: He Weiwei <hweiwei@vmware.com>