### PR TITLE
Use orm.Context instead request context in background go routing

### DIFF
--- a/src/controller/event/metadata/artifact.go
+++ b/src/controller/event/metadata/artifact.go
@@ -55,9 +55,9 @@ func (p *PushArtifactEventMetadata) Resolve(event *event.Event) error {
 
 // PullArtifactEventMetadata is the metadata from which the pull artifact event can be resolved
 type PullArtifactEventMetadata struct {
-	Ctx      context.Context
 	Artifact *artifact.Artifact
 	Tag      string
+	Operator string
 }
 
 // Resolve to the event from the metadata
@@ -74,10 +74,7 @@ func (p *PullArtifactEventMetadata) Resolve(event *event.Event) error {
 	data := &event2.PullArtifactEvent{
 		ArtifactEvent: ae,
 	}
-	ctx, exist := security.FromContext(p.Ctx)
-	if exist {
-		data.Operator = ctx.GetUsername()
-	}
+	data.Operator = p.Operator
 	event.Topic = event2.TopicPullArtifact
 	event.Data = data
 	return nil

--- a/src/controller/event/metadata/artifact_test.go
+++ b/src/controller/event/metadata/artifact_test.go
@@ -47,9 +47,9 @@ func (a *artifactEventTestSuite) TestResolveOfPushArtifactEventMetadata() {
 func (a *artifactEventTestSuite) TestResolveOfPullArtifactEventMetadata() {
 	e := &event.Event{}
 	metadata := &PullArtifactEventMetadata{
-		Ctx:      context.Background(),
 		Artifact: &artifact.Artifact{ID: 1},
 		Tag:      "latest",
+		Operator: "admin",
 	}
 	err := metadata.Resolve(e)
 	a.Require().Nil(err)

--- a/src/controller/proxy/local.go
+++ b/src/controller/proxy/local.go
@@ -210,11 +210,11 @@ func (l *localHelper) CheckDependencies(ctx context.Context, repo string, man di
 }
 
 // SendPullEvent send a pull image event
-func SendPullEvent(ctx context.Context, a *artifact.Artifact, tag string) {
+func SendPullEvent(a *artifact.Artifact, tag, operator string) {
 	e := &metadata.PullArtifactEventMetadata{
-		Ctx:      ctx,
 		Artifact: &a.Artifact,
 		Tag:      tag,
+		Operator: operator,
 	}
 	event.BuildAndPublish(e)
 }

--- a/src/server/registry/manifest.go
+++ b/src/server/registry/manifest.go
@@ -15,6 +15,7 @@
 package registry
 
 import (
+	"github.com/goharbor/harbor/src/common/security"
 	"github.com/goharbor/harbor/src/controller/artifact"
 	"github.com/goharbor/harbor/src/controller/event/metadata"
 	"github.com/goharbor/harbor/src/controller/repository"
@@ -54,9 +55,13 @@ func getManifest(w http.ResponseWriter, req *http.Request) {
 		req.UserAgent() == registry.UserAgent {
 		return
 	}
+	operator := ""
+	if secCtx, exist := security.FromContext(req.Context()); exist {
+		operator = secCtx.GetUsername()
+	}
 	e := &metadata.PullArtifactEventMetadata{
-		Ctx:      req.Context(),
 		Artifact: &art.Artifact,
+		Operator: operator,
 	}
 	// the reference is tag
 	if _, err = digest.Parse(reference); err != nil {


### PR DESCRIPTION
Fixes #12741: error sql: transaction has already been committed or rolled back

Signed-off-by: stonezdj <stonezdj@gmail.com>