### PR TITLE
Token service handling invalid resource

### DIFF
--- a/src/core/service/token/authutils.go
+++ b/src/core/service/token/authutils.go
@@ -94,7 +94,9 @@ func filterAccess(access []*token.ResourceActions, ctx security.Context,
 		err = f.filter(ctx, pm, a)
 		log.Debugf("user: %s, access: %v", ctx.GetUsername(), a)
 		if err != nil {
-			return err
+			log.Errorf("Failed to handle the resource %s:%s, due to error %v, returning empty access for it.",
+				a.Type, a.Name, err)
+			a.Actions = []string{}
 		}
 	}
 	return nil


### PR DESCRIPTION
This commit updates the way token service handles invalid resource, for
example a resource without projectname.
It will clear the requested access instead of returning 500 error.

Signed-off-by: Daniel Jiang <jiangd@vmware.com>