### PR TITLE
Return 403 when trying to push artifacts into the proxy cache project…

### DIFF
--- a/src/server/middleware/repoproxy/proxy.go
+++ b/src/server/middleware/repoproxy/proxy.go
@@ -184,7 +184,7 @@ func DisableBlobAndManifestUploadMiddleware() func(http.Handler) http.Handler {
 		}
 		if isProxyProject(p) && !isProxySession(ctx) {
 			httpLib.SendError(w,
-				errors.MethodNotAllowedError(
+				errors.DeniedError(
 					errors.Errorf("can not push artifact to a proxy project: %v", p.Name)))
 			return
 		}

--- a/src/server/registry/route.go
+++ b/src/server/registry/route.go
@@ -77,6 +77,7 @@ func RegisterRoutes() {
 	root.NewRoute().
 		Method(http.MethodPost).
 		Path("/*/blobs/uploads").
+		Middleware(repoproxy.DisableBlobAndManifestUploadMiddleware()).
 		Middleware(quota.PostInitiateBlobUploadMiddleware()).
 		Middleware(blob.PostInitiateBlobUploadMiddleware()).
 		Handler(proxy)
@@ -84,13 +85,11 @@ func RegisterRoutes() {
 	root.NewRoute().
 		Method(http.MethodPatch).
 		Path("/*/blobs/uploads/:session_id").
-		Middleware(repoproxy.DisableBlobAndManifestUploadMiddleware()).
 		Middleware(blob.PatchBlobUploadMiddleware()).
 		Handler(proxy)
 	root.NewRoute().
 		Method(http.MethodPut).
 		Path("/*/blobs/uploads/:session_id").
-		Middleware(repoproxy.DisableBlobAndManifestUploadMiddleware()).
 		Middleware(quota.PutBlobUploadMiddleware()).
 		Middleware(blob.PutBlobUploadMiddleware()).
 		Handler(proxy)


### PR DESCRIPTION
… to avoid the retrying in the docker client

Return 403 when trying to push artifacts into the proxy cache project to avoid the retrying in the docker client
fixes #12731

Signed-off-by: Wenkai Yin <yinw@vmware.com>