### PR TITLE
Disable the tag creation for the artifact under a proxy cache project

### DIFF
--- a/api/v2.0/swagger.yaml
+++ b/api/v2.0/swagger.yaml
@@ -606,6 +606,8 @@ paths:
           $ref: '#/responses/403'
         '404':
           $ref: '#/responses/404'
+        '405':
+          $ref: '#/responses/405'
         '409':
           $ref: '#/responses/409'
         '500':


### PR DESCRIPTION
Disable the tag creation for the artifact under a proxy cache project
Fixes #12713

Signed-off-by: Wenkai Yin <yinw@vmware.com>