### PR TITLE
add timeout for CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -27,6 +27,7 @@ jobs:
     runs-on:
       #- self-hosted
       - ubuntu-latest
+    timeout-minutes: 60
     steps:
       - name: Set up Go 1.14
         uses: actions/setup-go@v1
@@ -92,6 +93,7 @@ jobs:
     runs-on:
       #- self-hosted
       - ubuntu-latest
+    timeout-minutes: 60
     steps:
       - name: Set up Go 1.14
         uses: actions/setup-go@v1
@@ -195,6 +197,7 @@ jobs:
     runs-on:
       #- self-hosted
       - ubuntu-latest
+    timeout-minutes: 60
     steps:
       - name: Set up Go 1.14
         uses: actions/setup-go@v1
@@ -253,6 +256,7 @@ jobs:
     runs-on:
       #- self-hosted
       - ubuntu-latest
+    timeout-minutes: 60
     steps:
       - name: Set up Go 1.14
         uses: actions/setup-go@v1
@@ -309,6 +313,7 @@ jobs:
     runs-on:
       #- self-hosted
       - ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/setup-node@v1
         with:


### PR DESCRIPTION
Add 1 hour(60 minutes) as the timeout of gitactions.

Signed-off-by: wang yan <wangyan@vmware.com>