### PR TITLE
CSRF token cookie -> header 

### DIFF
--- a/src/portal/src/app/services/intercept-http.service.ts
+++ b/src/portal/src/app/services/intercept-http.service.ts
@@ -1,28 +1,58 @@
 import { Injectable } from '@angular/core';
-import { HttpInterceptor, HttpRequest, HttpHandler, HttpEvent, HttpResponse } from '@angular/common/http';
+import { HttpInterceptor, HttpRequest, HttpHandler, HttpResponse } from '@angular/common/http';
 import { Observable, throwError } from 'rxjs';
-import { tap, catchError } from 'rxjs/operators';
-import { CookieService } from 'ngx-cookie';
+import { catchError, tap } from 'rxjs/operators';
+
+const SAFE_METHODS: string[] = ["GET", "HEAD", "OPTIONS", "TRACE"];
 
 @Injectable({
   providedIn: 'root'
 })
 export class InterceptHttpService implements HttpInterceptor {
 
-  constructor(private cookie: CookieService) { }
+  constructor() { }
 
   intercept(request: HttpRequest<any>, next: HttpHandler): Observable<any> {
-
-    return next.handle(request).pipe(catchError(error => {
-      if (error.status === 403) {
-        let Xsrftoken = this.cookie.get("__csrf");
-        if (Xsrftoken && !request.headers.has('X-Harbor-CSRF-Token')) {
-          request = request.clone({ headers: request.headers.set('X-Harbor-CSRF-Token', Xsrftoken) });
-          return next.handle(request);
-        }
+    // Get the csrf token from localstorage
+    const token = localStorage.getItem("__csrf");
+    if (token) {
+      // Clone the request and replace the original headers with
+      // cloned headers, updated with the csrf token.
+      // not for requests using safe methods
+      if (request.method && SAFE_METHODS.indexOf(request.method.toUpperCase()) === -1) {
+        request = request.clone({
+          headers: request.headers.set('X-Harbor-CSRF-Token', token)
+        });
       }
-      return throwError(error);
-    }));
+    }
+    return next.handle(request).pipe(
+      tap(response => {
+        if (response && response instanceof HttpResponse && response.headers) {
+          const responseToken: string = response.headers.get('X-Harbor-CSRF-Token');
+          if (responseToken) {
+            localStorage.setItem("__csrf", responseToken);
+          }
+        }
+      },
+       error => {
+         if (error && error.headers) {
+           const responseToken: string = error.headers.get('X-Harbor-CSRF-Token');
+           if (responseToken) {
+             localStorage.setItem("__csrf", responseToken);
+           }
+         }
+       }))
+      .pipe(
+       catchError(error => {
+         if (error.status === 403) {
+           const csrfToken = localStorage.getItem("__csrf");
+           if (csrfToken) {
+             request = request.clone({ headers: request.headers.set('X-Harbor-CSRF-Token', csrfToken)});
+             return next.handle(request);
+           }
+         }
+         return throwError(error);
+       }));
   }
 }
 

--- a/src/portal/src/lib/utils/shared/shared.module.ts
+++ b/src/portal/src/lib/utils/shared/shared.module.ts
@@ -36,10 +36,6 @@ export function GeneralTranslatorLoader(http: HttpClient, config: IServiceConfig
     imports: [
         CommonModule,
         HttpClientModule,
-        HttpClientXsrfModule.withOptions({
-            cookieName: '__csrf',
-            headerName: 'X-Harbor-CSRF-Token'
-        }),
         FormsModule,
         ReactiveFormsModule,
         ClipboardModule,

--- a/src/server/middleware/csrf/csrf.go
+++ b/src/server/middleware/csrf/csrf.go
@@ -19,7 +19,6 @@ import (
 const (
 	csrfKeyEnv  = "CSRF_KEY"
 	tokenHeader = "X-Harbor-CSRF-Token"
-	tokenCookie = "__csrf"
 )
 
 var (
@@ -31,13 +30,7 @@ var (
 // attachToken makes sure if csrf generate a new token it will be included in the response header
 func attachToken(w http.ResponseWriter, r *http.Request) {
 	if t := csrf.Token(r); len(t) > 0 {
-		http.SetCookie(w, &http.Cookie{
-			Name:     tokenCookie,
-			Secure:   secureFlag,
-			Value:    t,
-			Path:     "/",
-			SameSite: http.SameSiteStrictMode,
-		})
+		w.Header().Set(tokenHeader, t)
 	} else {
 		log.Warningf("token not found in context, skip attaching")
 	}

--- a/src/server/middleware/csrf/csrf_test.go
+++ b/src/server/middleware/csrf/csrf_test.go
@@ -58,7 +58,7 @@ func TestMiddleware(t *testing.T) {
 		rec := httptest.NewRecorder()
 		srv.ServeHTTP(rec, c.req)
 		assert.Equal(t, c.statusCode, rec.Result().StatusCode)
-		assert.Equal(t, c.returnToken, hasCookie(rec.Result(), tokenCookie))
+		assert.Equal(t, c.returnToken, rec.Result().Header.Get(tokenHeader) != "")
 	}
 }
 


### PR DESCRIPTION
The current approach will prevent the effectiveness of `Cache-Control`
header and gorilla's library add `Vary:Cookie` header in all responses.

This PR sets the token in a header of response so the response can be
cached when needed.  It involves code change in both UI and backend middleware.

