### PR TITLE
Add id column to data_migration table

### DIFF
--- a/make/migrations/postgresql/0040_2.1.0_schema.up.sql
+++ b/make/migrations/postgresql/0040_2.1.0_schema.up.sql
@@ -117,7 +117,10 @@ ALTER TABLE schedule DROP COLUMN IF EXISTS status;
 UPDATE registry SET type = 'quay' WHERE type = 'quay-io';
 
 CREATE TABLE IF NOT EXISTS data_migrations (
-    version int
+    id SERIAL PRIMARY KEY NOT NULL,
+    version int,
+    creation_time timestamp default CURRENT_TIMESTAMP,
+    update_time timestamp default CURRENT_TIMESTAMP
 );
 INSERT INTO data_migrations (version) VALUES (
     CASE


### PR DESCRIPTION
Add id column to data_migration table and add logic to make sure there is only one data version record

Signed-off-by: Wenkai Yin <yinw@vmware.com>