### PR TITLE
Update all references of Golang to 1.14.7

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Go 1.14
         uses: actions/setup-go@v1
         with:
-           go-version: 1.14.5
+           go-version: 1.14.7
         id: go
       - name: setup Docker
         uses: docker-practice/actions-setup-docker@0.0.1
@@ -98,7 +98,7 @@ jobs:
       - name: Set up Go 1.14
         uses: actions/setup-go@v1
         with:
-          go-version: 1.14.5
+          go-version: 1.14.7
         id: go
       - name: setup Docker
         uses: docker-practice/actions-setup-docker@0.0.1
@@ -202,7 +202,7 @@ jobs:
       - name: Set up Go 1.14
         uses: actions/setup-go@v1
         with:
-          go-version: 1.14.5
+          go-version: 1.14.7
         id: go
       - name: setup Docker
         uses: docker-practice/actions-setup-docker@0.0.1
@@ -269,7 +269,7 @@ jobs:
       - name: Set up Go 1.14
         uses: actions/setup-go@v1
         with:
-          go-version: 1.14.5
+          go-version: 1.14.7
         id: go
       - name: setup Docker
         uses: docker-practice/actions-setup-docker@0.0.1

--- a/.github/workflows/conformance_test.yml
+++ b/.github/workflows/conformance_test.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up Go 1.14
         uses: actions/setup-go@v1
         with:
-          go-version: 1.14.5
+          go-version: 1.14.7
         id: go
       - name: setup Docker
         uses: docker-practice/actions-setup-docker@0.0.1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -137,7 +137,8 @@ Harbor backend is written in [Go](http://golang.org/). If you don't have a Harbo
 |   1.8    |    1.11.2     |
 |   1.9    |    1.12.12    |
 |   1.10   |    1.12.12    |
-|   1.11   |    1.14.5     |
+|   2.0    |    1.13.15    |
+|   2.1    |    1.14.7     |
 
 Ensure your GOPATH and PATH have been configured in accordance with the Go environment instructions.
 


### PR DESCRIPTION
In the previous change #12809 I missed a few places. This
should be complete now.