### PR TITLE
fix(jobservice) redis sentinel failover hang

### DIFF
--- a/make/photon/prepare/templates/registry/config.yml.jinja
+++ b/make/photon/prepare/templates/registry/config.yml.jinja
@@ -24,6 +24,9 @@ redis:
 {% else %}
   addr: {{redis_host}}
 {% endif %}
+  readtimeout: 10s
+  writetimeout: 10s
+  dialtimeout: 10s
   password: {{redis_password}}
   db: {{redis_db_index_reg}}
 http:


### PR DESCRIPTION
fix #12733
registry doesn't set any timeout when connect redis