### PR TITLE
fix registryapi error

### DIFF
--- a/contrib/registryapi/README.md
+++ b/contrib/registryapi/README.md
@@ -3,21 +3,24 @@ api for docker registry by token authorization
 
 + a simple api class which lies in registryapi.py, which simulates the interactions 
 between docker registry and the vendor authorization platform like harbor.
-```
+
 usage:
+
+```python
 from registryapi import RegistryApi
 api = RegistryApi('username', 'password', 'http://www.your_registry_url.com/')
 repos = api.getRepositoryList()
 tags = api.getTagList('public/ubuntu')
 manifest = api.getManifest('public/ubuntu', 'latest')
 res = api.deleteManifest('public/ubuntu', '23424545**4343')
-
 ```
 
 + a simple client tool based on api class, which contains basic read and delete 
 operations for repo, tag, manifest
-```
+
 usage:
+
+```shell
 ./cli.py --username username --password passwrod --registry_endpoint http://www.your_registry_url.com/ target action params
 
 target can be: repo, tag, manifest
@@ -25,5 +28,4 @@ action can be: list, get, delete
 params can be: --repo --ref --tag
 
 more see: ./cli.py -h
-
 ```

--- a/contrib/registryapi/registry.py
+++ b/contrib/registryapi/registry.py
@@ -36,8 +36,8 @@ class RegistryApi(object):
         except urllib2.HTTPError as e:
             headers = e.hdrs.dict
         try:
-            (realm, service, _) = headers['www-authenticate'].split(',')
-            return (realm[14:-1:], service[9:-1])
+            auth = headers['www-authenticate'].split(',')
+            return auth[0][14:-1:], auth[1][9:-1]
         except Exception as e:
             return None
 


### PR DESCRIPTION
Signed-off-by: shaowenchen <mail@chenshaowen.com>

In Harbor  v2.0.1-aa8bd64b/v1.9.3-c80751b8,  the length of registry_endpoint returned is 2 instead of 3, but `https://registry-1.docker.io` is 3.

https://github.com/goharbor/harbor/issues/12855