### PR TITLE
Add aws China regions ECR support

### DIFF
--- a/src/portal/src/lib/components/create-edit-endpoint/create-edit-endpoint.component.spec.ts
+++ b/src/portal/src/lib/components/create-edit-endpoint/create-edit-endpoint.component.spec.ts
@@ -198,6 +198,14 @@ describe("CreateEditEndpointComponent (inline template)", () => {
           {
             "key": "sa-east-1",
             "value": "https://api.ecr.sa-east-1.amazonaws.com"
+          },
+          {
+            "key": "cn-north-1",
+            "value": "https://api.ecr.cn-north-1.amazonaws.com.cn"
+          },
+          {
+            "key": "cn-northwest-1",
+            "value": "https://api.ecr.cn-northwest-1.amazonaws.com.cn"
           }
         ]
       },

--- a/src/portal/src/lib/components/endpoint/endpoint.component.spec.ts
+++ b/src/portal/src/lib/components/endpoint/endpoint.component.spec.ts
@@ -185,7 +185,16 @@ describe("EndpointComponent (inline template)", () => {
           {
             "key": "sa-east-1",
             "value": "https://api.ecr.sa-east-1.amazonaws.com"
+          },
+          {
+            "key": "cn-north-1",
+            "value": "https://api.ecr.cn-north-1.amazonaws.com.cn"
+          },
+          {
+            "key": "cn-northwest-1",
+            "value": "https://api.ecr.cn-northwest-1.amazonaws.com.cn"
           }
+
         ]
       },
       "credential_pattern": null

--- a/src/replication/adapter/awsecr/adapter.go
+++ b/src/replication/adapter/awsecr/adapter.go
@@ -189,6 +189,14 @@ func getAdapterInfo() *model.AdapterPattern {
 					Key:   "sa-east-1",
 					Value: "https://api.ecr.sa-east-1.amazonaws.com",
 				},
+				{
+					Key:   "cn-north-1",
+					Value: "https://api.ecr.cn-north-1.amazonaws.com.cn",
+				},
+				{
+					Key:   "cn-northwest-1",
+					Value: "https://api.ecr.cn-northwest-1.amazonaws.com.cn",
+				},
 			},
 		},
 	}

--- a/src/replication/adapter/awsecr/adapter_test.go
+++ b/src/replication/adapter/awsecr/adapter_test.go
@@ -55,6 +55,28 @@ func TestAdapter_NewAdapter(t *testing.T) {
 			AccessKey:    "xxx",
 			AccessSecret: "ppp",
 		},
+		URL: "https://api.ecr.test-china-region.amazonaws.com.cn",
+	})
+	assert.Nil(t, err)
+	assert.NotNil(t, adapter)
+
+	adapter, err = newAdapter(&model.Registry{
+		Type: model.RegistryTypeAwsEcr,
+		Credential: &model.Credential{
+			AccessKey:    "xxx",
+			AccessSecret: "ppp",
+		},
+		URL: "https://123456.dkr.ecr.test-china-region.amazonaws.com.cn",
+	})
+	assert.Nil(t, err)
+	assert.NotNil(t, adapter)
+
+	adapter, err = newAdapter(&model.Registry{
+		Type: model.RegistryTypeAwsEcr,
+		Credential: &model.Credential{
+			AccessKey:    "xxx",
+			AccessSecret: "ppp",
+		},
 	})
 	assert.Nil(t, adapter)
 	assert.NotNil(t, err)


### PR DESCRIPTION
Add aws China regions ECR support, both of cn-north-1 and cn-northwest-1 endpoints.

Copy origin PR from https://github.com/goharbor/harbor/pull/12264