### PR TITLE
Fix issue of missing swagger package for python API test

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -166,14 +166,8 @@ jobs:
           ./mconfig && \
           make -C builddir && \
           sudo make -C builddir install
-          python -V
-          sudo apt-get update -y && sudo apt-get install -y zbar-tools libzbar-dev python-zbar
-          sudo apt-get update -y
-          sudo apt-get install -y python3.6
-          sudo rm /usr/bin/python
-          sudo ln -s /usr/bin/python3.6 /usr/bin/python
-          sudo apt-get install -y python3-pip
-          python -V
+          sudo apt-get update -y ; sudo apt-get install -y zbar-tools libzbar-dev python-zbar python3.7
+          sudo rm /usr/bin/python ; sudo ln -s /usr/bin/python3.7 /usr/bin/python ; sudo apt-get install -y python3-pip
       - name: install
         run: |
           cd src/github.com/goharbor/harbor
@@ -236,14 +230,8 @@ jobs:
           sudo cp ./tests/harbor_ca.crt /usr/local/share/ca-certificates/
           sudo update-ca-certificates
           sudo service docker restart
-          python -V
-          sudo apt-get update -y && sudo apt-get install -y zbar-tools libzbar-dev python-zbar
-          sudo apt-get update -y
-          sudo apt-get install -y python3.6
-          sudo rm /usr/bin/python
-          sudo ln -s /usr/bin/python3.6 /usr/bin/python
-          sudo apt-get install -y python3-pip
-          python -V
+          sudo apt-get update -y ; sudo apt-get install -y zbar-tools libzbar-dev python-zbar python3.7
+          sudo rm /usr/bin/python ; sudo ln -s /usr/bin/python3.7 /usr/bin/python ; sudo apt-get install -y python3-pip
       - name: install
         run: |
           cd src/github.com/goharbor/harbor

--- a/tests/ci/api_common_install.sh
+++ b/tests/ci/api_common_install.sh
@@ -19,14 +19,15 @@ if [ "$2" = 'LDAP' ]; then
     cd tests && sudo ./ldapprepare.sh && cd ..
 fi
 
-
-
 # prepare a chart file for API_DB test...
 sudo curl -o $DIR/../../tests/apitests/python/mariadb-4.3.1.tgz https://storage.googleapis.com/harbor-builds/bin/charts/mariadb-4.3.1.tgz
 
-sudo apt-get update && sudo apt-get install -y --no-install-recommends python-dev openjdk-7-jdk libssl-dev && sudo apt-get autoremove -y && sudo rm -rf /var/lib/apt/lists/*
 sudo wget https://bootstrap.pypa.io/get-pip.py && sudo python ./get-pip.py && sudo pip install --ignore-installed urllib3 chardet requests && sudo pip install robotframework==3.2.1 robotframework-httplibrary requests --upgrade
 sudo make swagger_client
+#TODO: Swagger python package used to installed into dist-packages, but it's changed into site-packages all in a sudden, we havn't found the root cause.
+#      so current workround is to copy swagger packages from site-packages to dist-packages.
+sudo cp -r /usr/lib/python3.7/site-packages/* /usr/local/lib/python3.7/dist-packages
+
 if [ $GITHUB_TOKEN ];
 then
     sed "s/# github_token: xxx/github_token: $GITHUB_TOKEN/" -i make/harbor.yml

--- a/tests/robot-cases/Group0-BAT/API_DB.robot
+++ b/tests/robot-cases/Group0-BAT/API_DB.robot
@@ -2,7 +2,6 @@
 Documentation  Harbor BATs
 Resource  ../../resources/APITest-Util.robot
 Resource  ../../resources/Docker-Util.robot
-Library  ../../apitests/python/library/Harbor.py  ${SERVER_CONFIG}
 Library  OperatingSystem
 Library  String
 Library  Collections


### PR DESCRIPTION
1. Python API test can't import packages from swagger maker, the reason is that python install packages to site-packages instead of dist-packages,
   so the current solution is to copy pakages from site back to dist, I will try to find a way of using ENV variable to fix this;

2. Remove a python library no longer be used.

Signed-off-by: danfengliu <danfengl@vmware.com>