### PR TITLE
Fix issue of missing swagger package for python API test

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,329 @@
+name: CI
+env:
+   POSTGRESQL_HOST: localhost
+   POSTGRESQL_PORT: 5432
+   POSTGRESQL_USR: postgres
+   POSTGRESQL_PWD: root123
+   POSTGRESQL_DATABASE: registry
+   DOCKER_COMPOSE_VERSION: 1.23.0
+   HARBOR_ADMIN: admin
+   HARBOR_ADMIN_PASSWD: Harbor12345
+   CORE_SECRET: tempString
+   KEY_PATH: "/data/secret/keys/secretkey"
+   REDIS_HOST: localhost
+   REG_VERSION: v2.7.1-patch-2819-2553
+   UI_BUILDER_VERSION: 1.6.0
+
+on:
+  pull_request:
+  push:
+    paths-ignore:
+    - 'docs/**'
+
+jobs:
+  UTTEST:
+    env:
+       UTTEST: true
+    runs-on:
+      #- self-hosted
+      - ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Set up Go 1.14
+        uses: actions/setup-go@v1
+        with:
+           go-version: 1.14.7
+        id: go
+      - name: setup Docker
+        uses: docker-practice/actions-setup-docker@0.0.1
+        with:
+          docker_version: 18.09
+          docker_channel: stable
+      - uses: actions/checkout@v2
+        with:
+         path: src/github.com/goharbor/harbor
+      - name: setup env
+        run: |
+          cd src/github.com/goharbor/harbor
+          pwd
+          go env
+          echo "::set-env name=GOPATH::$(go env GOPATH):$GITHUB_WORKSPACE"
+          echo "::add-path::$(go env GOPATH)/bin"
+          echo "::set-env name=TOKEN_PRIVATE_KEY_PATH::${GITHUB_WORKSPACE}/src/github.com/goharbor/harbor/tests/private_key.pem"
+        shell: bash
+      - name: before_install
+        run: |
+          set -x
+          cd src/github.com/goharbor/harbor
+          pwd
+          env
+          #sudo apt install -y xvfb
+          #xvfb-run ls
+          curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
+          chmod +x docker-compose
+          sudo mv docker-compose /usr/local/bin
+          IP=`hostname -I | awk '{print $1}'`
+          echo '{"insecure-registries" : ["'$IP':5000"]}' | sudo tee /etc/docker/daemon.json
+          echo "::set-env name=IP::$IP"
+          sudo cp ./tests/harbor_ca.crt /usr/local/share/ca-certificates/
+          sudo update-ca-certificates
+          sudo service docker restart
+      - name: install
+        run: |
+          cd src/github.com/goharbor/harbor
+          env
+          df -h
+          bash ./tests/showtime.sh ./tests/ci/ut_install.sh
+      - name: script
+        run: |
+          echo IP: $IP
+          df -h
+          cd src/github.com/goharbor/harbor
+          bash ./tests/showtime.sh ./tests/ci/ut_run.sh $IP
+          df -h
+      - name: Codecov For BackEnd
+        uses: codecov/codecov-action@v1
+        with:
+          file: ./src/github.com/goharbor/harbor/profile.cov
+          flags: unittests
+
+  APITEST_DB:
+    env:
+      APITEST_DB: true
+    runs-on:
+      #- self-hosted
+      - ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Set up Go 1.14
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.14.7
+        id: go
+      - name: setup Docker
+        uses: docker-practice/actions-setup-docker@0.0.1
+        with:
+          docker_version: 18.09
+          docker_channel: stable
+      - uses: actions/checkout@v2
+        with:
+          path: src/github.com/goharbor/harbor
+      - name: setup env
+        run: |
+          cd src/github.com/goharbor/harbor
+          pwd
+          go env
+          echo "::set-env name=CNAB_PATH::$(go env GOPATH)/src/github.com/docker"
+          echo "::set-env name=GITHUB_TOKEN::${{ secrets.GITHUB_TOKEN }}"
+          echo "::set-env name=GOPATH::$(go env GOPATH):$GITHUB_WORKSPACE"
+          echo "::add-path::$(go env GOPATH)/bin"
+          echo "::set-env name=TOKEN_PRIVATE_KEY_PATH::${GITHUB_WORKSPACE}/src/github.com/goharbor/harbor/tests/private_key.pem"
+          IP=`hostname -I | awk '{print $1}'`
+          echo "::set-env name=IP::$IP"
+        shell: bash
+      - name: before_install
+        run: |
+          set -x
+          cd src/github.com/goharbor/harbor
+          pwd
+          env
+          df -h
+          #sudo apt install -y xvfb
+          #xvfb-run ls
+          curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
+          chmod +x docker-compose
+          sudo mv docker-compose /usr/local/bin
+          echo '{"insecure-registries" : ["'$IP':5000"]}' | sudo tee /etc/docker/daemon.json
+          sudo cp ./tests/harbor_ca.crt /usr/local/share/ca-certificates/
+          sudo update-ca-certificates
+          sudo service docker restart
+          wget https://get.helm.sh/helm-v2.14.1-linux-386.tar.gz && tar zxvf helm-v2.14.1-linux-386.tar.gz
+          sudo mv linux-386/helm /usr/local/bin/helm2
+          helm2 init --client-only
+          helm2 plugin list | grep push || helm2 plugin install https://github.com/chartmuseum/helm-push
+          wget https://get.helm.sh/helm-v3.1.1-linux-386.tar.gz && tar zxvf helm-v3.1.1-linux-386.tar.gz
+          sudo mv linux-386/helm /usr/local/bin/helm3
+          helm3 plugin list | grep push || helm3 plugin install https://github.com/chartmuseum/helm-push
+          rm -rf $CNAB_PATH;mkdir -p $CNAB_PATH && cd $CNAB_PATH && git clone https://github.com/cnabio/cnab-to-oci.git
+          cd cnab-to-oci && git checkout v0.3.0-beta4
+          go list
+          make build
+          sudo mv bin/cnab-to-oci /usr/local/bin
+          curl -LO https://github.com/deislabs/oras/releases/download/v0.8.1/oras_0.8.1_linux_amd64.tar.gz
+          mkdir -p oras-install/
+          tar -zxf oras_0.8.1_*.tar.gz -C oras-install/
+          sudo mv oras-install/oras /usr/local/bin/
+          sudo apt-get update && sudo apt-get install -y \
+          build-essential \
+          uuid-dev \
+          libgpgme-dev \
+          squashfs-tools \
+          libseccomp-dev \
+          pkg-config \
+          cryptsetup-bin
+          export VERSION=3.5.3 && \
+          wget https://github.com/sylabs/singularity/releases/download/v${VERSION}/singularity-${VERSION}.tar.gz && \
+          tar -xzf singularity-${VERSION}.tar.gz && cd singularity
+          ./mconfig && make -C builddir && sudo make -C builddir install
+          sudo apt-get update -y ; sudo apt-get install -y zbar-tools libzbar-dev python-zbar python3.7
+          sudo rm /usr/bin/python ; sudo ln -s /usr/bin/python3.7 /usr/bin/python ; sudo apt-get install -y python3-pip
+      - name: install
+        run: |
+          cd src/github.com/goharbor/harbor
+          env
+          df -h
+          docker system prune -a -f
+          bash ./tests/showtime.sh ./tests/ci/api_common_install.sh $IP DB
+      - name: script
+        run: |
+          cd src/github.com/goharbor/harbor
+          echo IP: $IP
+          df -h
+          bash ./tests/showtime.sh ./tests/ci/api_run.sh DB $IP
+          df -h
+
+  APITEST_LDAP:
+    env:
+      APITEST_LDAP: true
+    runs-on:
+      #- self-hosted
+      - ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Set up Go 1.14
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.14.7
+        id: go
+      - name: setup Docker
+        uses: docker-practice/actions-setup-docker@0.0.1
+        with:
+          docker_version: 18.09
+          docker_channel: stable
+      - uses: actions/checkout@v2
+        with:
+          path: src/github.com/goharbor/harbor
+      - name: setup env
+        run: |
+          cd src/github.com/goharbor/harbor
+          pwd
+          go env
+          echo "::set-env name=GOPATH::$(go env GOPATH):$GITHUB_WORKSPACE"
+          echo "::add-path::$(go env GOPATH)/bin"
+          echo "::set-env name=TOKEN_PRIVATE_KEY_PATH::${GITHUB_WORKSPACE}/src/github.com/goharbor/harbor/tests/private_key.pem"
+        shell: bash
+      - name: before_install
+        run: |
+          set -x
+          cd src/github.com/goharbor/harbor
+          pwd
+          env
+          df -h
+          #sudo apt install -y xvfb
+          #xvfb-run ls
+          curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
+          chmod +x docker-compose
+          sudo mv docker-compose /usr/local/bin
+          IP=`hostname -I | awk '{print $1}'`
+          echo '{"insecure-registries" : ["'$IP':5000"]}' | sudo tee /etc/docker/daemon.json
+          echo "::set-env name=IP::$IP"
+          python -V
+          sudo apt-get update -y ; sudo apt-get install -y zbar-tools libzbar-dev python-zbar python3.7
+          sudo rm /usr/bin/python ; sudo ln -s /usr/bin/python3.7 /usr/bin/python ; sudo apt-get install -y python3-pip
+      - name: install
+        run: |
+          cd src/github.com/goharbor/harbor
+          env
+          df -h
+          bash ./tests/showtime.sh ./tests/ci/api_common_install.sh $IP LDAP
+      - name: script
+        run: |
+          echo IP: $IP
+          df -h
+          cd src/github.com/goharbor/harbor
+          bash ./tests/showtime.sh ./tests/ci/api_run.sh LDAP $IP
+          df -h
+
+  OFFLINE:
+    env:
+      OFFLINE: true
+    runs-on:
+      #- self-hosted
+      - ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Set up Go 1.14
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.14.7
+        id: go
+      - name: setup Docker
+        uses: docker-practice/actions-setup-docker@0.0.1
+        with:
+          docker_version: 18.09
+          docker_channel: stable
+      - uses: actions/checkout@v2
+        with:
+          path: src/github.com/goharbor/harbor
+      - name: setup env
+        run: |
+          cd src/github.com/goharbor/harbor
+          pwd
+          docker version
+          go env
+          echo "::set-env name=GOPATH::$(go env GOPATH):$GITHUB_WORKSPACE"
+          echo "::add-path::$(go env GOPATH)/bin"
+          echo "::set-env name=TOKEN_PRIVATE_KEY_PATH::${GITHUB_WORKSPACE}/src/github.com/goharbor/harbor/tests/private_key.pem"
+        shell: bash
+      - name: before_install
+        run: |
+          set -x
+          cd src/github.com/goharbor/harbor
+          pwd
+          env
+          df -h
+          #sudo apt install -y xvfb
+          #xvfb-run ls
+          curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
+          chmod +x docker-compose
+          sudo mv docker-compose /usr/local/bin
+          IP=`hostname -I | awk '{print $1}'`
+          echo '{"insecure-registries" : ["'$IP':5000"]}' | sudo tee /etc/docker/daemon.json
+          echo "::set-env name=IP::$IP"
+          sudo cp ./tests/harbor_ca.crt /usr/local/share/ca-certificates/
+          sudo update-ca-certificates
+          sudo service docker restart
+      - name: script
+        run: |
+          echo IP: $IP
+          df -h
+          cd src/github.com/goharbor/harbor
+          bash ./tests/showtime.sh ./tests/ci/distro_installer.sh
+          df -h
+
+  UI_UT:
+    env:
+      UI_UT: true
+    runs-on:
+      #- self-hosted
+      - ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '10.16.2'
+      - uses: actions/checkout@v2
+        with:
+          path: src/github.com/goharbor/harbor
+      - name: script
+        run: |
+          echo IP: $IP
+          df -h
+          cd src/github.com/goharbor/harbor
+          bash ./tests/showtime.sh ./tests/ci/ui_ut_run.sh
+          df -h
+      - name: Codecov For UI
+        uses: codecov/codecov-action@v1
+        with:
+          file:  ./src/github.com/goharbor/harbor/src/portal/coverage/lcov.info
+          flags: unittests

--- a/tests/ci/api_common_install.sh
+++ b/tests/ci/api_common_install.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+set -x
+
+set +e
+sudo rm -fr /data/*
+sudo mkdir -p /data
+DIR="$(cd "$(dirname "$0")" && pwd)"
+
+set -e
+if [ -z "$1" ]; then echo no ip specified; exit 1;fi
+# prepare cert ...
+sudo ./tests/generateCerts.sh $1
+sudo mkdir -p /etc/docker/certs.d/$1 && sudo cp ./tests/harbor_ca.crt /etc/docker/certs.d/$1/ && rm -rf ~/.docker/ &&  mkdir -p ~/.docker/tls/$1:4443/ && sudo cp ./tests/harbor_ca.crt ~/.docker/tls/$1:4443/
+
+sudo ./tests/hostcfg.sh
+
+if [ "$2" = 'LDAP' ]; then
+    cd tests && sudo ./ldapprepare.sh && cd ..
+fi
+
+# prepare a chart file for API_DB test...
+sudo curl -o $DIR/../../tests/apitests/python/mariadb-4.3.1.tgz https://storage.googleapis.com/harbor-builds/bin/charts/mariadb-4.3.1.tgz
+
+sudo wget https://bootstrap.pypa.io/get-pip.py && sudo python ./get-pip.py && sudo pip install --ignore-installed urllib3 chardet requests && sudo pip install robotframework==3.2.1 robotframework-httplibrary requests --upgrade
+sudo make swagger_client
+#TODO: Swagger python package used to installed into dist-packages, but it's changed into site-packages all in a sudden, we havn't found the root cause.
+#      so current workround is to copy swagger packages from site-packages to dist-packages.
+sudo cp -r /usr/lib/python3.7/site-packages/* /usr/local/lib/python3.7/dist-packages
+
+if [ $GITHUB_TOKEN ];
+then
+    sed "s/# github_token: xxx/github_token: $GITHUB_TOKEN/" -i make/harbor.yml
+fi
+
+sudo make build_base_docker compile build prepare COMPILETAG=compile_golangimage GOBUILDTAGS="include_oss include_gcs" NOTARYFLAG=true CLAIRFLAG=true TRIVYFLAG=true CHARTFLAG=true GEN_TLS=true
+
+# set the debugging env
+echo "GC_TIME_WINDOW_HOURS=0" | sudo tee -a ./make/common/config/core/env
+sudo make start
+
+# waiting 5 minutes to start
+for((i=1;i<=30;i++)); do
+  echo $i waiting 10 seconds...
+  sleep 10
+  curl -k -L -f 127.0.0.1/api/v2.0/systeminfo && break
+  docker ps
+done

--- a/tests/robot-cases/Group0-BAT/API_DB.robot
+++ b/tests/robot-cases/Group0-BAT/API_DB.robot
@@ -2,7 +2,6 @@
 Documentation  Harbor BATs
 Resource  ../../resources/APITest-Util.robot
 Resource  ../../resources/Docker-Util.robot
-Library  ../../apitests/python/library/Harbor.py  ${SERVER_CONFIG}
 Library  OperatingSystem
 Library  String
 Library  Collections


### PR DESCRIPTION
1. Python API test can't import packages from swagger maker, the reason is that python install packages to site-packages instead of dist-packages,
   so the current solution is to copy pakages from site back to dist, I will try to find a way of using ENV variable to fix this;

2. Remove a python library no longer be used.

Signed-off-by: danfengliu <danfengl@vmware.com>