### PR TITLE
Check the tag in isArtifactSigned func -- cherrypick to 2.1

### DIFF
--- a/src/server/middleware/contenttrust/contenttrust.go
+++ b/src/server/middleware/contenttrust/contenttrust.go
@@ -21,6 +21,9 @@ var (
 		if err != nil {
 			return false, err
 		}
+		if len(art.Tag) > 0 {
+			return checker.IsTagSigned(art.Tag, art.Digest), nil
+		}
 		return checker.IsArtifactSigned(art.Digest), nil
 	}
 )


### PR DESCRIPTION
This commit ensures that when CLI is pulling a tag, the content trust middleware check the data in notary to ensure the particular tag is signed, not only the digest.

Signed-off-by: Daniel Jiang <jiangd@vmware.com>