### PR TITLE
Store User ID in session instead of the whole user model - cherry pick to 2.1

### DIFF
--- a/src/core/api/base.go
+++ b/src/core/api/base.go
@@ -35,11 +35,11 @@ import (
 	"github.com/goharbor/harbor/src/pkg/repository"
 	"github.com/goharbor/harbor/src/pkg/retention"
 	"github.com/goharbor/harbor/src/pkg/scheduler"
+	sec "github.com/goharbor/harbor/src/server/middleware/security"
 )
 
 const (
 	yamlFileContentType = "application/x-yaml"
-	userSessionKey      = "user"
 )
 
 // the managers/controllers used globally
@@ -176,7 +176,7 @@ func (b *BaseController) WriteYamlData(object interface{}) {
 // PopulateUserSession generates a new session ID and fill the user model in parm to the session
 func (b *BaseController) PopulateUserSession(u models.User) {
 	b.SessionRegenerateID()
-	b.SetSession(userSessionKey, u)
+	b.SetSession(sec.UserIDSessionKey, u.UserID)
 }
 
 // Init related objects/configurations for the API controllers

--- a/src/server/middleware/security/session.go
+++ b/src/server/middleware/security/session.go
@@ -19,12 +19,16 @@ import (
 	"net/http/httptest"
 
 	"github.com/astaxie/beego"
+	"github.com/goharbor/harbor/src/common/dao"
 	"github.com/goharbor/harbor/src/common/models"
 	"github.com/goharbor/harbor/src/common/security"
 	"github.com/goharbor/harbor/src/common/security/local"
 	"github.com/goharbor/harbor/src/core/config"
 	"github.com/goharbor/harbor/src/lib/log"
 )
+
+// UserIDSessionKey is the key for storing user id in session
+const UserIDSessionKey = "user_id"
 
 type session struct{}
 
@@ -35,15 +39,21 @@ func (s *session) Generate(req *http.Request) security.Context {
 		log.Errorf("failed to get the session store for request: %v", err)
 		return nil
 	}
-	userInterface := store.Get("user")
+	userInterface := store.Get(UserIDSessionKey)
 	if userInterface == nil {
 		return nil
 	}
-	user, ok := userInterface.(models.User)
+	uid, ok := userInterface.(int)
 	if !ok {
-		log.Warning("can not convert the user in session to user model")
+		log.Warning("can not convert the data in session to user id")
 		return nil
 	}
+	user, err := dao.GetUser(models.User{UserID: uid})
+	if err != nil {
+		log.Errorf("failed to get user info, error: %v, skip generating security context via session", err)
+		return nil
+	}
+
 	log.Debugf("a session security context generated for request %s %s", req.Method, req.URL.Path)
-	return local.NewSecurityContext(&user, config.GlobalProjectMgr)
+	return local.NewSecurityContext(user, config.GlobalProjectMgr)
 }


### PR DESCRIPTION
This commit makes a change so that the user id will be stored in sessoin
after user login instead of user model to avoid data inconsistency when
user model changes.

Fixes #12934

Signed-off-by: Daniel Jiang <jiangd@vmware.com>