### PR TITLE
 [CherryPick - 2.1] Store User ID in session instead of the whole user model

### DIFF
--- a/src/core/api/base.go
+++ b/src/core/api/base.go
@@ -35,11 +35,11 @@ import (
 	"github.com/goharbor/harbor/src/pkg/repository"
 	"github.com/goharbor/harbor/src/pkg/retention"
 	"github.com/goharbor/harbor/src/pkg/scheduler"
+	sec "github.com/goharbor/harbor/src/server/middleware/security"
 )
 
 const (
 	yamlFileContentType = "application/x-yaml"
-	userSessionKey      = "user"
 )
 
 // the managers/controllers used globally
@@ -176,7 +176,7 @@ func (b *BaseController) WriteYamlData(object interface{}) {
 // PopulateUserSession generates a new session ID and fill the user model in parm to the session
 func (b *BaseController) PopulateUserSession(u models.User) {
 	b.SessionRegenerateID()
-	b.SetSession(userSessionKey, u)
+	b.SetSession(sec.UserIDSessionKey, u.UserID)
 }
 
 // Init related objects/configurations for the API controllers

--- a/src/server/middleware/security/auth_proxy_test.go
+++ b/src/server/middleware/security/auth_proxy_test.go
@@ -17,25 +17,23 @@ package security
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
 	"github.com/goharbor/harbor/src/common"
 	"github.com/goharbor/harbor/src/common/models"
-	"github.com/goharbor/harbor/src/common/utils/test"
 	_ "github.com/goharbor/harbor/src/core/auth/authproxy"
 	"github.com/goharbor/harbor/src/core/config"
 	"github.com/goharbor/harbor/src/lib"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"io/ioutil"
 	"k8s.io/api/authentication/v1beta1"
-	"net/http"
-	"net/http/httptest"
-	"net/url"
-	"testing"
 )
 
 func TestAuthProxy(t *testing.T) {
-	config.Init()
-	test.InitDatabaseFromEnv()
 	authProxy := &authProxy{}
 
 	server, err := newAuthProxyTestServer()
@@ -49,7 +47,7 @@ func TestAuthProxy(t *testing.T) {
 		common.HTTPAuthProxyTokenReviewEndpoint: server.URL,
 		common.AUTHMode:                         common.HTTPAuth,
 	}
-	config.Upload(c)
+	config.InitWithSettings(c)
 	v, e := config.HTTPAuthProxySetting()
 	require.Nil(t, e)
 	assert.Equal(t, *v, models.HTTPAuthProxy{

--- a/src/server/middleware/security/security_test.go
+++ b/src/server/middleware/security/security_test.go
@@ -15,12 +15,20 @@
 package security
 
 import (
+	"github.com/goharbor/harbor/src/common/dao"
 	"github.com/goharbor/harbor/src/common/security"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"net/http"
+	"os"
 	"testing"
 )
+
+func TestMain(m *testing.M) {
+	dao.PrepareTestForPostgresSQL()
+	os.Exit(m.Run())
+}
 
 func TestSecurity(t *testing.T) {
 	var ctx security.Context


### PR DESCRIPTION
This commit makes a change so that the user id will be stored in sessoin
after user login instead of user model to avoid data inconsistency when
user model changes.

Fixes #12934

Signed-off-by: Daniel Jiang <jiangd@vmware.com>