### PR TITLE
[Cherry pick]feat(project): ignore enable_content_trust for proxy project

### DIFF
--- a/src/common/models/project.go
+++ b/src/common/models/project.go
@@ -80,6 +80,11 @@ func (p *Project) IsPublic() bool {
 	return isTrue(public)
 }
 
+// IsProxy returns true when the project type is proxy cache
+func (p *Project) IsProxy() bool {
+	return p.RegistryID > 0
+}
+
 // ContentTrustEnabled ...
 func (p *Project) ContentTrustEnabled() bool {
 	enabled, exist := p.GetMetadata(ProMetaEnableContentTrust)

--- a/src/server/middleware/repoproxy/proxy.go
+++ b/src/server/middleware/repoproxy/proxy.go
@@ -17,20 +17,20 @@ package repoproxy
 import (
 	"context"
 	"fmt"
-	"github.com/goharbor/harbor/src/common/security"
-	"github.com/goharbor/harbor/src/common/security/proxycachesecret"
-	"github.com/goharbor/harbor/src/lib/errors"
-	httpLib "github.com/goharbor/harbor/src/lib/http"
-	"github.com/goharbor/harbor/src/replication/model"
-	"github.com/goharbor/harbor/src/replication/registry"
 	"io"
 	"net/http"
 
 	"github.com/goharbor/harbor/src/common/models"
+	"github.com/goharbor/harbor/src/common/security"
+	"github.com/goharbor/harbor/src/common/security/proxycachesecret"
 	"github.com/goharbor/harbor/src/controller/project"
 	"github.com/goharbor/harbor/src/controller/proxy"
 	"github.com/goharbor/harbor/src/lib"
+	"github.com/goharbor/harbor/src/lib/errors"
+	httpLib "github.com/goharbor/harbor/src/lib/http"
 	"github.com/goharbor/harbor/src/lib/log"
+	"github.com/goharbor/harbor/src/replication/model"
+	"github.com/goharbor/harbor/src/replication/registry"
 	"github.com/goharbor/harbor/src/server/middleware"
 )
 
@@ -163,14 +163,6 @@ func setHeaders(w http.ResponseWriter, size int64, mediaType string, dig string)
 	h.Set("Etag", dig)
 }
 
-// isProxyProject check the project is a proxy project
-func isProxyProject(p *models.Project) bool {
-	if p == nil {
-		return false
-	}
-	return p.RegistryID > 0
-}
-
 // isProxySession check if current security context is proxy session
 func isProxySession(ctx context.Context) bool {
 	sc, ok := security.FromContext(ctx)
@@ -194,7 +186,7 @@ func DisableBlobAndManifestUploadMiddleware() func(http.Handler) http.Handler {
 			httpLib.SendError(w, err)
 			return
 		}
-		if isProxyProject(p) && !isProxySession(ctx) {
+		if p.IsProxy() && !isProxySession(ctx) {
 			httpLib.SendError(w,
 				errors.DeniedError(
 					errors.Errorf("can not push artifact to a proxy project: %v", p.Name)))

--- a/src/server/middleware/repoproxy/proxy_test.go
+++ b/src/server/middleware/repoproxy/proxy_test.go
@@ -18,43 +18,11 @@ import (
 	"context"
 	"testing"
 
-	"github.com/goharbor/harbor/src/common/models"
 	"github.com/goharbor/harbor/src/common/security"
 	"github.com/goharbor/harbor/src/common/security/proxycachesecret"
 	securitySecret "github.com/goharbor/harbor/src/common/security/secret"
 	"github.com/goharbor/harbor/src/core/config"
 )
-
-func TestIsProxyProject(t *testing.T) {
-	cases := []struct {
-		name string
-		in   *models.Project
-		want bool
-	}{
-		{
-			name: `no proxy`,
-			in:   &models.Project{RegistryID: 0},
-			want: false,
-		},
-		{
-			name: `normal proxy`,
-			in:   &models.Project{RegistryID: 1},
-			want: true,
-		},
-	}
-
-	for _, tt := range cases {
-		t.Run(tt.name, func(t *testing.T) {
-
-			got := isProxyProject(tt.in)
-
-			if got != tt.want {
-				t.Errorf(`(%v) = %v; want "%v"`, tt.in, got, tt.want)
-			}
-
-		})
-	}
-}
 
 func TestIsProxySession(t *testing.T) {
 	config.Init()

--- a/src/server/v2.0/handler/artifact.go
+++ b/src/server/v2.0/handler/artifact.go
@@ -17,9 +17,6 @@ package handler
 import (
 	"context"
 	"fmt"
-	"github.com/goharbor/harbor/src/controller/event/metadata"
-	"github.com/goharbor/harbor/src/controller/project"
-	"github.com/goharbor/harbor/src/pkg/notification"
 	"net/http"
 	"strings"
 	"time"
@@ -31,10 +28,13 @@ import (
 	"github.com/goharbor/harbor/src/common/utils"
 	"github.com/goharbor/harbor/src/controller/artifact"
 	"github.com/goharbor/harbor/src/controller/artifact/processor"
+	"github.com/goharbor/harbor/src/controller/event/metadata"
+	"github.com/goharbor/harbor/src/controller/project"
 	"github.com/goharbor/harbor/src/controller/repository"
 	"github.com/goharbor/harbor/src/controller/scan"
 	"github.com/goharbor/harbor/src/controller/tag"
 	"github.com/goharbor/harbor/src/lib/errors"
+	"github.com/goharbor/harbor/src/pkg/notification"
 	"github.com/goharbor/harbor/src/server/v2.0/handler/assembler"
 	"github.com/goharbor/harbor/src/server/v2.0/handler/model"
 	"github.com/goharbor/harbor/src/server/v2.0/models"
@@ -244,7 +244,7 @@ func (a *artifactAPI) requireNonProxyCacheProject(ctx context.Context, name stri
 	if err != nil {
 		return err
 	}
-	if pro.RegistryID > 0 {
+	if pro.IsProxy() {
 		return errors.New(nil).WithCode(errors.MethodNotAllowedCode).
 			WithMessage("the operation isn't supported for a proxy cache project")
 	}


### PR DESCRIPTION
Ignore enable_content_trust metadata for proxy cache project, see
https://github.com/goharbor/harbor/issues/12940 to get more info

Signed-off-by: He Weiwei <hweiwei@vmware.com>