### PR TITLE
(cherry-pick for 2.0) Set LDAP groupname when PopulateGroup

### DIFF
--- a/src/common/utils/ldap/ldap.go
+++ b/src/common/utils/ldap/ldap.go
@@ -388,7 +388,7 @@ func (session *Session) searchGroup(baseDN, filter, groupName, groupNameAttribut
 		var group models.LdapGroup
 		group.GroupDN = ldapEntry.DN
 		for _, attr := range ldapEntry.Attributes {
-			// OpenLdap sometimes contain leading space in useranme
+			// OpenLdap sometimes contain leading space in username
 			val := strings.TrimSpace(attr.Values[0])
 			log.Debugf("Current ldap entry attr name: %s\n", attr.Name)
 			switch strings.ToLower(attr.Name) {

--- a/src/common/utils/ldap/ldap_test.go
+++ b/src/common/utils/ldap/ldap_test.go
@@ -318,6 +318,12 @@ func TestSession_SearchGroupByDN(t *testing.T) {
 		LdapGroupNameAttribute: "cn",
 		LdapGroupSearchScope:   2,
 	}
+	ldapGroupConfig2 := models.LdapGroupConf{
+		LdapGroupBaseDN:        "ou=group,dc=example,dc=com",
+		LdapGroupFilter:        "objectclass=groupOfNames",
+		LdapGroupNameAttribute: "o",
+		LdapGroupSearchScope:   2,
+	}
 	type fields struct {
 		ldapConfig      models.LdapConf
 		ldapGroupConfig models.LdapGroupConf
@@ -345,6 +351,14 @@ func TestSession_SearchGroupByDN(t *testing.T) {
 			fields{ldapConfig: ldapConfig, ldapGroupConfig: ldapGroupConfig},
 			args{groupDN: "random string"},
 			nil, true},
+		{"search with gid = cn",
+			fields{ldapConfig: ldapConfig, ldapGroupConfig: ldapGroupConfig},
+			args{groupDN: "cn=harbor_group,ou=groups,dc=example,dc=com"},
+			[]models.LdapGroup{{GroupName: "harbor_group", GroupDN: "cn=harbor_group,ou=groups,dc=example,dc=com"}}, false},
+		{"search with gid = o",
+			fields{ldapConfig: ldapConfig, ldapGroupConfig: ldapGroupConfig2},
+			args{groupDN: "cn=harbor_group,ou=groups,dc=example,dc=com"},
+			[]models.LdapGroup{{GroupName: "hgroup", GroupDN: "cn=harbor_group,ou=groups,dc=example,dc=com"}}, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/src/core/auth/ldap/ldap.go
+++ b/src/core/auth/ldap/ldap.go
@@ -86,12 +86,12 @@ func (l *Auth) Authenticate(m models.AuthModel) (*models.User, error) {
 	u.Email = strings.TrimSpace(ldapUsers[0].Email)
 
 	l.syncUserInfoFromDB(&u)
-	l.attachLDAPGroup(ldapUsers, &u)
+	l.attachLDAPGroup(ldapUsers, &u, ldapSession)
 
 	return &u, nil
 }
 
-func (l *Auth) attachLDAPGroup(ldapUsers []models.LdapUser, u *models.User) {
+func (l *Auth) attachLDAPGroup(ldapUsers []models.LdapUser, u *models.User, sess *ldapUtils.Session) {
 	// Retrieve ldap related info in login to avoid too many traffic with LDAP server.
 	// Get group admin dn
 	groupCfg, err := config.LDAPGroupConf()
@@ -112,7 +112,16 @@ func (l *Auth) attachLDAPGroup(ldapUsers []models.LdapUser, u *models.User) {
 	}
 	userGroups := make([]models.UserGroup, 0)
 	for _, dn := range ldapUsers[0].GroupDNList {
-		userGroups = append(userGroups, models.UserGroup{GroupName: dn, LdapGroupDN: dn, GroupType: common.LDAPGroupType})
+		lGroups, err := sess.SearchGroupByDN(dn)
+		if err != nil {
+			log.Warningf("Can not get the ldap group name with DN %v, error %v", dn, err)
+			continue
+		}
+		if len(lGroups) == 0 {
+			log.Warningf("Can not get the ldap group name with DN %v", dn)
+			continue
+		}
+		userGroups = append(userGroups, models.UserGroup{GroupName: lGroups[0].GroupName, LdapGroupDN: dn, GroupType: common.LDAPGroupType})
 	}
 	u.GroupIDs, err = group.PopulateGroup(userGroups)
 	if err != nil {

--- a/tests/ldap_test.ldif
+++ b/tests/ldap_test.ldif
@@ -40,6 +40,7 @@ objectclass: top
 dn: cn=harbor_group,ou=groups,dc=example,dc=com
 cn: harbor_group
 description: harbor group
+o: hgroup
 member: cn=mike,ou=people,dc=example,dc=com
 member: cn=mike02,ou=people,dc=example,dc=com
 objectclass: groupOfNames


### PR DESCRIPTION
Search ldap group name with default ldap group attribute name
fixes #10940

Signed-off-by: stonezdj <stonezdj@gmail.com>