### PR TITLE
fix: Location Header in swagger api common response

### DIFF
--- a/api/v2.0/legacy_swagger.yaml
+++ b/api/v2.0/legacy_swagger.yaml
@@ -3679,6 +3679,10 @@ responses:
     description: 'Success'
   Created:
     description: 'Created'
+    headers:
+      Location:
+        type: string
+        description: The URL of the created resource
   BadRequest:
     description: 'Bad Request'
   Unauthorized:


### PR DESCRIPTION
* Add the Location Header to POST responses that use the common response
  Without the header, you cannot know which object you just created.