### PR TITLE
Support store the cron type in the schedule

### DIFF
--- a/make/migrations/postgresql/0050_2.2.0_schema.up.sql
+++ b/make/migrations/postgresql/0050_2.2.0_schema.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE schedule ADD COLUMN IF NOT EXISTS cron_type varchar(64);

--- a/src/controller/p2p/preheat/controller.go
+++ b/src/controller/p2p/preheat/controller.go
@@ -292,7 +292,7 @@ func (c *controller) CreatePolicy(ctx context.Context, schema *policyModels.Sche
 		schema.Trigger.Type == policyModels.TriggerTypeScheduled &&
 		len(schema.Trigger.Settings.Cron) > 0 {
 		// schedule and update policy
-		if _, err = c.scheduler.Schedule(ctx, job.P2PPreheat, id, schema.Trigger.Settings.Cron,
+		if _, err = c.scheduler.Schedule(ctx, job.P2PPreheat, id, "", schema.Trigger.Settings.Cron,
 			SchedulerCallback, TriggerParam{PolicyID: id}); err != nil {
 			return 0, err
 		}
@@ -384,7 +384,7 @@ func (c *controller) UpdatePolicy(ctx context.Context, schema *policyModels.Sche
 
 	// schedule new
 	if needSch {
-		if _, err := c.scheduler.Schedule(ctx, job.P2PPreheat, schema.ID, cron, SchedulerCallback,
+		if _, err := c.scheduler.Schedule(ctx, job.P2PPreheat, schema.ID, "", cron, SchedulerCallback,
 			TriggerParam{PolicyID: schema.ID}); err != nil {
 			return err
 		}

--- a/src/controller/p2p/preheat/controllor_test.go
+++ b/src/controller/p2p/preheat/controllor_test.go
@@ -241,7 +241,7 @@ func (s *preheatSuite) TestCreatePolicy() {
 		FiltersStr: `[{"type":"repository","value":"harbor*"},{"type":"tag","value":"2*"}]`,
 		TriggerStr: fmt.Sprintf(`{"type":"%s", "trigger_setting":{"cron":"* * * * */1"}}`, policy.TriggerTypeScheduled),
 	}
-	s.fakeScheduler.On("Schedule", s.ctx, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(int64(1), nil)
+	s.fakeScheduler.On("Schedule", s.ctx, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(int64(1), nil)
 	s.fakePolicyMgr.On("Create", s.ctx, policy).Return(int64(1), nil)
 	s.fakePolicyMgr.On("Update", s.ctx, mock.Anything, mock.Anything).Return(nil)
 	s.fakeScheduler.On("UnScheduleByVendor", s.ctx, mock.Anything, mock.Anything).Return(nil)

--- a/src/pkg/retention/controller.go
+++ b/src/pkg/retention/controller.go
@@ -93,7 +93,7 @@ func (r *DefaultAPIController) CreateRetention(p *policy.Metadata) (int64, error
 	if p.Trigger.Kind == policy.TriggerKindSchedule {
 		cron, ok := p.Trigger.Settings[policy.TriggerSettingsCron]
 		if ok && len(cron.(string)) > 0 {
-			if _, err = r.scheduler.Schedule(orm.Context(), schedulerVendorType, id, cron.(string), SchedulerCallback, TriggerParam{
+			if _, err = r.scheduler.Schedule(orm.Context(), schedulerVendorType, id, "", cron.(string), SchedulerCallback, TriggerParam{
 				PolicyID: id,
 				Trigger:  ExecutionTriggerSchedule,
 			}); err != nil {
@@ -152,7 +152,7 @@ func (r *DefaultAPIController) UpdateRetention(p *policy.Metadata) error {
 		}
 	}
 	if needSch {
-		_, err := r.scheduler.Schedule(orm.Context(), schedulerVendorType, p.ID, p.Trigger.Settings[policy.TriggerSettingsCron].(string), SchedulerCallback, TriggerParam{
+		_, err := r.scheduler.Schedule(orm.Context(), schedulerVendorType, p.ID, "", p.Trigger.Settings[policy.TriggerSettingsCron].(string), SchedulerCallback, TriggerParam{
 			PolicyID: p.ID,
 			Trigger:  ExecutionTriggerSchedule,
 		})

--- a/src/pkg/retention/controller_test.go
+++ b/src/pkg/retention/controller_test.go
@@ -220,7 +220,7 @@ func (s *ControllerTestSuite) TestExecution() {
 type fakeRetentionScheduler struct {
 }
 
-func (f *fakeRetentionScheduler) Schedule(ctx context.Context, vendorType string, vendorID int64, cron string, callbackFuncName string, params interface{}) (int64, error) {
+func (f *fakeRetentionScheduler) Schedule(ctx context.Context, vendorType string, vendorID int64, cronType string, cron string, callbackFuncName string, params interface{}) (int64, error) {
 	return 111, nil
 }
 

--- a/src/pkg/scheduler/dao.go
+++ b/src/pkg/scheduler/dao.go
@@ -32,6 +32,7 @@ type schedule struct {
 	ID                int64     `orm:"pk;auto;column(id)"`
 	VendorType        string    `orm:"column(vendor_type)"`
 	VendorID          int64     `orm:"column(vendor_id)"`
+	CRONType          string    `orm:"column(cron_type)"`
 	CRON              string    `orm:"column(cron)"`
 	CallbackFuncName  string    `orm:"column(callback_func_name)"`
 	CallbackFuncParam string    `orm:"column(callback_func_param)"`

--- a/src/pkg/scheduler/scheduler_test.go
+++ b/src/pkg/scheduler/scheduler_test.go
@@ -49,15 +49,15 @@ func (s *schedulerTestSuite) SetupTest() {
 
 func (s *schedulerTestSuite) TestSchedule() {
 	// empty vendor type
-	id, err := s.scheduler.Schedule(nil, "", 0, "0 * * * * *", "callback", nil)
+	id, err := s.scheduler.Schedule(nil, "", 0, "", "0 * * * * *", "callback", nil)
 	s.NotNil(err)
 
 	// invalid cron
-	id, err = s.scheduler.Schedule(nil, "vendor", 1, "", "callback", nil)
+	id, err = s.scheduler.Schedule(nil, "vendor", 1, "", "", "callback", nil)
 	s.NotNil(err)
 
 	// callback function not exist
-	id, err = s.scheduler.Schedule(nil, "vendor", 1, "0 * * * * *", "not-exist", nil)
+	id, err = s.scheduler.Schedule(nil, "vendor", 1, "", "0 * * * * *", "not-exist", nil)
 	s.NotNil(err)
 
 	// failed to submit to jobservice
@@ -70,7 +70,7 @@ func (s *schedulerTestSuite) TestSchedule() {
 		Status:      job.ErrorStatus.String(),
 	}, nil)
 	s.taskMgr.On("Stop", mock.Anything, mock.Anything).Return(nil)
-	_, err = s.scheduler.Schedule(nil, "vendor", 1, "0 * * * * *", "callback", "param")
+	_, err = s.scheduler.Schedule(nil, "vendor", 1, "", "0 * * * * *", "callback", "param")
 	s.Require().NotNil(err)
 	s.dao.AssertExpectations(s.T())
 	s.execMgr.AssertExpectations(s.T())
@@ -88,7 +88,7 @@ func (s *schedulerTestSuite) TestSchedule() {
 		ExecutionID: 1,
 		Status:      job.SuccessStatus.String(),
 	}, nil)
-	id, err = s.scheduler.Schedule(nil, "vendor", 1, "0 * * * * *", "callback", "param")
+	id, err = s.scheduler.Schedule(nil, "vendor", 1, "", "0 * * * * *", "callback", "param")
 	s.Require().Nil(err)
 	s.Equal(int64(1), id)
 	s.dao.AssertExpectations(s.T())

--- a/src/testing/pkg/scheduler/scheduler.go
+++ b/src/testing/pkg/scheduler/scheduler.go
@@ -62,20 +62,20 @@ func (_m *Scheduler) ListSchedules(ctx context.Context, query *q.Query) ([]*sche
 	return r0, r1
 }
 
-// Schedule provides a mock function with given fields: ctx, vendorType, vendorID, cron, callbackFuncName, params
-func (_m *Scheduler) Schedule(ctx context.Context, vendorType string, vendorID int64, cron string, callbackFuncName string, params interface{}) (int64, error) {
-	ret := _m.Called(ctx, vendorType, vendorID, cron, callbackFuncName, params)
+// Schedule provides a mock function with given fields: ctx, vendorType, vendorID, cronType, cron, callbackFuncName, params
+func (_m *Scheduler) Schedule(ctx context.Context, vendorType string, vendorID int64, cronType string, cron string, callbackFuncName string, params interface{}) (int64, error) {
+	ret := _m.Called(ctx, vendorType, vendorID, cronType, cron, callbackFuncName, params)
 
 	var r0 int64
-	if rf, ok := ret.Get(0).(func(context.Context, string, int64, string, string, interface{}) int64); ok {
-		r0 = rf(ctx, vendorType, vendorID, cron, callbackFuncName, params)
+	if rf, ok := ret.Get(0).(func(context.Context, string, int64, string, string, string, interface{}) int64); ok {
+		r0 = rf(ctx, vendorType, vendorID, cronType, cron, callbackFuncName, params)
 	} else {
 		r0 = ret.Get(0).(int64)
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, string, int64, string, string, interface{}) error); ok {
-		r1 = rf(ctx, vendorType, vendorID, cron, callbackFuncName, params)
+	if rf, ok := ret.Get(1).(func(context.Context, string, int64, string, string, string, interface{}) error); ok {
+		r1 = rf(ctx, vendorType, vendorID, cronType, cron, callbackFuncName, params)
 	} else {
 		r1 = ret.Error(1)
 	}


### PR DESCRIPTION
There is requirement that show the cron type(daily, weekly, etc.) on the UI, this commit adds the support for storing the cron type in the schedule model

Signed-off-by: Wenkai Yin <yinw@vmware.com>