### PR TITLE
Updated swagger definition for ImmutableTagRule

### DIFF
--- a/api/v2.0/legacy_swagger.yaml
+++ b/api/v2.0/legacy_swagger.yaml
@@ -5407,6 +5407,7 @@ definitions:
       enabled:
         type: boolean
         description: The quota is enable or disable
+
   ImmutableTagRule:
     type: object
     properties:
@@ -5416,10 +5417,34 @@ definitions:
       project_id:
         type: integer
         format: int64
-      tag_filter:
-        type: string
-      enabled:
+      priority:
+        type: integer
+      disabled:
         type: boolean
+      action:
+        type: string
+      template:
+        type: string
+      tag_selectors:
+        type: array
+        items:
+          $ref: '#/definitions/ImmutableTagRuleSelector'
+      scope_selectors:
+        type: object
+        additionalProperties:
+          type: array
+          items:
+            $ref: '#/definitions/ImmutableTagRuleSelector'
+
+  ImmutableTagRuleSelector:
+    type: object
+    properties:
+      kind:
+        type: string
+      decoration:
+        type: string
+      pattern:
+        type: string
 
   ScannerRegistration:
     type: object


### PR DESCRIPTION
The swagger definition for ImmutableTagRule wasn't matching the actual model used by the API. This caused generated clients to not function properly when when working with ImmutableTagRules.

I modified the swagger file to reflect the actual model used.

Related to goharbor/harbor#12474 specifically comment [659466710](https://github.com/goharbor/harbor/issues/12474#issuecomment-659466710)