### PR TITLE
Add error log in case encryption on config save fails

### DIFF
--- a/src/common/config/store/driver/db.go
+++ b/src/common/config/store/driver/db.go
@@ -72,6 +72,8 @@ func (d *Database) Save(cfgs map[string]interface{}) error {
 			if _, ok := item.ItemType.(*metadata.PasswordType); ok {
 				if encryptPassword, err := encrypt.Instance().Encrypt(strValue); err == nil {
 					entry.Value = encryptPassword
+				} else {
+					log.Errorf("encrypt password failed, error: %v", err)
 				}
 			}
 			configEntries = append(configEntries, *entry)


### PR DESCRIPTION
Solves issues like #12777 by providing an error if something fails.