### PR TITLE
fix #10913: initialize oidc provider before calling Load

### DIFF
--- a/src/common/utils/oidc/helper.go
+++ b/src/common/utils/oidc/helper.go
@@ -241,6 +241,11 @@ func refreshToken(ctx context.Context, token *Token) (*Token, error) {
 // UserInfoFromToken tries to call the UserInfo endpoint of the OIDC provider, and consolidate with ID token
 // to generate a UserInfo object, if the ID token is not in the input token struct, some attributes will be empty
 func UserInfoFromToken(ctx context.Context, token *Token) (*UserInfo, error) {
+	// #10913: preload the configuration, in case it was not previously loaded by the UI
+	_, err := provider.get()
+	if err != nil {
+		return nil, err
+	}
 	setting := provider.setting.Load().(models.OIDCSetting)
 	local, err := userInfoFromIDToken(ctx, token, setting)
 	if err != nil {


### PR DESCRIPTION
Fixes a panic in case oidc is used, and the UI is not called before a docker command is sent via /v2 api

Panic:
```
2020/09/21 08:38:52.203  [HTTP] http: panic serving 10.253.45.1:52494: interface conversion: interface {} is nil, not models.OIDCSetting
goroutine 251 [running]:
net/http.(*conn).serve.func1(0xc001080640)
	/usr/local/go/src/net/http/server.go:1800 +0x139
panic(0x1d80c40, 0xc001588870)
	/usr/local/go/src/runtime/panic.go:975 +0x3e3
github.com/goharbor/harbor/src/common/utils/oidc.UserInfoFromToken(0x250eb40, 0xc001588570, 0xc00047a1c0, 0x1e2bc00, 0xc00047a1c0, 0x0)
	/harbor/src/common/utils/oidc/helper.go:244 +0x693
github.com/goharbor/harbor/src/common/utils/oidc.(*defaultManager).VerifySecret(0x369bff0, 0x250eb40, 0xc001588570, 0xc00171e230, 0x22, 0xc00171e253, 0x20, 0xc00109e8c0, 0xc0018a4e98, 0x1a8e6f0)
	/harbor/src/common/utils/oidc/secret.go:116 +0x5b5
github.com/goharbor/harbor/src/common/utils/oidc.VerifySecret(...)
	/harbor/src/common/utils/oidc/secret.go:131
github.com/goharbor/harbor/src/server/middleware/security.(*oidcCli).Generate(0x36d0140, 0xc001898100, 0x0, 0x0)
	/harbor/src/server/middleware/security/oidc_cli.go:58 +0x1b6
github.com/goharbor/harbor/src/server/middleware/security.Middleware.func1.1(0x24f7c40, 0xc00221c230, 0xc000a13800)
	/harbor/src/server/middleware/security/security.go:58 +0x172
net/http.HandlerFunc.ServeHTTP(0xc001d67060, 0x24f7c40, 0xc00221c230, 0xc000a13800)
	/usr/local/go/src/net/http/server.go:2041 +0x44
github.com/goharbor/harbor/src/server/middleware/artifactinfo.Middleware.func1.1(0x24f7c40, 0xc00221c230, 0xc000a13800)
	/harbor/src/server/middleware/artifactinfo/artifact_info.go:55 +0x8ea
net/http.HandlerFunc.ServeHTTP(0xc001d67080, 0x24f7c40, 0xc00221c230, 0xc000a13800)
	/usr/local/go/src/net/http/server.go:2041 +0x44
github.com/goharbor/harbor/src/server/middleware/transaction.Middleware.func1.1(0x250eb40, 0xc0015b0e10, 0x0, 0xc001226500)
	/harbor/src/server/middleware/transaction/transaction.go:62 +0x19d
github.com/goharbor/harbor/src/lib/orm.WithTransaction.func1(0x250eb40, 0xc0015b0e10, 0x0, 0x0)
	/harbor/src/lib/orm/orm.go:73 +0x176
github.com/goharbor/harbor/src/server/middleware/transaction.Middleware.func1(0x24f7c80, 0xc001226520, 0xc00221e500, 0x24c4e20, 0xc001d67080)
	/harbor/src/server/middleware/transaction/transaction.go:71 +0xfe
github.com/goharbor/harbor/src/server/middleware.New.func1.1(0x24f7c80, 0xc001226520, 0xc00221e500)
	/harbor/src/server/middleware/middleware.go:57 +0x105
net/http.HandlerFunc.ServeHTTP(0xc0005c8940, 0x24f7c80, 0xc001226520, 0xc00221e500)
	/usr/local/go/src/net/http/server.go:2041 +0x44
github.com/goharbor/harbor/src/server/middleware/notification.Middleware.func1(0x2507540, 0xc00177e000, 0xc00221e400, 0x24c4e20, 0xc0005c8940)
	/harbor/src/server/middleware/notification/notification.go:31 +0x225
github.com/goharbor/harbor/src/server/middleware.New.func1.1(0x2507540, 0xc00177e000, 0xc00221e400)
	/harbor/src/server/middleware/middleware.go:57 +0x105
net/http.HandlerFunc.ServeHTTP(0xc0005c8980, 0x2507540, 0xc00177e000, 0xc00221e400)
	/usr/local/go/src/net/http/server.go:2041 +0x44
github.com/goharbor/harbor/src/server/middleware/orm.MiddlewareWithConfig.func1(0x2507540, 0xc00177e000, 0xc00221e300, 0x24c4e20, 0xc0005c8980)
	/harbor/src/server/middleware/orm/orm.go:53 +0x18b
github.com/goharbor/harbor/src/server/middleware.New.func1.1(0x2507540, 0xc00177e000, 0xc00221e300)
	/harbor/src/server/middleware/middleware.go:57 +0x105
net/http.HandlerFunc.ServeHTTP(0xc0005c89c0, 0x2507540, 0xc00177e000, 0xc00221e300)
	/usr/local/go/src/net/http/server.go:2041 +0x44
github.com/goharbor/harbor/src/server/middleware.New.func1.1(0x2507540, 0xc00177e000, 0xc00221e300)
	/harbor/src/server/middleware/middleware.go:52 +0xcc
net/http.HandlerFunc.ServeHTTP(0xc0005c8a00, 0x2507540, 0xc00177e000, 0xc00221e300)
	/usr/local/go/src/net/http/server.go:2041 +0x44
github.com/goharbor/harbor/src/server/middleware/session.Middleware.func1.1(0x2507540, 0xc00177e000, 0xc00221e300)
	/harbor/src/server/middleware/session/session.go:34 +0x99
net/http.HandlerFunc.ServeHTTP(0xc001d670a0, 0x2507540, 0xc00177e000, 0xc00221e300)
	/usr/local/go/src/net/http/server.go:2041 +0x44
github.com/goharbor/harbor/src/server/middleware/log.Middleware.func1(0x2507540, 0xc00177e000, 0xc00221e200, 0x24c4e20, 0xc001d670a0)
	/harbor/src/server/middleware/log/log.go:33 +0x422
github.com/goharbor/harbor/src/server/middleware.New.func1.1(0x2507540, 0xc00177e000, 0xc00221e200)
	/harbor/src/server/middleware/middleware.go:57 +0x105
net/http.HandlerFunc.ServeHTTP(0xc0005c8a40, 0x2507540, 0xc00177e000, 0xc00221e200)
	/usr/local/go/src/net/http/server.go:2041 +0x44
github.com/goharbor/harbor/src/server/middleware/requestid.Middleware.func1(0x2507540, 0xc00177e000, 0xc00221e200, 0x24c4e20, 0xc0005c8a40)
	/harbor/src/server/middleware/requestid/requestid.go:37 +0x1ad
github.com/goharbor/harbor/src/server/middleware.New.func1.1(0x2507540, 0xc00177e000, 0xc00221e200)
	/harbor/src/server/middleware/middleware.go:57 +0x105
net/http.HandlerFunc.ServeHTTP(0xc0005c8a80, 0x2507540, 0xc00177e000, 0xc00221e200)
	/usr/local/go/src/net/http/server.go:2041 +0x44
net/http.serverHandler.ServeHTTP(0xc0002cc1c0, 0x2507540, 0xc00177e000, 0xc00221e200)
	/usr/local/go/src/net/http/server.go:2836 +0xa3
net/http.(*conn).serve(0xc001080640, 0x250ea80, 0xc00123c4c0)
	/usr/local/go/src/net/http/server.go:1924 +0x86c
created by net/http.(*Server).Serve
	/usr/local/go/src/net/http/server.go:2962 +0x35c
```