### PR TITLE
Stop using python 2.x in the portal image build

### DIFF
--- a/api/v2.0/legacy_swagger.yaml
+++ b/api/v2.0/legacy_swagger.yaml
@@ -3323,7 +3323,7 @@ definitions:
         description: The name of the OIDC provider.
       oidc_scope:
         type: string
-        description: The scope sent to OIDC server during authentication, should be separated by comma. It has to contain “openid”, and “offline_access”. If you are using google, please remove “offline_access” from this field.
+        description: The scope sent to OIDC server during authentication, should be separated by comma. It has to contain "openid", and "offline_access". If you are using google, please remove "offline_access" from this field.
       oidc_verify_cert:
         type: boolean
         description: Whether verify your OIDC server certificate, disable it if your OIDC server is hosted via self-hosted certificate.
@@ -3438,7 +3438,7 @@ definitions:
         description: The name of the OIDC provider.
       oidc_scope:
         $ref: '#/definitions/StringConfigItem'
-        description: The scope sent to OIDC server during authentication, should be separated by comma. It has to contain “openid”, and “offline_access”. If you are using google, please remove “offline_access” from this field.
+        description: The scope sent to OIDC server during authentication, should be separated by comma. It has to contain "openid", and "offline_access". If you are using google, please remove "offline_access" from this field.
       oidc_verify_cert:
         $ref: '#/definitions/BoolConfigItem'
         description: Whether verify your OIDC server certificate, disable it if your OIDC server is hosted via self-hosted certificate.

--- a/make/photon/portal/Dockerfile
+++ b/make/photon/portal/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /build_dir
 ARG npm_registry=https://registry.npmjs.org
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends python-yaml=3.12-1
+    && apt-get install -y --no-install-recommends python3-yaml
 
 COPY src/portal/package.json /build_dir
 COPY src/portal/package-lock.json /build_dir
@@ -22,9 +22,9 @@ ENV NPM_CONFIG_REGISTRY=${npm_registry}
 RUN npm install --unsafe-perm
 RUN npm run generate-build-timestamp
 RUN node --max_old_space_size=2048 'node_modules/@angular/cli/bin/ng' build --prod
-RUN python -c 'import sys, yaml, json; y=yaml.load(sys.stdin.read()); print json.dumps(y)' < swagger.yaml > dist/swagger.json
-RUN python -c 'import sys, yaml, json; y=yaml.load(sys.stdin.read()); print json.dumps(y)' < swagger2.yaml > dist/swagger2.json
-RUN python -c 'import sys, yaml, json; y=yaml.load(sys.stdin.read()); print json.dumps(y)' < swagger3.yaml > dist/swagger3.json
+RUN python3 -c 'import sys, yaml, json; y=yaml.load(sys.stdin.read()); print(json.dumps(y))' < swagger.yaml > dist/swagger.json
+RUN python3 -c 'import sys, yaml, json; y=yaml.load(sys.stdin.read()); print(json.dumps(y))' < swagger2.yaml > dist/swagger2.json
+RUN python3 -c 'import sys, yaml, json; y=yaml.load(sys.stdin.read()); print(json.dumps(y))' < swagger3.yaml > dist/swagger3.json
 
 RUN cp swagger.yaml dist
 COPY ./LICENSE /build_dir/dist


### PR DESCRIPTION
Python 2.x is EOL since 2020, so stop using it.

We can switch to python 3.x which makes us more futureproof
to further updates.