### PR TITLE
Fix error handling in test docker API

### DIFF
--- a/tests/apitests/python/library/docker_api.py
+++ b/tests/apitests/python/library/docker_api.py
@@ -112,7 +112,7 @@ class DockerAPI(object):
                 if str(err).lower().find(expected_error_message.lower()) < 0:
                     raise Exception(r"Pull image: Return message {} is not as expected {}".format(str(err), expected_error_message))
             else:
-                raise Exception(r" Docker pull image {} failed, error is [{}]".format (image, message))
+                raise Exception(r" Docker pull image {} failed, error is [{}]".format (image, str(err)))
         if caught_err == False:
             if expected_error_message is not None:
                 if str(ret).lower().find(expected_error_message.lower()) < 0:
@@ -146,7 +146,7 @@ class DockerAPI(object):
                 if str(err).lower().find(expected_error_message.lower()) < 0:
                     raise Exception(r"Push image: Return message {} is not as expected {}".format(str(err), expected_error_message))
             else:
-                raise Exception(r" Docker push image {} failed, error is [{}]".format (harbor_registry, message))
+                raise Exception(r" Docker push image {} failed, error is [{}]".format (harbor_registry, str(err)))
         if caught_err == False:
             if expected_error_message is not None:
                 if str(ret).lower().find(expected_error_message.lower()) < 0:


### PR DESCRIPTION
If image pull/push operations fail while running test cases, an
incorrect error message is printed instead of the actual error, e.g.:

```
Traceback (most recent call last):
  File "./tests/apitests/python/test_user_view_logs.py", line 82, in testUserViewLogs
    repo_name, tag = push_image_to_project(project_user_view_logs_name, harbor_server, admin_name, admin_password, "tomcat", "latest")
  File "/var/lib/harbor-test/tests/apitests/python/library/repository.py", line 34, in push_image_to_project
    _docker_api.docker_image_push(new_harbor_registry, new_tag, expected_error_message = expected_error_message)
  File "/var/lib/harbor-test/tests/apitests/python/library/docker_api.py", line 152, in docker_image_push
    raise Exception(r" Docker push image {} failed, error is [{}]".format (harbor_registry, message))
NameError: global name 'message' is not defined
```

Signed-off-by: Stefan Nica <snica@suse.com>