### PR TITLE
Upgrade the Photon OS version in harbor-db image

### DIFF
--- a/make/photon/db/Dockerfile.base
+++ b/make/photon/db/Dockerfile.base
@@ -1,4 +1,4 @@
-FROM photon:2.0
+FROM photon:3.0
 
 ENV PGDATA /var/lib/postgresql/data
 


### PR DESCRIPTION
Using latest stable version of OS (photon:3.0) implies
using somewhat newer version of PostgreSQL: 10.10 instead of
postgresql 9.6 which is present in photon:2.0

Closes #12522

Signed-off-by: Jiří Suchomel <jiri.suchomel@suse.com>