### PR TITLE
Fix path in code cov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -21,6 +21,9 @@ parsers:
       method: no
       macro: no
 
+fixes:
+  - "src/github.com/goharbor/harbor/src/::src/"
+
 comment:
   layout: "reach,diff,flags,tree"
   behavior: default
@@ -29,5 +32,5 @@ comment:
 ignore:
   - "src/vendor"
   - "src/testing"
-  - "src/github.com/goharbor/harbor/src/server/v2.0/restapi/**/*"
-  - "src/github.com/goharbor/harbor/src/server/v2.0/models"
+  - "src/server/v2.0/restapi/**/*"
+  - "src/server/v2.0/models"


### PR DESCRIPTION
Referring https://docs.codecov.io/docs/fixing-paths , this commit fixes
the path to make sure the coverage changes can be viewed on codecov's
dashboard.

Signed-off-by: Daniel Jiang <jiangd@vmware.com>