### PR TITLE
Extends the timeout in CI jobs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -93,7 +93,7 @@ jobs:
     runs-on:
       #- self-hosted
       - ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 120
     steps:
       - name: Set up Go 1.14
         uses: actions/setup-go@v1
@@ -153,7 +153,7 @@ jobs:
     runs-on:
       #- self-hosted
       - ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 120
     steps:
       - name: Set up Go 1.14
         uses: actions/setup-go@v1
@@ -211,7 +211,7 @@ jobs:
     runs-on:
       #- self-hosted
       - ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 120
     steps:
       - name: Set up Go 1.14
         uses: actions/setup-go@v1


### PR DESCRIPTION
The jobs are taking more time to finish due to slowliness to pull docker
images from dockerhub (may due to rate limiting?)
This commit extends the timeout in some of the jobs to avoid CI failure.

Signed-off-by: Daniel Jiang <jiangd@vmware.com>