### PR TITLE
Update the LDAP utils to support LDAP paging.

### DIFF
--- a/src/common/const.go
+++ b/src/common/const.go
@@ -156,4 +156,7 @@ const (
 
 	// DefaultGCTimeWindowHours is the reserve blob time window used by GC, default is 2 hours
 	DefaultGCTimeWindowHours = int64(2)
+
+	// DefaultLDAPPage Size is the default page size used for LDAP queries, default is 500
+	DefaultLDAPPageSize = uint32(500)
 )

--- a/src/common/utils/ldap/ldap.go
+++ b/src/common/utils/ldap/ldap.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/goharbor/harbor/src/common"
 	"github.com/goharbor/harbor/src/common/models"
 	"github.com/goharbor/harbor/src/core/config"
 	"github.com/goharbor/harbor/src/lib/log"
@@ -315,7 +316,7 @@ func (session *Session) SearchLdapAttribute(baseDN, filter string, attributes []
 		nil,
 	)
 
-	result, err := session.ldapConn.Search(searchRequest)
+	result, err := session.ldapConn.SearchWithPaging(searchRequest, common.DefaultLDAPPageSize)
 	if result != nil {
 		log.Debugf("Found entries:%v\n", len(result.Entries))
 	} else {


### PR DESCRIPTION
#10940 & #11060 introduced a change where harbor would search for the name of LDAP group to populate user's group. In a situation where there is thousand of groups in LDAP the server would return result code 4 size limit exceed. This use paging to remove this edge case.