### PR TITLE
(cherry-pick) Use HEAD instead of GET for dockerhub rate limit

### DIFF
--- a/src/controller/proxy/remote.go
+++ b/src/controller/proxy/remote.go
@@ -23,12 +23,14 @@ import (
 	"io"
 )
 
-// remoteInterface defines operations related to remote repository under proxy
-type remoteInterface interface {
+// RemoteInterface defines operations related to remote repository under proxy
+type RemoteInterface interface {
 	// BlobReader create a reader for remote blob
 	BlobReader(repo, dig string) (int64, io.ReadCloser, error)
 	// Manifest get manifest by reference
 	Manifest(repo string, ref string) (distribution.Manifest, string, error)
+	// ManifestExist checks manifest exist, if exist, return digest
+	ManifestExist(repo string, ref string) (bool, string, error)
 }
 
 // remoteHelper defines operations related to remote repository under proxy
@@ -38,8 +40,8 @@ type remoteHelper struct {
 	registryMgr registry.Manager
 }
 
-// newRemoteHelper create a remoteHelper interface
-func newRemoteHelper(regID int64) (*remoteHelper, error) {
+// NewRemoteHelper create a remote interface
+func NewRemoteHelper(regID int64) (RemoteInterface, error) {
 	r := &remoteHelper{
 		regID:       regID,
 		registryMgr: registry.NewDefaultManager()}
@@ -82,4 +84,8 @@ func (r *remoteHelper) BlobReader(repo, dig string) (int64, io.ReadCloser, error
 
 func (r *remoteHelper) Manifest(repo string, ref string) (distribution.Manifest, string, error) {
 	return r.registry.PullManifest(repo, ref)
+}
+
+func (r *remoteHelper) ManifestExist(repo string, ref string) (bool, string, error) {
+	return r.registry.ManifestExist(repo, ref)
 }

--- a/src/server/middleware/repoproxy/proxy.go
+++ b/src/server/middleware/repoproxy/proxy.go
@@ -102,7 +102,11 @@ func handleManifest(w http.ResponseWriter, r *http.Request, next http.Handler) e
 		next.ServeHTTP(w, r)
 		return nil
 	}
-	useLocal, err := proxyCtl.UseLocalManifest(ctx, art)
+	remote, err := proxy.NewRemoteHelper(p.RegistryID)
+	if err != nil {
+		return err
+	}
+	useLocal, err := proxyCtl.UseLocalManifest(ctx, art, remote)
 	if err != nil {
 		return err
 	}
@@ -111,7 +115,7 @@ func handleManifest(w http.ResponseWriter, r *http.Request, next http.Handler) e
 		return nil
 	}
 	log.Debugf("the tag is %v, digest is %v", art.Tag, art.Digest)
-	err = proxyManifest(ctx, w, r, next, proxyCtl, p, art)
+	err = proxyManifest(ctx, w, proxyCtl, p, art, remote)
 	if err != nil {
 		if errors.IsNotFoundErr(err) {
 			return err
@@ -122,8 +126,8 @@ func handleManifest(w http.ResponseWriter, r *http.Request, next http.Handler) e
 	return nil
 }
 
-func proxyManifest(ctx context.Context, w http.ResponseWriter, r *http.Request, next http.Handler, ctl proxy.Controller, p *models.Project, art lib.ArtifactInfo) error {
-	man, err := ctl.ProxyManifest(ctx, p, art)
+func proxyManifest(ctx context.Context, w http.ResponseWriter, ctl proxy.Controller, p *models.Project, art lib.ArtifactInfo, remote proxy.RemoteInterface) error {
+	man, err := ctl.ProxyManifest(ctx, p, art, remote)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Compare the local digest and the remote digest when pull by tag
Use HEAD request (ManifestExist) instead of GET request (GetManifest) to avoid been throttled
For manifest list, it can avoid GET request because cached manifest list maybe different with the original manifest list
Make RemoteInterface public
Fixes #13112

Signed-off-by: stonezdj <stonezdj@gmail.com>