### PR TITLE
Add admin group support to OIDC auth mode

### DIFF
--- a/src/common/config/metadata/metadatalist.go
+++ b/src/common/config/metadata/metadatalist.go
@@ -139,6 +139,7 @@ var (
 		{Name: common.OIDCCLientID, Scope: UserScope, Group: OIDCGroup, ItemType: &StringType{}},
 		{Name: common.OIDCClientSecret, Scope: UserScope, Group: OIDCGroup, ItemType: &PasswordType{}},
 		{Name: common.OIDCGroupsClaim, Scope: UserScope, Group: OIDCGroup, ItemType: &StringType{}},
+		{Name: common.OIDCAdminGroup, Scope: UserScope, Group: OIDCGroup, ItemType: &StringType{}},
 		{Name: common.OIDCScope, Scope: UserScope, Group: OIDCGroup, ItemType: &StringType{}},
 		{Name: common.OIDCUserClaim, Scope: UserScope, Group: OIDCGroup, ItemType: &StringType{}},
 		{Name: common.OIDCVerifyCert, Scope: UserScope, Group: OIDCGroup, DefaultValue: "true", ItemType: &BoolType{}},

--- a/src/common/const.go
+++ b/src/common/const.go
@@ -105,6 +105,7 @@ const (
 	OIDCCLientID                     = "oidc_client_id"
 	OIDCClientSecret                 = "oidc_client_secret"
 	OIDCVerifyCert                   = "oidc_verify_cert"
+	OIDCAdminGroup                   = "oidc_admin_group"
 	OIDCGroupsClaim                  = "oidc_groups_claim"
 	OIDCAutoOnboard                  = "oidc_auto_onboard"
 	OIDCScope                        = "oidc_scope"

--- a/src/common/models/config.go
+++ b/src/common/models/config.go
@@ -85,6 +85,7 @@ type OIDCSetting struct {
 	ClientID     string   `json:"client_id"`
 	ClientSecret string   `json:"client_secret"`
 	GroupsClaim  string   `json:"groups_claim"`
+	AdminGroup   string   `json:"admin_group"`
 	RedirectURL  string   `json:"redirect_url"`
 	Scope        []string `json:"scope"`
 	UserClaim    string   `json:"user_claim"`

--- a/src/common/utils/oidc/helper.go
+++ b/src/common/utils/oidc/helper.go
@@ -126,7 +126,7 @@ type UserInfo struct {
 	Username         string   `json:"name"`
 	Email            string   `json:"email"`
 	Groups           []string `json:"groups"`
-	AdminGroupMember bool     `json:"AdminGroupMember"`
+	AdminGroupMember bool     `json:"admin_group_member"`
 	hasGroupClaim    bool
 }
 
@@ -382,8 +382,12 @@ func populateGroupsDB(groupNames []string) ([]int, error) {
 }
 
 // InjectGroupsToUser populates the group to DB and inject the group IDs to user model.
-// The third optional parm is for UT only, when using the func, the third
+// The third optional parm is for UT only.
 func InjectGroupsToUser(info *UserInfo, user *models.User, f ...populate) {
+	if info == nil || user == nil {
+		log.Warningf("user info or user model is nil, skip the func")
+		return
+	}
 	var populateGroups populate
 	if len(f) == 0 {
 		populateGroups = populateGroupsDB

--- a/src/common/utils/oidc/secret.go
+++ b/src/common/utils/oidc/secret.go
@@ -4,15 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/goharbor/harbor/src/common"
+	"sync"
+
 	"github.com/goharbor/harbor/src/common/dao"
-	"github.com/goharbor/harbor/src/common/dao/group"
 	"github.com/goharbor/harbor/src/common/models"
 	"github.com/goharbor/harbor/src/common/utils"
 	"github.com/goharbor/harbor/src/core/config"
 	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/lib/log"
-	"sync"
 )
 
 // SecretVerifyError wraps the different errors happened when verifying a secret for OIDC user.  When seeing this error,
@@ -117,12 +116,7 @@ func (dm *defaultManager) VerifySecret(ctx context.Context, username string, sec
 	if err != nil {
 		return nil, verifyError(err)
 	}
-	gids, err := group.PopulateGroup(models.UserGroupsFromName(info.Groups, common.OIDCGroupType))
-	if err != nil {
-		log.Warningf("failed to get group ID, error: %v, skip populating groups", err)
-	} else {
-		user.GroupIDs = gids
-	}
+	InjectGroupsToUser(info, user)
 	return user, nil
 }
 

--- a/src/common/utils/oidc/testutils.go
+++ b/src/common/utils/oidc/testutils.go
@@ -3,6 +3,8 @@ package oidc
 import (
 	"context"
 	"fmt"
+	"strconv"
+
 	"github.com/goharbor/harbor/src/common/models"
 )
 import "errors"
@@ -23,4 +25,15 @@ func (fv *fakeVerifier) VerifySecret(ctx context.Context, name string, secret st
 // Be reminded this is for testing only.
 func SetHardcodeVerifierForTest(s string) {
 	m = &fakeVerifier{s}
+}
+func mockPopulateGroups(groupNames []string) ([]int, error) {
+	res := make([]int, 0)
+	for _, g := range groupNames {
+		id, err := strconv.Atoi(g)
+		if err != nil {
+			return res, err
+		}
+		res = append(res, id)
+	}
+	return res, nil
 }

--- a/src/core/config/config.go
+++ b/src/core/config/config.go
@@ -440,6 +440,7 @@ func OIDCSetting() (*models.OIDCSetting, error) {
 		ClientID:     cfgMgr.Get(common.OIDCCLientID).GetString(),
 		ClientSecret: cfgMgr.Get(common.OIDCClientSecret).GetString(),
 		GroupsClaim:  cfgMgr.Get(common.OIDCGroupsClaim).GetString(),
+		AdminGroup:   cfgMgr.Get(common.OIDCAdminGroup).GetString(),
 		RedirectURL:  extEndpoint + common.OIDCCallbackPath,
 		Scope:        scope,
 		UserClaim:    cfgMgr.Get(common.OIDCUserClaim).GetString(),

--- a/src/server/middleware/security/idtoken.go
+++ b/src/server/middleware/security/idtoken.go
@@ -20,8 +20,6 @@ import (
 
 	"github.com/goharbor/harbor/src/common"
 	"github.com/goharbor/harbor/src/common/dao"
-	"github.com/goharbor/harbor/src/common/dao/group"
-	"github.com/goharbor/harbor/src/common/models"
 	"github.com/goharbor/harbor/src/common/security"
 	"github.com/goharbor/harbor/src/common/security/local"
 	"github.com/goharbor/harbor/src/common/utils/oidc"
@@ -33,14 +31,16 @@ import (
 type idToken struct{}
 
 func (i *idToken) Generate(req *http.Request) security.Context {
-	log := log.G(req.Context())
-	if lib.GetAuthMode(req.Context()) != common.OIDCAuth {
+	ctx := req.Context()
+	log := log.G(ctx)
+	if lib.GetAuthMode(ctx) != common.OIDCAuth {
 		return nil
 	}
 	if !strings.HasPrefix(req.URL.Path, "/api") {
 		return nil
 	}
-	claims, err := oidc.VerifyToken(req.Context(), bearerToken(req))
+	token := bearerToken(req)
+	claims, err := oidc.VerifyToken(ctx, token)
 	if err != nil {
 		log.Warningf("failed to verify token: %v", err)
 		return nil
@@ -54,19 +54,16 @@ func (i *idToken) Generate(req *http.Request) security.Context {
 		log.Warning("user matches token's claims is not onboarded.")
 		return nil
 	}
-	settings, err := config.OIDCSetting()
+	setting, err := config.OIDCSetting()
 	if err != nil {
 		log.Errorf("failed to get OIDC settings: %v", err)
 		return nil
 	}
-	if groupNames, ok := oidc.GroupsFromClaims(claims, settings.GroupsClaim); ok {
-		groups := models.UserGroupsFromName(groupNames, common.OIDCGroupType)
-		u.GroupIDs, err = group.PopulateGroup(groups)
-		if err != nil {
-			log.Errorf("failed to get group ID list for OIDC user %s: %v", u.Username, err)
-			return nil
-		}
+	info, err := oidc.UserInfoFromIDToken(ctx, &oidc.Token{RawIDToken: token}, *setting)
+	if err != nil {
+		log.Errorf("Failed to get user info from ID token: %v", err)
 	}
+	oidc.InjectGroupsToUser(info, u)
 	log.Debugf("an ID token security context generated for request %s %s", req.Method, req.URL.Path)
 	return local.NewSecurityContext(u, config.GlobalProjectMgr)
 }

--- a/src/server/middleware/security/idtoken.go
+++ b/src/server/middleware/security/idtoken.go
@@ -62,6 +62,7 @@ func (i *idToken) Generate(req *http.Request) security.Context {
 	info, err := oidc.UserInfoFromIDToken(ctx, &oidc.Token{RawIDToken: token}, *setting)
 	if err != nil {
 		log.Errorf("Failed to get user info from ID token: %v", err)
+		return nil
 	}
 	oidc.InjectGroupsToUser(info, u)
 	log.Debugf("an ID token security context generated for request %s %s", req.Method, req.URL.Path)


### PR DESCRIPTION
Add oidc_admin_group to configuration, and make sure a token with the
group name in group claim has the admin authority.

Signed-off-by: Daniel Jiang <jiangd@vmware.com>