### PR TITLE
Remove dup call to createGroupSearchFilter in searchGroup

### DIFF
--- a/src/common/utils/ldap/ldap.go
+++ b/src/common/utils/ldap/ldap.go
@@ -371,11 +371,7 @@ func (session *Session) SearchGroupByDN(groupDN string) ([]models.LdapGroup, err
 	if _, err := goldap.ParseDN(groupDN); err != nil {
 		return nil, ErrDNSyntax
 	}
-	ldapFilter, err := createGroupSearchFilter(session.ldapGroupConfig.LdapGroupFilter, "", session.ldapGroupConfig.LdapGroupNameAttribute)
-	if err != nil {
-		return nil, err
-	}
-	groupList, err := session.searchGroup(groupDN, ldapFilter, "", session.ldapGroupConfig.LdapGroupNameAttribute)
+	groupList, err := session.searchGroup(groupDN, session.ldapGroupConfig.LdapGroupFilter, "", session.ldapGroupConfig.LdapGroupNameAttribute)
 	if serverError, ok := err.(*goldap.Error); ok {
 		log.Debugf("resultCode:%v", serverError.ResultCode)
 	}


### PR DESCRIPTION
Avoid generate redunant info in the filter
Signed-off-by: stonezdj <stonezdj@gmail.com>