### PR TITLE
Return the location header when creating proxy cache project

### DIFF
--- a/src/server/v2.0/handler/project.go
+++ b/src/server/v2.0/handler/project.go
@@ -181,7 +181,6 @@ func (a *projectAPI) CreateProject(ctx context.Context, params operation.CreateP
 		if err := a.metadataMgr.Add(ctx, projectID, md); err != nil {
 			return a.SendError(ctx, err)
 		}
-		return nil
 	}
 
 	location := fmt.Sprintf("%s/%d", strings.TrimSuffix(params.HTTPRequest.URL.Path, "/"), projectID)


### PR DESCRIPTION
Fixes #13303. Return the location header when creating proxy cache project

Signed-off-by: Wenkai Yin <yinw@vmware.com>