### PR TITLE
ci: update env and path commands in github actions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -47,9 +47,9 @@ jobs:
           cd src/github.com/goharbor/harbor
           pwd
           go env
-          echo "::set-env name=GOPATH::$(go env GOPATH):$GITHUB_WORKSPACE"
-          echo "::add-path::$(go env GOPATH)/bin"
-          echo "::set-env name=TOKEN_PRIVATE_KEY_PATH::${GITHUB_WORKSPACE}/src/github.com/goharbor/harbor/tests/private_key.pem"
+          echo "GOPATH=$(go env GOPATH):$GITHUB_WORKSPACE" >> $GITHUB_ENV
+          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
+          echo "TOKEN_PRIVATE_KEY_PATH=${GITHUB_WORKSPACE}/src/github.com/goharbor/harbor/tests/private_key.pem" >> $GITHUB_ENV
         shell: bash
       - name: before_install
         run: |
@@ -64,7 +64,7 @@ jobs:
           sudo mv docker-compose /usr/local/bin
           IP=`hostname -I | awk '{print $1}'`
           echo '{"insecure-registries" : ["'$IP':5000"]}' | sudo tee /etc/docker/daemon.json
-          echo "::set-env name=IP::$IP"
+          echo "IP=$IP" >> $GITHUB_ENV
           sudo cp ./tests/harbor_ca.crt /usr/local/share/ca-certificates/
           sudo update-ca-certificates
           sudo service docker restart
@@ -113,12 +113,12 @@ jobs:
           cd src/github.com/goharbor/harbor
           pwd
           go env
-          echo "::set-env name=GITHUB_TOKEN::${{ secrets.GITHUB_TOKEN }}"
-          echo "::set-env name=GOPATH::$(go env GOPATH):$GITHUB_WORKSPACE"
-          echo "::add-path::$(go env GOPATH)/bin"
-          echo "::set-env name=TOKEN_PRIVATE_KEY_PATH::${GITHUB_WORKSPACE}/src/github.com/goharbor/harbor/tests/private_key.pem"
+          echo "GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}" >> $GITHUB_ENV
+          echo "GOPATH=$(go env GOPATH):$GITHUB_WORKSPACE" >> $GITHUB_ENV
+          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
+          echo "TOKEN_PRIVATE_KEY_PATH=${GITHUB_WORKSPACE}/src/github.com/goharbor/harbor/tests/private_key.pem" >> $GITHUB_ENV
           IP=`hostname -I | awk '{print $1}'`
-          echo "::set-env name=IP::$IP"
+          echo "IP=$IP" >> $GITHUB_ENV
         shell: bash
       - name: before_install
         run: |
@@ -173,11 +173,11 @@ jobs:
           cd src/github.com/goharbor/harbor
           pwd
           go env
-          echo "::set-env name=GOPATH::$(go env GOPATH):$GITHUB_WORKSPACE"
-          echo "::add-path::$(go env GOPATH)/bin"
-          echo "::set-env name=TOKEN_PRIVATE_KEY_PATH::${GITHUB_WORKSPACE}/src/github.com/goharbor/harbor/tests/private_key.pem"
+          echo "GOPATH=$(go env GOPATH):$GITHUB_WORKSPACE" >> $GITHUB_ENV
+          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
+          echo "TOKEN_PRIVATE_KEY_PATH=${GITHUB_WORKSPACE}/src/github.com/goharbor/harbor/tests/private_key.pem" >> $GITHUB_ENV
           IP=`hostname -I | awk '{print $1}'`
-          echo "::set-env name=IP::$IP"
+          echo "IP=$IP" >> $GITHUB_ENV
         shell: bash
       - name: before_install
         run: |
@@ -232,9 +232,9 @@ jobs:
           pwd
           docker version
           go env
-          echo "::set-env name=GOPATH::$(go env GOPATH):$GITHUB_WORKSPACE"
-          echo "::add-path::$(go env GOPATH)/bin"
-          echo "::set-env name=TOKEN_PRIVATE_KEY_PATH::${GITHUB_WORKSPACE}/src/github.com/goharbor/harbor/tests/private_key.pem"
+          echo "GOPATH=$(go env GOPATH):$GITHUB_WORKSPACE" >> $GITHUB_ENV
+          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
+          echo "TOKEN_PRIVATE_KEY_PATH=${GITHUB_WORKSPACE}/src/github.com/goharbor/harbor/tests/private_key.pem" >> $GITHUB_ENV
         shell: bash
       - name: before_install
         run: |
@@ -250,7 +250,7 @@ jobs:
           sudo mv docker-compose /usr/local/bin
           IP=`hostname -I | awk '{print $1}'`
           echo '{"insecure-registries" : ["'$IP':5000"]}' | sudo tee /etc/docker/daemon.json
-          echo "::set-env name=IP::$IP"
+          echo "IP=$IP" >> $GITHUB_ENV
           sudo cp ./tests/harbor_ca.crt /usr/local/share/ca-certificates/
           sudo update-ca-certificates
           sudo service docker restart


### PR DESCRIPTION
The `add-path` and `set-env` commands are deprecated and will be
disabled soon so update the CI.yml to use the new methods for these
commands.

 For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

Signed-off-by: He Weiwei <hweiwei@vmware.com>