### PR TITLE
Add deprecated mark to Helm Hub

### DIFF
--- a/src/portal/src/i18n/lang/en-us-lang.json
+++ b/src/portal/src/i18n/lang/en-us-lang.json
@@ -658,7 +658,8 @@
         "DELETED_FAILED": "Deleted endpoints failed.",
         "CANNOT_EDIT": "Endpoint cannot be changed while the replication rule is enabled.",
         "FAILED_TO_DELETE_TARGET_IN_USED": "Failed to delete the endpoint in use.",
-        "PLACEHOLDER": "We couldn't find any endpoints!"
+        "PLACEHOLDER": "We couldn't find any endpoints!",
+        "DEPRECATED": "Helm Hub is moving to Artifact Hub"
     },
     "REPOSITORY": {
         "COPY_DIGEST_ID": "Copy Digest",

--- a/src/portal/src/i18n/lang/es-es-lang.json
+++ b/src/portal/src/i18n/lang/es-es-lang.json
@@ -659,7 +659,8 @@
         "DELETED_FAILED": "Ha fallado la eliminación del endpoint.",
         "CANNOT_EDIT": "El endpoint no puede ser cambiado mientras la regla de replicación está activa.",
         "FAILED_TO_DELETE_TARGET_IN_USED": "Fallo al eliminar el endpoint en uso.",
-        "PLACEHOLDER": "We couldn't find any endpoints!"
+        "PLACEHOLDER": "We couldn't find any endpoints!",
+        "DEPRECATED": "Helm Hub is moving to Artifact Hub"
     },
     "REPOSITORY": {
         "COPY_DIGEST_ID": "Copy Digest",

--- a/src/portal/src/i18n/lang/fr-fr-lang.json
+++ b/src/portal/src/i18n/lang/fr-fr-lang.json
@@ -647,7 +647,8 @@
         "DELETED_FAILED": "Echec de la suppression du point final",
         "CANNOT_EDIT": "Le point final ne peut pas être modifié tant que la règle de réplication est activée.",
         "FAILED_TO_DELETE_TARGET_IN_USED": "Echec de la suppression du point final en cours d'utilisation",
-        "PLACEHOLDER": "Nous n'avons trouvé aucun point final !"
+        "PLACEHOLDER": "Nous n'avons trouvé aucun point final !",
+        "DEPRECATED": "Helm Hub is moving to Artifact Hub"
     },
     "REPOSITORY": {
         "COPY_DIGEST_ID": "Copier le Résumé",

--- a/src/portal/src/i18n/lang/pt-br-lang.json
+++ b/src/portal/src/i18n/lang/pt-br-lang.json
@@ -658,7 +658,8 @@
         "DELETED_FAILED": "Falha em endpoints removidos.",
         "CANNOT_EDIT": "Endpoint não pode ser alterado enquando a regra de replicação estiver ativa.",
         "FAILED_TO_DELETE_TARGET_IN_USED": "Falha ao remover endpoint em uso.",
-        "PLACEHOLDER": "Não foi possível encontrar nenhum endpoint!"
+        "PLACEHOLDER": "Não foi possível encontrar nenhum endpoint!",
+        "DEPRECATED": "Helm Hub is moving to Artifact Hub"
     },
     "REPOSITORY": {
         "COPY_DIGEST_ID": "Copiar Digest",

--- a/src/portal/src/i18n/lang/tr-tr-lang.json
+++ b/src/portal/src/i18n/lang/tr-tr-lang.json
@@ -658,7 +658,8 @@
         "DELETED_FAILED": "Silinen uç noktalar başarısız oldu.",
         "CANNOT_EDIT": "Çoğaltma kuralı etkinken uç noktası değiştirilemez.",
         "FAILED_TO_DELETE_TARGET_IN_USED": "Kullanılan uç nokta silinemedi.",
-        "PLACEHOLDER": "Uç noktaları bulamadık!"
+        "PLACEHOLDER": "Uç noktaları bulamadık!",
+        "DEPRECATED": "Helm Hub is moving to Artifact Hub"
     },
     "REPOSITORY": {
         "COPY_DIGEST_ID": "Özet Kopyala",

--- a/src/portal/src/i18n/lang/zh-cn-lang.json
+++ b/src/portal/src/i18n/lang/zh-cn-lang.json
@@ -659,7 +659,8 @@
         "DELETED_FAILED": "删除目标失败。",
         "CANNOT_EDIT": "当复制规则启用时目标无法修改。",
         "FAILED_TO_DELETE_TARGET_IN_USED": "无法删除正在使用的目标。",
-        "PLACEHOLDER": "未发现任何复制目标!"
+        "PLACEHOLDER": "未发现任何复制目标!",
+        "DEPRECATED": "Helm Hub 正被移至 Artifact Hub"
     },
     "REPOSITORY": {
         "COPY_DIGEST_ID": "复制摘要",

--- a/src/portal/src/i18n/lang/zh-tw-lang.json
+++ b/src/portal/src/i18n/lang/zh-tw-lang.json
@@ -655,7 +655,8 @@
     "DELETED_FAILED": "刪除目標失敗。",
     "CANNOT_EDIT": "當複制規則啟用時目標無法修改。",
     "FAILED_TO_DELETE_TARGET_IN_USED": "無法刪除正在使用的目標。",
-    "PLACEHOLDER": "未發現任何復制目標!"
+    "PLACEHOLDER": "未發現任何復制目標!",
+    "DEPRECATED": "Helm Hub is moving to Artifact Hub"
   },
   "REPOSITORY":{
     "COPY_DIGEST_ID": "複製摘要",

--- a/src/portal/src/lib/components/create-edit-endpoint/create-edit-endpoint.component.html
+++ b/src/portal/src/lib/components/create-edit-endpoint/create-edit-endpoint.component.html
@@ -14,7 +14,7 @@
       <clr-select-container>
         <label class="required">{{'DESTINATION.PROVIDER' | translate}}</label>
         <select clrSelect name="adapter" id="adapter" (change)="adapterChange($event)" [(ngModel)]="target.type" [disabled]="testOngoing || editDisabled">
-          <option *ngFor="let adapter of adapterList" value="{{adapter}}">{{getAdapterText(adapter)}}</option>
+          <option [ngClass]="{hidden: shouldHide(adapter)}" *ngFor="let adapter of adapterList" value="{{adapter}}">{{getAdapterText(adapter)}}</option>
         </select>
       </clr-select-container>
       <!-- Endpoint name -->

--- a/src/portal/src/lib/components/create-edit-endpoint/create-edit-endpoint.component.scss
+++ b/src/portal/src/lib/components/create-edit-endpoint/create-edit-endpoint.component.scss
@@ -64,3 +64,6 @@
     display: flex;
     align-items: center;
   }
+  .hidden{
+    display:none;
+  }

--- a/src/portal/src/lib/components/create-edit-endpoint/create-edit-endpoint.component.ts
+++ b/src/portal/src/lib/components/create-edit-endpoint/create-edit-endpoint.component.ts
@@ -25,7 +25,7 @@ import { NgForm } from "@angular/forms";
 import { Subscription, throwError as observableThrowError } from "rxjs";
 import { TranslateService } from "@ngx-translate/core";
 
-import { EndpointService } from "../../services/endpoint.service";
+import {EndpointService, HELM_HUB} from "../../services/endpoint.service";
 import { ErrorHandler } from "../../utils/error-handler";
 import { InlineAlertComponent } from "../inline-alert/inline-alert.component";
 import { Endpoint, PingEndpoint } from "../../services/interface";
@@ -37,7 +37,6 @@ import { AppConfigService } from '../../../app/services/app-config.service';
 const FAKE_PASSWORD = "rjGcfuRu";
 const FAKE_JSON_KEY = "No Change";
 const METADATA_URL = CURRENT_BASE_HREF + "/replication/adapterinfos";
-const HELM_HUB = "helm-hub";
 const FIXED_PATTERN_TYPE: string = "EndpointPatternTypeFix";
 @Component({
   selector: "hbr-create-edit-endpoint",
@@ -484,5 +483,9 @@ export class CreateEditEndpointComponent
 
   getAdapterText(adapter: string): string {
     return this.endpointService.getAdapterText(adapter);
+  }
+  // hide helm hub option when creating registry
+  shouldHide(adapter: string) {
+    return adapter === HELM_HUB && !this.endpointId;
   }
 }

--- a/src/portal/src/lib/components/endpoint/endpoint.component.html
+++ b/src/portal/src/lib/components/endpoint/endpoint.component.html
@@ -34,7 +34,17 @@
                         </ng-template>
                     </clr-dg-cell>
                     <clr-dg-cell class="flex-min-width">{{t.url}}</clr-dg-cell>
-                    <clr-dg-cell>{{getAdapterText(t.type)}}</clr-dg-cell>
+                    <clr-dg-cell>
+                        <span class="margin-right-2px">{{getAdapterText(t.type)}}</span>
+                        <clr-signpost *ngIf="isHelmHub(t.type)">
+                            <clr-icon clrSignpostTrigger
+                                      class="color-red" shape="error-standard"></clr-icon>
+                            <clr-signpost-content *clrIfOpen>
+                                <a href="https://helm.sh/blog/helm-hub-moving-to-artifact-hub"
+                                   target="_blank">{{'DESTINATION.DEPRECATED' | translate}}</a>
+                            </clr-signpost-content>
+                        </clr-signpost>
+                    </clr-dg-cell>
                     <clr-dg-cell>
                         {{!t.insecure}}
                     </clr-dg-cell>

--- a/src/portal/src/lib/components/endpoint/endpoint.component.scss
+++ b/src/portal/src/lib/components/endpoint/endpoint.component.scss
@@ -30,3 +30,6 @@
 .flex-min-width {
   min-width: 180px;
 }
+.margin-right-2px {
+  margin-right: 2px;
+}

--- a/src/portal/src/lib/components/endpoint/endpoint.component.ts
+++ b/src/portal/src/lib/components/endpoint/endpoint.component.ts
@@ -24,7 +24,7 @@ import { TranslateService } from "@ngx-translate/core";
 import { Comparator } from "../../services/interface";
 
 import { Endpoint } from "../../services/interface";
-import { EndpointService } from "../../services/endpoint.service";
+import {EndpointService, HELM_HUB} from "../../services/endpoint.service";
 
 import { ErrorHandler } from "../../utils/error-handler";
 import { map, catchError, finalize } from "rxjs/operators";
@@ -242,5 +242,8 @@ export class EndpointComponent implements OnInit, OnDestroy {
 
     getAdapterText(adapter: string): string {
         return this.endpointService.getAdapterText(adapter);
+    }
+    isHelmHub(str: string): boolean {
+        return str === HELM_HUB;
     }
 }

--- a/src/portal/src/lib/components/list-replication-rule/list-replication-rule.component.html
+++ b/src/portal/src/lib/components/list-replication-rule/list-replication-rule.component.html
@@ -1,5 +1,5 @@
 <div  class="list-rule">
-<clr-datagrid (clrDgRefresh)="clrLoad($event)" [clrDgLoading]="loading"  [(clrDgSingleSelected)]="selectedRow" (clrDgSingleSelectedChange)="selectRule($event)" [clrDgRowSelection]="true">
+<clr-datagrid (clrDgRefresh)="clrLoad($event)" [clrDgLoading]="loading"  [(clrDgSingleSelected)]="selectedRow" (clrDgSingleSelectedChange)="selectRule($event)">
     <clr-dg-action-bar>
         <button type="button" id="new_replication_rule_id" class="btn  btn-secondary" *ngIf="hasCreateReplicationPermission" (click)="openModal()"><clr-icon shape="plus" size="16"></clr-icon>&nbsp;{{'REPLICATION.NEW_REPLICATION_RULE' | translate}}</button>
         <button type="button" id="replication_exe_id" class="btn  btn-secondary" *ngIf="hasExecuteReplicationPermission" [disabled]="!selectedRow" (click)="replicateRule(selectedRow)"><clr-icon shape="export" size="16"></clr-icon>&nbsp;{{'REPLICATION.REPLICATE' | translate}}</button>
@@ -63,7 +63,15 @@
             </div>
         </clr-dg-cell>
         <clr-dg-cell class="col-width">
-            {{p.src_registry ? p.src_registry.name : ''}}
+            <span class="margin-right-2px">{{p.src_registry ? p.src_registry.name : ''}}</span>
+            <clr-signpost *ngIf="isHelmHub(p.src_registry)">
+                <clr-icon clrSignpostTrigger
+                          class="color-red" shape="error-standard"></clr-icon>
+                <clr-signpost-content *clrIfOpen>
+                    <a href="https://helm.sh/blog/helm-hub-moving-to-artifact-hub"
+                       target="_blank">{{'DESTINATION.DEPRECATED' | translate}}</a>
+                </clr-signpost-content>
+            </clr-signpost>
         </clr-dg-cell>
         <clr-dg-cell class="col-width">	
             {{p.src_registry && p.src_registry.id > 0 ? 'pull-based' : 'push-based'}}	

--- a/src/portal/src/lib/components/list-replication-rule/list-replication-rule.component.scss
+++ b/src/portal/src/lib/components/list-replication-rule/list-replication-rule.component.scss
@@ -18,3 +18,6 @@
 .icon-style {
     color: #C92100;
 }
+.margin-right-2px {
+    margin-right: 2px;
+}

--- a/src/portal/src/lib/components/list-replication-rule/list-replication-rule.component.ts
+++ b/src/portal/src/lib/components/list-replication-rule/list-replication-rule.component.ts
@@ -21,7 +21,7 @@ import {
 import { TranslateService } from "@ngx-translate/core";
 import { map, catchError, finalize } from "rxjs/operators";
 import { Observable, forkJoin, throwError as observableThrowError } from "rxjs";
-import { ReplicationService } from "../../services";
+import {HELM_HUB, ReplicationService} from "../../services";
 import {
     ReplicationRule
 } from "../../services";
@@ -256,5 +256,8 @@ export class ListReplicationRuleComponent  {
         this.selectedRow = null;
         this.ruleName = "";
         this.clrLoad();
+    }
+    isHelmHub(srcRegistry: any): boolean {
+      return srcRegistry && srcRegistry.type === HELM_HUB;
     }
 }

--- a/src/portal/src/lib/services/endpoint.service.ts
+++ b/src/portal/src/lib/services/endpoint.service.ts
@@ -22,10 +22,13 @@ const ADAPTERS_MAP = {
   "google-gcr": "Google GCR",
   "harbor": "Harbor",
   "helm-hub": "Helm Hub",
+  "artifact-hub": "Artifact Hub",
   "huawei-SWR": "Huawei SWR",
   "jfrog-artifactory": "JFrog Artifactory",
   "quay": "Quay"
 };
+
+export const HELM_HUB: string = "helm-hub";
 
 
 


### PR DESCRIPTION
UI changes for #13244
1. hide Helm Hub option when creating registry:
![image](https://user-images.githubusercontent.com/30999793/97824797-e1756880-1cf7-11eb-94be-fb1d4cc2bd1b.png)
2. Add deprecated mark to existed Helm Hub registry
![image](https://user-images.githubusercontent.com/30999793/97824858-0e298000-1cf8-11eb-9837-426b3d327290.png)

Signed-off-by: AllForNothing <sshijun@vmware.com>