### PR TITLE
feat: skip middlewares require db for ping

### DIFF
--- a/src/core/api/harborapi_test.go
+++ b/src/core/api/harborapi_test.go
@@ -214,7 +214,7 @@ func init() {
 	mockServer := test.NewJobServiceServer()
 	defer mockServer.Close()
 
-	chain := middleware.Chain(orm.Middleware(), security.Middleware())
+	chain := middleware.Chain(orm.Middleware(), security.Middleware(), security.UnauthorizedMiddleware())
 	handler = chain(beego.BeeApp.Handlers)
 }
 

--- a/src/core/middlewares/middlewares.go
+++ b/src/core/middlewares/middlewares.go
@@ -37,6 +37,10 @@ var (
 	match         = regexp.MustCompile
 	numericRegexp = match(`[0-9]+`)
 
+	// The ping endpoint will be blocked when DB conns reach the max open conns of the sql.DB
+	// which will make ping request timeout, so skip the middlewares which will require DB conn.
+	pingSkipper = middleware.MethodAndPathSkipper(http.MethodGet, match("^/api/v2.0/ping"))
+
 	// dbTxSkippers skip the transaction middleware for GET Blob, PATCH Blob Upload and PUT Blob Upload APIs
 	// because the APIs may take a long time to run, enable the transaction middleware in them will hold the database connections
 	// until the API finished, this behavior may eat all the database connections.
@@ -46,6 +50,7 @@ var (
 		middleware.MethodAndPathSkipper(http.MethodGet, distribution.BlobURLRegexp),
 		middleware.MethodAndPathSkipper(http.MethodPatch, distribution.BlobUploadURLRegexp),
 		middleware.MethodAndPathSkipper(http.MethodPut, distribution.BlobUploadURLRegexp),
+		pingSkipper,
 	}
 
 	// readonlySkippers skip the post request when harbor sets to readonly.
@@ -62,6 +67,7 @@ var (
 		middleware.MethodAndPathSkipper(http.MethodPost, match("^/service/notifications/jobs/retention/task/"+numericRegexp.String())),
 		middleware.MethodAndPathSkipper(http.MethodPost, match("^/service/notifications/jobs/schedules/"+numericRegexp.String())),
 		middleware.MethodAndPathSkipper(http.MethodPost, match("^/service/notifications/jobs/webhook/"+numericRegexp.String())),
+		pingSkipper,
 	}
 )
 
@@ -72,11 +78,12 @@ func MiddleWares() []beego.MiddleWare {
 		log.Middleware(),
 		session.Middleware(),
 		csrf.Middleware(),
-		orm.Middleware(),
-		notification.Middleware(), // notification must ahead of transaction ensure the DB transaction execution complete
+		orm.Middleware(pingSkipper),
+		notification.Middleware(pingSkipper), // notification must ahead of transaction ensure the DB transaction execution complete
 		transaction.Middleware(dbTxSkippers...),
 		artifactinfo.Middleware(),
-		security.Middleware(),
+		security.Middleware(pingSkipper),
+		security.UnauthorizedMiddleware(),
 		readonly.Middleware(readonlySkippers...),
 	}
 }


### PR DESCRIPTION
The ping endpoint will be blocked when DB conns reach the max open conns
of the sql.DB which will make ping request timeout,
so skip the middlewares which will require DB conn.

Signed-off-by: He Weiwei <hweiwei@vmware.com>