### PR TITLE
Suppress urllib3 warning and fix nightly element locator issue

### DIFF
--- a/tests/apitests/python/library/docker_api.py
+++ b/tests/apitests/python/library/docker_api.py
@@ -112,7 +112,7 @@ class DockerAPI(object):
                 if str(err).lower().find(expected_error_message.lower()) < 0:
                     raise Exception(r"Pull image: Return message {} is not as expected {}".format(str(err), expected_error_message))
             else:
-                raise Exception(r" Docker pull image {} failed, error is [{}]".format (image, message))
+                raise Exception(r" Docker pull image {} failed, error is [{}]".format (image, str(err)))
         if caught_err == False:
             if expected_error_message is not None:
                 if str(ret).lower().find(expected_error_message.lower()) < 0:

--- a/tests/apitests/python/library/project.py
+++ b/tests/apitests/python/library/project.py
@@ -49,7 +49,6 @@ class Project(base.Base):
             return
         base._assert_status_code(expect_status_code, status_code)
         base._assert_status_code(201, status_code)
-        print("==========header:", header)
         return base._get_id_from_header(header), name
 
     def get_projects(self, params, **kwargs):

--- a/tests/apitests/python/library/repository.py
+++ b/tests/apitests/python/library/repository.py
@@ -80,9 +80,12 @@ class Repository(base.Base, object):
             _, status_code, _ = client.delete_repository_with_http_info(project_name, repo_name)
         except Exception as e:
             base._assert_status_code(expect_status_code, e.status)
-            return e.body
-        base._assert_status_code(expect_status_code, status_code)
-        base._assert_status_code(200, status_code)
+            if expect_response_body is not None:
+                base._assert_status_body(expect_response_body, e.body)
+            return
+        else:
+            base._assert_status_code(expect_status_code, status_code)
+            base._assert_status_code(200, status_code)
 
 
     def list_repositories(self, project_name, **kwargs):

--- a/tests/apitests/python/test_add_member_to_private_project.py
+++ b/tests/apitests/python/test_add_member_to_private_project.py
@@ -3,18 +3,19 @@ from __future__ import absolute_import
 
 import unittest
 
-from testutils import ADMIN_CLIENT
+from testutils import ADMIN_CLIENT, suppress_urllib3_warning, TEARDOWN
 from library.project import Project
 from library.user import User
 
 class TestProjects(unittest.TestCase):
-    """UserGroup unit test stubs"""
+    @suppress_urllib3_warning
     def setUp(self):
         self.project = Project()
         self.user= User()
 
+    @unittest.skipIf(TEARDOWN == False, "Test data won't be erased.")
     def tearDown(self):
-        pass
+        print("Case completed")
 
     def testAddProjectMember(self):
         """

--- a/tests/apitests/python/test_add_replication_rule.py
+++ b/tests/apitests/python/test_add_replication_rule.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 import unittest
 
-from testutils import ADMIN_CLIENT
+from testutils import ADMIN_CLIENT, suppress_urllib3_warning
 from testutils import harbor_server
 from testutils import TEARDOWN
 from library.project import Project
@@ -11,19 +11,15 @@ from library.registry import Registry
 import swagger_client
 
 class TestProjects(unittest.TestCase):
-    @classmethod
+    @suppress_urllib3_warning
     def setUp(self):
         self.project = Project()
         self.user = User()
         self.replication = Replication()
         self.registry = Registry()
 
-    @classmethod
-    def tearDown(self):
-        print("Case completed")
-
     @unittest.skipIf(TEARDOWN == False, "Test data won't be erased.")
-    def test_ClearData(self):
+    def tearDown(self):
         #1. Delete rule(RA);
         self.replication.delete_replication_rule(TestProjects.rule_id, **ADMIN_CLIENT)
 

--- a/tests/apitests/python/test_add_sys_label_to_tag.py
+++ b/tests/apitests/python/test_add_sys_label_to_tag.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 import unittest
 
-from testutils import harbor_server
+from testutils import harbor_server, suppress_urllib3_warning
 from testutils import TEARDOWN
 from testutils import ADMIN_CLIENT
 from library.artifact import Artifact
@@ -13,7 +13,7 @@ from library.repository import push_image_to_project
 from library.label import Label
 
 class TestProjects(unittest.TestCase):
-    @classmethod
+    @suppress_urllib3_warning
     def setUp(self):
         self.project = Project()
         self.user = User()
@@ -21,12 +21,8 @@ class TestProjects(unittest.TestCase):
         self.repo = Repository()
         self.label = Label()
 
-    @classmethod
-    def tearDown(self):
-        print("Case completed")
-
     @unittest.skipIf(TEARDOWN == False, "Test data won't be erased.")
-    def test_ClearData(self):
+    def tearDown(self):
         #1. Delete repository(RA) by user(UA);
         self.repo.delete_repoitory(TestProjects.project_add_g_lbl_name, TestProjects.repo_name.split('/')[1], **TestProjects.USER_add_g_lbl_CLIENT)
 

--- a/tests/apitests/python/test_assign_role_to_ldap_group.py
+++ b/tests/apitests/python/test_assign_role_to_ldap_group.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 import unittest
 
-from testutils import harbor_server
+from testutils import harbor_server, suppress_urllib3_warning
 from testutils import TEARDOWN
 from testutils import ADMIN_CLIENT
 from testutils import created_user, created_project
@@ -16,7 +16,7 @@ from library.projectV2 import ProjectV2
 
 
 class TestAssignRoleToLdapGroup(unittest.TestCase):
-    @classmethod
+    @suppress_urllib3_warning
     def setUp(self):
         self.conf= Configurations()
         self.project = Project()
@@ -24,7 +24,7 @@ class TestAssignRoleToLdapGroup(unittest.TestCase):
         self.repo = Repository()
         self.user= User()
 
-    @classmethod
+    @unittest.skipIf(TEARDOWN == False, "Test data won't be erased.")
     def tearDown(self):
         print("Case completed")
 

--- a/tests/apitests/python/test_assign_sys_admin.py
+++ b/tests/apitests/python/test_assign_sys_admin.py
@@ -2,23 +2,19 @@ from __future__ import absolute_import
 
 import unittest
 
-from testutils import ADMIN_CLIENT
+from testutils import ADMIN_CLIENT, suppress_urllib3_warning
 from testutils import TEARDOWN
 from library.user import User
 from library.configurations import Configurations
 
 class TestProjects(unittest.TestCase):
-    @classmethod
+    @suppress_urllib3_warning
     def setUp(self):
         self.conf= Configurations()
         self.user = User()
 
-    @classmethod
-    def tearDown(self):
-        print("Case completed")
-
     @unittest.skipIf(TEARDOWN == False, "Test data won't be erased.")
-    def test_ClearData(self):
+    def tearDown(self):
         #1. Delete user(UA);
         self.user.delete_user(TestProjects.user_assign_sys_admin_id, **ADMIN_CLIENT)
 

--- a/tests/apitests/python/test_copy_artifact_outside_project.py
+++ b/tests/apitests/python/test_copy_artifact_outside_project.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 
 import unittest
 
-from testutils import ADMIN_CLIENT
+from testutils import ADMIN_CLIENT, suppress_urllib3_warning
 from testutils import harbor_server
 from testutils import TEARDOWN
 from library.base import _assert_status_code
@@ -15,19 +15,15 @@ from library.repository import push_image_to_project
 from library.repository import pull_harbor_image
 
 class TestProjects(unittest.TestCase):
-    @classmethod
-    def setUpClass(self):
+    @suppress_urllib3_warning
+    def setUp(self):
         self.project = Project()
         self.user = User()
         self.artifact = Artifact()
         self.repo = Repository()
 
-    @classmethod
-    def tearDownClass(self):
-        print("Case completed")
-
     @unittest.skipIf(TEARDOWN == False, "Test data won't be erased.")
-    def test_ClearData(self):
+    def tearDown(self):
         #1. Delete repository(RA);
         self.repo.delete_repoitory(TestProjects.project_src_repo_name, (TestProjects.src_repo_name).split('/')[1], **TestProjects.USER_RETAG_CLIENT)
 

--- a/tests/apitests/python/test_del_repo.py
+++ b/tests/apitests/python/test_del_repo.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 
 import unittest
 
-from testutils import ADMIN_CLIENT
+from testutils import ADMIN_CLIENT, suppress_urllib3_warning
 from testutils import harbor_server
 from testutils import TEARDOWN
 from library.base import _assert_status_code
@@ -13,18 +13,14 @@ from library.repository import Repository
 from library.repository import push_image_to_project
 
 class TestProjects(unittest.TestCase):
-    @classmethod
-    def setUpClass(self):
+    @suppress_urllib3_warning
+    def setUp(self):
         self.project= Project()
         self.user= User()
         self.repo= Repository()
 
-    @classmethod
-    def tearDownClass(self):
-        print("Case completed")
-
     @unittest.skipIf(TEARDOWN == False, "Test data won't be erased.")
-    def test_ClearData(self):
+    def tearDown(self):
         #1. Delete project(PA);
         self.project.delete_project(TestProjects.project_del_repo_id, **TestProjects.USER_del_repo_CLIENT)
 

--- a/tests/apitests/python/test_edit_project_creation.py
+++ b/tests/apitests/python/test_edit_project_creation.py
@@ -1,25 +1,21 @@
 from __future__ import absolute_import
 import unittest
 
-from testutils import ADMIN_CLIENT
+from testutils import ADMIN_CLIENT, suppress_urllib3_warning
 from testutils import TEARDOWN
 from library.project import Project
 from library.user import User
 from library.configurations import Configurations
 
 class TestProjects(unittest.TestCase):
-    @classmethod
+    @suppress_urllib3_warning
     def setUp(self):
         self.conf= Configurations()
         self.project= Project()
         self.user= User()
 
-    @classmethod
-    def tearDown(self):
-        print("Case completed")
-
     @unittest.skipIf(TEARDOWN == False, "Test data won't be erased.")
-    def test_ClearData(self):
+    def tearDown(self):
         #1. Delete project(PA);
         self.project.delete_project(TestProjects.project_edit_project_creation_id, **TestProjects.USER_edit_project_creation_CLIENT)
 

--- a/tests/apitests/python/test_garbage_collection.py
+++ b/tests/apitests/python/test_garbage_collection.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 import unittest
 import time
 
-from testutils import ADMIN_CLIENT
+from testutils import ADMIN_CLIENT, suppress_urllib3_warning
 from testutils import TEARDOWN
 from testutils import harbor_server
 from library.user import User
@@ -16,7 +16,7 @@ from library.repository import push_special_image_to_project
 from library.artifact import Artifact
 
 class TestProjects(unittest.TestCase):
-    @classmethod
+    @suppress_urllib3_warning
     def setUp(self):
         self.system = System()
         self.project = Project()
@@ -27,12 +27,8 @@ class TestProjects(unittest.TestCase):
         self.repo_name_untag = "test_untag"
         self.tag = "v1.0"
 
-    @classmethod
+    @unittest.skipIf(TEARDOWN == False, "Test data won't be erased.")
     def tearDown(self):
-        print("Case completed")
-
-    @unittest.skipIf(TEARDOWN == True, "Test data won't be erased.")
-    def test_ClearData(self):
         #2. Delete project(PA);
         self.project.delete_project(TestProjects.project_gc_id, **TestProjects.USER_GC_CLIENT)
 

--- a/tests/apitests/python/test_ldap_admin_role.py
+++ b/tests/apitests/python/test_ldap_admin_role.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 import unittest
 
-from testutils import harbor_server
+from testutils import harbor_server, suppress_urllib3_warning
 from testutils import TEARDOWN
 from testutils import ADMIN_CLIENT
 from library.user import User
@@ -10,18 +10,15 @@ from library.configurations import Configurations
 
 
 class TestLdapAdminRole(unittest.TestCase):
-    @classmethod
+    @suppress_urllib3_warning
     def setUp(self):
         url = ADMIN_CLIENT["endpoint"]
         self.conf= Configurations()
         self.user = User()
         self.project = Project()
         self.USER_MIKE=dict(endpoint = url, username = "mike", password = "zhu88jie")
+        self.project_id = None
 
-    @classmethod
-    def tearDown(self):
-        self.project.delete_project(TestLdapAdminRole.project_id, **self.USER_MIKE)
-        print("Case completed")
 
     def testLdapAdminRole(self):
         """
@@ -38,7 +35,8 @@ class TestLdapAdminRole(unittest.TestCase):
 
         self.conf.set_configurations_of_ldap(ldap_group_admin_dn="cn=harbor_users,ou=groups,dc=example,dc=com", **ADMIN_CLIENT)
 
-        TestLdapAdminRole.project_id, project_name = self.project.create_project(metadata = {"public": "false"}, **self.USER_MIKE)
+        self.project_id, project_name = self.project.create_project(metadata = {"public": "false"}, **self.USER_MIKE)
+        print("self.project_id:", self.project_id)
         self.project.check_project_name_exist(name=project_name, **self.USER_MIKE)
 
         _user = self.user.get_user_current(**self.USER_MIKE)
@@ -46,6 +44,12 @@ class TestLdapAdminRole(unittest.TestCase):
         self.assertFalse(_user.sysadmin_flag)
         self.assertTrue(_user.admin_role_in_auth)
 
+
+    @unittest.skipIf(TEARDOWN == False, "Test data won't be erased.")
+    def tearDown(self):
+        print("self.project_id:", self.project_id)
+        self.project.delete_project(self.project_id, **self.USER_MIKE)
+        print("Case completed")
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/apitests/python/test_list_helm_charts.py
+++ b/tests/apitests/python/test_list_helm_charts.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 import unittest
 
-from testutils import ADMIN_CLIENT, CHART_API_CLIENT
+from testutils import ADMIN_CLIENT, CHART_API_CLIENT, suppress_urllib3_warning
 from testutils import TEARDOWN
 import base
 from library.user import User
@@ -10,18 +10,14 @@ from library.project import Project
 from library.chart import Chart
 
 class TestProjects(unittest.TestCase):
-    @classmethod
+    @suppress_urllib3_warning
     def setUp(self):
         self.chart= Chart()
         self.project= Project()
         self.user= User()
 
-    @classmethod
-    def tearDown(self):
-        print("Case completed")
-
     @unittest.skipIf(TEARDOWN == False, "Test data won't be erased.")
-    def test_ClearData(self):
+    def tearDown(self):
         #1. Delete chart file;
         self.chart.delete_chart_with_version(TestProjects.project_chart_name, TestProjects.CHART_NAME, TestProjects.VERSION, **CHART_API_CLIENT)
 

--- a/tests/apitests/python/test_manage_project_member.py
+++ b/tests/apitests/python/test_manage_project_member.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 import unittest
 
-from testutils import harbor_server
+from testutils import harbor_server, suppress_urllib3_warning
 from testutils import TEARDOWN
 from testutils import ADMIN_CLIENT
 from library.project import Project
@@ -11,18 +11,14 @@ from library.repository import push_image_to_project
 from library.repository import Repository
 
 class TestProjects(unittest.TestCase):
-    @classmethod
+    @suppress_urllib3_warning
     def setUp(self):
         self.project = Project()
         self.user = User()
         self.repo = Repository()
 
-    @classmethod
-    def tearDown(self):
-        print("Case completed")
-
     @unittest.skipIf(TEARDOWN == False, "Test data won't be erased.")
-    def test_ClearData(self):
+    def tearDown(self):
         #1. Delete repository(RA) by admin;
         self.repo.delete_repoitory(TestProjects.project_alice_name, TestProjects.repo_name.split('/')[1], **ADMIN_CLIENT)
 

--- a/tests/apitests/python/test_project_level_cve_allowlist.py
+++ b/tests/apitests/python/test_project_level_cve_allowlist.py
@@ -4,7 +4,7 @@ import unittest
 import v2_swagger_client
 import time
 
-from testutils import ADMIN_CLIENT, TEARDOWN
+from testutils import ADMIN_CLIENT, TEARDOWN, suppress_urllib3_warning
 from library.project import Project
 from library.user import User
 
@@ -32,7 +32,7 @@ class TestProjectCVEAllowlist(unittest.TestCase):
         2. Delete project(PA)
         3. Delete User(RA)
     """
-
+    @suppress_urllib3_warning
     def setUp(self):
         self.user = User()
         self.project = Project()
@@ -49,11 +49,8 @@ class TestProjectCVEAllowlist(unittest.TestCase):
         m_id = self.project.add_project_members(self.project_pa_id, user_id=self.user_ra_id, member_role_id=3, **ADMIN_CLIENT)
         self.member_id = int(m_id)
 
-    def tearDown(self):
-        print("Case completed")
-
     @unittest.skipIf(TEARDOWN == False, "Test data won't be erased.")
-    def test_ClearData(self):
+    def tearDown(self):
         print("Tearing down...")
         self.project.delete_project_member(self.project_pa_id, self.member_id, **ADMIN_CLIENT)
         self.project.delete_project(self.project_pa_id,**ADMIN_CLIENT)

--- a/tests/apitests/python/test_project_level_policy_content_trust.py
+++ b/tests/apitests/python/test_project_level_policy_content_trust.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 import unittest
 
-from testutils import ADMIN_CLIENT
+from testutils import ADMIN_CLIENT, suppress_urllib3_warning
 from testutils import harbor_server
 from testutils import TEARDOWN
 from library.artifact import Artifact
@@ -13,19 +13,15 @@ from library.repository import push_image_to_project
 from library.repository import pull_harbor_image
 
 class TestProjects(unittest.TestCase):
-    @classmethod
+    @suppress_urllib3_warning
     def setUp(self):
         self.project= Project()
         self.user= User()
         self.artifact= Artifact()
         self.repo= Repository()
 
-    @classmethod
-    def tearDown(self):
-        print("Case completed")
-
     @unittest.skipIf(TEARDOWN == False, "Test data won't be erased.")
-    def test_ClearData(self):
+    def tearDown(self):
         #1. Delete repository(RA) by user(UA);
         self.repo.delete_repoitory(TestProjects.project_content_trust_name, TestProjects.repo_name.split('/')[1], **TestProjects.USER_CONTENT_TRUST_CLIENT)
 

--- a/tests/apitests/python/test_project_quota.py
+++ b/tests/apitests/python/test_project_quota.py
@@ -1,20 +1,20 @@
 from __future__ import absolute_import
 import unittest
 
-from testutils import harbor_server, created_project, created_user
-from testutils import ADMIN_CLIENT
+from testutils import harbor_server, created_project, created_user, \
+                      TEARDOWN, ADMIN_CLIENT,suppress_urllib3_warning
 from library.repository import Repository
 from library.repository import push_image_to_project
 from library.system import System
 
 class TestProjects(unittest.TestCase):
-    @classmethod
+    @suppress_urllib3_warning
     def setUp(cls):
         cls.repo = Repository()
         cls.system = System()
 
-    @classmethod
-    def tearDown(cls):
+    @unittest.skipIf(TEARDOWN == False, "Test data won't be erased.")
+    def tearDown(self):
         print("Case completed")
 
     def testProjectQuota(self):

--- a/tests/apitests/python/test_proxy_cache.py
+++ b/tests/apitests/python/test_proxy_cache.py
@@ -5,7 +5,7 @@ import unittest
 import urllib
 import sys
 
-from testutils import ADMIN_CLIENT
+from testutils import ADMIN_CLIENT, suppress_urllib3_warning
 from testutils import harbor_server
 from testutils import TEARDOWN
 from library.base import _random_name
@@ -20,8 +20,8 @@ from library.artifact import Artifact
 import library.containerd
 
 class TestProxyCache(unittest.TestCase):
-    @classmethod
-    def setUpClass(self):
+    @suppress_urllib3_warning
+    def setUp(self):
         self.url = ADMIN_CLIENT["endpoint"]
         self.user_password = "Aa123456"
         self.project= Project()
@@ -30,8 +30,8 @@ class TestProxyCache(unittest.TestCase):
         self.registry = Registry()
         self.artifact = Artifact()
 
-    @classmethod
-    def tearDownClass(self):
+    @unittest.skipIf(TEARDOWN == False, "Test data won't be erased.")
+    def tearDown(self):
         print("Case completed")
 
     def do_validate(self, registry_type):

--- a/tests/apitests/python/test_push_chart_by_helm2_helm3_with_robot_Account.py
+++ b/tests/apitests/python/test_push_chart_by_helm2_helm3_with_robot_Account.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 
 import unittest
 
-from testutils import ADMIN_CLIENT, CHART_API_CLIENT
+from testutils import ADMIN_CLIENT, CHART_API_CLIENT, suppress_urllib3_warning
 from testutils import harbor_server
 from testutils import TEARDOWN
 import library.repository
@@ -13,8 +13,8 @@ from library.user import User
 from library.chart import Chart
 
 class TestProjects(unittest.TestCase):
-    @classmethod
-    def setUpClass(self):
+    @suppress_urllib3_warning
+    def setUp(self):
         self.project= Project()
         self.user= User()
         self.chart=  Chart()
@@ -28,12 +28,8 @@ class TestProjects(unittest.TestCase):
         self.chart_repo_name = "chart_local"
         self.repo_name = "harbor_api_test"
 
-    @classmethod
-    def tearDownClass(self):
-        print("Case completed")
-
     @unittest.skipIf(TEARDOWN == False, "Test data won't be erased.")
-    def test_ClearData(self):
+    def tearDown(self):
         #1. Delete user(UA).
         self.user.delete_user(TestProjects.user_id, **ADMIN_CLIENT)
 

--- a/tests/apitests/python/test_push_chart_by_helm3_chart_cli.py
+++ b/tests/apitests/python/test_push_chart_by_helm3_chart_cli.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 
 import unittest
 
-from testutils import ADMIN_CLIENT
+from testutils import ADMIN_CLIENT, suppress_urllib3_warning
 from testutils import harbor_server
 from testutils import TEARDOWN
 import library.repository
@@ -14,8 +14,8 @@ from library.repository import Repository
 from library.artifact import Artifact
 
 class TestProjects(unittest.TestCase):
-    @classmethod
-    def setUpClass(self):
+    @suppress_urllib3_warning
+    def setUp(self):
         self.project= Project()
         self.user= User()
         self.artifact = Artifact()
@@ -27,12 +27,8 @@ class TestProjects(unittest.TestCase):
         self.verion = "0.2.0"
         self.repo_name = "harbor_api_test"
 
-    @classmethod
-    def tearDownClass(self):
-        print("Case completed")
-
     @unittest.skipIf(TEARDOWN == False, "Test data won't be erased.")
-    def test_ClearData(self):
+    def tearDown(self):
         #1. Delete repository chart(CA) by user(UA);
         self.repo.delete_repoitory(TestProjects.project_push_chart_name, self.repo_name, **TestProjects.USER_CLIENT)
 

--- a/tests/apitests/python/test_push_cnab_bundle.py
+++ b/tests/apitests/python/test_push_cnab_bundle.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 
 import unittest
 
-from testutils import ADMIN_CLIENT
+from testutils import ADMIN_CLIENT, suppress_urllib3_warning
 from testutils import harbor_server
 from testutils import TEARDOWN
 import library.repository
@@ -15,8 +15,8 @@ from library.artifact import Artifact
 from library.docker_api import DockerAPI
 
 class TestProjects(unittest.TestCase):
-    @classmethod
-    def setUpClass(self):
+    @suppress_urllib3_warning
+    def setUp(self):
         self.project= Project()
         self.user= User()
         self.artifact = Artifact()
@@ -26,12 +26,8 @@ class TestProjects(unittest.TestCase):
         self.cnab_repo_name = "test_cnab"
         self.cnab_tag = "test_cnab_tag"
 
-    @classmethod
-    def tearDownClass(self):
-        print("Case completed")
-
     @unittest.skipIf(TEARDOWN == False, "Test data won't be erased.")
-    def test_ClearData(self):
+    def tearDown(self):
         #1. Delete repository(RA) by user(UA);
         self.repo.delete_repoitory(TestProjects.project_push_bundle_name, self.cnab_repo_name, **TestProjects.USER_CLIENT)
 

--- a/tests/apitests/python/test_push_files_by_oras.py
+++ b/tests/apitests/python/test_push_files_by_oras.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 import unittest
 import urllib
 
-from testutils import ADMIN_CLIENT
+from testutils import ADMIN_CLIENT, suppress_urllib3_warning
 from testutils import harbor_server
 from testutils import TEARDOWN
 import library.oras
@@ -14,7 +14,7 @@ from library.artifact import Artifact
 
 
 class TestProjects(unittest.TestCase):
-    @classmethod
+    @suppress_urllib3_warning
     def setUp(self):
         self.project = Project()
         self.user = User()
@@ -23,12 +23,8 @@ class TestProjects(unittest.TestCase):
         self.repo_name = "hello-artifact"
         self.tag = "test_v2"
 
-    @classmethod
-    def tearDown(self):
-        print("Case completed")
-
     @unittest.skipIf(TEARDOWN == False, "Test data won't be erased.")
-    def test_ClearData(self):
+    def tearDown(self):
         #1. Delete user(UA);
         self.user.delete_user(TestProjects.user_sign_image_id, **ADMIN_CLIENT)
 

--- a/tests/apitests/python/test_push_image_with_special_name.py
+++ b/tests/apitests/python/test_push_image_with_special_name.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 import unittest
 import urllib
 
-from testutils import ADMIN_CLIENT
+from testutils import ADMIN_CLIENT, suppress_urllib3_warning
 from testutils import harbor_server
 from testutils import TEARDOWN
 from library.sign import sign_image
@@ -13,19 +13,15 @@ from library.repository import Repository
 from library.repository import push_image_to_project
 
 class TestProjects(unittest.TestCase):
-    @classmethod
+    @suppress_urllib3_warning
     def setUp(self):
         self.project = Project()
         self.user = User()
         self.artifact = Artifact()
         self.repo = Repository()
 
-    @classmethod
-    def tearDown(self):
-        print("Case completed")
-
     @unittest.skipIf(TEARDOWN == False, "Test data won't be erased.")
-    def test_ClearData(self):
+    def tearDown(self):
         # remove the deletion as the signed image cannot be deleted.
         #1. Delete repository(RA) by user(UA);
         #self.repo.delete_repoitory(TestProjects.project_sign_image_name, TestProjects.repo_name.split('/')[1], **TestProjects.USER_sign_image_CLIENT)

--- a/tests/apitests/python/test_push_index_by_docker_manifest.py
+++ b/tests/apitests/python/test_push_index_by_docker_manifest.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 
 import unittest
 
-from testutils import ADMIN_CLIENT
+from testutils import ADMIN_CLIENT, suppress_urllib3_warning
 from testutils import harbor_server
 from testutils import TEARDOWN
 import library.repository
@@ -18,8 +18,8 @@ from library.repository import push_image_to_project
 from library.repository import pull_harbor_image
 
 class TestProjects(unittest.TestCase):
-    @classmethod
-    def setUpClass(self):
+    @suppress_urllib3_warning
+    def setUp(self):
         self.project= Project()
         self.user= User()
         self.artifact = Artifact()
@@ -31,12 +31,8 @@ class TestProjects(unittest.TestCase):
         self.image_a = "alpine"
         self.image_b = "busybox"
 
-    @classmethod
-    def tearDownClass(self):
-        print("Case completed")
-
     @unittest.skipIf(TEARDOWN == False, "Test data won't be erased.")
-    def test_ClearData(self):
+    def tearDown(self):
         #1. Delete repository(RA,RB,IA) by user(UA);
         self.repo.delete_repoitory(TestProjects.project_push_index_name, self.index_name, **TestProjects.USER_CLIENT)
         self.repo.delete_repoitory(TestProjects.project_push_index_name, self.image_a, **TestProjects.USER_CLIENT)
@@ -95,6 +91,7 @@ class TestProjects(unittest.TestCase):
 
         #6. Get index(IA) by reference successfully;
         index_data = self.artifact.get_reference_info(TestProjects.project_push_index_name, self.index_name, self.index_tag, **TestProjects.USER_CLIENT)
+        print("===========index_data:",index_data)
         manifests_sha256_harbor_ret = [index_data.references[1].child_digest, index_data.references[0].child_digest]
 
         #7. Verify harbor index is index(IA) pushed by docker manifest CLI;

--- a/tests/apitests/python/test_push_sif_by_singularity.py
+++ b/tests/apitests/python/test_push_sif_by_singularity.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 import unittest
 import urllib
 
-from testutils import ADMIN_CLIENT
+from testutils import ADMIN_CLIENT, suppress_urllib3_warning
 from testutils import harbor_server
 from testutils import TEARDOWN
 import library.singularity
@@ -14,7 +14,7 @@ from library.artifact import Artifact
 
 
 class TestProjects(unittest.TestCase):
-    @classmethod
+    @suppress_urllib3_warning
     def setUp(self):
         self.project = Project()
         self.user = User()
@@ -23,12 +23,8 @@ class TestProjects(unittest.TestCase):
         self.repo_name = "busybox"
         self.tag = "1.28"
 
-    @classmethod
-    def tearDown(self):
-        print("Case completed")
-
     @unittest.skipIf(TEARDOWN == False, "Test data won't be erased.")
-    def test_ClearData(self):
+    def tearDown(self):
         #1. Delete user(UA);
         self.user.delete_user(TestProjects.user_sign_image_id, **ADMIN_CLIENT)
 

--- a/tests/apitests/python/test_registry_api.py
+++ b/tests/apitests/python/test_registry_api.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 import unittest
 
-from testutils import harbor_server
+from testutils import harbor_server, suppress_urllib3_warning
 from testutils import admin_user
 from testutils import admin_pwd
 from testutils import TEARDOWN
@@ -20,7 +20,7 @@ import library.base
 import json
 
 class TestProjects(unittest.TestCase):
-    @classmethod
+    @suppress_urllib3_warning
     def setUp(self):
         self.system = System()
         self.project= Project()
@@ -29,12 +29,8 @@ class TestProjects(unittest.TestCase):
         self.repo = Repository()
         self.repo_name = "hello-world"
 
-    @classmethod
-    def tearDown(self):
-        print("Case completed")
-
     @unittest.skipIf(TEARDOWN == False, "Test data won't be erased.")
-    def test_ClearData(self):
+    def tearDown(self):
         #1. Delete Alice's repository and Luca's repository;
         self.repo.delete_repoitory(TestProjects.project_Alice_name, TestProjects.repo_a.split('/')[1], **ADMIN_CLIENT)
         self.repo.delete_repoitory(TestProjects.project_Alice_name, TestProjects.repo_b.split('/')[1], **ADMIN_CLIENT)

--- a/tests/apitests/python/test_replication_from_dockerhub.py
+++ b/tests/apitests/python/test_replication_from_dockerhub.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 import unittest
 
-from testutils import ADMIN_CLIENT
+from testutils import ADMIN_CLIENT, suppress_urllib3_warning
 from testutils import TEARDOWN
 from library.project import Project
 from library.user import User
@@ -12,7 +12,7 @@ from library.repository import Repository
 import swagger_client
 
 class TestProjects(unittest.TestCase):
-    @classmethod
+    @suppress_urllib3_warning
     def setUp(self):
         self.project = Project()
         self.user = User()
@@ -23,12 +23,8 @@ class TestProjects(unittest.TestCase):
         self.image = "alpine"
         self.tag = "latest"
 
-    @classmethod
-    def tearDown(self):
-        print("Case completed")
-
     @unittest.skipIf(TEARDOWN == False, "Test data won't be erased.")
-    def test_ClearData(self):
+    def tearDown(self):
         #1. Delete rule(RA);
         self.replication.delete_replication_rule(TestProjects.rule_id, **ADMIN_CLIENT)
 

--- a/tests/apitests/python/test_retention.py
+++ b/tests/apitests/python/test_retention.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 import unittest
 import time
 
-from testutils import ADMIN_CLIENT
+from testutils import ADMIN_CLIENT, suppress_urllib3_warning
 from testutils import TEARDOWN
 from testutils import harbor_server
 from library.repository import push_special_image_to_project
@@ -31,8 +31,8 @@ class TestProjects(unittest.TestCase):
     Tear Down:
         1. Delete project test-retention
     """
-    @classmethod
-    def setUpClass(self):
+    @suppress_urllib3_warning
+    def setUp(self):
         self.user = User()
         self.system = System()
         self.repo = Repository()
@@ -41,6 +41,16 @@ class TestProjects(unittest.TestCase):
         self.artifact = Artifact()
         self.repo_name_1 = "test1"
         self.repo_name_2 = "test2"
+
+    @unittest.skipIf(TEARDOWN == False, "Test data won't be erased.")
+    def tearDown(self):
+        # TODO delete_repoitory will fail when no tags left anymore
+        #     resp=self.repo.list_repositories(TestProjects.project_src_repo_id, **TestProjects.USER_RA_CLIENT)
+        #     for repo in resp:
+        #         self.repo.delete_repoitory(repo.name, **TestProjects.USER_RA_CLIENT)
+        #     self.project.delete_project(TestProjects.project_src_repo_id, **TestProjects.USER_RA_CLIENT)
+        #     self.user.delete_user(TestProjects.user_ra_id, **ADMIN_CLIENT)
+        print("Case completed")
 
     def testTagRetention(self):
         user_ra_password = "Aa123456"
@@ -118,20 +128,6 @@ class TestProjects(unittest.TestCase):
         artifacts_2 = self.artifact.list_artifacts(TestProjects.project_src_repo_name, self.repo_name_2, **TestProjects.USER_RA_CLIENT)
         self.assertTrue(len(artifacts_2)==1)
         self.assertEqual(artifacts_2[0].digest, tag_data_artifact2_image2.digest)
-
-    @classmethod
-    def tearDownClass(self):
-        print("Case completed")
-
-    # TODO delete_repoitory will fail when no tags left anymore
-    # @unittest.skipIf(TEARDOWN == False, "Test data won't be erased.")
-    # def test_ClearData(self):
-    #     resp=self.repo.list_repositories(TestProjects.project_src_repo_id, **TestProjects.USER_RA_CLIENT)
-    #     for repo in resp:
-    #         self.repo.delete_repoitory(repo.name, **TestProjects.USER_RA_CLIENT)
-    #     self.project.delete_project(TestProjects.project_src_repo_id, **TestProjects.USER_RA_CLIENT)
-    #     self.user.delete_user(TestProjects.user_ra_id, **ADMIN_CLIENT)
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/apitests/python/test_robot_account.py
+++ b/tests/apitests/python/test_robot_account.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 import unittest
 
-from testutils import ADMIN_CLIENT
+from testutils import ADMIN_CLIENT, suppress_urllib3_warning
 from testutils import TEARDOWN
 from testutils import harbor_server
 from library.user import User
@@ -13,13 +13,13 @@ from library.repository import push_image_to_project
 from library.base import _assert_status_code
 
 class TestProjects(unittest.TestCase):
-    @classmethod
+    @suppress_urllib3_warning
     def setUp(self):
         self.project = Project()
         self.user = User()
         self.repo = Repository()
 
-    @classmethod
+    @unittest.skipIf(TEARDOWN == False, "Test data won't be erased.")
     def tearDown(self):
         print("Case completed")
 

--- a/tests/apitests/python/test_scan_image_artifact.py
+++ b/tests/apitests/python/test_scan_image_artifact.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 import unittest
 import sys
 
-from testutils import harbor_server
+from testutils import harbor_server, suppress_urllib3_warning
 from testutils import TEARDOWN
 from testutils import ADMIN_CLIENT
 from library.project import Project
@@ -11,22 +11,20 @@ from library.repository import Repository
 from library.repository import push_image_to_project
 from library.artifact import Artifact
 from library.scan import Scan
-from library.scanner import Scanner
 from library.sign import sign_image
 
 class TestScan(unittest.TestCase):
-    @classmethod
+    @suppress_urllib3_warning
     def setUp(self):
         self.project= Project()
         self.user= User()
         self.artifact = Artifact()
         self.repo = Repository()
         self.scan = Scan()
-        self.scanner = Scanner()
 
         self.url = ADMIN_CLIENT["endpoint"]
         self.user_password = "Aa123456"
-        self.project_id, self.project_name, self.user_id, self.user_name = [None] * 4
+        self.project_id, self.project_name, self.user_id, self.user_name, self.repo_name1, self.repo_name2 = [None] * 6
         self.user_id, self.user_name = self.user.create_user(user_password = self.user_password, **ADMIN_CLIENT)
         self.USER_CLIENT = dict(with_signature = True, with_immutable_status = True, endpoint = self.url, username = self.user_name, password = self.user_password, with_scan_overview = True)
 
@@ -37,14 +35,11 @@ class TestScan(unittest.TestCase):
         #3. Add user(UA) as a member of project(PA) with project-admin role;
         self.project.add_project_members(self.project_id, user_id = self.user_id, **ADMIN_CLIENT)
 
-    @classmethod
-    def tearDown(self):
-        print("Case completed")
-
     @unittest.skipIf(TEARDOWN == True, "Test data won't be erased.")
-    def test_ClearData(self):
+    def do_tearDown(self):
         #1. Delete repository(RA) by user(UA);
-        self.repo.delete_repoitory(self.project_name, TestScan.repo_name.split('/')[1], **self.USER_CLIENTT)
+        self.repo.delete_repoitory(self.project_name, self.repo_name1.split('/')[1], **self.USER_CLIENT)
+        self.repo.delete_repoitory(self.project_name, self.repo_name2.split('/')[1], **self.USER_CLIENT)
 
         #2. Delete project(PA);
         self.project.delete_project(self.project_id, **self.USER_CLIENT)
@@ -80,22 +75,13 @@ class TestScan(unittest.TestCase):
         image = "docker"
         src_tag = "1.13"
         #5. Create a new repository(RA) and tag(TA) in project(PA) by user(UA);
-        TestScan.repo_name, tag = push_image_to_project(self.project_name, harbor_server, self.user_name, self.user_password, image, src_tag)
+        self.repo_name1, tag = push_image_to_project(self.project_name, harbor_server, self.user_name, self.user_password, image, src_tag)
 
         #6. Send scan image command and get tag(TA) information to check scan result, it should be finished;
-        self.scan.scan_artifact(self.project_name, TestScan.repo_name.split('/')[1], tag, **self.USER_CLIENT)
+        self.scan.scan_artifact(self.project_name, self.repo_name1.split('/')[1], tag, **self.USER_CLIENT)
         self.artifact.check_image_scan_result(self.project_name, image, tag, **self.USER_CLIENT)
 
-        #7. Swith Scanner;
-        uuid = self.scanner.scanners_get_uuid(**ADMIN_CLIENT)
-        self.scanner.scanners_registration_id_patch(uuid, **ADMIN_CLIENT)
-
-        image = "tomcat"
-        src_tag = "latest"
-        TestScan.repo_name, tag = push_image_to_project(self.project_name, harbor_server, self.user_name, self.user_password, image, src_tag)
-        #8. Send scan another image command and get tag(TA) information to check scan result, it should be finished.
-        self.scan.scan_artifact(self.project_name, TestScan.repo_name.split('/')[1], tag, **self.USER_CLIENT)
-        self.artifact.check_image_scan_result(self.project_name, image, tag, **self.USER_CLIENT)
+        self.do_tearDown()
 
     def testScanSignedImage(self):
         """

--- a/tests/apitests/python/test_scan_image_artifact_in_public_project.py
+++ b/tests/apitests/python/test_scan_image_artifact_in_public_project.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 import unittest
 
-from testutils import harbor_server
+from testutils import harbor_server, TEARDOWN, suppress_urllib3_warning
 from testutils import created_user, created_project
 from library.artifact import Artifact
 from library.repository import Repository, push_image_to_project
@@ -9,13 +9,13 @@ from library.scan import Scan
 
 
 class TestScanImageInPublicProject(unittest.TestCase):
-    @classmethod
+    @suppress_urllib3_warning
     def setUp(self):
         self.artifact = Artifact()
         self.repo = Repository()
         self.scan = Scan()
 
-    @classmethod
+    @unittest.skipIf(TEARDOWN == False, "Test data won't be erased.")
     def tearDown(self):
         print("Case completed")
 

--- a/tests/apitests/python/test_sign_image.py
+++ b/tests/apitests/python/test_sign_image.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 import unittest
 
-from testutils import ADMIN_CLIENT
+from testutils import ADMIN_CLIENT, suppress_urllib3_warning
 from testutils import harbor_server
 from testutils import TEARDOWN
 from library.sign import sign_image
@@ -13,7 +13,7 @@ from library.repository import push_image_to_project
 from library.repository import push_special_image_to_project
 
 class TestProjects(unittest.TestCase):
-    @classmethod
+    @suppress_urllib3_warning
     def setUp(self):
         self.project = Project()
         self.user = User()
@@ -21,12 +21,8 @@ class TestProjects(unittest.TestCase):
         self.repo = Repository()
         self.repo_name_1 = "test1_sign"
 
-    @classmethod
-    def tearDown(self):
-        print("Case completed")
-
     @unittest.skipIf(TEARDOWN == False, "Test data won't be erased.")
-    def test_ClearData(self):
+    def tearDown(self):
         # remove the deletion as the signed image cannot be deleted.
         #1. Delete repository(RA) by user(UA);
         #self.repo.delete_repoitory(TestProjects.project_sign_image_name, TestProjects.repo_name.split('/')[1], **TestProjects.USER_sign_image_CLIENT)
@@ -85,9 +81,7 @@ class TestProjects(unittest.TestCase):
         push_special_image_to_project(TestProjects.project_sign_image_name, harbor_server, user_sign_image_name, user_001_password, self.repo_name_1, ['1.0'])
         self.repo.delete_repoitory(TestProjects.project_sign_image_name, self.repo_name_1, **TestProjects.USER_sign_image_CLIENT)
 
-        ret = self.repo.delete_repoitory(TestProjects.project_sign_image_name, TestProjects.repo_name.split('/')[1], expect_status_code=412, **TestProjects.USER_sign_image_CLIENT)
-        self.assertIn("with signature cannot be deleted", ret)
-
+        self.repo.delete_repoitory(TestProjects.project_sign_image_name, TestProjects.repo_name.split('/')[1], expect_status_code=412, expect_response_body = "with signature cannot be deleted", **TestProjects.USER_sign_image_CLIENT)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/apitests/python/test_system_level_scan_all.py
+++ b/tests/apitests/python/test_system_level_scan_all.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 import unittest
 
-from testutils import harbor_server
+from testutils import harbor_server, suppress_urllib3_warning
 from testutils import TEARDOWN
 from testutils import ADMIN_CLIENT
 from library.system import System
@@ -10,35 +10,29 @@ from library.user import User
 from library.repository import Repository
 from library.repository import push_image_to_project
 from library.artifact import Artifact
-from library.scanner import Scanner
-
-class TestProjects(unittest.TestCase):
-    @classmethod
+class TestScanAll(unittest.TestCase):
+    @suppress_urllib3_warning
     def setUp(self):
         self.system = System()
         self.project= Project()
         self.user= User()
         self.artifact = Artifact()
         self.repo = Repository()
-        self.scanner = Scanner()
-
-    @classmethod
-    def tearDown(self):
-        print("Case completed")
 
     @unittest.skipIf(TEARDOWN == False, "Test data won't be erased.")
-    def test_ClearData(self):
+    def tearDown(self):
         #1. Delete Alice's repository and Luca's repository;
-        self.repo.delete_repoitory(TestProjects.project_Alice_name, TestProjects.repo_Alice_name.split('/')[1], **ADMIN_CLIENT)
-        self.repo.delete_repoitory(TestProjects.project_Luca_name, TestProjects.repo_Luca_name.split('/')[1], **ADMIN_CLIENT)
+        self.repo.delete_repoitory(TestScanAll.project_Alice_name, TestScanAll.repo_Alice_name.split('/')[1], **ADMIN_CLIENT)
+        self.repo.delete_repoitory(TestScanAll.project_Luca_name, TestScanAll.repo_Luca_name.split('/')[1], **ADMIN_CLIENT)
 
         #2. Delete Alice's project and Luca's project;
-        self.project.delete_project(TestProjects.project_Alice_id, **ADMIN_CLIENT)
-        self.project.delete_project(TestProjects.project_Luca_id, **ADMIN_CLIENT)
+        self.project.delete_project(TestScanAll.project_Alice_id, **ADMIN_CLIENT)
+        self.project.delete_project(TestScanAll.project_Luca_id, **ADMIN_CLIENT)
 
         #3. Delete user Alice and Luca.
-        self.user.delete_user(TestProjects.user_Alice_id, **ADMIN_CLIENT)
-        self.user.delete_user(TestProjects.user_Luca_id, **ADMIN_CLIENT)
+        self.user.delete_user(TestScanAll.user_Alice_id, **ADMIN_CLIENT)
+        self.user.delete_user(TestScanAll.user_Luca_id, **ADMIN_CLIENT)
+        print("Case completed")
 
     def testSystemLevelScanALL(self):
         """
@@ -59,15 +53,15 @@ class TestProjects(unittest.TestCase):
         user_common_password = "Aa123456"
 
         #1. Create user Alice and Luca;
-        TestProjects.user_Alice_id, user_Alice_name = self.user.create_user(user_password = user_common_password, **ADMIN_CLIENT)
-        TestProjects.user_Luca_id, user_Luca_name = self.user.create_user(user_password = user_common_password, **ADMIN_CLIENT)
+        TestScanAll.user_Alice_id, user_Alice_name = self.user.create_user(user_password = user_common_password, **ADMIN_CLIENT)
+        TestScanAll.user_Luca_id, user_Luca_name = self.user.create_user(user_password = user_common_password, **ADMIN_CLIENT)
 
         USER_ALICE_CLIENT=dict(endpoint = url, username = user_Alice_name, password = user_common_password, with_scan_overview = True)
         USER_LUCA_CLIENT=dict(endpoint = url, username = user_Luca_name, password = user_common_password, with_scan_overview = True)
 
         #2. Create 2 new private projects project_Alice and project_Luca;
-        TestProjects.project_Alice_id, TestProjects.project_Alice_name = self.project.create_project(metadata = {"public": "false"}, **USER_ALICE_CLIENT)
-        TestProjects.project_Luca_id, TestProjects.project_Luca_name = self.project.create_project(metadata = {"public": "false"}, **USER_LUCA_CLIENT)
+        TestScanAll.project_Alice_id, TestScanAll.project_Alice_name = self.project.create_project(metadata = {"public": "false"}, **USER_ALICE_CLIENT)
+        TestScanAll.project_Luca_id, TestScanAll.project_Luca_name = self.project.create_project(metadata = {"public": "false"}, **USER_LUCA_CLIENT)
 
         #3. Push a image to project_Alice and push another image to project_Luca;
 
@@ -77,33 +71,21 @@ class TestProjects(unittest.TestCase):
         image_a = "mariadb"
         src_tag = "latest"
         #3.1 Push a image to project_Alice;
-        TestProjects.repo_Alice_name, tag_Alice = push_image_to_project(TestProjects.project_Alice_name, harbor_server, user_Alice_name, user_common_password, image_a, src_tag)
+        TestScanAll.repo_Alice_name, tag_Alice = push_image_to_project(TestScanAll.project_Alice_name, harbor_server, user_Alice_name, user_common_password, image_a, src_tag)
 
         #Note: Please make sure that this Image has never been pulled before by any other cases,
         #          so it is a not-scanned image rigth after repository creation.
         image_b = "httpd"
         src_tag = "latest"
         #3.2 push another image to project_Luca;
-        TestProjects.repo_Luca_name, tag_Luca = push_image_to_project(TestProjects.project_Luca_name, harbor_server, user_Luca_name, user_common_password, image_b, src_tag)
+        TestScanAll.repo_Luca_name, tag_Luca = push_image_to_project(TestScanAll.project_Luca_name, harbor_server, user_Luca_name, user_common_password, image_b, src_tag)
 
         #4. Trigger scan all event;
         self.system.scan_now(**ADMIN_CLIENT)
 
         #5. Check if image in project_Alice and another image in project_Luca were both scanned.
-        self.artifact.check_image_scan_result(TestProjects.project_Alice_name, image_a, tag_Alice, **USER_ALICE_CLIENT)
-        self.artifact.check_image_scan_result(TestProjects.project_Luca_name, image_b, tag_Luca, **USER_LUCA_CLIENT)
-
-        #6. Swith Scanner;
-        uuid = self.scanner.scanners_get_uuid(**ADMIN_CLIENT)
-        self.scanner.scanners_registration_id_patch(uuid, **ADMIN_CLIENT)
-
-        #7. Trigger scan all event;
-        self.system.scan_now(**ADMIN_CLIENT)
-
-        #8. Check if image in project_Alice and another image in project_Luca were both scanned.
-        self.artifact.check_image_scan_result(TestProjects.project_Alice_name, image_a, tag_Alice, **USER_ALICE_CLIENT)
-        self.artifact.check_image_scan_result(TestProjects.project_Luca_name, image_b, tag_Luca, **USER_LUCA_CLIENT)
-
+        self.artifact.check_image_scan_result(TestScanAll.project_Alice_name, image_a, tag_Alice, **USER_ALICE_CLIENT)
+        self.artifact.check_image_scan_result(TestScanAll.project_Luca_name, image_b, tag_Luca, **USER_LUCA_CLIENT)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/apitests/python/test_tag_crud.py
+++ b/tests/apitests/python/test_tag_crud.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 
 import unittest
 
-from testutils import ADMIN_CLIENT
+from testutils import ADMIN_CLIENT, suppress_urllib3_warning
 from testutils import harbor_server
 from testutils import TEARDOWN
 import library.repository
@@ -17,8 +17,8 @@ from library.repository import push_image_to_project
 from library.repository import pull_harbor_image
 
 class TestProjects(unittest.TestCase):
-    @classmethod
-    def setUpClass(self):
+    @suppress_urllib3_warning
+    def setUp(self):
         self.project= Project()
         self.user= User()
         self.artifact = Artifact()
@@ -27,12 +27,8 @@ class TestProjects(unittest.TestCase):
         self.user_password = "Aa123456"
         self.repo_name = "hello-world"
 
-    @classmethod
-    def tearDownClass(self):
-        print("Case completed")
-
     @unittest.skipIf(TEARDOWN == False, "Test data won't be erased.")
-    def test_ClearData(self):
+    def tearDown(self):
         #1. Delete repository(RA,IA) by user(UA);
         self.repo.delete_repoitory(TestProjects.project_name, self.repo_name, **TestProjects.USER_CLIENT)
 
@@ -41,6 +37,7 @@ class TestProjects(unittest.TestCase):
 
         #3. Delete user(UA).
         self.user.delete_user(TestProjects.user_id, **ADMIN_CLIENT)
+        print("Case completed")
 
     def testCreateDeleteTag(self):
         """

--- a/tests/apitests/python/testutils.py
+++ b/tests/apitests/python/testutils.py
@@ -1,6 +1,8 @@
 import time
 import os
 import sys
+import warnings
+from functools import wraps
 
 sys.path.insert(0, os.environ["SWAGGER_CLIENT_PATH"])
 path=os.getcwd() + "/library"
@@ -62,6 +64,17 @@ class TestResult(object):
             for each_err_msg in self.error_message:
                 print("Error message:", each_err_msg)
             raise Exception(r"Test case failed with {} errors.".format(self.num_errors))
+
+def suppress_urllib3_warning(func):
+    @wraps(func)
+    def inner_func(*args):
+        warnings.filterwarnings(action="ignore",
+                                message="unclosed",
+                                category=ResourceWarning)
+        warnings.filterwarnings(action='ignore',
+                                message='Unverified HTTPS request')
+        func(*args)
+    return inner_func
 
 from contextlib import contextmanager
 

--- a/tests/resources/APITest-Util.robot
+++ b/tests/resources/APITest-Util.robot
@@ -14,4 +14,5 @@ Harbor API Test
     Log To Console  ${ip}
     ${rc}  ${output}=  Run And Return Rc And Output  SWAGGER_CLIENT_PATH=${current_dir}/harborclient HARBOR_HOST=${ip} python ${testcase_name}
     Log To Console  ${output}
+    Log  ${output}
     Should Be Equal As Integers  ${rc}  0

--- a/tests/resources/Harbor-Pages/Replication.robot
+++ b/tests/resources/Harbor-Pages/Replication.robot
@@ -149,8 +149,8 @@ Rename Rule
     Retry Element Click  ${rule_filter_search}
     Retry Text Input  ${rule_filter_input}  ${rule}
     Retry Element Click  //clr-dg-row[contains(.,'${rule}')]//label
-    Retry Element Click  ${replication_action}
-    Retry Element Click  ${action_bar_edit}
+    Retry Element Click  ${replication_rule_action}
+    Retry Element Click  ${replication_rule_action_bar_edit}
     Retry Text Input  ${rule_name}  ${newname}
     Retry Element Click  ${rule_save_button}
 
@@ -159,8 +159,8 @@ Delete Rule
     Retry Element Click  ${rule_filter_search}
     Retry Text Input   ${rule_filter_input}  ${rule}
     Retry Element Click  //clr-dg-row[contains(.,'${rule}')]//label
-    Retry Element Click  ${replication_action}
-    Retry Element Click  ${action_bar_delete}
+    Retry Element Click  ${replication_rule_action}
+    Retry Element Click  ${replication_rule_action_bar_delete}
     Retry Wait Until Page Contains Element  ${dialog_delete}
     #change from click to mouse down and up
     Mouse Down  ${dialog_delete}
@@ -169,7 +169,7 @@ Delete Rule
 
 Select Rule
     [Arguments]  ${rule}
-    Retry Double Keywords When Error  Retry Element Click  //clr-dg-cell[contains(.,'${rule}')]  Retry Wait Element  ${replication_exec_id}
+    Retry Double Keywords When Error  Retry Element Click  //clr-dg-row[contains(.,'${rule}')]/div/div[1]/div  Retry Wait Element  ${replication_rule_exec_id}
 
 Stop Jobs
     Retry Element Click  ${stop_jobs_button}
@@ -180,25 +180,25 @@ View Job Log
     Retry Text Input  ${job_filter_input}  ${job}
     Retry Link Click  //clr-dg-row[contains(.,'${job}')]//a
 
-Find Item And Click Edit Button
+Find Registry And Click Edit Button
     [Arguments]    ${name}
     Filter Object    ${name}
     Retry Select Object    ${name}
-    Retry Element Click    ${action_bar_edit}
+    Retry Element Click    ${registry_edit_btn}
 
 Find Rule And Click Edit Button
     [Arguments]    ${name}
     Filter Object    ${name}
     Retry Select Object    ${name}
-    Retry Element Click    ${replication_action}
-    Retry Element Click    ${action_bar_edit}
+    Retry Element Click    ${replication_rule_action}
+    Retry Element Click    ${replication_rule_action_bar_edit}
 
-Find Item And Click Delete Button
+Find Rule And Click Delete Button
     [Arguments]    ${name}
     Filter Object    ${name}
     Retry Select Object    ${name}
-    Retry Element Click    ${replication_action}
-    Retry Element Click    ${action_bar_delete}
+    Retry Element Click    ${replication_rule_action}
+    Retry Element Click    ${replication_rule_action_bar_delete}
 
 Switch To Replication Manage Page
     [Arguments]    ${name}
@@ -213,7 +213,7 @@ Delete Replication Rule By Name
     [Arguments]    ${name}
     Switch To Registries
     Switch To Replication Manage
-    Find Item And Click Delete Button  ${name}
+    Find Rule And Click Delete Button  ${name}
 
 Ensure Delete Replication Rule By Name
     [Arguments]    ${name}
@@ -223,7 +223,7 @@ Ensure Delete Replication Rule By Name
 
 Rename Endpoint
     [arguments]  ${name}  ${newname}
-    Find Item And Click Edit Button  ${name}
+    Find Registry And Click Edit Button  ${name}
     Retry Wait Until Page Contains Element  ${destination_name_xpath}
     Retry Text Input  ${destination_name_xpath}  ${newname}
     Retry Element Click  ${replication_save_xpath}
@@ -233,15 +233,15 @@ Delete Endpoint
     Retry Element Click  ${endpoint_filter_search}
     Retry Text Input   ${endpoint_filter_input}  ${name}
     #click checkbox before target endpoint
-    Retry Double Keywords When Error  Retry Element Click  //clr-dg-row[contains(.,'${name}')]//clr-checkbox-wrapper  Retry Wait Element  ${action_bar_delete}
-    Retry Element Click  ${action_bar_delete}
+    Retry Double Keywords When Error  Retry Element Click  //clr-dg-row[contains(.,'${name}')]//clr-checkbox-wrapper  Retry Wait Element  ${registry_del_btn}
+    Retry Element Click  ${registry_del_btn}
     Wait Until Page Contains Element  ${dialog_delete}
     Retry Element Click  ${dialog_delete}
 
 Select Rule And Replicate
     [Arguments]  ${rule_name}
     Select Rule  ${rule_name}
-    Retry Element Click    ${replication_exec_id}
+    Retry Element Click    ${replication_rule_exec_id}
     Retry Double Keywords When Error    Retry Element Click    xpath=${dialog_replicate}    Retry Wait Until Page Not Contains Element    xpath=${dialog_replicate}
 
 Delete Replication Rule
@@ -250,8 +250,8 @@ Delete Replication Rule
     Retry Text Input   ${endpoint_filter_input}  ${name}
     #click checkbox before target endpoint
     Retry Element Click  //clr-dg-row[contains(.,'${name}')]//label
-    Retry Element Click  ${replication_action}
-    Retry Element Click  ${action_bar_delete}
+    Retry Element Click  ${replication_rule_action}
+    Retry Element Click  ${replication_rule_action_bar_delete}
     Wait Until Page Contains Element  ${dialog_delete}
     Retry Element Click  ${dialog_delete}
 

--- a/tests/resources/Harbor-Pages/Replication_Elements.robot
+++ b/tests/resources/Harbor-Pages/Replication_Elements.robot
@@ -51,8 +51,7 @@ ${job_filter_search}  //hbr-replication/div/div[3]//hbr-filter/span/clr-icon
 ${job_filter_input}  //hbr-replication/div/div[3]//hbr-filter/span//input
 ${endpoint_filter_search}  //hbr-filter/span/clr-icon
 ${endpoint_filter_input}  //hbr-filter/span//input
-${action_bar_edit}  //button[contains(.,'Edit')]
-${action_bar_delete}  //button[contains(.,'Delete')]
+
 ${stop_jobs_button}  //button[contains(.,'Stop Jobs')]
 ${dialog_close}  //clr-modal//button[contains(.,'CLOSE')]
 ${dialog_delete}  //clr-modal//button[contains(.,'DELETE')]
@@ -68,10 +67,14 @@ ${rule_resource_selector}  //*[@id='select_resource']
 ${trigger_mode_selector}  //*[@id='ruleTrigger']
 ${dest_namespace_xpath}  //*[@id='dest_namespace']
 ${new_replication_rule_id}  //*[@id='new_replication_rule_id']
-${edit_replication_rule_id}  //*[@id='edit_replication_rule_id']
-${replication_action}  //*[@id='rule-action']
-${delete_replication_rule_id}  //*[@id='delete_replication_rule_id']
-${replication_exec_id}  //*[@id='replication_exe_id']
+
+${registry_edit_btn}  //button[contains(.,'Edit')]
+${registry_del_btn}   //button[contains(.,'Delete')]
+
+${replication_rule_action}              //*[@id='rule-action']
+${replication_rule_action_bar_edit}     //*[@id='edit_replication_rule_id']
+${replication_rule_action_bar_delete}   //*[@id='delete_replication_rule_id']
+${replication_rule_exec_id}             //*[@id='replication_exe_id']
 ${replication_task_line_1}  //clr-datagrid//clr-dg-row/div/div[2]//clr-checkbox-wrapper/label[1]
 ${is_overide_xpath}  //label[contains(.,'Replace the destination resources if name exists')]
 ${enable_rule_xpath}  //label[contains(.,'Enable rule')]


### PR DESCRIPTION
1. Since upgrade python to 3.7, some urllib3 warnings come out during
   execution, because missing disconnection when using request by docker
   library, it's not affect script execution, therefore ignore them first.
2. Replication tests failed in nightly due to new UI code, some element
   locators are not valid anymore;
3. Remove switch scanner test steps, since Clair was removed.

Signed-off-by: danfengliu <danfengl@vmware.com>