### PR TITLE
Fix api ldap group search by name

### DIFF
--- a/src/common/utils/ldap/ldap.go
+++ b/src/common/utils/ldap/ldap.go
@@ -424,7 +424,7 @@ func (session *Session) searchGroup(groupDN, filter, gName, groupNameAttribute s
 		groupName = result.Entries[0].Attributes[0].Values[0]
 	}
 	group := models.LdapGroup{
-		GroupDN:   groupDN,
+		GroupDN:   result.Entries[0].DN,
 		GroupName: groupName,
 	}
 	ldapGroups = append(ldapGroups, group)

--- a/src/core/api/harborapi_test.go
+++ b/src/core/api/harborapi_test.go
@@ -795,6 +795,26 @@ func (a testapi) LdapPost(authInfo usrInfo, ldapConf apilib.LdapConf) (int, erro
 	return httpStatusCode, err
 }
 
+// Search Ldap Groups
+func (a testapi) LdapGroupsSearch(groupName, groupDN string, authInfo ...usrInfo) (int, []apilib.LdapGroupsSearch, error) {
+	_sling := sling.New().Get(a.basePath)
+	// create path and map variables
+	path := "/api/ldap/groups/search"
+	_sling = _sling.Path(path)
+	// body params
+	type QueryParams struct {
+		GroupName string `url:"groupname, omitempty"`
+		GroupDN   string `url:"groupdn, omitempty"`
+	}
+	_sling = _sling.QueryStruct(&QueryParams{GroupName: groupName, GroupDN: groupDN})
+	httpStatusCode, body, err := request(_sling, jsonAcceptHeader, authInfo...)
+	var successPayLoad []apilib.LdapGroupsSearch
+	if 200 == httpStatusCode && nil == err {
+		err = json.Unmarshal(body, &successPayLoad)
+	}
+	return httpStatusCode, successPayLoad, err
+}
+
 func (a testapi) GetConfig(authInfo usrInfo) (int, map[string]*value, error) {
 	_sling := sling.New().Base(a.basePath).Get("/api/configurations")
 

--- a/src/core/api/ldap_test.go
+++ b/src/core/api/ldap_test.go
@@ -1,0 +1,89 @@
+// Copyright 2018 Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package api
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/goharbor/harbor/src/common"
+	"github.com/goharbor/harbor/src/common/utils/test"
+	"github.com/goharbor/harbor/src/core/config"
+	"github.com/goharbor/harbor/src/testing/apitests/apilib"
+	"github.com/stretchr/testify/assert"
+)
+
+var ldapTestConfig = map[string]interface{}{
+	common.ExtEndpoint:            "host01.com",
+	common.AUTHMode:               "ldap_auth",
+	common.DatabaseType:           "postgresql",
+	common.PostGreSQLHOST:         "127.0.0.1",
+	common.PostGreSQLPort:         5432,
+	common.PostGreSQLUsername:     "postgres",
+	common.PostGreSQLPassword:     "root123",
+	common.PostGreSQLDatabase:     "registry",
+	common.LDAPURL:                "ldap://127.0.0.1",
+	common.LDAPSearchDN:           "cn=admin,dc=example,dc=com",
+	common.LDAPSearchPwd:          "admin",
+	common.LDAPBaseDN:             "dc=example,dc=com",
+	common.LDAPUID:                "uid",
+	common.LDAPFilter:             "",
+	common.LDAPScope:              2,
+	common.LDAPTimeout:            30,
+	common.AdminInitialPassword:   "password",
+	common.LDAPGroupSearchFilter:  "objectclass=groupOfNames",
+	common.LDAPGroupBaseDN:        "dc=example,dc=com",
+	common.LDAPGroupAttributeName: "cn",
+	common.LDAPGroupSearchScope:   2,
+	common.LDAPGroupAdminDn:       "cn=harbor_users,ou=groups,dc=example,dc=com",
+}
+
+func TestLdapGroupsSearch(t *testing.T) {
+
+	fmt.Println("Testing Ldap Groups Search")
+	assert := assert.New(t)
+	config.InitWithSettings(ldapTestConfig)
+	apiTest := newHarborAPI()
+
+	ldapGroup := apilib.LdapGroupsSearch{
+		GroupName: "harbor_users",
+		GroupDN:   "cn=harbor_users,ou=groups,dc=example,dc=com",
+	}
+
+	// case 1: search group by name
+	code, groups, err := apiTest.LdapGroupsSearch(ldapGroup.GroupName, "", *admin)
+	if err != nil {
+		t.Error("Error occurred while search ldap groups", err.Error())
+		t.Log(err)
+	} else {
+		assert.Equal(200, code, "Search ldap group status should be 200")
+		assert.Equal(1, len(groups), "Search ldap groups record should be 1")
+		assert.Equal(ldapGroup.GroupDN, groups[0].GroupDN, "Group DNs should be equal")
+		assert.Equal(ldapGroup.GroupName, groups[0].GroupName, "Group names should be equal")
+	}
+
+	// case 2: search group by DN
+	code, groups, err = apiTest.LdapGroupsSearch("", ldapGroup.GroupDN, *admin)
+	if err != nil {
+		t.Error("Error occurred while search ldap groups", err.Error())
+		t.Log(err)
+	} else {
+		assert.Equal(200, code, "Search ldap groups status should be 200")
+		assert.Equal(1, len(groups), "Search ldap groups record should be 1 ")
+		assert.Equal(ldapGroup.GroupDN, groups[0].GroupDN, "Group DNs should be equal")
+		assert.Equal(ldapGroup.GroupName, groups[0].GroupName, "Group names should be equal")
+	}
+
+	config.InitWithSettings(test.GetDefaultConfigMap())
+}

--- a/src/testing/apitests/apilib/ldap.go
+++ b/src/testing/apitests/apilib/ldap.go
@@ -32,3 +32,9 @@ type LdapConf struct {
 	LdapScope             int    `json:"ldap_scope"`
 	LdapConnectionTimeout int    `json:"ldap_connection_timeout"`
 }
+
+// LdapGroupsSearch the ldap group search type
+type LdapGroupsSearch struct {
+	GroupName string `json:"group_name,omitempty"`
+	GroupDN   string `json:"ldap_group_dn,omitempty"`
+}


### PR DESCRIPTION
The `searchGroup` function assumed, that the input groupDN is also the DN of the result. But in case of `searchGroupByName` which is used by the `ldap/groups/search` api endpoint, the input DN is a baseDN and won't match the result. This fix will return the DN of the result.

I also added a couple of test.

Fixes #13495 