### PR TITLE
Support LDAP without memberof overlay

### DIFF
--- a/src/common/config/metadata/metadatalist.go
+++ b/src/common/config/metadata/metadatalist.go
@@ -99,6 +99,7 @@ var (
 		{Name: common.LDAPURL, Scope: UserScope, Group: LdapBasicGroup, EnvKey: "LDAP_URL", DefaultValue: "", ItemType: &NonEmptyStringType{}, Editable: false},
 		{Name: common.LDAPVerifyCert, Scope: UserScope, Group: LdapBasicGroup, EnvKey: "LDAP_VERIFY_CERT", DefaultValue: "true", ItemType: &BoolType{}, Editable: false},
 		{Name: common.LDAPGroupMembershipAttribute, Scope: UserScope, Group: LdapBasicGroup, EnvKey: "LDAP_GROUP_MEMBERSHIP_ATTRIBUTE", DefaultValue: "memberof", ItemType: &StringType{}, Editable: true},
+		{Name: common.LDAPGroupUseMemberOf, Scope: UserScope, Group: LdapBasicGroup, EnvKey: "LDAP_GROUP_USE_MEMBER_OF", DefaultValue: "true", ItemType: &BoolType{}, Editable: false},
 
 		{Name: common.MaxJobWorkers, Scope: SystemScope, Group: BasicGroup, EnvKey: "MAX_JOB_WORKERS", DefaultValue: "10", ItemType: &IntType{}, Editable: false},
 		{Name: common.NotaryURL, Scope: SystemScope, Group: BasicGroup, EnvKey: "NOTARY_URL", DefaultValue: "http://notary-server:4443", ItemType: &StringType{}, Editable: false},

--- a/src/common/const.go
+++ b/src/common/const.go
@@ -128,6 +128,7 @@ const (
 	OIDCGroupType                     = 3
 	LDAPGroupAdminDn                  = "ldap_group_admin_dn"
 	LDAPGroupMembershipAttribute      = "ldap_group_membership_attribute"
+	LDAPGroupUseMemberOf              = "ldap_group_use_member_of"
 	DefaultRegistryControllerEndpoint = "http://registryctl:8080"
 	WithChartMuseum                   = "with_chartmuseum"
 	ChartRepoURL                      = "chart_repository_url"

--- a/src/common/models/ldap.go
+++ b/src/common/models/ldap.go
@@ -35,6 +35,7 @@ type LdapGroupConf struct {
 	LdapGroupSearchScope         int    `json:"ldap_group_search_scope"`
 	LdapGroupAdminDN             string `json:"ldap_group_admin_dn,omitempty"`
 	LdapGroupMembershipAttribute string `json:"ldap_group_membership_attribute,omitempty"`
+	LdapGroupUseMemberOf         bool   `json:"ldap_group_use_member_of"`
 }
 
 // LdapUser ...

--- a/src/core/config/config.go
+++ b/src/core/config/config.go
@@ -175,6 +175,7 @@ func LDAPGroupConf() (*models.LdapGroupConf, error) {
 		LdapGroupSearchScope:         cfgMgr.Get(common.LDAPGroupSearchScope).GetInt(),
 		LdapGroupAdminDN:             cfgMgr.Get(common.LDAPGroupAdminDn).GetString(),
 		LdapGroupMembershipAttribute: cfgMgr.Get(common.LDAPGroupMembershipAttribute).GetString(),
+		LdapGroupUseMemberOf:         cfgMgr.Get(common.LDAPGroupUseMemberOf).GetBool(),
 	}, nil
 }
 

--- a/src/portal/src/app/config/auth/config-auth.component.html
+++ b/src/portal/src/app/config/auth/config-auth.component.html
@@ -193,6 +193,21 @@
         </clr-input-container>
 
         <!-- End of ldap group admin dn -->
+        <clr-checkbox-container>
+            <label for="ldapGroupUseMemberOf">{{'CONFIG.LDAP.LDAP_GROUP_USE_MEMBER_OF' | translate}}
+                    <clr-tooltip>
+                            <clr-icon clrTooltipTrigger shape="info-circle" size="24"></clr-icon>
+                            <clr-tooltip-content clrPosition="top-right" clrSize="lg" *clrIfOpen>
+                                <span>{{'CONFIG.LDAP.LDAP_GROUP_USE_MEMBER_OF_INFO' | translate}}</span>
+                            </clr-tooltip-content>
+                        </clr-tooltip>
+            </label>
+            <clr-checkbox-wrapper>
+                <input type="checkbox" clrCheckbox name="ldapGroupUseMemberOf" id="ldapGroupUseMemberOf"
+                    [ngModel]="currentConfig.ldap_group_use_member_of.value"
+                    (ngModelChange)="setLdapGroupUseMemberOfValue($event)" />
+            </clr-checkbox-wrapper>
+        </clr-checkbox-container>
         <clr-input-container>
             <label for="ldapGroupAdminDN">{{'CONFIG.LDAP.LDAP_GROUP_MEMBERSHIP' | translate}}
                 <clr-tooltip>

--- a/src/portal/src/app/config/auth/config-auth.component.ts
+++ b/src/portal/src/app/config/auth/config-auth.component.ts
@@ -107,6 +107,10 @@ export class ConfigurationAuthComponent implements OnChanges, OnInit {
         return !isEmpty(this.getChanges());
     }
 
+    setLdapGroupUseMemberOfValue($event: any) {
+        this.currentConfig.ldap_group_use_member_of.value = $event;
+    }
+
     setVerifyCertValue($event: any) {
         this.currentConfig.ldap_verify_cert.value = $event;
     }

--- a/src/portal/src/i18n/lang/en-us-lang.json
+++ b/src/portal/src/i18n/lang/en-us-lang.json
@@ -901,7 +901,9 @@
             "LDAP_GROUP_ADMIN_DN": "LDAP Group Admin DN",
             "LDAP_GROUP_ADMIN_DN_INFO": "Specify an LDAP group DN. All LDAP user in this group will have harbor admin privilege. Keep it blank if you do not want to.",
             "LDAP_GROUP_MEMBERSHIP": "LDAP Group Membership",
-            "LDAP_GROUP_MEMBERSHIP_INFO": "The attribute indicates the membership of LDAP group, default value is memberof, in some LDAP server it could be \"ismemberof\"",
+            "LDAP_GROUP_MEMBERSHIP_INFO": "The attribute indicates the membership of LDAP group, default value is memberof, in some LDAP server it could be \"ismemberof\". If \"Group Membership Attribute at User\" is disabled, it could be \"member\".",
+            "LDAP_GROUP_USE_MEMBER_OF": "Group Membership Attribute at User",
+            "LDAP_GROUP_USE_MEMBER_OF_INFO": "If enabled, the \"LDAP Group Membership\" Attribute of the user is evaluated for group memberships. If disabled, the \"LDAP Group Membership\" attribute at the groups are evaluated (disable, if memberof-overlay is missing).",
             "GROUP_SCOPE": "LDAP Group Scope",
             "GROUP_SCOPE_INFO": "The scope to search for groups, select Subtree by default."
 

--- a/src/portal/src/lib/components/config/config.ts
+++ b/src/portal/src/lib/components/config/config.ts
@@ -70,6 +70,7 @@ export class Configuration {
     ldap_group_attribute_name: StringValueItem;
     ldap_group_search_scope: NumberValueItem;
     ldap_group_membership_attribute: StringValueItem;
+    ldap_group_use_member_of: BoolValueItem;
     ldap_group_admin_dn: StringValueItem;
     uaa_client_id: StringValueItem;
     uaa_client_secret?: StringValueItem;
@@ -125,6 +126,7 @@ export class Configuration {
         this.ldap_group_attribute_name = new StringValueItem("", true);
         this.ldap_group_search_scope = new NumberValueItem(0, true);
         this.ldap_group_membership_attribute = new StringValueItem("", true);
+        this.ldap_group_use_member_of = new BoolValueItem(true, true);
         this.ldap_group_admin_dn = new StringValueItem("", true);
         this.uaa_client_id = new StringValueItem("", true);
         this.uaa_client_secret = new StringValueItem("", true);


### PR DESCRIPTION
My harbor installation uses an openldap which doesn't have the memberof-overlay. Currently, I can't get the membership information for the users in harbor. Since the LDAP is not in my responsibility, I can''t just install the overlay.

This MR introduces a flag, which decides where to look for the membership attribute, at the user or at the group. In the default case, the flag is true and harbor would look for the memberof attribute at the user.
If the new flag is deactivated, harbor will search for the membership attribute at the groups. In most cases, this would be the `member` attribute. For each user that logs in, harbor will make a ldap search with the filter `(&(<default-group-filter>)(<membership-attribute>=<userDN>)`. The result are the groups where the user is a member of and created in harbor.

I would like to have some feedback about the way the problem would be handled. If it looks good, I can add a couple of tests. I'm also open to change the name of the flag (in Code and UI).

This might also resolve #9328, but I can't tell for sure, since it isn't my issue.