### PR TITLE
Add docker login with credential before building harbor package

### DIFF
--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -114,6 +114,7 @@ function uploader {
 
 function package_installer {
     echo "Package Harbor offline installer."
+    docker login -u $DOCKER_HUB_USERNAME -p $DOCKER_HUB_PASSWORD
     pybot --removekeywords TAG:secret --include Bundle tests/robot-cases/Group0-Distro-Harbor
     harbor_offline_build_bundle=$(basename harbor-offline-installer-*.tgz)
     harbor_online_build_bundle=$(basename harbor-online-installer-*.tgz)


### PR DESCRIPTION
Due to docker hub access limitation, add docker login with credential
before building harbor package

Signed-off-by: wang yan <wangyan@vmware.com>