### PR TITLE
[Cherry pick]fix: remove auto re-readable body in BeforeRequest

### DIFF
--- a/src/server/middleware/blob/put_manifest.go
+++ b/src/server/middleware/blob/put_manifest.go
@@ -15,10 +15,11 @@
 package blob
 
 import (
-	"github.com/goharbor/harbor/src/lib/errors"
 	"io/ioutil"
 	"net/http"
 
+	"github.com/goharbor/harbor/src/lib"
+	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/lib/log"
 	"github.com/goharbor/harbor/src/pkg/distribution"
 	"github.com/goharbor/harbor/src/server/middleware"
@@ -32,6 +33,7 @@ func PutManifestMiddleware() func(http.Handler) http.Handler {
 		ctx := r.Context()
 		logger := log.G(ctx)
 
+		lib.NopCloseRequest(r) // make the r.Body re-readable
 		body, err := ioutil.ReadAll(r.Body)
 		if err != nil {
 			return err

--- a/src/server/middleware/middleware.go
+++ b/src/server/middleware/middleware.go
@@ -15,10 +15,10 @@
 package middleware
 
 import (
-	lib_http "github.com/goharbor/harbor/src/lib/http"
 	"net/http"
 
 	"github.com/goharbor/harbor/src/lib"
+	lib_http "github.com/goharbor/harbor/src/lib/http"
 )
 
 // Middleware receives a handler and returns another handler.
@@ -62,7 +62,7 @@ func New(fn func(http.ResponseWriter, *http.Request, http.Handler), skippers ...
 // BeforeRequest make a middleware which will call hook before the next handler
 func BeforeRequest(hook func(*http.Request) error, skippers ...Skipper) func(http.Handler) http.Handler {
 	return New(func(w http.ResponseWriter, r *http.Request, next http.Handler) {
-		if err := hook(lib.NopCloseRequest(r)); err != nil {
+		if err := hook(r); err != nil {
 			lib_http.SendError(w, err)
 			return
 		}


### PR DESCRIPTION
Remove nop close body in the BeforeRequest helper function.
Middleware must make the request body re-readable itself when it wants
read the body in the middleware.

Closes #13556

Signed-off-by: He Weiwei <hweiwei@vmware.com>