### PR TITLE
fix(quota): ignore the fail when getting reference of quota

### DIFF
--- a/make/migrations/postgresql/0050_2.2.0_schema.up.sql
+++ b/make/migrations/postgresql/0050_2.2.0_schema.up.sql
@@ -5,6 +5,13 @@ Fixes issue https://github.com/goharbor/harbor/issues/13317
 UPDATE role SET role_id=4 WHERE name='maintainer' AND role_id!=4;
 UPDATE role SET role_id=5 WHERE name='limitedGuest' AND role_id!=5;
 
+/*
+Clean the dirty data in quota/quota_usage
+  Remove quota/quota_usage when the referenced project not exists
+*/
+DELETE FROM quota WHERE reference='project' AND reference_id::integer NOT IN (SELECT project_id FROM project WHERE deleted=FALSE);
+DELETE FROM quota_usage WHERE reference='project' AND reference_id::integer NOT IN (SELECT project_id FROM project WHERE deleted=FALSE);
+
 ALTER TABLE schedule ADD COLUMN IF NOT EXISTS cron_type varchar(64);
 ALTER TABLE robot ADD COLUMN IF NOT EXISTS secret varchar(2048);
 

--- a/src/controller/quota/controller.go
+++ b/src/controller/quota/controller.go
@@ -132,10 +132,11 @@ func (c *controller) assembleQuota(ctx context.Context, q *quota.Quota, opts *Op
 
 		ref, err := driver.Load(ctx, q.ReferenceID)
 		if err != nil {
-			return nil, err
+			log.G(ctx).Warningf("failed to load referenced %s object %s for quota %d, error %v",
+				q.Reference, q.ReferenceID, q.ID, err)
+		} else {
+			q.Ref = ref
 		}
-
-		q.Ref = ref
 	}
 
 	return q, nil


### PR DESCRIPTION
1. Clean the dirty data in quota/quota_usage.
2. Ignore the fail when getting the reference of quota.

Closes #13387

Signed-off-by: He Weiwei <hweiwei@vmware.com>