### PR TITLE
Add optional DBAuth

### DIFF
--- a/api/v2.0/legacy_swagger.yaml
+++ b/api/v2.0/legacy_swagger.yaml
@@ -3961,6 +3961,9 @@ definitions:
       external_url:
         type: string
         description: The external URL of Harbor, with protocol.
+      basic_auth_enabled:
+        type: boolean
+        description: 'Allow basicAuth login when auth_mode is not basicAuth'
       auth_mode:
         type: string
         description: The auth mode of current Harbor instance.
@@ -4075,6 +4078,9 @@ definitions:
   Configurations:
     type: object
     properties:
+      basic_auth_enabled:
+        type: boolean
+        description: 'Allow basicAuth login when auth_mode is not basicAuth'
       auth_mode:
         type: string
         description: 'The auth mode of current system, such as "db_auth", "ldap_auth"'
@@ -4193,6 +4199,9 @@ definitions:
   ConfigurationsResponse:
     type: object
     properties:
+      basic_auth_enabled:
+        $ref: '#/definitions/BoolConfigItem'
+        description: 'Allow basicAuth login when auth_mode is not basicAuth'
       auth_mode:
         $ref: '#/definitions/StringConfigItem'
         description: 'The auth mode of current system, such as "db_auth", "ldap_auth"'

--- a/api/v2.0/swagger.yaml
+++ b/api/v2.0/swagger.yaml
@@ -2188,6 +2188,9 @@ definitions:
       endpoint:
         type: string
         description: The service endpoint of this instance
+      basic_auth_enabled:
+        type: boolean
+        description: 'Allow basicAuth login when auth_mode is not basicAuth'
       auth_mode:
         type: string
         description: The authentication way supported

--- a/src/common/config/metadata/metadata_test.go
+++ b/src/common/config/metadata/metadata_test.go
@@ -24,6 +24,7 @@ func TestCfgMetaData_InitFromArray(t *testing.T) {
 	testArray := []Item{
 		{Scope: SystemScope, Group: BasicGroup, EnvKey: "HARBOR_ADMIN_PASSWORD", DefaultValue: "", Name: common.AdminInitialPassword, ItemType: &PasswordType{}, Editable: true},
 		{Scope: UserScope, Group: BasicGroup, EnvKey: "AUTH_MODE", DefaultValue: "db_auth", Name: common.AUTHMode, ItemType: &StringType{}, Editable: false},
+		{Scope: SystemScope, Group: BasicGroup, EnvKey: "BASIC_AUTH_ENABLED", DefaultValue: "true", Name: common.BasicAuthEnabled, ItemType: &BoolType{}, Editable: true},
 		{Scope: SystemScope, Group: BasicGroup, EnvKey: "CHART_REPOSITORY_URL", DefaultValue: "http://chartmuseum:9999", Name: common.ChartRepoURL, ItemType: &StringType{}, Editable: false},
 	}
 	curInst := Instance()

--- a/src/common/config/metadata/metadatalist.go
+++ b/src/common/config/metadata/metadatalist.go
@@ -63,6 +63,7 @@ var (
 
 		{Name: common.AdminInitialPassword, Scope: SystemScope, Group: BasicGroup, EnvKey: "HARBOR_ADMIN_PASSWORD", DefaultValue: "", ItemType: &PasswordType{}, Editable: true},
 		{Name: common.AUTHMode, Scope: UserScope, Group: BasicGroup, EnvKey: "AUTH_MODE", DefaultValue: "db_auth", ItemType: &AuthModeType{}, Editable: false},
+		{Name: common.BasicAuthEnabled, Scope: SystemScope, Group: BasicGroup, EnvKey: "BASIC_AUTH_ENABLED", DefaultValue: "true", ItemType: &BoolType{}, Editable: true},
 		{Name: common.ChartRepoURL, Scope: SystemScope, Group: BasicGroup, EnvKey: "CHART_REPOSITORY_URL", DefaultValue: "http://chartmuseum:9999", ItemType: &StringType{}, Editable: false},
 
 		{Name: common.ClairAdapterURL, Scope: SystemScope, Group: ClairGroup, EnvKey: "CLAIR_ADAPTER_URL", DefaultValue: "http://clair-adapter:8080", ItemType: &StringType{}, Editable: false},

--- a/src/common/const.go
+++ b/src/common/const.go
@@ -47,6 +47,7 @@ const (
 
 	ExtEndpoint                      = "ext_endpoint"
 	AUTHMode                         = "auth_mode"
+	BasicAuthEnabled                 = "basic_auth_enabled"
 	DatabaseType                     = "database_type"
 	PostGreSQLHOST                   = "postgresql_host"
 	PostGreSQLPort                   = "postgresql_port"

--- a/src/core/auth/db/db.go
+++ b/src/core/auth/db/db.go
@@ -19,6 +19,7 @@ import (
 	"github.com/goharbor/harbor/src/common/dao"
 	"github.com/goharbor/harbor/src/common/models"
 	"github.com/goharbor/harbor/src/core/auth"
+	"github.com/goharbor/harbor/src/core/config"
 )
 
 // Auth implements Authenticator interface to authenticate user against DB.
@@ -53,5 +54,7 @@ func (d *Auth) OnBoardUser(u *models.User) error {
 }
 
 func init() {
-	auth.Register(common.DBAuth, &Auth{})
+	if basicAuthEnabled, err := config.BasicAuthEnabled(); basicAuthEnabled{
+		auth.Register(common.DBAuth, &Auth{})
+	}
 }

--- a/src/core/config/config.go
+++ b/src/core/config/config.go
@@ -122,6 +122,16 @@ func AuthMode() (string, error) {
 	return cfgMgr.Get(common.AUTHMode).GetString(), nil
 }
 
+// BasicAuthEnabled ...
+func BasicAuthEnabled() (bool, error) {
+	err := cfgMgr.Load()
+	if err != nil {
+		log.Errorf("failed to load config, error %v", err)
+		return "true", err
+	}
+	return cfgMgr.Get(common.BasicAuthEnabled).GetBool(), nil
+}
+
 // TokenPrivateKeyPath returns the path to the key for signing token for registry
 func TokenPrivateKeyPath() string {
 	path := os.Getenv("TOKEN_PRIVATE_KEY_PATH")

--- a/src/portal/src/app/project/project.component.spec.ts
+++ b/src/portal/src/app/project/project.component.spec.ts
@@ -27,6 +27,10 @@ describe('ProjectComponent', () => {
     const mockConfigurationService = {
         getConfiguration: () => {
             return of({
+                "basic_auth_enabled": {
+                  "value": true,
+                  "editable": true
+                },
                 "auth_mode": {
                   "value": "oidc_auth",
                   "editable": false

--- a/src/portal/src/app/sign-in/sign-in.component.html
+++ b/src/portal/src/app/sign-in/sign-in.component.html
@@ -11,7 +11,7 @@
                     <span>{{'BUTTON.LOG_IN_OIDC' | translate }}</span>
                 </button>
             </a>
-            <div class="login-group">
+            <div class="login-group" *ngIf="isBasicLoginMode">
                 <clr-input-container>
                     <input clrInput class="username" type="text" required [(ngModel)]="signInCredential.principal" name="login_username" id="login_username"
                            placeholder='{{"PLACEHOLDER.SIGN_IN_NAME" | translate}}' #userNameInput='ngModel'>

--- a/src/portal/src/app/sign-in/sign-in.component.ts
+++ b/src/portal/src/app/sign-in/sign-in.component.ts
@@ -141,6 +141,9 @@ export class SignInComponent implements AfterViewChecked, OnInit {
         return this.appConfig.auth_mode === CONFIG_AUTH_MODE.DB_AUTH
             && this.appConfig.self_registration;
     }
+    public get isBasicLoginMode(): boolean {
+        return this.appConfig.auth_mode === CONFIG_AUTH_MODE.DB_AUTH;
+    }
     public get isOidcLoginMode(): boolean {
         return this.appConfig.auth_mode === CONFIG_AUTH_MODE.OIDC_AUTH;
     }
@@ -295,5 +298,3 @@ export class SignInComponent implements AfterViewChecked, OnInit {
         }
     }
 }
-
-


### PR DESCRIPTION
fixes: https://github.com/goharbor/harbor/issues/9006

[portal]
* Only show username:password login fields for DBAuth if enabled (default: true)

[core]
* Add BASIC_AUTH_ENABLED to api/configurations to enable/disable user authentication using DBAuth (includes admin)

**HALP NEEDED**
I didn't manage to compile the core container after applying changes, and i don't know why it's not triggering

Also, my idea here is to enable/disable the registration of the DBAuth AuthN method so that authentication.login() would only work with other set-up methods. Do you think this is the correct way.
This actually depends on how the harbor-core reloads the configurations after the user submits these.

This is my first commit here, so i am a bit lost, still trying to understand the Arch. Some points would be nice



