### PR TITLE
[CherryPick-2.1.0]Move security/readonly middleware ahead of transaction middleware

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on:
       #- self-hosted
       - ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 180
     steps:
       - name: Set up Go 1.14
         uses: actions/setup-go@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -93,7 +93,7 @@ jobs:
     runs-on:
       #- self-hosted
       - ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 180
     steps:
       - name: Set up Go 1.14
         uses: actions/setup-go@v1

--- a/src/common/security/proxycachesecret/context.go
+++ b/src/common/security/proxycachesecret/context.go
@@ -80,7 +80,7 @@ func (s *SecurityContext) Can(action types.Action, resource types.Resource) bool
 	}
 	namespace, ok := rbac.ProjectNamespaceParse(resource)
 	if !ok {
-		log.Debugf("got no namespace from the resource %s", resource)
+		log.Warningf("got no namespace from the resource %s", resource)
 		return false
 	}
 	project, err := s.getProject(namespace.Identity())
@@ -89,12 +89,12 @@ func (s *SecurityContext) Can(action types.Action, resource types.Resource) bool
 		return false
 	}
 	if project == nil {
-		log.Debugf("project not found %v", namespace.Identity())
+		log.Warningf("project not found %v", namespace.Identity())
 		return false
 	}
 	pro, _ := utils.ParseRepository(s.repository)
 	if project.Name != pro {
-		log.Debugf("unauthorized for project %s", project.Name)
+		log.Warningf("unauthorized for project %s", project.Name)
 		return false
 	}
 	return true

--- a/src/core/middlewares/middlewares.go
+++ b/src/core/middlewares/middlewares.go
@@ -74,9 +74,9 @@ func MiddleWares() []beego.MiddleWare {
 		csrf.Middleware(),
 		orm.Middleware(),
 		notification.Middleware(), // notification must ahead of transaction ensure the DB transaction execution complete
-		transaction.Middleware(dbTxSkippers...),
-		artifactinfo.Middleware(),
 		security.Middleware(),
 		readonly.Middleware(readonlySkippers...),
+		transaction.Middleware(dbTxSkippers...),
+		artifactinfo.Middleware(),
 	}
 }

--- a/src/pkg/proxy/secret/authorizer.go
+++ b/src/pkg/proxy/secret/authorizer.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"github.com/goharbor/harbor/src/lib"
+	"github.com/goharbor/harbor/src/lib/log"
 )
 
 const (
@@ -35,6 +36,7 @@ func NewAuthorizer() lib.Authorizer {
 type authorizer struct{}
 
 func (s *authorizer) Modify(req *http.Request) error {
+	logger := log.G(req.Context())
 	if req == nil {
 		return errors.New("the request is null")
 	}
@@ -48,7 +50,9 @@ func (s *authorizer) Modify(req *http.Request) error {
 			}
 		}
 	}
+	logger.Infof("ddddd  generating secret for repo: %s", repository)
 	secret := GetManager().Generate(repository)
+	logger.Infof("attaching secret for repo: %s, secret: %s", repository, secret)
 	req.Header.Set("Authorization", fmt.Sprintf("%s %s", secretPrefix, secret))
 	return nil
 }

--- a/src/pkg/proxy/secret/manager.go
+++ b/src/pkg/proxy/secret/manager.go
@@ -78,7 +78,7 @@ func (man *mgr) Verify(sec, rn string) bool {
 
 	p, ok := v.(targetRepository)
 	if ok {
-		log.Infof("target repository found for secret: %s, repo name: %s, expires: $v", sec, p.name, p.expiresAt)
+		log.Infof("target repository found for secret: %s, repo name: %s, expires: %v", sec, p.name, p.expiresAt)
 	}
 	if ok && p.name == rn {
 		defer man.delete(sec)

--- a/src/pkg/proxy/secret/manager.go
+++ b/src/pkg/proxy/secret/manager.go
@@ -69,11 +69,17 @@ func (man *mgr) Generate(rn string) string {
 }
 
 func (man *mgr) Verify(sec, rn string) bool {
+	log.Infof("verifying secret: %s, repo: %s", sec, rn)
 	v, ok := man.m.Load(sec)
 	if !ok {
+		log.Infof("not in the map secret: %s, repo: %s", sec, rn)
 		return false
 	}
+
 	p, ok := v.(targetRepository)
+	if ok {
+		log.Infof("target repository found for secret: %s, repo name: %s, expires: $v", sec, p.name, p.expiresAt)
+	}
 	if ok && p.name == rn {
 		defer man.delete(sec)
 		return p.expiresAt.After(time.Now())


### PR DESCRIPTION
In v2.1 security/readonly middleware will query DB by creating new
connection.
If it is put after transaction middleware there's a bigger chance of
deadlock if the concurrent open connections are set too low (#13155)

This commit mitigates that issue.  But we still need work to lowerthe
connections and better handle the case when http connection is closed.

Signed-off-by: Daniel Jiang <jiangd@vmware.com>