### PR TITLE
add with details option for list project

### DIFF
--- a/api/v2.0/swagger.yaml
+++ b/api/v2.0/swagger.yaml
@@ -46,6 +46,12 @@ paths:
           description: The name of project owner.
           required: false
           type: string
+        - name: with_detail
+          in: query
+          description: Bool value indicating whether return detailed information of the project
+          type: boolean
+          required: false
+          default: true
       responses:
         '200':
           description: Return all matched projects.

--- a/src/controller/project/controller.go
+++ b/src/controller/project/controller.go
@@ -251,6 +251,9 @@ func (c *controller) ListRoles(ctx context.Context, projectID int64, u *user.Use
 
 func (c *controller) assembleProjects(ctx context.Context, projects models.Projects, options ...Option) error {
 	opts := newOptions(options...)
+	if !opts.WithDetail {
+		return nil
+	}
 	if opts.WithMetadata {
 		if err := c.loadMetadatas(ctx, projects); err != nil {
 			return err

--- a/src/controller/project/options.go
+++ b/src/controller/project/options.go
@@ -19,10 +19,18 @@ type Option func(*Options)
 
 // Options options used by `Get` method of `Controller`
 type Options struct {
+	WithDetail             bool
 	WithCVEAllowlist       bool // get project with cve allowlist
 	WithEffectCVEAllowlist bool // get project with effect cve allowlist
 	WithMetadata           bool // get project with metadata
 	WithOwner              bool // get project with owner name
+}
+
+// Detail set WithDetail for the Options
+func Detail(detail bool) Option {
+	return func(opts *Options) {
+		opts.WithDetail = detail
+	}
 }
 
 // WithCVEAllowlist set WithCVEAllowlist for the Options
@@ -56,6 +64,7 @@ func WithOwner() Option {
 
 func newOptions(options ...Option) *Options {
 	opts := &Options{
+		WithDetail:   true, // default get project details
 		WithMetadata: true, // default get project with metadata
 	}
 

--- a/src/server/v2.0/handler/project.go
+++ b/src/server/v2.0/handler/project.go
@@ -409,7 +409,7 @@ func (a *projectAPI) ListProjects(ctx context.Context, params operation.ListProj
 		return operation.NewListProjectsOK().WithXTotalCount(0).WithPayload([]*models.Project{})
 	}
 
-	projects, err := a.projectCtl.List(ctx, query, project.WithCVEAllowlist(), project.WithOwner())
+	projects, err := a.projectCtl.List(ctx, query, project.Detail(lib.BoolValue(params.WithDetail)), project.WithCVEAllowlist(), project.WithOwner())
 	if err != nil {
 		return a.SendError(ctx, err)
 	}


### PR DESCRIPTION
default is true and don't break any existing api, and when to set it to false, the api only return the basic project infor
without meta, CVE settings and etc of the project.

Signed-off-by: wang yan <wangyan@vmware.com>