### PR TITLE
Cherry-pick 2.1.0 Fix scan all python test script issue of missing test step

### DIFF
--- a/api/v2.0/legacy_swagger.yaml
+++ b/api/v2.0/legacy_swagger.yaml
@@ -5433,6 +5433,10 @@ definitions:
           'Success': 5
           'Error': 2,
           'Running': 3
+      ongoing:
+        type: boolean
+        description: A flag indicating job status of scan all .
+
   SupportedWebhookEventTypes:
     type: object
     description: Supportted webhook event types and notify types.

--- a/tests/apitests/python/library/system.py
+++ b/tests/apitests/python/library/system.py
@@ -117,6 +117,21 @@ class System(base.Base):
         base._assert_status_code(expect_status_code, status_code)
         return base._get_id_from_header(header)
 
+    def wait_until_scans_all_finish(self, **kwargs):
+        client = self._get_client(**kwargs)
+        timeout_count = 50
+        scan_status=""
+        while True:
+            time.sleep(5)
+            timeout_count = timeout_count - 1
+            if (timeout_count == 0):
+                break
+            stats = client.scans_all_metrics_get()
+            print("Scan all status:", stats)
+            if stats.ongoing:
+                return
+        raise Exception("Error: Scan all job is timeout.")
+
     def create_scan_all_schedule(self, schedule_type, cron = None, expect_status_code = 201, expect_response_body = None, **kwargs):
         client = self._get_client(**kwargs)
         scanschedule = swagger_client.AdminJobScheduleObj()

--- a/tests/apitests/python/test_system_level_scan_all.py
+++ b/tests/apitests/python/test_system_level_scan_all.py
@@ -82,6 +82,7 @@ class TestScanAll(unittest.TestCase):
 
         #4. Trigger scan all event;
         self.system.scan_now(**ADMIN_CLIENT)
+        self.system.wait_until_scans_all_finish(**ADMIN_CLIENT)
 
         #5. Check if image in project_Alice and another image in project_Luca were both scanned.
         self.artifact.check_image_scan_result(TestScanAll.project_Alice_name, image_a, tag_Alice, **USER_ALICE_CLIENT)


### PR DESCRIPTION
1. In scan all py-test, missing a important test step for checkin scan all status,
2. which indicate the ending of scan all job.
In swagger, ongoig field is missing in stats struct.

Signed-off-by: danfengliu <danfengl@vmware.com>