### PR TITLE
Consider the default port when comparing the hosts

### DIFF
--- a/src/server/middleware/v2auth/auth_test.go
+++ b/src/server/middleware/v2auth/auth_test.go
@@ -266,3 +266,65 @@ func TestGetChallenge(t *testing.T) {
 	}
 
 }
+
+func TestMatch(t *testing.T) {
+	cases := []struct {
+		reqHost string
+		rawURL  string
+		expect  bool
+	}{
+		{
+			"abc.com",
+			"http://abc.com",
+			true,
+		},
+		{
+			"abc.com",
+			"https://abc.com",
+			true,
+		},
+		{
+			"abc.com:80",
+			"http://abc.com",
+			true,
+		},
+		{
+			"abc.com:80",
+			"https://abc.com",
+			false,
+		},
+		{
+			"abc.com:443",
+			"http://abc.com",
+			false,
+		},
+		{
+			"abc.com:443",
+			"https://abc.com",
+			true,
+		},
+		{
+			"abcd.com:443",
+			"https://abc.com",
+			false,
+		},
+		{
+			"abc.com:8443",
+			"https://abc.com:8443",
+			true,
+		},
+		{
+			"abc.com",
+			"https://abc.com:443",
+			true,
+		},
+		{
+			"abc.com",
+			"http://abc.com:443",
+			false,
+		},
+	}
+	for _, c := range cases {
+		assert.Equal(t, c.expect, match(context.Background(), c.reqHost, c.rawURL))
+	}
+}


### PR DESCRIPTION
This commit cover the cases when the port is set in one of the Host of
request or the core URL, to make sure the comparison works as expected
when the default port (80, 443) is added in only one of them.

Signed-off-by: Daniel Jiang <jiangd@vmware.com>