### PR TITLE
Changes "Remember me" to the more intuitive "Remember username"

### DIFF
--- a/src/portal/src/i18n/lang/en-us-lang.json
+++ b/src/portal/src/i18n/lang/en-us-lang.json
@@ -10,8 +10,8 @@
         "THEME_LIGHT_TEXT": "LIGHT"
     },
     "SIGN_IN": {
-        "REMEMBER": "Remember me",
-        "INVALID_MSG": "Invalid user name or password.",
+        "REMEMBER": "Remember username",
+        "INVALID_MSG": "Invalid username or password.",
         "FORGOT_PWD": "Forgot password",
         "HEADER_LINK": "Sign In",
         "CORE_SERVICE_NOT_AVAILABLE": "Core service is not available."
@@ -927,7 +927,7 @@
             "SCOPE": "OIDC Scope",
             "OIDC_VERIFYCERT": "Verify Certificate",
             "OIDC_AUTOONBOARD": "Automatic onboarding",
-            "USER_CLAIM": "Username Claim",    
+            "USER_CLAIM": "Username Claim",
             "OIDC_SETNAME": "Set OIDC Username",
             "OIDC_SETNAMECONTENT": "You must create a Harbor username the first time when authenticating via a third party(OIDC).This will be used within Harbor to be associated with projects, roles, etc.",
             "OIDC_USERNAME": "Username",


### PR DESCRIPTION
It took me finding #1744 to figure out why I kept having to log in to the portal every so often. Personally I've come to expect "Remember Me" to mean, "Don't make me have to log in for a while" (where "a while" is a period significantly longer than what happens when it is not selected). 

I also changed the INVALID_MSG's `"user name"` to `"username"` as that is more consistent with the placeholder text used for the field itself. According to the [dictionary](https://www.merriam-webster.com/dictionary/username) no space in username seems to be valid.

(last change is just my editor trimming trailing spaces)

Signed-off-by: Gijs Kunze <gwkunze@gmail.com>