### PR TITLE
Move security/readonly middleware ahead of transaction middleware

### DIFF
--- a/src/core/middlewares/middlewares.go
+++ b/src/core/middlewares/middlewares.go
@@ -74,9 +74,9 @@ func MiddleWares() []beego.MiddleWare {
 		csrf.Middleware(),
 		orm.Middleware(),
 		notification.Middleware(), // notification must ahead of transaction ensure the DB transaction execution complete
-		transaction.Middleware(dbTxSkippers...),
 		artifactinfo.Middleware(),
 		security.Middleware(),
 		readonly.Middleware(readonlySkippers...),
+		transaction.Middleware(dbTxSkippers...),
 	}
 }


### PR DESCRIPTION
In v2.1 security/readonly middleware will query DB by creating new
connection.
If it is put after transaction middleware there's a bigger chance of
deadlock if the concurrent open connections are set too low (#13155)

This commit mitigates that issue.  But we still need work to lower the
connections and better handle the case when http connection is closed.

Signed-off-by: Daniel Jiang <jiangd@vmware.com>