### PR TITLE
Cache manifest list for proxy cache

### DIFF
--- a/src/controller/proxy/local.go
+++ b/src/controller/proxy/local.go
@@ -127,7 +127,7 @@ func (l *localHelper) PushManifest(repo string, ref string, manifest distributio
 
 // DeleteManifest cleanup delete tag from local repo
 func (l *localHelper) DeleteManifest(repo, ref string) {
-	log.Debug("Remove tag from repo if it is exist")
+	log.Debugf("Remove tag from repo if it is exist, repo: %v ref: %v", repo, ref)
 	if err := l.registry.DeleteManifest(repo, ref); err != nil {
 		// sometimes user pull a non-exist image
 		log.Warningf("failed to remove artifact, error %v", err)


### PR DESCRIPTION
Fixes #13566: Quota of dockerhub is still used in v2.1.1 after the image is cached
Cache manifest list in redis cache

Signed-off-by: stonezdj <stonezdj@gmail.com>