### PR TITLE
test(quota): increase sleep time to fix fail of test

### DIFF
--- a/src/controller/quota/controller_test.go
+++ b/src/controller/quota/controller_test.go
@@ -85,7 +85,7 @@ func (suite *ControllerTestSuite) TestGetReservedResources() {
 		suite.Len(resources, 1)
 	}
 
-	time.Sleep(reservedExpiration)
+	time.Sleep(reservedExpiration * 2)
 
 	{
 		resources, err := ctl.getReservedResources(context.TODO(), reference, referenceID)


### PR DESCRIPTION
Increase the sleep time to fix the fail in TestGetReservedResources of
quota

Signed-off-by: He Weiwei <hweiwei@vmware.com>