### PR TITLE
Add py-test for scan manifest list and CNAB bundle

### DIFF
--- a/tests/apitests/python/library/artifact.py
+++ b/tests/apitests/python/library/artifact.py
@@ -107,6 +107,15 @@ class Artifact(base.Base, object):
             if (timeout_count == 0):
                 break
             artifact = self.get_reference_info(project_name, repo_name, reference, **kwargs)
+            if expected_scan_status in ["Not Scanned", "No Scan Overview"]:
+                if artifact.scan_overview is None:
+                    if (timeout_count > 24):
+                        continue
+                    print("artifact is not scanned.")
+                    return
+                else:
+                    raise Exception("Artifact should not be scanned {}.".format(artifact.scan_overview))
+
             scan_status = artifact.scan_overview['application/vnd.scanner.adapter.vuln.report.harbor+json; version=1.0'].scan_status
             if scan_status == expected_scan_status:
                 return

--- a/tests/apitests/python/test_proxy_cache.py
+++ b/tests/apitests/python/test_proxy_cache.py
@@ -127,12 +127,9 @@ class TestProxyCache(unittest.TestCase):
     #def test_proxy_cache_from_dockerhub(self):
     #    self.do_validate("docker-hub")
 
-    def suite():
-        suite = unittest.TestSuite(unittest.makeSuite(TestProxyCache))
-        return suite
-
 if __name__ == '__main__':
-    result = unittest.TextTestRunner(sys.stdout, verbosity=2, failfast=True).run(TestProxyCache.suite())
+    suite = unittest.TestSuite(unittest.makeSuite(TestProxyCache))
+    result = unittest.TextTestRunner(sys.stdout, verbosity=2, failfast=True).run(suite)
     if not result.wasSuccessful():
         raise Exception(r"Proxy cache test failed: ".format(result))
 

--- a/tests/apitests/python/test_push_cnab_bundle.py
+++ b/tests/apitests/python/test_push_cnab_bundle.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-
+import sys
 import unittest
 
 from testutils import ADMIN_CLIENT, suppress_urllib3_warning
@@ -12,31 +12,31 @@ from library.project import Project
 from library.user import User
 from library.repository import Repository
 from library.artifact import Artifact
+from library.scan import Scan
 
-class TestProjects(unittest.TestCase):
+class TestCNAB(unittest.TestCase):
     @suppress_urllib3_warning
     def setUp(self):
-        self.project= Project()
-        self.user= User()
-        self.artifact = Artifact()
-        self.repo= Repository()
-        self.url = ADMIN_CLIENT["endpoint"]
-        self.user_push_cnab_password = "Aa123456"
-        self.cnab_repo_name = "test_cnab"
-        self.cnab_tag = "test_cnab_tag"
+        print("Setup")
 
     @unittest.skipIf(TEARDOWN == False, "Test data won't be erased.")
-    def tearDown(self):
+    def do_tearDown(self):
+        """
+        Tear down:
+            1. Delete repository(RA) by user(UA);
+            2. Delete project(PA);
+            3. Delete user(UA);
+        """
         #1. Delete repository(RA) by user(UA);
-        self.repo.delete_repoitory(TestProjects.project_push_bundle_name, self.cnab_repo_name, **TestProjects.USER_CLIENT)
+        TestCNAB.repo.delete_repoitory(TestCNAB.project_name, TestCNAB.cnab_repo_name, **TestCNAB.USER_CLIENT)
 
         #2. Delete project(PA);
-        self.project.delete_project(TestProjects.project_push_bundle_id, **TestProjects.USER_CLIENT)
+        TestCNAB.project.delete_project(TestCNAB.project_id, **TestCNAB.USER_CLIENT)
 
         #3. Delete user(UA).
-        self.user.delete_user(TestProjects.user_id, **ADMIN_CLIENT)
+        TestCNAB.user.delete_user(TestCNAB.user_id, **ADMIN_CLIENT)
 
-    def testPushBundleByCnab(self):
+    def test_01_PushBundleByCnab(self):
         """
         Test case:
             Push Bundle By Cnab
@@ -48,42 +48,101 @@ class TestProjects(unittest.TestCase):
             5. Verfiy bundle name;
             6. Get artifact by sha256;
             7. Verify artifact information.
-        Tear down:
-            1. Delete repository(RA) by user(UA);
-            2. Delete project(PA);
-            3. Delete user(UA).
         """
-        #1. Create a new user(UA);
-        TestProjects.user_id, user_name = self.user.create_user(user_password = self.user_push_cnab_password, **ADMIN_CLIENT)
-        TestProjects.USER_CLIENT=dict(endpoint = self.url, username = user_name, password = self.user_push_cnab_password)
+        TestCNAB.project= Project()
+        TestCNAB.user= User()
+        TestCNAB.artifact = Artifact()
+        TestCNAB.repo= Repository()
+        TestCNAB.scan = Scan()
+        TestCNAB.url = ADMIN_CLIENT["endpoint"]
+        TestCNAB.user_push_cnab_password = "Aa123456"
+        TestCNAB.cnab_repo_name = "test_cnab"
+        TestCNAB.cnab_tag = "test_cnab_tag"
+        TestCNAB.project_name = None
+        TestCNAB.artifacts_config_ref_child_list = None
+        TestCNAB.artifacts_ref_child_list = None
 
+        #1. Create a new user(UA);
+        TestCNAB.user_id, TestCNAB.user_name = TestCNAB.user.create_user(user_password = TestCNAB.user_push_cnab_password, **ADMIN_CLIENT)
+        TestCNAB.USER_CLIENT=dict(endpoint = TestCNAB.url, username = TestCNAB.user_name, password = TestCNAB.user_push_cnab_password, with_scan_overview = True)
 
         #2. Create a new project(PA) by user(UA);
-        TestProjects.project_push_bundle_id, TestProjects.project_push_bundle_name = self.project.create_project(metadata = {"public": "false"}, **TestProjects.USER_CLIENT)
+        TestCNAB.project_id, TestCNAB.project_name = TestCNAB.project.create_project(metadata = {"public": "false"}, **TestCNAB.USER_CLIENT)
 
         #3. Push bundle to harbor as repository(RA);
-        target = harbor_server + "/" + TestProjects.project_push_bundle_name  + "/" + self.cnab_repo_name  + ":" + self.cnab_tag
-        reference_sha256 = library.cnab.push_cnab_bundle(harbor_server, user_name, self.user_push_cnab_password, "photon:latest", "kong:latest", target)
+        target = harbor_server + "/" + TestCNAB.project_name  + "/" + TestCNAB.cnab_repo_name  + ":" + TestCNAB.cnab_tag
+        TestCNAB.reference_sha256 = library.cnab.push_cnab_bundle(harbor_server, TestCNAB.user_name, TestCNAB.user_push_cnab_password, "photon:latest", "kong:latest", target)
 
         #4. Get repository from Harbor successfully;
-        index_data = self.repo.get_repository(TestProjects.project_push_bundle_name, self.cnab_repo_name, **TestProjects.USER_CLIENT)
+        TestCNAB.cnab_bundle_data = TestCNAB.repo.get_repository(TestCNAB.project_name, TestCNAB.cnab_repo_name, **TestCNAB.USER_CLIENT)
+        print(TestCNAB.cnab_bundle_data)
+
+        #4.1 Get refs of CNAB bundle;
+        TestCNAB.artifacts = TestCNAB.artifact.list_artifacts(TestCNAB.project_name, TestCNAB.cnab_repo_name, **TestCNAB.USER_CLIENT)
+        print("artifacts:", TestCNAB.artifacts)
+        TestCNAB.artifacts_ref_child_list = []
+        TestCNAB.artifacts_config_ref_child_list = []
+        for ref in TestCNAB.artifacts[0].references:
+            if ref.annotations["io.cnab.manifest.type"] != 'config':
+                TestCNAB.artifacts_ref_child_list.append(ref.child_digest)
+            else:
+                TestCNAB.artifacts_config_ref_child_list.append(ref.child_digest)
+        self.assertEqual(len(TestCNAB.artifacts_ref_child_list), 2, msg="Image artifact count should be 2.")
+        self.assertEqual(len(TestCNAB.artifacts_config_ref_child_list), 1, msg="Bundle count should be 1.")
+        print(TestCNAB.artifacts_ref_child_list)
 
         #4.2 Cnab bundle can be pulled by ctr successfully;
         # This step might not successful since ctr does't support cnab fully, it might be uncomment sometime in future.
         # Please keep them in comment!
-        #library.containerd.ctr_images_pull(user_name, self.user_push_cnab_password, target)
+        #library.containerd.ctr_images_pull(TestCNAB.user_name, TestCNAB.user_push_cnab_password, target)
         #library.containerd.ctr_images_list(oci_ref = target)
 
         #5. Verfiy bundle name;
-        self.assertEqual(index_data.name, TestProjects.project_push_bundle_name + "/" + self.cnab_repo_name)
+        self.assertEqual(TestCNAB.cnab_bundle_data.name, TestCNAB.project_name + "/" + TestCNAB.cnab_repo_name)
 
         #6. Get artifact by sha256;
-        artifact = self.artifact.get_reference_info(TestProjects.project_push_bundle_name, self.cnab_repo_name, reference_sha256, **TestProjects.USER_CLIENT)
+        artifact = TestCNAB.artifact.get_reference_info(TestCNAB.project_name, TestCNAB.cnab_repo_name, TestCNAB.reference_sha256, **TestCNAB.USER_CLIENT)
 
         #7. Verify artifact information;
         self.assertEqual(artifact.type, 'CNAB')
-        self.assertEqual(artifact.digest, reference_sha256)
+        self.assertEqual(artifact.digest, TestCNAB.reference_sha256)
+
+    def test_02_ScanCNAB(self):
+        """
+        Test case:
+            Scan CNAB
+        Test step and expected result:
+            1. Scan config artifact, it should be failed with 400 status code;
+            2. Scan 1st child artifact, it should be scanned, the other should be not scanned, repository should not be scanned;
+            3. Scan 2cn child artifact, it should be scanned, repository should not be scanned;
+            4. Scan repository, it should be scanned;
+        Tear down:
+        """
+        #1. Scan config artifact, it should be failed with 400 status code;
+        TestCNAB.scan.scan_artifact(TestCNAB.project_name, TestCNAB.cnab_repo_name, TestCNAB.artifacts_config_ref_child_list[0], expect_status_code = 400, **TestCNAB.USER_CLIENT)
+
+        #2. Scan 1st child artifact, it should be scanned, the other should be not scanned, repository should not be scanned;
+        TestCNAB.scan.scan_artifact(TestCNAB.project_name, TestCNAB.cnab_repo_name, TestCNAB.artifacts_ref_child_list[0], **TestCNAB.USER_CLIENT)
+        TestCNAB.artifact.check_image_scan_result(TestCNAB.project_name, TestCNAB.cnab_repo_name, TestCNAB.artifacts_ref_child_list[0], **TestCNAB.USER_CLIENT)
+        TestCNAB.artifact.check_image_scan_result(TestCNAB.project_name, TestCNAB.cnab_repo_name, TestCNAB.artifacts_ref_child_list[1], expected_scan_status = "Not Scanned", **TestCNAB.USER_CLIENT)
+        TestCNAB.artifact.check_image_scan_result(TestCNAB.project_name, TestCNAB.cnab_repo_name, TestCNAB.artifacts_config_ref_child_list[0], expected_scan_status = "No Scan Overview", **TestCNAB.USER_CLIENT)
+        TestCNAB.artifact.check_image_scan_result(TestCNAB.project_name, TestCNAB.cnab_repo_name, TestCNAB.artifacts[0].digest, expected_scan_status = "Not Scanned", **TestCNAB.USER_CLIENT)
+
+        #3. Scan 2cn child artifact, it should be scanned, repository should not be scanned;
+        TestCNAB.scan.scan_artifact(TestCNAB.project_name, TestCNAB.cnab_repo_name, TestCNAB.artifacts_ref_child_list[1], **TestCNAB.USER_CLIENT)
+        TestCNAB.artifact.check_image_scan_result(TestCNAB.project_name, TestCNAB.cnab_repo_name, TestCNAB.artifacts_ref_child_list[1], **TestCNAB.USER_CLIENT)
+        TestCNAB.artifact.check_image_scan_result(TestCNAB.project_name, TestCNAB.cnab_repo_name, TestCNAB.artifacts_config_ref_child_list[0], expected_scan_status = "No Scan Overview", **TestCNAB.USER_CLIENT)
+        TestCNAB.artifact.check_image_scan_result(TestCNAB.project_name, TestCNAB.cnab_repo_name, TestCNAB.artifacts[0].digest, expected_scan_status = "Not Scanned", **TestCNAB.USER_CLIENT)
+
+        #4. Scan repository, it should be scanned;
+        TestCNAB.scan.scan_artifact(TestCNAB.project_name, TestCNAB.cnab_repo_name, TestCNAB.artifacts[0].digest, **TestCNAB.USER_CLIENT)
+        TestCNAB.artifact.check_image_scan_result(TestCNAB.project_name, TestCNAB.cnab_repo_name, TestCNAB.artifacts[0].digest, **TestCNAB.USER_CLIENT)
+
+        self.do_tearDown()
 
 if __name__ == '__main__':
-    unittest.main()
+    suite = unittest.TestSuite(unittest.makeSuite(TestCNAB))
+    result = unittest.TextTestRunner(sys.stdout, verbosity=2, failfast=True).run(suite)
+    if not result.wasSuccessful():
+        raise Exception(r"CNAB test failed: {}".format(result))
 

--- a/tests/apitests/python/test_push_index_by_docker_manifest.py
+++ b/tests/apitests/python/test_push_index_by_docker_manifest.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-
+import sys
 import unittest
 
 from testutils import ADMIN_CLIENT, suppress_urllib3_warning
@@ -16,35 +16,33 @@ from library.repository import Repository
 from library.artifact import Artifact
 from library.repository import push_self_build_image_to_project
 from library.repository import pull_harbor_image
+from library.scan import Scan
 
-class TestProjects(unittest.TestCase):
+class TestManifest(unittest.TestCase):
     @suppress_urllib3_warning
     def setUp(self):
-        self.project= Project()
-        self.user= User()
-        self.artifact = Artifact()
-        self.repo= Repository()
-        self.url = ADMIN_CLIENT["endpoint"]
-        self.user_push_index_password = "Aa123456"
-        self.index_name = "ci_test_index"
-        self.index_tag = "test_tag"
-        self.image_a = "alpine"
-        self.image_b = "busybox"
+        print("Setup")
 
     @unittest.skipIf(TEARDOWN == False, "Test data won't be erased.")
-    def tearDown(self):
+    def do_tearDown(self):
+        """
+        Tear down:
+            1. Delete repository(RA,RB,IA) by user(UA);
+            2. Delete project(PA);
+            3. Delete user(UA).
+        """
         #1. Delete repository(RA,RB,IA) by user(UA);
-        self.repo.delete_repoitory(TestProjects.project_push_index_name, self.index_name, **TestProjects.USER_CLIENT)
-        self.repo.delete_repoitory(TestProjects.project_push_index_name, self.image_a, **TestProjects.USER_CLIENT)
-        self.repo.delete_repoitory(TestProjects.project_push_index_name, self.image_b, **TestProjects.USER_CLIENT)
+        TestManifest.repo.delete_repoitory(TestManifest.project_name, TestManifest.index_name, **TestManifest.USER_CLIENT)
+        TestManifest.repo.delete_repoitory(TestManifest.project_name, TestManifest.image_a, **TestManifest.USER_CLIENT)
+        TestManifest.repo.delete_repoitory(TestManifest.project_name, TestManifest.image_b, **TestManifest.USER_CLIENT)
 
         #2. Delete project(PA);
-        self.project.delete_project(TestProjects.project_push_index_id, **TestProjects.USER_CLIENT)
+        TestManifest.project.delete_project(TestManifest.project_id, **TestManifest.USER_CLIENT)
 
         #3. Delete user(UA).
-        self.user.delete_user(TestProjects.user_id, **ADMIN_CLIENT)
+        TestManifest.user.delete_user(TestManifest.user_id, **ADMIN_CLIENT)
 
-    def testAddIndexByDockerManifest(self):
+    def test_01_AddIndexByDockerManifest(self):
         """
         Test case:
             Push Index By Docker Manifest
@@ -66,70 +64,110 @@ class TestProjects(unittest.TestCase):
             2. Delete project(PA);
             3. Delete user(UA).
         """
-        #1. Create a new user(UA);
-        TestProjects.user_id, user_name = self.user.create_user(user_password = self.user_push_index_password, **ADMIN_CLIENT)
+        TestManifest.project= Project()
+        TestManifest.user= User()
+        TestManifest.artifact = Artifact()
+        TestManifest.repo= Repository()
+        TestManifest.scan = Scan()
+        TestManifest.url = ADMIN_CLIENT["endpoint"]
+        TestManifest.user_push_index_password = "Aa123456"
+        TestManifest.index_name = "ci_test_index"
+        TestManifest.index_tag = "test_tag"
+        TestManifest.image_a = "alpine"
+        TestManifest.image_b = "busybox"
 
-        TestProjects.USER_CLIENT=dict(endpoint = self.url, username = user_name, password = self.user_push_index_password)
+        #1. Create a new user(UA);
+        TestManifest.user_id, TestManifest.user_name = TestManifest.user.create_user(user_password = TestManifest.user_push_index_password, **ADMIN_CLIENT)
+
+        TestManifest.USER_CLIENT=dict(endpoint = TestManifest.url, username = TestManifest.user_name, password = TestManifest.user_push_index_password, with_scan_overview = True)
 
         #2. Create a new project(PA) by user(UA);
-        TestProjects.project_push_index_id, TestProjects.project_push_index_name = self.project.create_project(metadata = {"public": "false"}, **TestProjects.USER_CLIENT)
+        TestManifest.project_id, TestManifest.project_name = TestManifest.project.create_project(metadata = {"public": "false"}, **TestManifest.USER_CLIENT)
 
         #3. Create 2 new repositorys(RA,RB) in project(PA) by user(UA);
-        repo_name_a, tag_a = push_self_build_image_to_project(TestProjects.project_push_index_name, harbor_server, 'admin', 'Harbor12345', self.image_a, "latest")
-        repo_name_b, tag_b = push_self_build_image_to_project(TestProjects.project_push_index_name, harbor_server, 'admin', 'Harbor12345', self.image_b, "latest")
+        repo_name_a, tag_a = push_self_build_image_to_project(TestManifest.project_name, harbor_server, 'admin', 'Harbor12345', TestManifest.image_a, "latest")
+        repo_name_b, tag_b = push_self_build_image_to_project(TestManifest.project_name, harbor_server, 'admin', 'Harbor12345', TestManifest.image_b, "latest")
 
         #4. Push an index(IA) to Harbor by docker manifest CLI successfully;
         manifests = [harbor_server+"/"+repo_name_a+":"+tag_a, harbor_server+"/"+repo_name_b+":"+tag_b]
-        index = harbor_server+"/"+TestProjects.project_push_index_name+"/"+self.index_name+":"+self.index_tag
-        index_sha256_cli_ret, manifests_sha256_cli_ret = library.docker_api.docker_manifest_push_to_harbor(index, manifests, harbor_server, user_name, self.user_push_index_password)
+        index = harbor_server+"/"+TestManifest.project_name+"/"+TestManifest.index_name+":"+TestManifest.index_tag
+        TestManifest.index_sha256_cli_ret, TestManifest.manifests_sha256_cli_ret = library.docker_api.docker_manifest_push_to_harbor(index, manifests, harbor_server, TestManifest.user_name, TestManifest.user_push_index_password)
 
         #5. Get Artifacts successfully;
-        artifacts = self.artifact.list_artifacts(TestProjects.project_push_index_name, self.index_name, **TestProjects.USER_CLIENT)
-        artifacts_ref_child_list = [artifacts[0].references[1].child_digest, artifacts[0].references[0].child_digest]
-        self.assertEqual(artifacts_ref_child_list.count(manifests_sha256_cli_ret[0]), 1)
-        self.assertEqual(artifacts_ref_child_list.count(manifests_sha256_cli_ret[1]), 1)
+        artifacts = TestManifest.artifact.list_artifacts(TestManifest.project_name, TestManifest.index_name, **TestManifest.USER_CLIENT)
+        TestManifest.artifacts_ref_child_list = [artifacts[0].references[1].child_digest, artifacts[0].references[0].child_digest]
+        self.assertEqual(TestManifest.artifacts_ref_child_list.count(TestManifest.manifests_sha256_cli_ret[0]), 1)
+        self.assertEqual(TestManifest.artifacts_ref_child_list.count(TestManifest.manifests_sha256_cli_ret[1]), 1)
 
         #6. Get index(IA) by reference successfully;
-        index_data = self.artifact.get_reference_info(TestProjects.project_push_index_name, self.index_name, self.index_tag, **TestProjects.USER_CLIENT)
-        print("===========index_data:",index_data)
+        index_data = TestManifest.artifact.get_reference_info(TestManifest.project_name, TestManifest.index_name, TestManifest.index_tag, **TestManifest.USER_CLIENT)
+        print("index_data:",index_data)
         manifests_sha256_harbor_ret = [index_data.references[1].child_digest, index_data.references[0].child_digest]
 
         #7. Verify harbor index is index(IA) pushed by docker manifest CLI;
-        self.assertEqual(index_data.digest, index_sha256_cli_ret)
-        self.assertEqual(manifests_sha256_harbor_ret.count(manifests_sha256_cli_ret[0]), 1)
-        self.assertEqual(manifests_sha256_harbor_ret.count(manifests_sha256_cli_ret[1]), 1)
+        self.assertEqual(index_data.digest, TestManifest.index_sha256_cli_ret)
+        self.assertEqual(manifests_sha256_harbor_ret.count(TestManifest.manifests_sha256_cli_ret[0]), 1)
+        self.assertEqual(manifests_sha256_harbor_ret.count(TestManifest.manifests_sha256_cli_ret[1]), 1)
 
         #8.1 Verify harbor index(IA) can be pulled by docker CLI successfully;
-        pull_harbor_image(harbor_server, user_name, self.user_push_index_password, TestProjects.project_push_index_name+"/"+self.index_name, self.index_tag)
+        pull_harbor_image(harbor_server, TestManifest.user_name, TestManifest.user_push_index_password, TestManifest.project_name+"/"+TestManifest.index_name, TestManifest.index_tag)
 
         #8.2 Verify harbor index(IA) can be pulled by ctr successfully;
-        oci_ref = harbor_server+"/"+TestProjects.project_push_index_name+"/"+self.index_name+":"+self.index_tag
-        library.containerd.ctr_images_pull(user_name, self.user_push_index_password, oci_ref)
+        oci_ref = harbor_server+"/"+TestManifest.project_name+"/"+TestManifest.index_name+":"+TestManifest.index_tag
+        library.containerd.ctr_images_pull(TestManifest.user_name, TestManifest.user_push_index_password, oci_ref)
         library.containerd.ctr_images_list(oci_ref = oci_ref)
 
         #9. Get addition successfully;
-        addition_v = self.artifact.get_addition(TestProjects.project_push_index_name, self.index_name, self.index_tag, "vulnerabilities", **TestProjects.USER_CLIENT)
+        addition_v = TestManifest.artifact.get_addition(TestManifest.project_name, TestManifest.index_name, TestManifest.index_tag, "vulnerabilities", **TestManifest.USER_CLIENT)
         self.assertEqual(addition_v[0], '{}')
         #This artifact has no build history
 
-        addition_v = self.artifact.get_addition(TestProjects.project_push_index_name, self.index_name, manifests_sha256_cli_ret[0], "vulnerabilities", **TestProjects.USER_CLIENT)
+        addition_v = TestManifest.artifact.get_addition(TestManifest.project_name, TestManifest.index_name, TestManifest.manifests_sha256_cli_ret[0], "vulnerabilities", **TestManifest.USER_CLIENT)
         self.assertEqual(addition_v[0], '{}')
-        addition_b = self.artifact.get_addition(TestProjects.project_push_index_name, self.index_name, manifests_sha256_cli_ret[0], "build_history", **TestProjects.USER_CLIENT)
+        addition_b = TestManifest.artifact.get_addition(TestManifest.project_name, TestManifest.index_name, TestManifest.manifests_sha256_cli_ret[0], "build_history", **TestManifest.USER_CLIENT)
         self.assertIn("ADD file:", addition_b[0])
-        image_data = self.artifact.get_reference_info(TestProjects.project_push_index_name, self.index_name, manifests_sha256_cli_ret[0], **TestProjects.USER_CLIENT)
+        image_data = TestManifest.artifact.get_reference_info(TestManifest.project_name, TestManifest.index_name, TestManifest.manifests_sha256_cli_ret[0], **TestManifest.USER_CLIENT)
 
-        addition_v = self.artifact.get_addition(TestProjects.project_push_index_name, self.index_name, manifests_sha256_cli_ret[1], "vulnerabilities", **TestProjects.USER_CLIENT)
+        addition_v = TestManifest.artifact.get_addition(TestManifest.project_name, TestManifest.index_name, TestManifest.manifests_sha256_cli_ret[1], "vulnerabilities", **TestManifest.USER_CLIENT)
         self.assertEqual(addition_v[0], '{}')
-        addition_b = self.artifact.get_addition(TestProjects.project_push_index_name, self.index_name, manifests_sha256_cli_ret[1], "build_history", **TestProjects.USER_CLIENT)
+        addition_b = TestManifest.artifact.get_addition(TestManifest.project_name, TestManifest.index_name, TestManifest.manifests_sha256_cli_ret[1], "build_history", **TestManifest.USER_CLIENT)
         self.assertIn("ADD file:", addition_b[0])
-        image_data = self.artifact.get_reference_info(TestProjects.project_push_index_name, self.index_name, manifests_sha256_cli_ret[0], **TestProjects.USER_CLIENT)
+        image_data = TestManifest.artifact.get_reference_info(TestManifest.project_name, TestManifest.index_name, TestManifest.manifests_sha256_cli_ret[0], **TestManifest.USER_CLIENT)
 
+    @unittest.skipIf(TEARDOWN == True, "Test data won't be erased.")
+    def test_99_ManifestDeletion(self):
         #10. Unable to Delete artifact in manifest list;
-        self.artifact.delete_artifact(TestProjects.project_push_index_name, self.index_name, manifests_sha256_cli_ret[0], expect_status_code = 412, **TestProjects.USER_CLIENT)
+        TestManifest.artifact.delete_artifact(TestManifest.project_name, TestManifest.index_name, TestManifest.manifests_sha256_cli_ret[0], expect_status_code = 412, **TestManifest.USER_CLIENT)
 
         #11. Delete index successfully.
-        self.artifact.delete_artifact(TestProjects.project_push_index_name, self.index_name, self.index_tag, **TestProjects.USER_CLIENT)
+        TestManifest.artifact.delete_artifact(TestManifest.project_name, TestManifest.index_name, TestManifest.index_tag, **TestManifest.USER_CLIENT)
+
+        TestManifest.do_tearDown()
+
+    def test_02_ScanManifestList(self):
+        """
+        Test case:
+            Scan Manifest List
+        Test step and expected result:
+            1. Scan 1st child artifact, it should be scanned, 2nd child should be Not Scanned, index should be Not Scanned;
+            2. Scan 2nd child artifact, it should be scanned, index should be scanned;
+        """
+        #1. Scan 1st child artifact, it should be scanned, 2nd child should be Not Scanned, index should be Not Scanned;
+        TestManifest.scan.scan_artifact(TestManifest.project_name, TestManifest.index_name, TestManifest.artifacts_ref_child_list[0], **TestManifest.USER_CLIENT)
+        TestManifest.artifact.check_image_scan_result(TestManifest.project_name, TestManifest.index_name, TestManifest.artifacts_ref_child_list[0], **TestManifest.USER_CLIENT)
+
+        TestManifest.artifact.check_image_scan_result(TestManifest.project_name, TestManifest.index_name, TestManifest.artifacts_ref_child_list[1], expected_scan_status = "Not Scanned", **TestManifest.USER_CLIENT)
+        TestManifest.artifact.check_image_scan_result(TestManifest.project_name, TestManifest.index_name, TestManifest.index_sha256_cli_ret, expected_scan_status = "Not Scanned", **TestManifest.USER_CLIENT)
+
+        #2. Scan 2nd child artifact, it should be scanned, index should be scanned;
+        TestManifest.scan.scan_artifact(TestManifest.project_name, TestManifest.index_name, TestManifest.artifacts_ref_child_list[1], **TestManifest.USER_CLIENT)
+        TestManifest.artifact.check_image_scan_result(TestManifest.project_name, TestManifest.index_name, TestManifest.artifacts_ref_child_list[1], **TestManifest.USER_CLIENT)
+        TestManifest.artifact.check_image_scan_result(TestManifest.project_name, TestManifest.index_name, TestManifest.index_sha256_cli_ret, **TestManifest.USER_CLIENT)
+
 
 if __name__ == '__main__':
-    unittest.main()
+    suite = unittest.TestSuite(unittest.makeSuite(TestManifest))
+    result = unittest.TextTestRunner(sys.stdout, verbosity=2, failfast=True).run(suite)
+    if not result.wasSuccessful():
+        raise Exception(r"Manifest test failed: {}".format(result))
 

--- a/tests/apitests/python/test_scan_image_artifact.py
+++ b/tests/apitests/python/test_scan_image_artifact.py
@@ -24,7 +24,7 @@ class TestScan(unittest.TestCase):
 
         self.url = ADMIN_CLIENT["endpoint"]
         self.user_password = "Aa123456"
-        self.project_id, self.project_name, self.user_id, self.user_name, self.repo_name1, self.repo_name2 = [None] * 6
+        self.project_id, self.project_name, self.user_id, self.user_name, self.repo_name1 = [None] * 5
         self.user_id, self.user_name = self.user.create_user(user_password = self.user_password, **ADMIN_CLIENT)
         self.USER_CLIENT = dict(with_signature = True, with_immutable_status = True, endpoint = self.url, username = self.user_name, password = self.user_password, with_scan_overview = True)
 
@@ -35,11 +35,10 @@ class TestScan(unittest.TestCase):
         #3. Add user(UA) as a member of project(PA) with project-admin role;
         self.project.add_project_members(self.project_id, user_id = self.user_id, **ADMIN_CLIENT)
 
-    @unittest.skipIf(TEARDOWN == True, "Test data won't be erased.")
+    @unittest.skipIf(TEARDOWN == False, "Test data won't be erased.")
     def do_tearDown(self):
         #1. Delete repository(RA) by user(UA);
         self.repo.delete_repoitory(self.project_name, self.repo_name1.split('/')[1], **self.USER_CLIENT)
-        self.repo.delete_repoitory(self.project_name, self.repo_name2.split('/')[1], **self.USER_CLIENT)
 
         #2. Delete project(PA);
         self.project.delete_project(self.project_id, **self.USER_CLIENT)


### PR DESCRIPTION
Due to complicate logic of scan report in multi-level artifacts, should add scan tests
for into manifest list and CNAB bundle python test suit.

Fixed issue: #13764
Signed-off-by: danfengliu <danfengl@vmware.com>