### PR TITLE
fix_tencenttcr_getAdapterInfo

### DIFF
--- a/src/replication/adapter/tencentcr/adapter.go
+++ b/src/replication/adapter/tencentcr/adapter.go
@@ -53,7 +53,7 @@ func (f *factory) AdapterPattern() *model.AdapterPattern {
 }
 
 func getAdapterInfo() *model.AdapterPattern {
-	return &model.AdapterPattern{}
+	return nil
 }
 
 type adapter struct {


### PR DESCRIPTION
close #13758
for standard adapter that don't have any specific credential or endpoint, it should return null in getAdapterInfo()
although currently no impact for GUI

![image](https://user-images.githubusercontent.com/188115/102057216-8e2f2380-3e28-11eb-91f2-f5a87b832991.png)

