### PR TITLE
migration admin job data

### DIFF
--- a/src/controller/gc/model.go
+++ b/src/controller/gc/model.go
@@ -7,7 +7,7 @@ import (
 // Policy ...
 type Policy struct {
 	Trigger        *Trigger               `json:"trigger"`
-	DeleteUntagged bool                   `json:"bool"`
+	DeleteUntagged bool                   `json:"deleteuntagged"`
 	DryRun         bool                   `json:"dryrun"`
 	ExtraAttrs     map[string]interface{} `json:"extra_attrs"`
 }


### PR DESCRIPTION
1, migrate gc and scan all schedule to schedule/task/exectuion
2, migrate gc history to task/execution

Signed-off-by: Wang Yan <wangyan@vmware.com>