### PR TITLE
fix gc log not found issue

### DIFF
--- a/src/controller/gc/controller.go
+++ b/src/controller/gc/controller.go
@@ -37,6 +37,8 @@ type Controller interface {
 
 	// GetTask gets the specific task
 	GetTask(ctx context.Context, id int64) (*Task, error)
+	// ListTasks lists the tasks according to the query
+	ListTasks(ctx context.Context, query *q.Query) (tasks []*Task, err error)
 	// GetTaskLog gets log of the specific task
 	GetTaskLog(ctx context.Context, id int64) ([]byte, error)
 
@@ -149,6 +151,21 @@ func (c *controller) GetTask(ctx context.Context, id int64) (*Task, error) {
 			WithMessage("garbage collection task %d not found", id)
 	}
 	return convertTask(tasks[0]), nil
+}
+
+// ListTasks ...
+func (c *controller) ListTasks(ctx context.Context, query *q.Query) ([]*Task, error) {
+	query = q.MustClone(query)
+	query.Keywords["VendorType"] = GCVendorType
+	tks, err := c.taskMgr.List(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	var tasks []*Task
+	for _, tk := range tks {
+		tasks = append(tasks, convertTask(tk))
+	}
+	return tasks, nil
 }
 
 // GetTaskLog ...

--- a/src/controller/gc/controller_test.go
+++ b/src/controller/gc/controller_test.go
@@ -111,6 +111,22 @@ func (g *gcCtrTestSuite) TestListExecutions() {
 	g.Equal("Manual", hs[0].Trigger)
 }
 
+func (g *gcCtrTestSuite) TestListTasks() {
+	g.taskMgr.On("List", mock.Anything, mock.Anything).Return([]*task.Task{
+		{
+			ID:          1,
+			ExecutionID: 1,
+			Status:      job.RunningStatus.String(),
+		},
+	}, nil)
+	tasks, err := g.ctl.ListTasks(nil, nil)
+	g.Require().Nil(err)
+	g.Require().Len(tasks, 1)
+	g.Equal(int64(1), tasks[0].ID)
+	g.Equal(int64(1), tasks[0].ExecutionID)
+	g.taskMgr.AssertExpectations(g.T())
+}
+
 func (g *gcCtrTestSuite) TestGetSchedule() {
 	g.scheduler.On("ListSchedules", mock.Anything, mock.Anything).Return([]*scheduler.Schedule{
 		{


### PR DESCRIPTION
It needs to use the execution ID to get task firstly and then use the required task id to query GC log

Signed-off-by: Wang Yan <wangyan@vmware.com>