### PR TITLE
GitLab replication adapter: improve projects search

### DIFF
--- a/src/replication/adapter/gitlab/client.go
+++ b/src/replication/adapter/gitlab/client.go
@@ -100,7 +100,7 @@ func (c *Client) getProjects() ([]*Project, error) {
 
 func (c *Client) getProjectsByName(name string) ([]*Project, error) {
 	var projects []*Project
-	urlAPI := fmt.Sprintf("%s/api/v4/projects?search=%s&membership=1&per_page=50", c.url, name)
+	urlAPI := fmt.Sprintf("%s/api/v4/projects?search=%s&search_namespaces=1&membership=1&per_page=50", c.url, name)
 	if err := c.GetAndIteratePagination(urlAPI, &projects); err != nil {
 		return nil, err
 	}
@@ -151,6 +151,7 @@ func (c *Client) GetAndIteratePagination(endpoint string, v interface{}) error {
 		if err != nil {
 			return err
 		}
+
 		defer resp.Body.Close()
 		data, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
@@ -178,5 +179,6 @@ func (c *Client) GetAndIteratePagination(endpoint string, v interface{}) error {
 		}
 	}
 	rv.Elem().Set(resources)
+
 	return nil
 }


### PR DESCRIPTION
Adds a query parameter to search in ancestor namespaces which should
find projects in subgroups matching a name filter component.