### PR TITLE
Replace tilde in install_cert.sh

### DIFF
--- a/make/photon/common/install_cert.sh
+++ b/make/photon/common/install_cert.sh
@@ -7,11 +7,13 @@ if ! grep -q "Photon" /etc/lsb-release; then
     exit 0
 fi
 
-if [ ! -f ~/ca-bundle.crt.original ]; then
-    cp /etc/pki/tls/certs/ca-bundle.crt ~/ca-bundle.crt.original
+ORIGINAL_LOCATION=$(dirname "$0")
+
+if [ ! -f $ORIGINAL_LOCATION/ca-bundle.crt.original ]; then
+    cp /etc/pki/tls/certs/ca-bundle.crt $ORIGINAL_LOCATION/ca-bundle.crt.original
 fi
 
-cp ~/ca-bundle.crt.original /etc/pki/tls/certs/ca-bundle.crt
+cp $ORIGINAL_LOCATION/ca-bundle.crt.original /etc/pki/tls/certs/ca-bundle.crt
 
 # Install /etc/harbor/ssl/{component}/ca.crt to trust CA.
 echo "Appending internal tls trust CA to ca-bundle ..."


### PR DESCRIPTION
This commit fixes #13287 to remove the usage of tilde as the $HOME is not available in some
cases.  More details see #13287

Signed-off-by: Daniel Jiang <jiangd@vmware.com>