### PR TITLE
Replace tilde in install_cert.sh

### DIFF
--- a/make/photon/common/install_cert.sh
+++ b/make/photon/common/install_cert.sh
@@ -7,11 +7,13 @@ if ! grep -q "Photon" /etc/lsb-release; then
     exit 0
 fi
 
-if [ ! -f ~/ca-bundle.crt.original ]; then
-    cp /etc/pki/tls/certs/ca-bundle.crt ~/ca-bundle.crt.original
+ORIGINAL_LOCATION=$(dirname "$0")
+
+if [ ! -f $ORIGINAL_LOCATION/ca-bundle.crt.original ]; then
+    cp /etc/pki/tls/certs/ca-bundle.crt $ORIGINAL_LOCATION/ca-bundle.crt.original
 fi
 
-cp ~/ca-bundle.crt.original /etc/pki/tls/certs/ca-bundle.crt
+cp $ORIGINAL_LOCATION/ca-bundle.crt.original /etc/pki/tls/certs/ca-bundle.crt
 
 # Install /etc/harbor/ssl/{component}/ca.crt to trust CA.
 echo "Appending internal tls trust CA to ca-bundle ..."

--- a/make/photon/core/Dockerfile
+++ b/make/photon/core/Dockerfile
@@ -11,9 +11,10 @@ COPY ./make/migrations /harbor/migrations
 COPY ./icons /harbor/icons
 
 RUN chown -R harbor:harbor /etc/pki/tls/certs \
-    && chown harbor:harbor /harbor/entrypoint.sh && chmod u+x /harbor/entrypoint.sh \
-    && chown harbor:harbor /harbor/install_cert.sh && chmod u+x /harbor/install_cert.sh \
-    && chown harbor:harbor /harbor/harbor_core && chmod u+x /harbor/harbor_core
+    && chown -R harbor:harbor /harbor/ \
+    && chmod u+x /harbor/entrypoint.sh \
+    && chmod u+x /harbor/install_cert.sh \
+    && chmod u+x /harbor/harbor_core
 
 WORKDIR /harbor/
 USER harbor

--- a/make/photon/jobservice/Dockerfile
+++ b/make/photon/jobservice/Dockerfile
@@ -8,9 +8,10 @@ COPY ./make/photon/jobservice/harbor_jobservice /harbor/
 
 
 RUN chown -R harbor:harbor /etc/pki/tls/certs \
-    && chown harbor:harbor /harbor/entrypoint.sh && chmod u+x /harbor/entrypoint.sh \
-    && chown harbor:harbor /harbor/install_cert.sh && chmod u+x /harbor/install_cert.sh \
-    && chown harbor:harbor /harbor/harbor_jobservice && chmod u+x /harbor/harbor_jobservice
+    && chown -R harbor:harbor /harbor/ \
+    && chmod u+x /harbor/entrypoint.sh \
+    && chmod u+x /harbor/install_cert.sh \
+    && chmod u+x /harbor/harbor_jobservice
 
 WORKDIR /harbor/
 


### PR DESCRIPTION
This commit fixes #13287 to remove the usage of tilde as the $HOME is not available in some
cases.  More details see #13287

Signed-off-by: Daniel Jiang <jiangd@vmware.com>