### PR TITLE
Fix docker20 policy check

### DIFF
--- a/src/server/registry/route.go
+++ b/src/server/registry/route.go
@@ -54,6 +54,8 @@ func RegisterRoutes() {
 		Method(http.MethodHead).
 		Path("/*/manifests/:reference").
 		Middleware(repoproxy.ManifestMiddleware()).
+		Middleware(contenttrust.Middleware()).
+		Middleware(vulnerable.Middleware()).
 		HandlerFunc(getManifest)
 	root.NewRoute().
 		Method(http.MethodDelete).


### PR DESCRIPTION
For docker client v20, it sends the head manifest rather than get manifest during pull image, to make sure the vul and ct middleware work,
it has to intercept the head manifest request.

Signed-off-by: Wang Yan <wangyan@vmware.com>