### PR TITLE
Refine the token scope generation -- cherrypick to 1.10

### DIFF
--- a/src/core/service/token/authutils.go
+++ b/src/core/service/token/authutils.go
@@ -122,23 +122,6 @@ func MakeToken(username, service string, access []*token.ResourceActions) (*mode
 	}, nil
 }
 
-func permToActions(p string) []string {
-	res := []string{}
-	if strings.Contains(p, "W") {
-		res = append(res, "push")
-	}
-	if strings.Contains(p, "M") {
-		res = append(res, "*")
-	}
-	if strings.Contains(p, "R") {
-		res = append(res, "pull")
-	}
-	if strings.Contains(p, "S") {
-		res = append(res, "scanner-pull")
-	}
-	return res
-}
-
 // make token core
 func makeTokenCore(issuer, subject, audience string, expiration int,
 	access []*token.ResourceActions, signingKey libtrust.PrivateKey) (t *token.Token, expiresIn int, issuedAt *time.Time, err error) {

--- a/src/core/service/token/creator.go
+++ b/src/core/service/token/creator.go
@@ -33,6 +33,14 @@ import (
 var creatorMap map[string]Creator
 var registryFilterMap map[string]accessFilter
 var notaryFilterMap map[string]accessFilter
+var actionScopeMap = map[rbac.Action]string{
+	// Scopes checked by distribution, see: https://github.com/docker/distribution/blob/master/registry/handlers/app.go
+	rbac.ActionPull:   "pull",
+	rbac.ActionPush:   "push",
+	rbac.ActionDelete: "delete",
+	// For skipping policy check when scanner pulls artifacts
+	rbac.ActionScannerPull: "scanner-pull",
+}
 
 const (
 	// Notary service
@@ -160,7 +168,6 @@ func (rep repositoryFilter) filter(ctx security.Context, pm promgr.ProjectManage
 		return err
 	}
 	projectName := img.namespace
-	permission := ""
 
 	project, err := pm.Get(projectName)
 	if err != nil {
@@ -171,20 +178,23 @@ func (rep repositoryFilter) filter(ctx security.Context, pm promgr.ProjectManage
 		a.Actions = []string{}
 		return nil
 	}
-
 	resource := rbac.NewProjectNamespace(project.ProjectID).Resource(rbac.ResourceRepository)
-	if ctx.Can(rbac.ActionPush, resource) && ctx.Can(rbac.ActionPull, resource) {
-		permission = "RWM"
-	} else if ctx.Can(rbac.ActionPush, resource) {
-		permission = "RW"
-	} else if ctx.Can(rbac.ActionScannerPull, resource) {
-		permission = "RS"
-	} else if ctx.Can(rbac.ActionPull, resource) {
-		permission = "R"
+	scopeList := make([]string, 0)
+	for s := range resourceScopes(ctx, resource) {
+		scopeList = append(scopeList, s)
 	}
-
-	a.Actions = permToActions(permission)
+	a.Actions = scopeList
 	return nil
+}
+
+func resourceScopes(sCtx security.Context, rc rbac.Resource) map[string]struct{} {
+	res := map[string]struct{}{}
+	for a, s := range actionScopeMap {
+		if sCtx.Can(a, rc) {
+			res[s] = struct{}{}
+		}
+	}
+	return res
 }
 
 type generalCreator struct {

--- a/src/pkg/scan/api/scan/base_controller.go
+++ b/src/pkg/scan/api/scan/base_controller.go
@@ -425,10 +425,16 @@ func (bc *basicController) createRobotAccount(projectID int64, repository string
 	}
 
 	resource := rbac.NewProjectNamespace(projectID).Resource(rbac.ResourceRepository)
-	access := []*rbac.Policy{{
-		Resource: resource,
-		Action:   rbac.ActionScannerPull,
-	}}
+	access := []*rbac.Policy{
+		{
+			Resource: resource,
+			Action:   rbac.ActionScannerPull,
+		},
+		{
+			Resource: resource,
+			Action:   rbac.ActionPull,
+		},
+	}
 
 	robotReq := &model.RobotCreate{
 		Name:        UUID,

--- a/src/pkg/scan/api/scan/base_controller_test.go
+++ b/src/pkg/scan/api/scan/base_controller_test.go
@@ -160,10 +160,16 @@ func (suite *ControllerTestSuite) SetupSuite() {
 	rc := &MockRobotController{}
 
 	resource := fmt.Sprintf("/project/%d/repository", suite.artifact.NamespaceID)
-	access := []*rbac.Policy{{
-		Resource: rbac.Resource(resource),
-		Action:   rbac.ActionScannerPull,
-	}}
+	access := []*rbac.Policy{
+		{
+			Resource: rbac.Resource(resource),
+			Action:   rbac.ActionScannerPull,
+		},
+		{
+			Resource: rbac.Resource(resource),
+			Action:   rbac.ActionPull,
+		},
+	}
 
 	rname := "the-uuid-123"
 	account := &model.RobotCreate{


### PR DESCRIPTION
This commit directly maps the actoin permission in security context to
the scope generated by the token service in harbor-core.

Signed-off-by: Daniel Jiang <jiangd@vmware.com>