### PR TITLE
Refine the token scope generation

### DIFF
--- a/src/common/security/v2token/context.go
+++ b/src/common/security/v2token/context.go
@@ -99,12 +99,14 @@ func New(ctx context.Context, name string, access []*registry_token.ResourceActi
 				actionMap[rbac.ActionPull] = struct{}{}
 			case "push":
 				actionMap[rbac.ActionPush] = struct{}{}
+			case "delete":
+				actionMap[rbac.ActionDelete] = struct{}{}
+			case "scanner-pull":
+				actionMap[rbac.ActionScannerPull] = struct{}{}
 			case "*":
 				actionMap[rbac.ActionPull] = struct{}{}
 				actionMap[rbac.ActionPush] = struct{}{}
 				actionMap[rbac.ActionDelete] = struct{}{}
-			case "scanner-pull":
-				actionMap[rbac.ActionScannerPull] = struct{}{}
 			}
 		}
 		m[l[0]] = actionMap

--- a/src/core/service/token/authutils.go
+++ b/src/core/service/token/authutils.go
@@ -154,20 +154,3 @@ func MakeToken(username, service string, access []*token.ResourceActions) (*mode
 		IssuedAt:  now.Format(time.RFC3339),
 	}, nil
 }
-
-func permToActions(p string) []string {
-	res := make([]string, 0)
-	if strings.Contains(p, "W") {
-		res = append(res, "push")
-	}
-	if strings.Contains(p, "M") {
-		res = append(res, "*")
-	}
-	if strings.Contains(p, "R") {
-		res = append(res, "pull")
-	}
-	if strings.Contains(p, "S") {
-		res = append(res, "scanner-pull")
-	}
-	return res
-}

--- a/src/core/service/token/token_test.go
+++ b/src/core/service/token/token_test.go
@@ -156,21 +156,6 @@ func TestMakeToken(t *testing.T) {
 	assert.Equal(t, claims.Audience, svc, "Audience mismatch")
 }
 
-func TestPermToActions(t *testing.T) {
-	perm1 := "RWM"
-	perm2 := "MRR"
-	perm3 := ""
-	expect1 := []string{"push", "*", "pull"}
-	expect2 := []string{"*", "pull"}
-	expect3 := make([]string, 0)
-	res1 := permToActions(perm1)
-	res2 := permToActions(perm2)
-	res3 := permToActions(perm3)
-	assert.Equal(t, res1, expect1, fmt.Sprintf("actions mismatch for permission: %s", perm1))
-	assert.Equal(t, res2, expect2, fmt.Sprintf("actions mismatch for permission: %s", perm2))
-	assert.Equal(t, res3, expect3, fmt.Sprintf("actions mismatch for permission: %s", perm3))
-}
-
 type parserTestRec struct {
 	input       string
 	expect      image
@@ -223,7 +208,8 @@ func TestEndpointParser(t *testing.T) {
 }
 
 type fakeSecurityContext struct {
-	isAdmin bool
+	isAdmin   bool
+	rcActions map[rbac.Resource][]rbac.Action
 }
 
 func (f *fakeSecurityContext) Name() string {
@@ -245,8 +231,16 @@ func (f *fakeSecurityContext) IsSolutionUser() bool {
 	return false
 }
 func (f *fakeSecurityContext) Can(ctx context.Context, action rbac.Action, resource rbac.Resource) bool {
+	if actions, ok := f.rcActions[resource]; ok {
+		for _, a := range actions {
+			if a == action {
+				return true
+			}
+		}
+	}
 	return false
 }
+
 func (f *fakeSecurityContext) GetMyProjects() ([]*models.Project, error) {
 	return nil, nil
 }
@@ -302,4 +296,57 @@ func TestParseScopes(t *testing.T) {
 	r1, _ := url.Parse(u1)
 	l1 := parseScopes(r1)
 	assert.Equal([]string{"repository:library/registry:push,pull", "repository:hello-world/registry:pull"}, l1)
+}
+
+func TestResourceScopes(t *testing.T) {
+	sctx := &fakeSecurityContext{
+		isAdmin: false,
+		rcActions: map[rbac.Resource][]rbac.Action{
+			rbac.NewProjectNamespace(1).Resource(rbac.ResourceRepository): {rbac.ActionPull, rbac.ActionScannerPull},
+			rbac.NewProjectNamespace(2).Resource(rbac.ResourceRepository): {rbac.ActionPull, rbac.ActionScannerPull, rbac.ActionPush},
+			rbac.NewProjectNamespace(3).Resource(rbac.ResourceRepository): {rbac.ActionPull, rbac.ActionScannerPull, rbac.ActionPush, rbac.ActionDelete},
+			rbac.NewProjectNamespace(4).Resource(rbac.ResourceRepository): {},
+		},
+	}
+	ctx := security.NewContext(context.TODO(), sctx)
+	cases := []struct {
+		rc     rbac.Resource
+		expect map[string]struct{}
+	}{
+		{
+			rc: rbac.NewProjectNamespace(1).Resource(rbac.ResourceRepository),
+			expect: map[string]struct{}{
+				"pull":         {},
+				"scanner-pull": {},
+			},
+		},
+		{
+			rc: rbac.NewProjectNamespace(2).Resource(rbac.ResourceRepository),
+			expect: map[string]struct{}{
+				"pull":         {},
+				"scanner-pull": {},
+				"push":         {},
+			},
+		},
+		{
+			rc: rbac.NewProjectNamespace(3).Resource(rbac.ResourceRepository),
+			expect: map[string]struct{}{
+				"pull":         {},
+				"scanner-pull": {},
+				"push":         {},
+				"delete":       {},
+			},
+		},
+		{
+			rc:     rbac.NewProjectNamespace(4).Resource(rbac.ResourceRepository),
+			expect: map[string]struct{}{},
+		},
+		{
+			rc:     rbac.NewProjectNamespace(5).Resource(rbac.ResourceRepository),
+			expect: map[string]struct{}{},
+		},
+	}
+	for _, c := range cases {
+		assert.Equal(t, c.expect, resourceScopes(ctx, c.rc))
+	}
 }


### PR DESCRIPTION
This commit directly maps the actoin permission in security context to
the scope generated by the token service in harbor-core.

Signed-off-by: Daniel Jiang <jiangd@vmware.com>