### PR TITLE
feat: save summary for the scan all execution

### DIFF
--- a/src/controller/scan/base_controller_test.go
+++ b/src/controller/scan/base_controller_test.go
@@ -479,14 +479,16 @@ func (suite *ControllerTestSuite) TestScanAll() {
 		executionID := int64(1)
 
 		suite.execMgr.On(
-			"Create", ctx, "IMAGE_SCAN_ALL", int64(0), "SCHEDULE", map[string]interface{}{},
+			"Create", ctx, "IMAGE_SCAN_ALL", int64(0), "SCHEDULE",
 		).Return(executionID, nil).Once()
 
 		mock.OnAnything(suite.artifactCtl, "List").Return([]*artifact.Artifact{}, nil).Once()
 
 		suite.taskMgr.On("Count", ctx, q.New(q.KeyWords{"execution_id": executionID})).Return(int64(0), nil).Once()
 
-		suite.execMgr.On("MarkDone", ctx, executionID, "no artifact found").Return(nil).Once()
+		mock.OnAnything(suite.execMgr, "UpdateExtraAttrs").Return(nil).Once()
+
+		suite.execMgr.On("MarkDone", ctx, executionID, mock.Anything).Return(nil).Once()
 
 		_, err := suite.c.ScanAll(ctx, "SCHEDULE", false)
 		suite.NoError(err)
@@ -499,7 +501,7 @@ func (suite *ControllerTestSuite) TestScanAll() {
 		executionID := int64(1)
 
 		suite.execMgr.On(
-			"Create", ctx, "IMAGE_SCAN_ALL", int64(0), "SCHEDULE", map[string]interface{}{},
+			"Create", ctx, "IMAGE_SCAN_ALL", int64(0), "SCHEDULE",
 		).Return(executionID, nil).Once()
 
 		mock.OnAnything(suite.artifactCtl, "List").Return([]*artifact.Artifact{suite.artifact}, nil).Once()
@@ -513,8 +515,8 @@ func (suite *ControllerTestSuite) TestScanAll() {
 		mock.OnAnything(suite.reportMgr, "Delete").Return(nil).Once()
 		mock.OnAnything(suite.reportMgr, "Create").Return("uuid", nil).Once()
 		mock.OnAnything(suite.taskMgr, "Create").Return(int64(0), fmt.Errorf("failed")).Once()
-
-		suite.execMgr.On("MarkDone", ctx, executionID, "no task found").Return(nil).Once()
+		mock.OnAnything(suite.execMgr, "UpdateExtraAttrs").Return(nil).Once()
+		suite.execMgr.On("MarkError", ctx, executionID, mock.Anything).Return(nil).Once()
 
 		_, err := suite.c.ScanAll(ctx, "SCHEDULE", false)
 		suite.NoError(err)

--- a/src/controller/scan/callback_test.go
+++ b/src/controller/scan/callback_test.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/goharbor/harbor/src/controller/artifact"
 	"github.com/goharbor/harbor/src/jobservice/job"
-	"github.com/goharbor/harbor/src/lib/q"
 	"github.com/goharbor/harbor/src/pkg/scan"
 	dscan "github.com/goharbor/harbor/src/pkg/scan/dao/scan"
 	"github.com/goharbor/harbor/src/pkg/task"
@@ -165,7 +164,7 @@ func (suite *CallbackTestSuite) TestScanAllCallback() {
 	{
 		// create execution failed
 		suite.execMgr.On(
-			"Create", context.TODO(), "IMAGE_SCAN_ALL", int64(0), "SCHEDULE", map[string]interface{}{},
+			"Create", context.TODO(), "IMAGE_SCAN_ALL", int64(0), "SCHEDULE",
 		).Return(int64(0), fmt.Errorf("failed")).Once()
 
 		suite.Error(scanAllCallback(context.TODO(), ""))
@@ -175,7 +174,7 @@ func (suite *CallbackTestSuite) TestScanAllCallback() {
 		executionID := int64(1)
 
 		suite.execMgr.On(
-			"Create", context.TODO(), "IMAGE_SCAN_ALL", int64(0), "SCHEDULE", map[string]interface{}{},
+			"Create", context.TODO(), "IMAGE_SCAN_ALL", int64(0), "SCHEDULE",
 		).Return(executionID, nil).Once()
 
 		suite.execMgr.On(
@@ -184,9 +183,9 @@ func (suite *CallbackTestSuite) TestScanAllCallback() {
 
 		mock.OnAnything(suite.artifactCtl, "List").Return([]*artifact.Artifact{}, nil).Once()
 
-		suite.taskMgr.On("Count", context.TODO(), q.New(q.KeyWords{"execution_id": executionID})).Return(int64(0), nil).Once()
+		mock.OnAnything(suite.execMgr, "UpdateExtraAttrs").Return(nil).Once()
 
-		suite.execMgr.On("MarkDone", context.TODO(), executionID, "no artifact found").Return(nil).Once()
+		suite.execMgr.On("MarkDone", context.TODO(), executionID, mock.Anything).Return(nil).Once()
 
 		suite.NoError(scanAllCallback(context.TODO(), ""))
 	}

--- a/src/pkg/task/execution.go
+++ b/src/pkg/task/execution.go
@@ -45,6 +45,8 @@ type ExecutionManager interface {
 	// The "extraAttrs" can be used to set the customized attributes
 	Create(ctx context.Context, vendorType string, vendorID int64, trigger string,
 		extraAttrs ...map[string]interface{}) (id int64, err error)
+	// Update the extra attributes of the specified execution
+	UpdateExtraAttrs(ctx context.Context, id int64, extraAttrs map[string]interface{}) (err error)
 	// MarkDone marks the status of the specified execution as success.
 	// It must be called to update the execution status if the created execution contains no tasks.
 	// In other cases, the execution status can be calculated from the referenced tasks automatically
@@ -166,6 +168,21 @@ func (e *executionManager) sweep(ctx context.Context, vendorType string) error {
 			}
 		}
 	}
+}
+
+func (e *executionManager) UpdateExtraAttrs(ctx context.Context, id int64, extraAttrs map[string]interface{}) error {
+	data, err := json.Marshal(extraAttrs)
+	if err != nil {
+		return err
+	}
+
+	execution := &dao.Execution{
+		ID:         id,
+		ExtraAttrs: string(data),
+		UpdateTime: time.Now(),
+	}
+
+	return e.executionDAO.Update(ctx, execution, "ExtraAttrs", "UpdateTime")
 }
 
 func (e *executionManager) MarkDone(ctx context.Context, id int64, message string) error {

--- a/src/pkg/task/execution_test.go
+++ b/src/pkg/task/execution_test.go
@@ -71,6 +71,13 @@ func (e *executionManagerTestSuite) TestCreate() {
 	e.ormCreator.AssertExpectations(e.T())
 }
 
+func (e *executionManagerTestSuite) TestUpdateExtraAttrs() {
+	e.execDAO.On("Update", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	err := e.execMgr.UpdateExtraAttrs(nil, 1, map[string]interface{}{"key": "value"})
+	e.Require().Nil(err)
+	e.execDAO.AssertExpectations(e.T())
+}
+
 func (e *executionManagerTestSuite) TestMarkDone() {
 	e.execDAO.On("Update", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	err := e.execMgr.MarkDone(nil, 1, "success")

--- a/src/testing/pkg/task/execution_manager.go
+++ b/src/testing/pkg/task/execution_manager.go
@@ -182,3 +182,17 @@ func (_m *ExecutionManager) StopAndWait(ctx context.Context, id int64, timeout t
 
 	return r0
 }
+
+// UpdateExtraAttrs provides a mock function with given fields: ctx, id, extraAttrs
+func (_m *ExecutionManager) UpdateExtraAttrs(ctx context.Context, id int64, extraAttrs map[string]interface{}) error {
+	ret := _m.Called(ctx, id, extraAttrs)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, int64, map[string]interface{}) error); ok {
+		r0 = rf(ctx, id, extraAttrs)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}


### PR DESCRIPTION
Compute the summary info for the scan all and save it to the extra attrs
of the execution.

Signed-off-by: He Weiwei <hweiwei@vmware.com>