### PR TITLE
chore: delete records of scan_report

### DIFF
--- a/make/migrations/postgresql/0050_2.2.0_schema.up.sql
+++ b/make/migrations/postgresql/0050_2.2.0_schema.up.sql
@@ -478,6 +478,11 @@ Common vulnerability reporting schema.
 Github proposal link : https://github.com/goharbor/community/pull/145
 */
 
+/*
+The old scan_report not work well with report_vulnerability_record and vulnerability_record so delete them
+*/
+DELETE FROM scan_report;
+
 -- --------------------------------------------------
 --  Table Structure for `main.VulnerabilityRecord`
 -- --------------------------------------------------


### PR DESCRIPTION
The report in previous scan_report records not work well the
vulnerabilities stored in the schema table, so delete the scan_report
records.

Signed-off-by: He Weiwei <hweiwei@vmware.com>