### PR TITLE
Update the reg-exp to match v2/catalog api

### DIFF
--- a/src/lib/patterns.go
+++ b/src/lib/patterns.go
@@ -27,7 +27,7 @@ var (
 	// V2BlobUploadURLRe is the regular expression for matching the request to v2 handler to upload a blob, the upload uuid currently is not put into a group
 	V2BlobUploadURLRe = regexp.MustCompile(fmt.Sprintf(`^/v2/(?P<%s>%s)/blobs/uploads[/a-zA-Z0-9\-_\.=]*$`, RepositorySubexp, reference.NameRegexp.String()))
 	// V2CatalogURLRe is the regular expression for mathing the request to v2 handler to list catalog
-	V2CatalogURLRe = regexp.MustCompile(`^/v2/_catalog/?$`)
+	V2CatalogURLRe = regexp.MustCompile(`^/v2/_catalog(/.*)?$`)
 )
 
 // MatchManifestURLPattern checks whether the provided path matches the manifest URL pattern,

--- a/src/lib/patterns_test.go
+++ b/src/lib/patterns_test.go
@@ -81,11 +81,24 @@ func TestMatchCatalogURLPattern(t *testing.T) {
 			match: true,
 		},
 		{
+			url:   "/v2/_catalog////",
+			match: true,
+		},
+		{
 			url:   "/v2/_catalog/xxx",
-			match: false,
+			match: true,
+		},
+		{
+			url:   "/v2/_catalog////#",
+			match: true,
+		},
+		{
+			url:   "/v2/_catalog//#//",
+			match: true,
 		},
 	}
 	for _, c := range cases {
-		assert.Equal(t, c.match, len(V2CatalogURLRe.FindStringSubmatch(c.url)) == 1)
+
+		assert.Equal(t, c.match, V2CatalogURLRe.MatchString(c.url), "failed for %s", c.url)
 	}
 }

--- a/src/server/middleware/v2auth/access.go
+++ b/src/server/middleware/v2auth/access.go
@@ -71,7 +71,7 @@ func accessList(req *http.Request) []access {
 		})
 		return l
 	}
-	if len(lib.V2CatalogURLRe.FindStringSubmatch(req.URL.Path)) == 1 {
+	if lib.V2CatalogURLRe.MatchString(req.URL.Path) {
 		l = append(l, access{
 			target: catalog,
 		})

--- a/src/server/middleware/v2auth/auth.go
+++ b/src/server/middleware/v2auth/auth.go
@@ -84,8 +84,7 @@ func (rc *reqChecker) projectID(ctx context.Context, name string) (int64, error)
 func getChallenge(req *http.Request, accessList []access) string {
 	logger := log.G(req.Context())
 	auth := req.Header.Get(authHeader)
-	if len(auth) > 0 ||
-		len(lib.V2CatalogURLRe.FindStringSubmatch(req.URL.Path)) == 1 {
+	if len(auth) > 0 || lib.V2CatalogURLRe.MatchString(req.URL.Path) {
 		// Return basic auth challenge by default, incl. request to '/v2/_catalog'
 		return `Basic realm="harbor"`
 	}


### PR DESCRIPTION
A more strict check is applied such that all requests to
/v2/_catalog/...  will be verified.

Signed-off-by: Daniel Jiang <jiangd@vmware.com>