### PR TITLE
fix improper spelling

### DIFF
--- a/src/jobservice/runtime/bootstrap.go
+++ b/src/jobservice/runtime/bootstrap.go
@@ -62,13 +62,13 @@ var JobService = &Bootstrap{}
 
 // Bootstrap is coordinating process to help load and start the other components to serve.
 type Bootstrap struct {
-	jobConextInitializer job.ContextInitializer
+	jobContextInitializer job.ContextInitializer
 }
 
 // SetJobContextInitializer set the job context initializer
 func (bs *Bootstrap) SetJobContextInitializer(initializer job.ContextInitializer) {
 	if initializer != nil {
-		bs.jobConextInitializer = initializer
+		bs.jobContextInitializer = initializer
 	}
 }
 
@@ -82,8 +82,8 @@ func (bs *Bootstrap) LoadAndRun(ctx context.Context, cancel context.CancelFunc) 
 	}
 
 	// Build specified job context
-	if bs.jobConextInitializer != nil {
-		rootContext.JobContext, err = bs.jobConextInitializer(ctx)
+	if bs.jobContextInitializer != nil {
+		rootContext.JobContext, err = bs.jobContextInitializer(ctx)
 		if err != nil {
 			return errors.Errorf("initialize job context error: %s", err)
 		}


### PR DESCRIPTION
Signed-off-by: shaobo <shaobo@caicloud.io>

fix improper spelling of `jobContextInitializer`