### PR TITLE
Remove raw token from header in token review reuqest - 1.10.x

### DIFF
--- a/src/pkg/authproxy/http.go
+++ b/src/pkg/authproxy/http.go
@@ -26,7 +26,6 @@ func TokenReview(rawToken string, authProxyConfig *models.HTTPAuthProxy) (k8s_ap
 			GroupVersion:         &schema.GroupVersion{},
 			NegotiatedSerializer: serializer.DirectCodecFactory{CodecFactory: scheme.Codecs},
 		},
-		BearerToken:     rawToken,
 		TLSClientConfig: getTLSConfig(authProxyConfig),
 	}
 	authClient, err := rest.RESTClientFor(authClientCfg)


### PR DESCRIPTION
The server to handle token-review may have a limitation for the size of
the header.  When the token is huge the token review may fail.
This commit remove the necessary header to harden the flow.

Signed-off-by: Daniel Jiang <jiangd@vmware.com>