### PR TITLE
fix: ignore tag in the scan webhook when it's empty

### DIFF
--- a/src/controller/event/handler/util/util.go
+++ b/src/controller/event/handler/util/util.go
@@ -3,12 +3,14 @@ package util
 import (
 	"errors"
 	"fmt"
+	"strings"
+
 	"github.com/goharbor/harbor/src/common/models"
 	"github.com/goharbor/harbor/src/core/config"
 	"github.com/goharbor/harbor/src/lib/log"
+	"github.com/goharbor/harbor/src/pkg/distribution"
 	"github.com/goharbor/harbor/src/pkg/notifier/event"
 	notifyModel "github.com/goharbor/harbor/src/pkg/notifier/model"
-	"strings"
 )
 
 // SendHookWithPolicies send hook by publishing topic of specified target type(notify type)
@@ -56,11 +58,15 @@ func GetNameFromImgRepoFullName(repo string) string {
 }
 
 // BuildImageResourceURL ...
-func BuildImageResourceURL(repoName, tag string) (string, error) {
+func BuildImageResourceURL(repoName, reference string) (string, error) {
 	extURL, err := config.ExtURL()
 	if err != nil {
 		return "", fmt.Errorf("get external endpoint failed: %v", err)
 	}
-	resURL := fmt.Sprintf("%s/%s:%s", extURL, repoName, tag)
-	return resURL, nil
+
+	if distribution.IsDigest(reference) {
+		return fmt.Sprintf("%s/%s@%s", extURL, repoName, reference), nil
+	}
+
+	return fmt.Sprintf("%s/%s:%s", extURL, repoName, reference), nil
 }

--- a/src/controller/event/handler/util/util_test.go
+++ b/src/controller/event/handler/util/util_test.go
@@ -1,0 +1,51 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/goharbor/harbor/src/common"
+	"github.com/goharbor/harbor/src/core/config"
+)
+
+func TestBuildImageResourceURL(t *testing.T) {
+	cfg := map[string]interface{}{
+		common.ExtEndpoint: "https://demo.goharbor.io",
+	}
+	config.InitWithSettings(cfg)
+
+	type args struct {
+		repoName  string
+		reference string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			"digest",
+			args{"library/photon", "sha256:1f240846ba3fc84aaa3c5eeb24e6b119394e9c3bf9536371d485a8a405e3deb3"},
+			"demo.goharbor.io/library/photon@sha256:1f240846ba3fc84aaa3c5eeb24e6b119394e9c3bf9536371d485a8a405e3deb3",
+			false,
+		},
+		{
+			"tag",
+			args{"library/photon", "2.0"},
+			"demo.goharbor.io/library/photon:2.0",
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := BuildImageResourceURL(tt.args.repoName, tt.args.reference)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("BuildImageResourceURL() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("BuildImageResourceURL() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/src/controller/event/handler/webhook/scan/scan.go
+++ b/src/controller/event/handler/webhook/scan/scan.go
@@ -110,17 +110,17 @@ func constructScanImagePayload(event *event.ScanImageEvent, project *models.Proj
 		Operator: event.Operator,
 	}
 
-	resURL, err := util.BuildImageResourceURL(event.Artifact.Repository, event.Artifact.Tag)
+	reference := event.Artifact.Digest
+	if reference == "" {
+		reference = event.Artifact.Tag
+	}
+
+	resURL, err := util.BuildImageResourceURL(event.Artifact.Repository, reference)
 	if err != nil {
 		return nil, errors.Wrap(err, "construct scan payload")
 	}
 
 	ctx := orm.NewContext(context.TODO(), o.NewOrm())
-
-	reference := event.Artifact.Digest
-	if reference == "" {
-		reference = event.Artifact.Tag
-	}
 
 	art, err := artifact.Ctl.GetByReference(ctx, event.Artifact.Repository, event.Artifact.Digest, nil)
 	if err != nil {

--- a/src/pkg/notifier/model/event.go
+++ b/src/pkg/notifier/model/event.go
@@ -33,7 +33,7 @@ type EventData struct {
 // Resource describe infos of resource triggered notification
 type Resource struct {
 	Digest       string                 `json:"digest,omitempty"`
-	Tag          string                 `json:"tag"`
+	Tag          string                 `json:"tag,omitempty"`
 	ResourceURL  string                 `json:"resource_url,omitempty"`
 	ScanOverview map[string]interface{} `json:"scan_overview,omitempty"`
 }


### PR DESCRIPTION
Closes #13464

Signed-off-by: He Weiwei <hweiwei@vmware.com>