### PR TITLE
[Cherry-pick 2.1.0] Upgrade python to v3 in git action CI host

### DIFF
--- a/tests/ci/api_common_install.sh
+++ b/tests/ci/api_common_install.sh
@@ -10,7 +10,18 @@ set -e
 if [ -z "$1" ]; then echo no ip specified; exit 1;fi
 # prepare cert ...
 sudo ./tests/generateCerts.sh $1
-sudo wget https://bootstrap.pypa.io/get-pip.py && sudo python ./get-pip.py && sudo pip install --ignore-installed urllib3 chardet requests --upgrade
+
+python --version
+pip -V
+cat /etc/issue
+cat /proc/version
+sudo apt-get update -y && sudo apt-get install -y zbar-tools libzbar-dev python-zbar python3.7
+sudo rm /usr/bin/python && sudo ln -s /usr/bin/python3.7 /usr/bin/python
+sudo apt-get install -y python3-pip
+pip -V
+sudo -H pip install --ignore-installed urllib3 chardet requests --upgrade
+python --version
+
 sudo ./tests/hostcfg.sh
 
 if [ "$2" = 'LDAP' ]; then


### PR DESCRIPTION
The original python packaged: in git action host is V2, it should be upgraded to
V3.

Signed-off-by: danfengliu <danfengl@vmware.com>