### PR TITLE
Update oras to 0.9.0 to fix "zip slip" vulnerability

### DIFF
--- a/tests/e2e-image/Dockerfile
+++ b/tests/e2e-image/Dockerfile
@@ -117,9 +117,9 @@ RUN wget https://get.helm.sh/helm-v3.3.3-linux-amd64.tar.gz && tar zxvf helm-v3.
     mv linux-amd64/helm /usr/local/bin/helm3 && \
     helm3 plugin install https://github.com/chartmuseum/helm-push
 
-RUN curl -LO https://github.com/deislabs/oras/releases/download/v0.8.1/oras_0.8.1_linux_amd64.tar.gz && \
+RUN curl -LO https://github.com/deislabs/oras/releases/download/v0.9.0/oras_0.9.0_linux_amd64.tar.gz && \
     mkdir -p oras-install/  && \
-    tar -zxf oras_0.8.1_*.tar.gz -C oras-install/  && \
+    tar -zxf oras_0.9.0_*.tar.gz -C oras-install/  && \
     mv oras-install/oras /usr/local/bin/
 
 RUN wget https://github.com/theupdateframework/notary/releases/download/v0.6.1/notary-Linux-amd64 && \


### PR DESCRIPTION
See https://github.com/deislabs/oras/security/advisories/GHSA-g5v4-5x39-vwhx
for details