### PR TITLE
Tokens

### DIFF
--- a/src/pkg/token/option_test.go
+++ b/src/pkg/token/option_test.go
@@ -9,13 +9,20 @@ import (
 
 func TestNewOptions(t *testing.T) {
 	defaultOpt := DefaultTokenOptions()
-	assert.NotNil(t, defaultOpt)
+	if defaultOpt == nil {
+		assert.NotNil(t, defaultOpt)
+		return
+	}
 	assert.Equal(t, defaultOpt.SignMethod, jwt.GetSigningMethod("RS256"))
 	assert.Equal(t, defaultOpt.Issuer, "harbor-token-defaultIssuer")
 }
 
 func TestGetKey(t *testing.T) {
 	defaultOpt := DefaultTokenOptions()
+	if defaultOpt == nil {
+		assert.NotNil(t, defaultOpt)
+		return
+	}
 	key, err := defaultOpt.GetKey()
 	assert.Nil(t, err)
 	assert.NotNil(t, key)

--- a/src/pkg/token/token_test.go
+++ b/src/pkg/token/token_test.go
@@ -81,7 +81,10 @@ func TestRaw(t *testing.T) {
 		return
 	}
 	token, err := New(defaultOpt, robot)
-	assert.Nil(t, err)
+	if err != nil {
+		assert.Nil(t, err)
+		return
+	}
 
 	rawTk, err := token.Raw()
 	assert.Nil(t, err)

--- a/src/pkg/token/token_test.go
+++ b/src/pkg/token/token_test.go
@@ -41,7 +41,12 @@ func TestNew(t *testing.T) {
 			ExpiresAt: expiresAt,
 		},
 	}
-	token, err := New(DefaultTokenOptions(), robot)
+	defaultOpt := DefaultTokenOptions()
+	if defaultOpt == nil {
+		assert.NotNil(t, defaultOpt)
+		return
+	}
+	token, err := New(defaultOpt, robot)
 
 	assert.Nil(t, err)
 	assert.Equal(t, token.Header["alg"], "RS256")
@@ -70,7 +75,12 @@ func TestRaw(t *testing.T) {
 			ExpiresAt: expiresAt,
 		},
 	}
-	token, err := New(DefaultTokenOptions(), robot)
+	defaultOpt := DefaultTokenOptions()
+	if defaultOpt == nil {
+		assert.NotNil(t, defaultOpt)
+		return
+	}
+	token, err := New(defaultOpt, robot)
 	assert.Nil(t, err)
 
 	rawTk, err := token.Raw()
@@ -81,8 +91,12 @@ func TestRaw(t *testing.T) {
 func TestParseWithClaims(t *testing.T) {
 	rawTk := "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJJRCI6MTIzLCJQcm9qZWN0SUQiOjAsIkFjY2VzcyI6W3siUmVzb3VyY2UiOiIvcHJvamVjdC9saWJyYXkvcmVwb3NpdG9yeSIsIkFjdGlvbiI6InB1bGwiLCJFZmZlY3QiOiIifV0sIlN0YW5kYXJkQ2xhaW1zIjp7ImV4cCI6MTU0ODE0MDIyOSwiaXNzIjoiaGFyYm9yLXRva2VuLWlzc3VlciJ9fQ.Jc3qSKN4SJVUzAvBvemVpRcSOZaHlu0Avqms04qzPm4ru9-r9IRIl3mnSkI6m9XkzLUeJ7Kiwyw63ghngnVKw_PupeclOGC6s3TK5Cfmo4h-lflecXjZWwyy-dtH_e7Us_ItS-R3nXDJtzSLEpsGHCcAj-1X2s93RB2qD8LNSylvYeDezVkTzqRzzfawPJheKKh9JTrz-3eUxCwQard9-xjlwvfUYULoHTn9npNAUq4-jqhipW4uE8HL-ym33AGF57la8U0RO11hmDM5K8-PiYknbqJ_oONeS3HBNym2pEFeGjtTv2co213wl4T5lemlg4SGolMBuJ03L7_beVZ0o-MKTkKDqDwJalb6_PM-7u3RbxC9IzJMiwZKIPnD3FvV10iPxUUQHaH8Jz5UZ2pFIhi_8BNnlBfT0JOPFVYATtLjHMczZelj2YvAeR1UHBzq3E0jPpjjwlqIFgaHCaN_KMwEvadTo_Fi2sEH4pNGP7M3yehU_72oLJQgF4paJarsmEoij6ZtPs6xekBz1fccVitq_8WNIz9aeCUdkUBRwI5QKw1RdW4ua-w74ld5MZStWJA8veyoLkEb_Q9eq2oAj5KWFjJbW5-ltiIfM8gxKflsrkWAidYGcEIYcuXr7UdqEKXxtPiWM0xb3B91ovYvO5402bn3f9-UGtlcestxNHA"
 	rClaims := &robot_claim.Claim{}
-	_, _ = Parse(DefaultTokenOptions(), rawTk, rClaims)
-	assert.Equal(t, int64(123), rClaims.TokenID)
+	defaultOpt := DefaultTokenOptions()
+	if defaultOpt == nil {
+		assert.NotNil(t, defaultOpt)
+		return
+	}
+	_, _ = Parse(defaultOpt, rawTk, rClaims)
 	assert.Equal(t, int64(0), rClaims.ProjectID)
 	assert.Equal(t, "/project/libray/repository", rClaims.Access[0].Resource.String())
 }

--- a/src/server/middleware/security/robot.go
+++ b/src/server/middleware/security/robot.go
@@ -39,8 +39,12 @@ func (r *robot) Generate(req *http.Request) security.Context {
 		return nil
 	}
 	rClaims := &robot_claim.Claim{}
-	opt := pkg_token.DefaultTokenOptions()
-	rtk, err := pkg_token.Parse(opt, robotTk, rClaims)
+	defaultOpt := pkg_token.DefaultTokenOptions()
+	if defaultOpt == nil {
+		log.Error("failed to get default token options")
+		return nil
+	}
+	rtk, err := pkg_token.Parse(defaultOpt, robotTk, rClaims)
 	if err != nil {
 		log.Errorf("failed to decrypt robot token: %v", err)
 		return nil

--- a/src/server/middleware/security/v2_token.go
+++ b/src/server/middleware/security/v2_token.go
@@ -41,9 +41,13 @@ func (vt *v2Token) Generate(req *http.Request) security.Context {
 		return nil
 	}
 
-	opt := token.DefaultTokenOptions()
+	defaultOpt := token.DefaultTokenOptions()
+	if defaultOpt == nil {
+		logger.Warningf("failed to get default options")
+		return nil
+	}
 	cl := &v2TokenClaims{}
-	t, err := token.Parse(opt, tokenStr, cl)
+	t, err := token.Parse(defaultOpt, tokenStr, cl)
 	if err != nil {
 		logger.Warningf("failed to decode bearer token: %v", err)
 		return nil


### PR DESCRIPTION
While trying to debug some failing tests outside of Docker, certain things kept crashing. These changes make it easier to test.

One thing that I'm not doing here that would be helpful is if the tests actually set the env var to point to their key instead of expecting users to try to figure out how to set the environment variable in their IDE (which is not fun).