### PR TITLE
Reduce warning logs in OIDC middleware

### DIFF
--- a/src/server/middleware/security/idtoken.go
+++ b/src/server/middleware/security/idtoken.go
@@ -40,6 +40,9 @@ func (i *idToken) Generate(req *http.Request) security.Context {
 		return nil
 	}
 	token := bearerToken(req)
+	if len(token) == 0 {
+		return nil
+	}
 	claims, err := oidc.VerifyToken(ctx, token)
 	if err != nil {
 		log.Warningf("failed to verify token: %v", err)

--- a/src/server/middleware/security/idtoken_test.go
+++ b/src/server/middleware/security/idtoken_test.go
@@ -15,12 +15,13 @@
 package security
 
 import (
+	"net/http"
+	"testing"
+
 	"github.com/goharbor/harbor/src/common"
 	"github.com/goharbor/harbor/src/lib"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"net/http"
-	"testing"
 )
 
 func TestIDToken(t *testing.T) {


### PR DESCRIPTION
If the request does not have bearer token in the header, do not decode
the empty string.
Fixes #12261

Signed-off-by: Daniel Jiang <jiangd@vmware.com>