### PR TITLE
Add support for http proxy in oidc insecureTransport

### DIFF
--- a/src/common/utils/oidc/helper.go
+++ b/src/common/utils/oidc/helper.go
@@ -110,6 +110,7 @@ var insecureTransport = &http.Transport{
 	TLSClientConfig: &tls.Config{
 		InsecureSkipVerify: true,
 	},
+	Proxy: http.ProxyFromEnvironment,
 }
 
 // Token wraps the attributes of a oauth2 token plus the attribute of ID token


### PR DESCRIPTION
Add support for http proxy in OIDC authentication with "Verify Certificate" option disabled.