### PR TITLE
fix: remove default execution sweeper count

### DIFF
--- a/src/controller/gc/controller.go
+++ b/src/controller/gc/controller.go
@@ -2,12 +2,18 @@ package gc
 
 import (
 	"context"
+
 	"github.com/goharbor/harbor/src/jobservice/job"
 	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/lib/q"
 	"github.com/goharbor/harbor/src/pkg/scheduler"
 	"github.com/goharbor/harbor/src/pkg/task"
 )
+
+func init() {
+	// keep only the latest created 50 gc execution records
+	task.SetExecutionSweeperCount(GCVendorType, 50)
+}
 
 var (
 	// Ctl is a global garbage collection controller instance

--- a/src/controller/p2p/preheat/enforcer.go
+++ b/src/controller/p2p/preheat/enforcer.go
@@ -44,6 +44,11 @@ import (
 	"github.com/goharbor/harbor/src/pkg/task"
 )
 
+func init() {
+	// keep only the latest created 50 p2p preheat execution records
+	task.SetExecutionSweeperCount(job.P2PPreheat, 50)
+}
+
 const (
 	defaultSeverityCode     = 99
 	extraAttrTotal          = "totalCount"

--- a/src/controller/replication/controller.go
+++ b/src/controller/replication/controller.go
@@ -29,6 +29,11 @@ import (
 	"github.com/goharbor/harbor/src/replication/model"
 )
 
+func init() {
+	// keep only the latest created 50 replication execution records
+	task.SetExecutionSweeperCount(job.Replication, 50)
+}
+
 // Controller defines the operations related with replication
 type Controller interface {
 	// Start the replication according to the policy

--- a/src/controller/retention/controller.go
+++ b/src/controller/retention/controller.go
@@ -17,6 +17,8 @@ package retention
 import (
 	"context"
 	"fmt"
+	"time"
+
 	"github.com/goharbor/harbor/src/jobservice/job"
 	"github.com/goharbor/harbor/src/jobservice/logger"
 	"github.com/goharbor/harbor/src/lib/q"
@@ -26,8 +28,12 @@ import (
 	"github.com/goharbor/harbor/src/pkg/retention/policy"
 	"github.com/goharbor/harbor/src/pkg/scheduler"
 	"github.com/goharbor/harbor/src/pkg/task"
-	"time"
 )
+
+func init() {
+	// keep only the latest created 50 retention execution records
+	task.SetExecutionSweeperCount(job.Retention, 50)
+}
 
 // go:generate mockery -name Controller -case snake
 

--- a/src/pkg/task/execution.go
+++ b/src/pkg/task/execution.go
@@ -31,9 +31,8 @@ import (
 
 var (
 	// ExecMgr is a global execution manager instance
-	ExecMgr                            = NewExecutionManager()
-	executionSweeperCount              = map[string]uint8{}
-	defaultExecutionSweeperCount uint8 = 50
+	ExecMgr               = NewExecutionManager()
+	executionSweeperCount = map[string]uint8{}
 )
 
 // ExecutionManager manages executions.
@@ -139,8 +138,10 @@ func (e *executionManager) Create(ctx context.Context, vendorType string, vendor
 func (e *executionManager) sweep(ctx context.Context, vendorType string, vendorID int64) error {
 	count := executionSweeperCount[vendorType]
 	if count == 0 {
-		count = defaultExecutionSweeperCount
+		log.Debugf("the execution sweeper count doesn't set for %s, skip sweep", vendorType)
+		return nil
 	}
+
 	for {
 		// the function "List" of the execution manager returns the execution records
 		// ordered by start time. After the sorting is supported in query, we should

--- a/src/pkg/task/execution_test.go
+++ b/src/pkg/task/execution_test.go
@@ -58,6 +58,8 @@ func (e *executionManagerTestSuite) TestCount() {
 }
 
 func (e *executionManagerTestSuite) TestCreate() {
+	SetExecutionSweeperCount("vendor", 50)
+
 	e.execDAO.On("Create", mock.Anything, mock.Anything).Return(int64(1), nil)
 	e.ormCreator.On("Create").Return(&orm.FakeOrmer{})
 	e.execDAO.On("List", mock.Anything, mock.Anything).Return(nil, nil)


### PR DESCRIPTION
1. Remove the default execution sweeper count for execution vendor.
2. Set the execution sweeper count for gc, preheat, replication,
retention to 50.
3. Keep the executions for the scan job.

Signed-off-by: He Weiwei <hweiwei@vmware.com>