### PR TITLE
fix(jobservice):wrong depth of job logging

### DIFF
--- a/src/jobservice/logger/known_loggers.go
+++ b/src/jobservice/logger/known_loggers.go
@@ -1,9 +1,10 @@
 package logger
 
 import (
-	"github.com/goharbor/harbor/src/jobservice/logger/backend"
 	"reflect"
 	"strings"
+
+	"github.com/goharbor/harbor/src/jobservice/logger/backend"
 )
 
 const (
@@ -39,10 +40,10 @@ var knownLoggers = map[string]*Declaration{
 }
 
 // IsKnownLogger checks if the logger is supported with name.
-func IsKnownLogger(name string) bool {
-	_, ok := knownLoggers[name]
+func IsKnownLogger(name string) (*Declaration, bool) {
+	d, ok := knownLoggers[name]
 
-	return ok
+	return d, ok
 }
 
 // HasSweeper checks if the logger with the name provides a sweeper.
@@ -57,11 +58,6 @@ func HasGetter(name string) bool {
 	d, ok := knownLoggers[name]
 
 	return ok && d.Getter != nil
-}
-
-// KnownLoggers return the declaration by the name
-func KnownLoggers(name string) *Declaration {
-	return knownLoggers[name]
 }
 
 // All known levels which are supported.

--- a/src/jobservice/logger/known_loggers_test.go
+++ b/src/jobservice/logger/known_loggers_test.go
@@ -1,20 +1,23 @@
 package logger
 
 import (
-	"github.com/goharbor/harbor/src/jobservice/logger/backend"
-	"github.com/stretchr/testify/require"
 	"os"
 	"path"
 	"testing"
+
+	"github.com/goharbor/harbor/src/jobservice/logger/backend"
+	"github.com/stretchr/testify/require"
 )
 
 // TestKnownLoggers
 func TestKnownLoggers(t *testing.T) {
-	b := IsKnownLogger("Unknown")
+	l, b := IsKnownLogger("Unknown")
 	require.False(t, b)
+	require.Nil(t, l)
 
-	b = IsKnownLogger(NameFile)
+	l, b = IsKnownLogger(NameFile)
 	require.True(t, b)
+	require.NotNil(t, l)
 
 	// no getter
 	b = HasGetter(NameStdOutput)
@@ -29,13 +32,6 @@ func TestKnownLoggers(t *testing.T) {
 	// has sweeper
 	b = HasSweeper(NameDB)
 	require.True(t, b)
-
-	// unknown logger
-	l := KnownLoggers("unknown")
-	require.Nil(t, l)
-	// known logger
-	l = KnownLoggers(NameDB)
-	require.NotNil(t, l)
 
 	// unknown level
 	b = IsKnownLevel("unknown")


### PR DESCRIPTION
- use separate std logger for job, not shared with jobservice std logger
- merge and remove useless functions

Signed-off-by: Steven Zou <szou@vmware.com>

fix #14079