### PR TITLE
[CP - v2.2]: Use the Email address from DB instead of request

### DIFF
--- a/src/core/controllers/base.go
+++ b/src/core/controllers/base.go
@@ -230,7 +230,7 @@ func (cc *CommonController) SendResetEmail() {
 		60, settings.SSL,
 		settings.Insecure,
 		settings.From,
-		[]string{email},
+		[]string{u.Email},
 		"Reset Harbor user password",
 		message.String())
 	if err != nil {


### PR DESCRIPTION
This commit updates the controller for sending reset pwd Email,
to make it use the Email from DB query result.

Signed-off-by: Daniel Jiang <jiangd@vmware.com>