### PR TITLE
add PR template to repo

### DIFF
--- a/.github/PR_TEMPLATE.md
+++ b/.github/PR_TEMPLATE.md
@@ -10,4 +10,5 @@ Fixes #(issue)
 ### Please indicate you've done the following:
 
 - [ ] [Accepted the DCO](https://github.com/goharbor/harbor/blob/master/CONTRIBUTING.md#commit). Commits without the DCO will delay acceptance.
-- [ ] Updated the corresponding documentation in this repo or https://github.com/goharbor/website.
+- [ ] Made sure tests are passing and test coverage is added if needed.
+- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.

--- a/.github/PR_TEMPLATE.md
+++ b/.github/PR_TEMPLATE.md
@@ -1,0 +1,13 @@
+Thank you for contributing to Harbor!
+
+### Summary of your change
+
+
+### Issue being fixed
+
+Fixes #(issue)
+
+### Please indicate you've done the following:
+
+- [ ] [Accepted the DCO](https://github.com/goharbor/harbor/blob/master/CONTRIBUTING.md#commit). Commits without the DCO will delay acceptance.
+- [ ] Updated the corresponding documentation in this repo or https://github.com/goharbor/website.


### PR DESCRIPTION
Signed-off-by: Abigail McCarthy <mabigail@vmware.com>

Opening this PR as a Draft to start a discussion on adding a PR template to the repo. I'm not sure if this has come up before, but I think these templates can be very helpful to make sure folks fill in some basic info about what the PR is for and remind folks to do the required steps to get the PR merged that can get missed, like the DCO.

I'd also like to make sure we call out updating docs now that the docs are kept in a separate repo.

Is there anything else we should call out here? Like for creating release notes or how to run/pass tests? 