### PR TITLE
Refine the way to set X-Forwarded-Proto in nginx

### DIFF
--- a/make/photon/prepare/templates/nginx/nginx.http.conf.jinja
+++ b/make/photon/prepare/templates/nginx/nginx.http.conf.jinja
@@ -41,6 +41,11 @@ http {
 
   access_log /dev/stdout timed_combined;
 
+  map $http_x_forwarded_proto $x_forwarded_proto {
+    default $http_x_forwarded_proto;
+    ""      $scheme;
+  }
+
   server {
     listen 8080;
     server_tokens off;
@@ -70,9 +75,7 @@ http {
       proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-
-      # When setting up Harbor behind other proxy, such as an Nginx instance, remove the below line if the proxy already has similar settings.
-      proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_set_header X-Forwarded-Proto $x_forwarded_proto;
       
       proxy_buffering off;
       proxy_request_buffering off;
@@ -94,9 +97,7 @@ http {
       proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-
-      # When setting up Harbor behind other proxy, such as an Nginx instance, remove the below line if the proxy already has similar settings.
-      proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_set_header X-Forwarded-Proto $x_forwarded_proto;
       
       proxy_buffering off;
       proxy_request_buffering off;
@@ -118,9 +119,7 @@ http {
       proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-
-      # When setting up Harbor behind other proxy, such as an Nginx instance, remove the below line if the proxy already has similar settings.
-      proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_set_header X-Forwarded-Proto $x_forwarded_proto;
       
       proxy_buffering off;
       proxy_request_buffering off;
@@ -142,9 +141,7 @@ http {
       proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-
-      # When setting up Harbor behind other proxy, such as an Nginx instance, remove the below line if the proxy already has similar settings.
-      proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_set_header X-Forwarded-Proto $x_forwarded_proto;
       
       proxy_buffering off;
       proxy_request_buffering off;
@@ -170,9 +167,7 @@ http {
       proxy_set_header Host $http_host;
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-
-      # When setting up Harbor behind other proxy, such as an Nginx instance, remove the below line if the proxy already has similar settings.
-      proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_set_header X-Forwarded-Proto $x_forwarded_proto;
       proxy_buffering off;
       proxy_request_buffering off;
 
@@ -196,9 +191,7 @@ http {
       proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-
-      # When setting up Harbor behind other proxy, such as an Nginx instance, remove the below line if the proxy already has similar settings.
-      proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_set_header X-Forwarded-Proto $x_forwarded_proto;
 
       proxy_buffering off;
       proxy_request_buffering off;

--- a/make/photon/prepare/templates/nginx/nginx.https.conf.jinja
+++ b/make/photon/prepare/templates/nginx/nginx.https.conf.jinja
@@ -42,6 +42,11 @@ http {
 
   access_log /dev/stdout timed_combined;
 
+  map $http_x_forwarded_proto $x_forwarded_proto {
+    default $http_x_forwarded_proto;
+    ""      $scheme;
+  }
+
   include /etc/nginx/conf.d/*.server.conf;
 
   server {
@@ -88,9 +93,7 @@ http {
       proxy_set_header Host $http_host;
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-      
-      # When setting up Harbor behind other proxy, such as an Nginx instance, remove the below line if the proxy already has similar settings.
-      proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_set_header X-Forwarded-Proto $x_forwarded_proto;
 
       proxy_cookie_path / "/; HttpOnly; Secure";
 
@@ -114,9 +117,7 @@ http {
       proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-
-      # When setting up Harbor behind other proxy, such as an Nginx instance, remove the below line if the proxy already has similar settings.
-      proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_set_header X-Forwarded-Proto $x_forwarded_proto;
 
       proxy_cookie_path / "/; Secure";
 
@@ -140,9 +141,7 @@ http {
       proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-
-      # When setting up Harbor behind other proxy, such as an Nginx instance, remove the below line if the proxy already has similar settings.
-      proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_set_header X-Forwarded-Proto $x_forwarded_proto;
 
       proxy_cookie_path / "/; Secure";
       
@@ -166,9 +165,7 @@ http {
       proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-
-      # When setting up Harbor behind other proxy, such as an Nginx instance, remove the below line if the proxy already has similar settings.
-      proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_set_header X-Forwarded-Proto $x_forwarded_proto;
 
       proxy_cookie_path / "/; Secure";
       
@@ -196,9 +193,7 @@ http {
       proxy_set_header Host $http_host;
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-      
-      # When setting up Harbor behind other proxy, such as an Nginx instance, remove the below line if the proxy already has similar settings.
-      proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_set_header X-Forwarded-Proto $x_forwarded_proto;
       proxy_buffering off;
       proxy_request_buffering off;
       proxy_send_timeout 900;
@@ -221,9 +216,7 @@ http {
       proxy_set_header Host $http_host;
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-      
-      # When setting up Harbor behind other proxy, such as an Nginx instance, remove the below line if the proxy already has similar settings.
-      proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_set_header X-Forwarded-Proto $x_forwarded_proto;
 
       proxy_cookie_path / "/; Secure";
 


### PR DESCRIPTION
Refine the way to set the header so user won't need to comment it if
Harbor is sitting behind a reverse proxy.

Signed-off-by: Daniel Jiang <jiangd@vmware.com>