### PR TITLE
Remove external_redis.port from migration script since not used since v1.10.0

### DIFF
--- a/make/photon/prepare/migrations/version_2_0_0/harbor.yml.jinja
+++ b/make/photon/prepare/migrations/version_2_0_0/harbor.yml.jinja
@@ -323,7 +323,7 @@ external_redis:
   # host for redis: <host_redis>:<port_redis>
   # host for redis+sentinel:
   #  <host_sentinel1>:<port_sentinel1>,<host_sentinel2>:<port_sentinel2>,<host_sentinel3>:<port_sentinel3>
-  host: {{ external_redis.host }}
+  host: {{ external_redis.host }}::{{ external_redis.port }}
   password: {{ external_redis.password }}
   # sentinel_master_set must be set to support redis+sentinel
   #sentinel_master_set:

--- a/make/photon/prepare/migrations/version_2_0_0/harbor.yml.jinja
+++ b/make/photon/prepare/migrations/version_2_0_0/harbor.yml.jinja
@@ -323,7 +323,7 @@ external_redis:
   # host for redis: <host_redis>:<port_redis>
   # host for redis+sentinel:
   #  <host_sentinel1>:<port_sentinel1>,<host_sentinel2>:<port_sentinel2>,<host_sentinel3>:<port_sentinel3>
-  host: {{ external_redis.host }}::{{ external_redis.port }}
+  host: {{ external_redis.host }}:{{ external_redis.port }}
   password: {{ external_redis.password }}
   # sentinel_master_set must be set to support redis+sentinel
   #sentinel_master_set:

--- a/make/photon/prepare/migrations/version_2_0_0/harbor.yml.jinja
+++ b/make/photon/prepare/migrations/version_2_0_0/harbor.yml.jinja
@@ -323,7 +323,7 @@ external_redis:
   # host for redis: <host_redis>:<port_redis>
   # host for redis+sentinel:
   #  <host_sentinel1>:<port_sentinel1>,<host_sentinel2>:<port_sentinel2>,<host_sentinel3>:<port_sentinel3>
-  host: {{ external_redis.host }}:{{ external_redis.port }}
+  host: {{ external_redis.host }}
   password: {{ external_redis.password }}
   # sentinel_master_set must be set to support redis+sentinel
   #sentinel_master_set:

--- a/make/photon/prepare/migrations/version_2_1_0/harbor.yml.jinja
+++ b/make/photon/prepare/migrations/version_2_1_0/harbor.yml.jinja
@@ -373,7 +373,7 @@ external_redis:
   # host for redis: <host_redis>:<port_redis>
   # host for redis+sentinel:
   #  <host_sentinel1>:<port_sentinel1>,<host_sentinel2>:<port_sentinel2>,<host_sentinel3>:<port_sentinel3>
-  host: {{ external_redis.host }}:{{ external_redis.port }}
+  host: {{ external_redis.host }}
   password: {{ external_redis.password }}
   # sentinel_master_set must be set to support redis+sentinel
   #sentinel_master_set:

--- a/make/photon/prepare/migrations/version_2_1_0/harbor.yml.jinja
+++ b/make/photon/prepare/migrations/version_2_1_0/harbor.yml.jinja
@@ -373,7 +373,7 @@ external_redis:
   # host for redis: <host_redis>:<port_redis>
   # host for redis+sentinel:
   #  <host_sentinel1>:<port_sentinel1>,<host_sentinel2>:<port_sentinel2>,<host_sentinel3>:<port_sentinel3>
-  host: {{ external_redis.host }}
+  host: {{ external_redis.host }}:{{ external_redis.port }}
   password: {{ external_redis.password }}
   # sentinel_master_set must be set to support redis+sentinel
   #sentinel_master_set:

--- a/make/photon/prepare/migrations/version_2_2_0/harbor.yml.jinja
+++ b/make/photon/prepare/migrations/version_2_2_0/harbor.yml.jinja
@@ -350,7 +350,7 @@ external_redis:
   # host for redis: <host_redis>:<port_redis>
   # host for redis+sentinel:
   #  <host_sentinel1>:<port_sentinel1>,<host_sentinel2>:<port_sentinel2>,<host_sentinel3>:<port_sentinel3>
-  host: {{ external_redis.host }}:{{ external_redis.port }}
+  host: {{ external_redis.host }}
   password: {{ external_redis.password }}
   # sentinel_master_set must be set to support redis+sentinel
   #sentinel_master_set:


### PR DESCRIPTION
Hello,

Trying to update Harbor from v2.1.2 to 2.2.0, we faced an issue due to how jinja2 template is made.
We are using redis+sentinel and we were unable to make the migration works.

Navigating to the jinja2 template you made, it allowed me to see a field "{{ external_redis.port }}" was used but removed since v1.10.0 (version since when you're supporting redis and redis+sentinel).

Anyway, removing this field allowed me to migrate my harbor.yml file.

I don't know if there are side-effects for such a modification but don't hesitate to tell me if there is something more to change.

Alexis

_(I made a PR few minutes ago but she wasn't following your contribution requirements)_