### PR TITLE
Before fetching the GitLab repository check if the project has container registry enabled to avoid 403 error

### DIFF
--- a/src/replication/adapter/gitlab/adapter.go
+++ b/src/replication/adapter/gitlab/adapter.go
@@ -116,6 +116,11 @@ func (a *adapter) FetchArtifacts(filters []*model.Filter) ([]*model.Resource, er
 	}
 
 	for _, project := range projects {
+		if !project.RegistryEnabled {
+			log.Debugf("Skipping project %s: Registry is not enabled", project.Name)
+			continue
+		}
+
 		repositories, err := a.clientGitlabAPI.getRepositories(project.ID)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
registry enabled.
closes #14328 
closes #13353

Signed-off-by: Vadim Bauer <vb@container-registry.com>