### PR TITLE
Remove python3.7 deployment in CI installtion phase.

### DIFF
--- a/tests/ci/api_common_install.sh
+++ b/tests/ci/api_common_install.sh
@@ -15,10 +15,6 @@ python --version
 pip -V
 cat /etc/issue
 cat /proc/version
-sudo apt-get update -y && sudo apt-get install -y zbar-tools libzbar-dev python-zbar python3.7
-sudo rm /usr/bin/python && sudo ln -s /usr/bin/python3.7 /usr/bin/python
-sudo apt-get install -y python3-pip
-pip -V
 sudo -H pip install --ignore-installed urllib3 chardet requests --upgrade
 python --version
 


### PR DESCRIPTION
Git action work node OS had python3.8 deployed already, so won't necessary to install python3.7 in CI.

Signed-off-by: danfengliu <danfengl@vmware.com>