### PR TITLE
[cherry-pick 2.2.0] Replace python3.7 by 3.6 in CI installtion phase

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -93,7 +93,7 @@ jobs:
     runs-on:
       #- self-hosted
       - ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 90
     steps:
       - name: Set up Go 1.14
         uses: actions/setup-go@v1
@@ -153,7 +153,7 @@ jobs:
     runs-on:
       #- self-hosted
       - ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 90
     steps:
       - name: Set up Go 1.14
         uses: actions/setup-go@v1

--- a/tests/ci/api_common_install.sh
+++ b/tests/ci/api_common_install.sh
@@ -15,8 +15,8 @@ python --version
 pip -V
 cat /etc/issue
 cat /proc/version
-sudo apt-get update -y && sudo apt-get install -y zbar-tools libzbar-dev python-zbar python3.7
-sudo rm /usr/bin/python && sudo ln -s /usr/bin/python3.7 /usr/bin/python
+sudo apt-get update -y && sudo apt-get install -y python3.6
+sudo rm /usr/bin/python && sudo ln -s /usr/bin/python3.6 /usr/bin/python
 sudo apt-get install -y python3-pip
 pip -V
 sudo -H pip install --ignore-installed urllib3 chardet requests --upgrade


### PR DESCRIPTION
Remove python packges, and install python 3.6  to  replace python 3.7.

Signed-off-by: danfengliu <danfengl@vmware.com>