### PR TITLE
Use exec in all components' entrypoints

### DIFF
--- a/make/photon/chartserver/docker-entrypoint.sh
+++ b/make/photon/chartserver/docker-entrypoint.sh
@@ -5,6 +5,4 @@ set -e
 /home/chart/install_cert.sh
 
 #Start the server process
-/home/chart/chartm
-
-set +e
+exec /home/chart/chartm

--- a/make/photon/core/entrypoint.sh
+++ b/make/photon/core/entrypoint.sh
@@ -4,4 +4,4 @@ set -e
 
 /harbor/install_cert.sh
 
-/harbor/harbor_core
+exec /harbor/harbor_core

--- a/make/photon/exporter/entrypoint.sh
+++ b/make/photon/exporter/entrypoint.sh
@@ -4,4 +4,4 @@ set -e
 
 /harbor/install_cert.sh
 
-/harbor/harbor_exporter
+exec /harbor/harbor_exporter

--- a/make/photon/jobservice/entrypoint.sh
+++ b/make/photon/jobservice/entrypoint.sh
@@ -4,4 +4,4 @@ set -e
 
 /harbor/install_cert.sh
 
-/harbor/harbor_jobservice -c /etc/jobservice/config.yml
+exec /harbor/harbor_jobservice -c /etc/jobservice/config.yml

--- a/make/photon/registry/entrypoint.sh
+++ b/make/photon/registry/entrypoint.sh
@@ -10,4 +10,4 @@ set -e
 
 /home/harbor/install_cert.sh
 
-/usr/bin/registry_DO_NOT_USE_GC serve /etc/registry/config.yml
+exec /usr/bin/registry_DO_NOT_USE_GC serve /etc/registry/config.yml

--- a/make/photon/trivy-adapter/entrypoint.sh
+++ b/make/photon/trivy-adapter/entrypoint.sh
@@ -4,4 +4,4 @@ set -e
 
 /home/scanner/install_cert.sh
 
-/home/scanner/bin/scanner-trivy
+exec /home/scanner/bin/scanner-trivy


### PR DESCRIPTION
Use the exec Bash command so that the final running application becomes
the container’s PID 1. This allows the application to receive any Unix
signals sent to the container, in accordance with
https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#entrypoint

Currently, SIGTERM signals sent by kubernetes are not passed to the
executed binary.

Closes #14382

Signed-off-by: Xavier Duthil <xavier.duthil@ovhcloud.com>