### PR TITLE
[Cherry-pick 2.0.0] Remove deploytment of python3.6 and set dns for docker

### DIFF
--- a/tests/ci/api_common_install.sh
+++ b/tests/ci/api_common_install.sh
@@ -16,12 +16,36 @@ python --version
 pip -V
 cat /etc/issue
 cat /proc/version
-sudo apt-get update -y && sudo apt-get install -y python3.6
-sudo rm /usr/bin/python && sudo ln -s /usr/bin/python3.6 /usr/bin/python
-sudo apt-get install -y python3-pip
 pip -V
 sudo -H pip install --ignore-installed urllib3 chardet requests --upgrade
 python --version
+
+#---------------Set DNS for docker v20----------------------#
+# In docker v20, it fixed an issue named  "Wrong resolv.conf
+# used on Ubuntu 19", this fix caused DNS solve problem
+# in container. So the current work round is read DNS server
+# from system and set the value in /etc/docker/daemon.json.
+
+ip addr
+dns_ip=$(netplan ip leases eth0 | grep -i dns | awk -F = '{print $2}')
+dns_ip_list=$(echo $dns_ip | tr " " "\n")
+dns_cfg=""
+for ip in $dns_ip_list
+do
+    dns_cfg="$dns_cfg,\"$ip\""
+done
+
+cat /etc/docker/daemon.json
+
+if [ $(cat /etc/docker/daemon.json |grep \"dns\" |wc -l) -eq 0 ];then
+    sudo sed "s/}/,\n   \"dns\": [${dns_cfg:1}]\n}/" -i /etc/docker/daemon.json
+fi
+
+cat /etc/docker/daemon.json
+sudo systemctl daemon-reload
+sudo systemctl restart docker
+sudo systemctl status docker
+#-------------------------------------------------------------#
 
 sudo ./tests/hostcfg.sh
 


### PR DESCRIPTION
Docker v20 is the default version for git action, dns should be set manually.
Python v3.8 is the default version for git action, so remove deployment for python v3.6.

Signed-off-by: danfengliu <danfengl@vmware.com>