### PR TITLE
Add order by ID when listing tasks to avoid duplicated records

### DIFF
--- a/src/pkg/task/dao/task.go
+++ b/src/pkg/task/dao/task.go
@@ -76,7 +76,7 @@ func (t *taskDAO) List(ctx context.Context, query *q.Query) ([]*Task, error) {
 	if err != nil {
 		return nil, err
 	}
-	qs = qs.OrderBy("-StartTime")
+	qs = qs.OrderBy("-StartTime", "ID")
 	if _, err = qs.All(&tasks); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Add order by ID when listing tasks to avoid duplicated records

Signed-off-by: Wenkai Yin <yinw@vmware.com>