### PR TITLE
fix the DB perms

### DIFF
--- a/make/photon/db/docker-entrypoint.sh
+++ b/make/photon/db/docker-entrypoint.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+chmod -R 0700 /var/lib/postgresql/data/pgdata
+
 # usage: file_env VAR [DEFAULT]
 #    ie: file_env 'XYZ_DB_PASSWORD' 'example'
 # (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of

--- a/make/photon/db/docker-entrypoint.sh
+++ b/make/photon/db/docker-entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-chmod -R 0700 /var/lib/postgresql/data/pgdata
+find /var/lib/postgresql/data -type d -print0 | xargs -0 chmod 700
 
 # usage: file_env VAR [DEFAULT]
 #    ie: file_env 'XYZ_DB_PASSWORD' 'example'


### PR DESCRIPTION
I opened an issue with the helm chart @ https://github.com/goharbor/harbor-helm/issues/910 and linked in two more issues. Additionally I see that other people have changed the helm chart in an attempt to fix this probem: https://github.com/goharbor/harbor-helm/blob/master/templates/database/database-ss.yaml#L53-L65

I feel like the best fix isn't hoping kubernetes (or the PVC) does things in the correct order - lets just set the permissions before postgres actually does anything. We can simplify the helm chart and not need an initcontainer which will help it start faster, and reliably twiddle the permissions as late as possible.