### PR TITLE
feat(oidc): support custom email claim

### DIFF
--- a/src/common/const.go
+++ b/src/common/const.go
@@ -115,6 +115,7 @@ const (
 	OIDCExtraRedirectParms           = "oidc_extra_redirect_parms"
 	OIDCScope                        = "oidc_scope"
 	OIDCUserClaim                    = "oidc_user_claim"
+	OIDCEmailClaim                   = "oidc_email_claim"
 
 	CfgDriverDB                       = "db"
 	NewHarborAdminName                = "admin@harbor.local"

--- a/src/lib/config/metadata/metadatalist.go
+++ b/src/lib/config/metadata/metadatalist.go
@@ -145,6 +145,7 @@ var (
 		{Name: common.OIDCAdminGroup, Scope: UserScope, Group: OIDCGroup, ItemType: &StringType{}, Description: `The OIDC group which has the harbor admin privileges`},
 		{Name: common.OIDCScope, Scope: UserScope, Group: OIDCGroup, ItemType: &StringType{}, Description: `The scope of the OIDC provider`},
 		{Name: common.OIDCUserClaim, Scope: UserScope, Group: OIDCGroup, ItemType: &StringType{}, Description: `The attribute claims the username`},
+		{Name: common.OIDCEmailClaim, Scope: UserScope, Group: OIDCGroup, ItemType: &StringType{}},
 		{Name: common.OIDCVerifyCert, Scope: UserScope, Group: OIDCGroup, DefaultValue: "true", ItemType: &BoolType{}, Description: `Verify the OIDC provider's certificate'`},
 		{Name: common.OIDCAutoOnboard, Scope: UserScope, Group: OIDCGroup, DefaultValue: "false", ItemType: &BoolType{}, Description: `Auto onboard the OIDC user`},
 		{Name: common.OIDCExtraRedirectParms, Scope: UserScope, Group: OIDCGroup, DefaultValue: "{}", ItemType: &StringToStringMapType{}, Description: `Extra parameters to add when redirect request to OIDC provider`},

--- a/src/lib/config/models/model.go
+++ b/src/lib/config/models/model.go
@@ -54,6 +54,7 @@ type OIDCSetting struct {
 	RedirectURL        string            `json:"redirect_url"`
 	Scope              []string          `json:"scope"`
 	UserClaim          string            `json:"user_claim"`
+	EmailClaim         string            `json:"email_claim"`
 	ExtraRedirectParms map[string]string `json:"extra_redirect_parms"`
 }
 

--- a/src/lib/config/test/userconfig_test.go
+++ b/src/lib/config/test/userconfig_test.go
@@ -272,6 +272,7 @@ func TestOIDCSetting(t *testing.T) {
 		common.OIDCScope:        "openid, profile",
 		common.OIDCGroupsClaim:  "my_group",
 		common.OIDCUserClaim:    "username",
+		common.OIDCEmailClaim:   "email",
 		common.OIDCCLientID:     "client",
 		common.OIDCClientSecret: "secret",
 		common.ExtEndpoint:      "https://harbor.test",
@@ -289,6 +290,7 @@ func TestOIDCSetting(t *testing.T) {
 	assert.Equal(t, "https://harbor.test/c/oidc/callback", v.RedirectURL)
 	assert.ElementsMatch(t, []string{"openid", "profile"}, v.Scope)
 	assert.Equal(t, "username", v.UserClaim)
+	assert.Equal(t, "email", v.EmailClaim)
 }
 
 func TestSplitAndTrim(t *testing.T) {

--- a/src/lib/config/userconfig.go
+++ b/src/lib/config/userconfig.go
@@ -187,6 +187,7 @@ func OIDCSetting(ctx context.Context) (*cfgModels.OIDCSetting, error) {
 		RedirectURL:        extEndpoint + common.OIDCCallbackPath,
 		Scope:              scope,
 		UserClaim:          mgr.Get(ctx, common.OIDCUserClaim).GetString(),
+		EmailClaim:         mgr.Get(ctx, common.OIDCEmailClaim).GetString(),
 		ExtraRedirectParms: mgr.Get(ctx, common.OIDCExtraRedirectParms).GetStringToStringMap(),
 	}, nil
 }

--- a/src/portal/src/app/base/left-side-nav/config/auth/config-auth.component.html
+++ b/src/portal/src/app/base/left-side-nav/config/auth/config-auth.component.html
@@ -437,6 +437,19 @@
                 [(ngModel)]="currentConfig.oidc_user_claim.value" id="oidcUserClaim" size="40"
                 [disabled]="!currentConfig.oidc_auto_onboard.value || disabled(currentConfig.oidc_user_claim)" pattern="^[a-zA-Z0-9_-]*$">
         </clr-input-container>
+        <clr-input-container>
+            <label  for="oidcEmailClaim">{{'CONFIG.OIDC.EMAIL_CLAIM' | translate}}
+                <clr-tooltip>
+                    <clr-icon clrTooltipTrigger shape="info-circle" size="24"></clr-icon>
+                    <clr-tooltip-content clrPosition="top-right" clrSize="lg" *clrIfOpen>
+                        <span>{{'TOOLTIP.OIDC_EMAIL_CLAIM' | translate}}</span>
+                    </clr-tooltip-content>
+                </clr-tooltip>
+            </label>
+            <input autocomplete="off" clrInput name="oidcEmailClaim" type="text" #oidcEmailClaimInput="ngModel"
+                   [(ngModel)]="currentConfig.oidc_email_claim.value" id="oidcEmailClaim" size="40"
+                   [disabled]="!currentConfig.oidc_auto_onboard.value || disabled(currentConfig.oidc_email_claim)" pattern="^[a-zA-Z0-9_-]*$">
+        </clr-input-container>
         <div class="oidc-tip">{{ 'CONFIG.OIDC.OIDC_REDIREC_URL' | translate}}
             <span>{{redirectUrl}}/c/oidc/callback</span>
         </div>

--- a/src/portal/src/app/base/left-side-nav/config/config.ts
+++ b/src/portal/src/app/base/left-side-nav/config/config.ts
@@ -103,6 +103,7 @@ export class Configuration {
     oidc_auto_onboard?: BoolValueItem;
     oidc_scope?: StringValueItem;
     oidc_user_claim?: StringValueItem;
+    oidc_email_claim?: StringValueItem;
     count_per_project: NumberValueItem;
     storage_per_project: NumberValueItem;
     cfg_expiration: NumberValueItem;
@@ -167,6 +168,7 @@ export class Configuration {
         this.oidc_groups_claim = new StringValueItem('', true);
         this.oidc_admin_group = new StringValueItem('', true);
         this.oidc_user_claim = new StringValueItem('', true);
+        this.oidc_email_claim = new StringValueItem('', true);
         this.count_per_project = new NumberValueItem(-1, true);
         this.storage_per_project = new NumberValueItem(-1, true);
     }

--- a/src/portal/src/i18n/lang/en-us-lang.json
+++ b/src/portal/src/i18n/lang/en-us-lang.json
@@ -105,6 +105,7 @@
         "OIDC_GROUP_CLAIM_WARNING": "It can only contain letters, numbers, underscores, and the input length is no more than 256 characters.",
         "OIDC_AUTOONBOARD": "Skip the onboarding screen, so user cannot change its username. Username is provided from ID Token",
         "OIDC_USER_CLAIM": "The name of the claim in the ID Token where the username is retrieved from. If not specified, it will default to 'name'",
+        "OIDC_EMAIL_CLAIM": "The name of the claim in the ID Token where the email is retrieved from. If not specified, it will default to 'email'",
         "NEW_SECRET": "The secret must longer than 8 chars with at least 1 uppercase letter, 1 lowercase letter and 1 number"
     },
     "PLACEHOLDER": {
@@ -940,6 +941,7 @@
             "OIDC_VERIFYCERT": "Verify Certificate",
             "OIDC_AUTOONBOARD": "Automatic onboarding",
             "USER_CLAIM": "Username Claim",    
+            "EMAIL_CLAIM": "Email Claim",
             "OIDC_SETNAME": "Set OIDC Username",
             "OIDC_SETNAMECONTENT": "You must create a Harbor username the first time when authenticating via a third party(OIDC).This will be used within Harbor to be associated with projects, roles, etc.",
             "OIDC_USERNAME": "Username",


### PR DESCRIPTION
Since `email` is required to be unique, this will enable other claims to be used in cases where the `email` claim from UserInfo endpoint is blank or does not exist.
Fixes https://github.com/goharbor/harbor/issues/13269

Signed-off-by: Jeremy Tan <jeremy.tan@verys.com>