### PR TITLE
Support proxy cache for docker-registry type

### DIFF
--- a/make/photon/prepare/templates/core/env.jinja
+++ b/make/photon/prepare/templates/core/env.jinja
@@ -39,7 +39,7 @@ WITH_CHARTMUSEUM={{with_chartmuseum}}
 REGISTRY_CREDENTIAL_USERNAME={{registry_username}}
 REGISTRY_CREDENTIAL_PASSWORD={{registry_password}}
 CSRF_KEY={{csrf_key}}
-PERMITTED_REGISTRY_TYPES_FOR_PROXY_CACHE=docker-hub,harbor,azure-acr,aws-ecr,google-gcr,quay
+PERMITTED_REGISTRY_TYPES_FOR_PROXY_CACHE=docker-hub,harbor,azure-acr,aws-ecr,google-gcr,quay,docker-registry
 
 HTTP_PROXY={{core_http_proxy}}
 HTTPS_PROXY={{core_https_proxy}}


### PR DESCRIPTION
Add proxy cache for docker registry type
Fixes #14477, #14547
Signed-off-by: stonezdj <stonezdj@gmail.com>