### PR TITLE
Fix nightly issue: can not add user that never logged in projectmember api

### DIFF
--- a/src/controller/member/controller.go
+++ b/src/controller/member/controller.go
@@ -137,7 +137,7 @@ func (c *controller) Create(ctx context.Context, projectNameOrID interface{}, re
 		var userID int
 		member.EntityType = common.UserMember
 		u, err := c.userManager.GetByName(ctx, req.MemberUser.Username)
-		if err != nil {
+		if err != nil && !errors.IsNotFoundErr(err) {
 			return 0, err
 		}
 		if u != nil {


### PR DESCRIPTION
Handle the NotFoundError in userManager.GetUserByName()

Signed-off-by: stonezdj <stonezdj@gmail.com>