### PR TITLE
[ 2.1.0 ] Add build base step to UT test in CI

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -45,20 +45,11 @@ jobs:
       - uses: actions/checkout@v2
         with:
           path: src/github.com/goharbor/harbor
-      - name: Build Dev Base Image
-        if: contains(steps.changed-files.outputs.modified, 'Dockerfile.base') && contains(github.ref, 'master')
+      - name: Build Base Image
+        if: contains(steps.changed-files.outputs.modified, 'Dockerfile.base') || contains(steps.changed-files.outputs.modified, 'VERSION')
         run: |
           set -x
           base_image_tag=$(cat ./VERSION)
-          echo "Start to build base image for dev ......"
-          cd src/github.com/goharbor/harbor
-          sudo make build_base_docker -e BASEIMAGETAG=$base_image_tag -e REGISTRYUSER="${{ secrets.DOCKER_HUB_USERNAME }}" -e REGISTRYPASSWORD="${{ secrets.DOCKER_HUB_PASSWORD }}" -e PUSHBASEIMAGE=yes
-      - name: Build Release Base Image
-        if: contains(steps.changed-files.outputs.modified, 'VERSION')
-        run: |
-          set -x
-          base_image_tag=$(cat ./VERSION)
-          echo "Start to build base image for release $(base_image_tag) ......"
           cd src/github.com/goharbor/harbor
           sudo make build_base_docker -e BASEIMAGETAG=$base_image_tag -e REGISTRYUSER="${{ secrets.DOCKER_HUB_USERNAME }}" -e REGISTRYPASSWORD="${{ secrets.DOCKER_HUB_PASSWORD }}" -e PUSHBASEIMAGE=yes
       - name: Build Package

--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,7 @@ VERSIONTAG=dev
 PUSHBASEIMAGE=
 BASEIMAGETAG=dev
 BASEIMAGENAMESPACE=goharbor
+BUILDBASETARGET=chartserver clair clair-adapter trivy-adapter core db jobservice log nginx notary-server notary-signer portal prepare redis registry registryctl
 # for harbor package name
 PKGVERSIONTAG=dev
 
@@ -425,7 +426,7 @@ build_base_docker:
 	else \
 		echo "No docker credentials provided, please make sure enough priviledges to access docker hub!" ; \
 	fi
-	@for name in chartserver clair clair-adapter trivy-adapter core db jobservice log nginx notary-server notary-signer portal prepare redis registry registryctl; do \
+	@for name in $(BUILDBASETARGET); do \
 		echo $$name ; \
 		$(DOCKERBUILD) --pull --no-cache -f $(MAKEFILEPATH_PHOTON)/$$name/Dockerfile.base -t $(BASEIMAGENAMESPACE)/harbor-$$name-base:$(BASEIMAGETAG) --label base-build-date=$(date +"%Y%m%d") . && \
 		if [ -n "$(PUSHBASEIMAGE)" ] ; then \
@@ -434,7 +435,7 @@ build_base_docker:
 	done
 
 pull_base_docker:
-	@for name in chartserver clair clair-adapter trivy-adapter core db jobservice log nginx notary-server notary-signer portal prepare redis registry registryctl; do \
+	@for name in $(BUILDBASETARGET); do \
 		echo $$name ; \
 		$(DOCKERPULL) $(BASEIMAGENAMESPACE)/harbor-$$name-base:$(BASEIMAGETAG) ; \
 	done

--- a/tests/ci/ut_install.sh
+++ b/tests/ci/ut_install.sh
@@ -21,6 +21,7 @@ sudo rm -rf /data/*
 sudo -E env "PATH=$PATH" make go_check
 sudo ./tests/hostcfg.sh
 sudo ./tests/generateCerts.sh
+sudo make build_base_docker -e BUILDBASETARGET="db registry prepare"
 sudo make build -e BUILDTARGET="_build_db _build_registry _build_prepare"
 docker run --rm -v /:/hostfs:z goharbor/prepare:dev gencert -p /etc/harbor/tls/internal
 sudo MAKEPATH=$(pwd)/make ./make/prepare

--- a/tests/robot-cases/Group1-Nightly/Setup_Nightly.robot
+++ b/tests/robot-cases/Group1-Nightly/Setup_Nightly.robot
@@ -19,6 +19,7 @@ Default Tags  Nightly
 
 *** Test Cases ***
 Test Suites Setup For UI Test
+    [Tags]  setup
     Nightly Test Setup For Nightly  ${ip}  ${HARBOR_PASSWORD}  ${ip1}
     Setup API Test
 


### PR DESCRIPTION
1. Add buid base step to UT test in CI, base image used by UI test
should be built before buiding harbor image;
2. In build package workflow, trigger build base image step in condition of changing both in
Dockerfile.base and VERSION
3. Add tag for setup nightly test

Signed-off-by: danfengliu <danfengl@vmware.com>