### PR TITLE
Do not get OIDC info for admin user

### DIFF
--- a/src/controller/user/controller.go
+++ b/src/controller/user/controller.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/goharbor/harbor/src/common/security"
 	"github.com/goharbor/harbor/src/common/security/local"
+	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/lib/q"
 	"github.com/goharbor/harbor/src/pkg/oidc"
 	"github.com/goharbor/harbor/src/pkg/user"
@@ -102,7 +103,7 @@ func (c *controller) Get(ctx context.Context, id int, opt *Option) (*models.User
 	if opt != nil && opt.WithOIDCInfo {
 		oidcMeta, err := c.oidcMetaMgr.GetByUserID(ctx, id)
 		if err != nil {
-			return nil, err
+			return nil, errors.UnknownError(err)
 		}
 		u.OIDCUserMeta = oidcMeta
 	}

--- a/src/server/v2.0/handler/user.go
+++ b/src/server/v2.0/handler/user.go
@@ -224,7 +224,7 @@ func (u *usersAPI) getUserByID(ctx context.Context, id int) (*models.UserResp, e
 	}
 
 	opt := &user.Option{
-		WithOIDCInfo: auth == common.OIDCAuth,
+		WithOIDCInfo: auth == common.OIDCAuth && id > 1, // Super user is authenticated via DB
 	}
 
 	us, err := u.ctl.Get(ctx, id, opt)


### PR DESCRIPTION
This commit skips getting OIDC meta info for admin user.
It fixes the issue that admin user cannot login to portal, which was
introduced in refactor.

Signed-off-by: Daniel Jiang <jiangd@vmware.com>