### PR TITLE
refactor: use singular as the tag for user APIs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -297,7 +297,7 @@ endif
 SWAGGER_IMAGENAME=goharbor/swagger
 SWAGGER_VERSION=v0.21.0
 SWAGGER=$(DOCKERCMD) run --rm -u $(shell id -u):$(shell id -g) -v $(BUILDPATH):$(BUILDPATH) -w $(BUILDPATH) ${SWAGGER_IMAGENAME}:${SWAGGER_VERSION}
-SWAGGER_GENERATE_SERVER=${SWAGGER} generate server --template-dir=$(TOOLSPATH)/swagger/templates --exclude-main --additional-initialism=CVE --additional-initialism=GC
+SWAGGER_GENERATE_SERVER=${SWAGGER} generate server --template-dir=$(TOOLSPATH)/swagger/templates --exclude-main --additional-initialism=CVE --additional-initialism=GC --additional-initialism=OIDC
 SWAGGER_IMAGE_BUILD_CMD=${DOCKERBUILD} -f ${TOOLSPATH}/swagger/Dockerfile --build-arg SWAGGER_VERSION=${SWAGGER_VERSION} -t ${SWAGGER_IMAGENAME}:$(SWAGGER_VERSION) .
 
 SWAGGER_IMAGENAME:

--- a/api/v2.0/swagger.yaml
+++ b/api/v2.0/swagger.yaml
@@ -182,7 +182,7 @@ paths:
         '403':
           description: User does not have permission of admin role.
         '500':
-          description: Unexpected internal errors.        
+          description: Unexpected internal errors.
   /configurations:
     get:
       summary: Get system configurations.
@@ -191,7 +191,7 @@ paths:
       tags:
         - configure
       parameters:
-        - $ref: '#/parameters/requestId'  
+        - $ref: '#/parameters/requestId'
       responses:
         '200':
           description: Get system configurations successfully. The response body is a map.
@@ -455,7 +455,7 @@ paths:
       parameters:
         - $ref: '#/parameters/requestId'
         - $ref: '#/parameters/isResourceName'
-        - $ref: '#/parameters/projectNameOrId'        
+        - $ref: '#/parameters/projectNameOrId'
         - $ref: '#/parameters/page'
         - $ref: '#/parameters/pageSize'
         - name: entityname
@@ -473,12 +473,12 @@ paths:
               type: integer
             Link:
               description: Link refers to the previous page and next page
-              type: string          
+              type: string
           schema:
             type: array
             items:
               $ref: '#/definitions/ProjectMemberEntity'
-               
+
         '400':
           $ref: '#/responses/400'
         '401':
@@ -498,7 +498,7 @@ paths:
       parameters:
         - $ref: '#/parameters/requestId'
         - $ref: '#/parameters/isResourceName'
-        - $ref: '#/parameters/projectNameOrId'        
+        - $ref: '#/parameters/projectNameOrId'
         - name: project_member
           in: body
           schema:
@@ -530,7 +530,7 @@ paths:
       parameters:
         - $ref: '#/parameters/requestId'
         - $ref: '#/parameters/isResourceName'
-        - $ref: '#/parameters/projectNameOrId'        
+        - $ref: '#/parameters/projectNameOrId'
         - name: mid
           in: path
           type: integer
@@ -561,7 +561,7 @@ paths:
       parameters:
         - $ref: '#/parameters/requestId'
         - $ref: '#/parameters/isResourceName'
-        - $ref: '#/parameters/projectNameOrId'        
+        - $ref: '#/parameters/projectNameOrId'
         - name: mid
           in: path
           type: integer
@@ -593,7 +593,7 @@ paths:
       parameters:
         - $ref: '#/parameters/requestId'
         - $ref: '#/parameters/isResourceName'
-        - $ref: '#/parameters/projectNameOrId'    
+        - $ref: '#/parameters/projectNameOrId'
         - name: mid
           in: path
           type: integer
@@ -610,7 +610,7 @@ paths:
         '403':
           $ref: '#/responses/403'
         '500':
-          $ref: '#/responses/500'     
+          $ref: '#/responses/500'
   /repositories:
     get:
       summary: List all authorized repositories
@@ -4485,7 +4485,7 @@ paths:
     get:
       summary: List users
       tags:
-        - users
+        - user
       operationId: listUsers
       parameters:
         - $ref: '#/parameters/requestId'
@@ -4517,7 +4517,7 @@ paths:
       summary: Create a local user.
       description: This API can be used only when the authentication mode is for local DB.  When self registration is disabled.
       tags:
-        - users
+        - user
       operationId: createUser
       parameters:
         - $ref: '#/parameters/requestId'
@@ -4544,7 +4544,7 @@ paths:
     get:
       summary: Get current user info.
       tags:
-        - users
+        - user
       operationId: getCurrentUserInfo
       parameters:
         - $ref: '#/parameters/requestId'
@@ -4563,7 +4563,7 @@ paths:
       description: |
         This endpoint is to search the users by username.  It's open for all authenticated requests.
       tags:
-        - users
+        - user
       operationId: searchUsers
       parameters:
         - $ref: '#/parameters/requestId'
@@ -4603,7 +4603,7 @@ paths:
           format: int
           required: true
       tags:
-        - users
+        - user
       operationId: getUser
       responses:
         '200':
@@ -4635,7 +4635,7 @@ paths:
           schema:
             $ref: '#/definitions/UserProfile'
       tags:
-        - users
+        - user
       operationId: updateUserProfile
       responses:
         '200':
@@ -4660,7 +4660,7 @@ paths:
           required: true
           description: User ID for marking as to be removed.
       tags:
-        - users
+        - user
       operationId: deleteUser
       responses:
         '200':
@@ -4677,7 +4677,7 @@ paths:
     put:
       summary: Update a registered user to change to be an administrator of Harbor.
       tags:
-       - users
+       - user
       operationId: setUserSysAdmin
       parameters:
         - name: user_id
@@ -4708,7 +4708,7 @@ paths:
       description: |
         This endpoint is for user to update password. Users with the admin role can change any user's password. Regular users can change only their own password.
       tags:
-        - users
+        - user
       operationId: updateUserPassword
       parameters:
         - name: user_id
@@ -4737,7 +4737,7 @@ paths:
     get:
       summary: Get current user permissions.
       tags:
-        - users
+        - user
       operationId: getCurrentUserPermissions
       parameters:
         - name: scope
@@ -4771,7 +4771,7 @@ paths:
         Once this API returns with successful status, the old secret will be invalid, as there will be only one CLI secret
         for a user.
       tags:
-        - users
+        - user
       operationId: setCliSecret
       parameters:
         - $ref: '#/parameters/requestId'
@@ -7528,7 +7528,7 @@ definitions:
             description: 'The parameters of the policy, the values are dependant on the type of the policy.'
   Configurations:
     type: object
-    additionalProperties:               
+    additionalProperties:
       type: object
   StringConfigItem:
     type: object

--- a/src/server/v2.0/handler/handler.go
+++ b/src/server/v2.0/handler/handler.go
@@ -55,11 +55,11 @@ func New() http.Handler {
 		WebhookAPI:            newNotificationPolicyAPI(),
 		WebhookjobAPI:         newNotificationJobAPI(),
 		ImmutableAPI:          newImmutableAPI(),
-		OidcAPI:               newOIDCAPI(),
+		OIDCAPI:               newOIDCAPI(),
 		SystemCVEAllowlistAPI: newSystemCVEAllowListAPI(),
 		ConfigureAPI:          newConfigAPI(),
 		UsergroupAPI:          newUserGroupAPI(),
-		UsersAPI:              newUsersAPI(),
+		UserAPI:               newUsersAPI(),
 	})
 	if err != nil {
 		log.Fatal(err)

--- a/src/server/v2.0/handler/model/user.go
+++ b/src/server/v2.0/handler/model/user.go
@@ -42,7 +42,7 @@ func (u *User) ToUserResp() *svrmodels.UserResp {
 		UpdateTime:      strfmt.DateTime(u.UpdateTime),
 	}
 	if u.OIDCUserMeta != nil {
-		res.OidcUserMeta = &svrmodels.OIDCUserInfo{
+		res.OIDCUserMeta = &svrmodels.OIDCUserInfo{
 			ID:           u.OIDCUserMeta.ID,
 			UserID:       int64(u.OIDCUserMeta.UserID),
 			Subiss:       u.OIDCUserMeta.SubIss,

--- a/src/server/v2.0/handler/user_test.go
+++ b/src/server/v2.0/handler/user_test.go
@@ -41,7 +41,7 @@ type UserTestSuite struct {
 func (uts *UserTestSuite) SetupSuite() {
 	uts.uCtl = &usertesting.Controller{}
 	uts.Config = &restapi.Config{
-		UsersAPI: &usersAPI{
+		UserAPI: &usersAPI{
 			ctl: uts.uCtl,
 			getAuth: func(ctx context.Context) (string, error) {
 				return common.DBAuth, nil

--- a/tests/apitests/python/library/base.py
+++ b/tests/apitests/python/library/base.py
@@ -31,7 +31,7 @@ def _create_client(server, credential, debug, api_type="products"):
     cfg = None
     if api_type in ('projectv2', 'artifact', 'repository', 'scanner', 'scan', 'scanall', 'preheat', 'quota',
                     'replication', 'registry', 'robot', 'gc', 'retention', 'immutable', 'system_cve_allowlist',
-                    'configure', 'users', 'member'):
+                    'configure', 'user', 'member'):
         cfg = v2_swagger_client.Configuration()
     else:
         cfg = swagger_client.Configuration()
@@ -72,7 +72,7 @@ def _create_client(server, credential, debug, api_type="products"):
         "immutable":   v2_swagger_client.ImmutableApi(v2_swagger_client.ApiClient(cfg)),
         "system_cve_allowlist":  v2_swagger_client.SystemCVEAllowlistApi(v2_swagger_client.ApiClient(cfg)),
         "configure":   v2_swagger_client.ConfigureApi(v2_swagger_client.ApiClient(cfg)),
-        "users": v2_swagger_client.UsersApi(v2_swagger_client.ApiClient(cfg)),
+        "user": v2_swagger_client.UserApi(v2_swagger_client.ApiClient(cfg)),
         "member": v2_swagger_client.MemberApi(v2_swagger_client.ApiClient(cfg)),
     }.get(api_type,'Error: Wrong API type')
 

--- a/tests/apitests/python/library/user.py
+++ b/tests/apitests/python/library/user.py
@@ -8,7 +8,7 @@ from v2_swagger_client.rest import ApiException
 class User(base.Base, object):
 
     def __init__(self):
-        super(User, self).__init__(api_type = "users")
+        super(User, self).__init__(api_type = "user")
 
     def create_user(self, name=None,
                     email=None, user_password=None, realname=None, expect_status_code=201, **kwargs):


### PR DESCRIPTION
Use singular as the tag for user APIs to align with other APIs.

Signed-off-by: He Weiwei <hweiwei@vmware.com>