### PR TITLE
[ Cherry-pick 2.2.0 ] Add build base image step in build package git action workflow

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -36,9 +36,22 @@ jobs:
         with:
           docker_version: 18.09
           docker_channel: stable
+      - uses: actions/checkout@v2.1.0
+      - uses: jitterbit/get-changed-files@v1
+        id: changed-files
+        with:
+          format: space-delimited
+          token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@v2
         with:
           path: src/github.com/goharbor/harbor
+      - name: Build Base Image
+        if: contains(steps.changed-files.outputs.modified, 'Dockerfile.base') || contains(steps.changed-files.outputs.modified, 'VERSION')
+        run: |
+          set -x
+          base_image_tag=$(cat ./VERSION)
+          cd src/github.com/goharbor/harbor
+          sudo make build_base_docker -e BASEIMAGETAG=$base_image_tag -e REGISTRYUSER="${{ secrets.DOCKER_HUB_USERNAME }}" -e REGISTRYPASSWORD="${{ secrets.DOCKER_HUB_PASSWORD }}" -e PUSHBASEIMAGE=yes
       - name: Build Package
         run: |
           set -x
@@ -58,20 +71,16 @@ jobs:
 
           if [[ $target_branch == "master" ]]; then
             Harbor_Assets_Version=$Harbor_Package_Version
+            harbor_target_bucket=$harbor_builds_bucket
           else
             Harbor_Assets_Version=$target_release_version
+            harbor_target_bucket=$harbor_releases_bucket/$target_branch
           fi
 
           if [[ $target_branch == "release-"* ]]; then
             Harbor_Build_Base_Tag=$target_release_version
           else
             Harbor_Build_Base_Tag=dev
-          fi
-
-          if [[ $target_branch == "master" ]]; then
-            harbor_target_bucket=$harbor_builds_bucket
-          else
-            harbor_target_bucket=$harbor_releases_bucket/$target_branch
           fi
 
           cd src/github.com/goharbor/harbor
@@ -108,4 +117,3 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
         if: always()
-

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,5 @@ src/core/conf/app.conf
 
 src/server/v2.0/models/
 src/server/v2.0/restapi/
+.editorconfig
+

--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,7 @@ VERSIONTAG=dev
 PUSHBASEIMAGE=
 BASEIMAGETAG=dev
 BASEIMAGENAMESPACE=goharbor
+BUILDBASETARGET=chartserver trivy-adapter core db jobservice log nginx notary-server notary-signer portal prepare redis registry registryctl exporter
 # for harbor package name
 PKGVERSIONTAG=dev
 
@@ -411,7 +412,7 @@ build_base_docker:
 	else \
 		echo "No docker credentials provided, please make sure enough priviledges to access docker hub!" ; \
 	fi
-	@for name in chartserver trivy-adapter core db jobservice log nginx notary-server notary-signer portal prepare redis registry registryctl exporter; do \
+	@for name in $(BUILDBASETARGET); do \
 		echo $$name ; \
 		sleep 30 ; \
 		$(DOCKERBUILD) --pull --no-cache -f $(MAKEFILEPATH_PHOTON)/$$name/Dockerfile.base -t $(BASEIMAGENAMESPACE)/harbor-$$name-base:$(BASEIMAGETAG) --label base-build-date=$(date +"%Y%m%d") . && \
@@ -421,7 +422,7 @@ build_base_docker:
 	done
 
 pull_base_docker:
-	@for name in chartserver trivy-adapter core db jobservice log nginx notary-server notary-signer portal prepare redis registry registryctl; do \
+	@for name in $(BUILDBASETARGET); do \
 		echo $$name ; \
 		$(DOCKERPULL) $(BASEIMAGENAMESPACE)/harbor-$$name-base:$(BASEIMAGETAG) ; \
 	done

--- a/make/pushimage.sh
+++ b/make/pushimage.sh
@@ -112,3 +112,16 @@ if [ $? -ne 0 ];then
 else
   success "Pushing image $IMAGE succeeded";
 fi
+
+h2 "Remove local goharbor images"
+DOCKER_RMI="docker rmi -f $(docker images | grep "goharbor" | awk '{print $3}')"
+info "$DOCKER_RMI"
+DOCKER_RMI_OUTPUT=$($DOCKER_RMI)
+
+if [ $? -ne 0 ];then
+  warn $DOCKER_RMI_OUTPUT
+  error "Clean local goharbor images failed";
+else
+  success "Clean local goharbor images succeeded";
+fi
+

--- a/tests/ci/ut_install.sh
+++ b/tests/ci/ut_install.sh
@@ -21,6 +21,7 @@ sudo rm -rf /data/*
 sudo -E env "PATH=$PATH" make go_check
 sudo ./tests/hostcfg.sh
 sudo ./tests/generateCerts.sh
+sudo make build_base_docker -e BUILDBASETARGET="db registry prepare"
 sudo make build -e BUILDTARGET="_build_db _build_registry _build_prepare"
 docker run --rm -v /:/hostfs:z goharbor/prepare:dev gencert -p /etc/harbor/tls/internal
 sudo MAKEPATH=$(pwd)/make ./make/prepare

--- a/tests/robot-cases/Group1-Nightly/Setup_Nightly.robot
+++ b/tests/robot-cases/Group1-Nightly/Setup_Nightly.robot
@@ -19,6 +19,7 @@ Default Tags  Nightly
 
 *** Test Cases ***
 Test Suites Setup For UI Test
+    [Tags]  setup
     Nightly Test Setup For Nightly  ${ip}  ${HARBOR_PASSWORD}  ${ip1}
     Setup API Test
 


### PR DESCRIPTION
Build base image step should be in build package workflow, and local base images build by new step should be removed since images have been pushed to docker hub.

1. Add build base image step in build package git action workflow;
2. Add build base step to UT test in CI, base image used by UI test should be built before building harbor image in the same runtime;
3. In build package workflow, trigger build base image step in condition of changing both in
Dockerfile.base and VERSION;
4. Add tag for setup nightly test.

Signed-off-by: danfengliu <danfengl@vmware.com>