### PR TITLE
Fix: Use local host on db's healthcheck

### DIFF
--- a/make/photon/db/docker-healthcheck.sh
+++ b/make/photon/db/docker-healthcheck.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 set -eo pipefail
 
-h="$(hostname -i || echo '127.0.0.1')"
-host="${h%%[[:space:]]*}" #remove the trailing space
+host="localhost"
 user="${POSTGRES_USER:-postgres}"
 db="${POSTGRES_DB:-$POSTGRES_USER}"
 export PGPASSWORD="${POSTGRES_PASSWORD:-}"


### PR DESCRIPTION
hostname -i will malfunction in some cases like the `nsswitch.conf` file does'nt exist

Signed-off-by: DQ <dengq@vmware.com>