### PR TITLE
feat: add artifact count cache

### DIFF
--- a/src/core/main.go
+++ b/src/core/main.go
@@ -45,8 +45,8 @@ import (
 	"github.com/goharbor/harbor/src/core/middlewares"
 	"github.com/goharbor/harbor/src/core/service/token"
 	"github.com/goharbor/harbor/src/lib/cache"
-	_ "github.com/goharbor/harbor/src/lib/cache/memory" // memory cache
-	_ "github.com/goharbor/harbor/src/lib/cache/redis"  // redis cache
+	"github.com/goharbor/harbor/src/lib/cache/memory"
+	_ "github.com/goharbor/harbor/src/lib/cache/redis" // redis cache
 	"github.com/goharbor/harbor/src/lib/config"
 	"github.com/goharbor/harbor/src/lib/log"
 	"github.com/goharbor/harbor/src/lib/metric"
@@ -164,8 +164,13 @@ func main() {
 			beego.BConfig.WebConfig.Session.SessionProviderConfig = strings.Join(ss, ",")
 		}
 
-		log.Info("initializing cache ...")
+		log.Infof("initializing %s cache ...", u.Scheme)
 		if err := cache.Initialize(u.Scheme, redisURL); err != nil {
+			log.Fatalf("failed to initialize cache: %v", err)
+		}
+	} else {
+		log.Info("initializing in-memory cache ...")
+		if err := cache.Initialize(memory.MemoryCacheName, ""); err != nil {
 			log.Fatalf("failed to initialize cache: %v", err)
 		}
 	}

--- a/src/lib/cache/memory/memory.go
+++ b/src/lib/cache/memory/memory.go
@@ -23,6 +23,8 @@ import (
 	"github.com/goharbor/harbor/src/lib/cache"
 )
 
+const MemoryCacheName = "memory"
+
 type entry struct {
 	data        []byte
 	expiratedAt int64
@@ -48,7 +50,7 @@ func (c *Cache) Contains(key string) bool {
 	}
 
 	if e.(*entry).isExpirated() {
-		c.Delete(c.opts.Key(key))
+		_ = c.Delete(c.opts.Key(key))
 		return false
 	}
 
@@ -70,7 +72,7 @@ func (c *Cache) Fetch(key string, value interface{}) error {
 
 	e := v.(*entry)
 	if e.isExpirated() {
-		c.Delete(c.opts.Key(key))
+		_ = c.Delete(c.opts.Key(key))
 		return cache.ErrNotFound
 	}
 
@@ -116,5 +118,5 @@ func New(opts cache.Options) (cache.Cache, error) {
 }
 
 func init() {
-	cache.Register("memory", New)
+	cache.Register(MemoryCacheName, New)
 }


### PR DESCRIPTION
The artifact count function is used heavily when browsing the repository pages (and I suspect during retention jobs as well).

This PR adds a 10-minute query result cache using the keywords passed to the query.

Tested projects with repositories with tags in the 5k+ range and works well