### PR TITLE
feat: add DISABLE_QUOTA option

### DIFF
--- a/src/controller/quota/controller.go
+++ b/src/controller/quota/controller.go
@@ -143,6 +143,9 @@ func (c *controller) assembleQuota(ctx context.Context, q *quota.Quota, opts *Op
 }
 
 func (c *controller) IsEnabled(ctx context.Context, reference, referenceID string) (bool, error) {
+	if os.Getenv("DISABLE_QUOTA") == "true" {
+		return false, nil
+	}
 	d, err := Driver(ctx, reference)
 	if err != nil {
 		return false, err


### PR DESCRIPTION
Quotas are an expensive feature as `FOR UPDATE` locks are taken each time a image is written AND when tags are removed, 

On a large scale repo with per image tag counts in the 5k+ range, this reduces tag deletion by almost 80% from 10s to +- 2s