### PR TITLE
[Cherrypick to v2.2]: Add attribute admin username for authproxy

### DIFF
--- a/src/common/config/metadata/metadatalist.go
+++ b/src/common/config/metadata/metadatalist.go
@@ -130,6 +130,7 @@ var (
 		{Name: common.HTTPAuthProxyEndpoint, Scope: UserScope, Group: HTTPAuthGroup, ItemType: &StringType{}},
 		{Name: common.HTTPAuthProxyTokenReviewEndpoint, Scope: UserScope, Group: HTTPAuthGroup, ItemType: &StringType{}},
 		{Name: common.HTTPAuthProxyAdminGroups, Scope: UserScope, Group: HTTPAuthGroup, ItemType: &StringType{}},
+		{Name: common.HTTPAuthProxyAdminUsernames, Scope: UserScope, Group: HTTPAuthGroup, ItemType: &StringType{}},
 		{Name: common.HTTPAuthProxyVerifyCert, Scope: UserScope, Group: HTTPAuthGroup, DefaultValue: "true", ItemType: &BoolType{}},
 		{Name: common.HTTPAuthProxySkipSearch, Scope: UserScope, Group: HTTPAuthGroup, DefaultValue: "false", ItemType: &BoolType{}},
 		{Name: common.HTTPAuthProxyServerCertificate, Scope: UserScope, Group: HTTPAuthGroup, ItemType: &StringType{}},

--- a/src/common/const.go
+++ b/src/common/const.go
@@ -97,6 +97,7 @@ const (
 	HTTPAuthProxyEndpoint            = "http_authproxy_endpoint"
 	HTTPAuthProxyTokenReviewEndpoint = "http_authproxy_tokenreview_endpoint"
 	HTTPAuthProxyAdminGroups         = "http_authproxy_admin_groups"
+	HTTPAuthProxyAdminUsernames      = "http_authproxy_admin_usernames"
 	HTTPAuthProxyVerifyCert          = "http_authproxy_verify_cert"
 	HTTPAuthProxySkipSearch          = "http_authproxy_skip_search"
 	HTTPAuthProxyServerCertificate   = "http_authproxy_server_certificate"

--- a/src/common/models/config.go
+++ b/src/common/models/config.go
@@ -72,6 +72,7 @@ type HTTPAuthProxy struct {
 	Endpoint            string   `json:"endpoint"`
 	TokenReviewEndpoint string   `json:"tokenreivew_endpoint"`
 	AdminGroups         []string `json:"admin_groups"`
+	AdminUsernames      []string `json:"admin_usernames"`
 	VerifyCert          bool     `json:"verify_cert"`
 	SkipSearch          bool     `json:"skip_search"`
 	ServerCertificate   string   `json:"server_certificate"`

--- a/src/core/auth/authproxy/auth.go
+++ b/src/core/auth/authproxy/auth.go
@@ -116,7 +116,7 @@ func (a *Auth) tokenReview(sessionID string) (*models.User, error) {
 	if err != nil {
 		return nil, err
 	}
-	u, err := authproxy.UserFromReviewStatus(reviewStatus, httpAuthProxySetting.AdminGroups)
+	u, err := authproxy.UserFromReviewStatus(reviewStatus, httpAuthProxySetting.AdminGroups, httpAuthProxySetting.AdminUsernames)
 	if err != nil {
 		return nil, err
 	}

--- a/src/core/config/config.go
+++ b/src/core/config/config.go
@@ -392,6 +392,7 @@ func HTTPAuthProxySetting() (*models.HTTPAuthProxy, error) {
 		Endpoint:            cfgMgr.Get(common.HTTPAuthProxyEndpoint).GetString(),
 		TokenReviewEndpoint: cfgMgr.Get(common.HTTPAuthProxyTokenReviewEndpoint).GetString(),
 		AdminGroups:         splitAndTrim(cfgMgr.Get(common.HTTPAuthProxyAdminGroups).GetString(), ","),
+		AdminUsernames:      splitAndTrim(cfgMgr.Get(common.HTTPAuthProxyAdminUsernames).GetString(), ","),
 		VerifyCert:          cfgMgr.Get(common.HTTPAuthProxyVerifyCert).GetBool(),
 		SkipSearch:          cfgMgr.Get(common.HTTPAuthProxySkipSearch).GetBool(),
 		ServerCertificate:   cfgMgr.Get(common.HTTPAuthProxyServerCertificate).GetString(),

--- a/src/core/config/config_test.go
+++ b/src/core/config/config_test.go
@@ -248,6 +248,7 @@ y1bQusZMygQezfCuEzsewF+OpANFovCTUEs6s5vyoVNP8lk=
 	assert.Equal(t, *v, models.HTTPAuthProxy{
 		Endpoint:          "https://auth.proxy/suffix",
 		AdminGroups:       []string{"group1", "group2"},
+		AdminUsernames:    []string{},
 		SkipSearch:        true,
 		VerifyCert:        true,
 		ServerCertificate: certificate,

--- a/src/pkg/authproxy/http_test.go
+++ b/src/pkg/authproxy/http_test.go
@@ -27,16 +27,18 @@ func TestUserFromReviewStatus(t *testing.T) {
 		adminInAuth bool
 	}
 	cases := []struct {
-		input       v1beta1.TokenReviewStatus
-		adminGroups []string
-		expect      result
+		input          v1beta1.TokenReviewStatus
+		adminGroups    []string
+		adminUsernames []string
+		expect         result
 	}{
 		{
 			input: v1beta1.TokenReviewStatus{
 				Authenticated: false,
 				Error:         "connection error",
 			},
-			adminGroups: []string{"admin"},
+			adminGroups:    []string{"admin"},
+			adminUsernames: []string{},
 			expect: result{
 				hasErr: true,
 			},
@@ -49,7 +51,8 @@ func TestUserFromReviewStatus(t *testing.T) {
 					UID:      "u-1",
 				},
 			},
-			adminGroups: []string{"admin"},
+			adminGroups:    []string{"admin"},
+			adminUsernames: []string{},
 			expect: result{
 				hasErr:      false,
 				username:    "jack",
@@ -66,7 +69,8 @@ func TestUserFromReviewStatus(t *testing.T) {
 				},
 				Error: "",
 			},
-			adminGroups: []string{"group2", "admin"},
+			adminGroups:    []string{"group2", "admin"},
+			adminUsernames: []string{},
 			expect: result{
 				hasErr:      false,
 				username:    "daniel",
@@ -83,17 +87,18 @@ func TestUserFromReviewStatus(t *testing.T) {
 				},
 				Error: "",
 			},
-			adminGroups: []string{},
+			adminGroups:    []string{},
+			adminUsernames: []string{"daniel", "admin"},
 			expect: result{
 				hasErr:      false,
 				username:    "daniel",
 				groupLen:    2,
-				adminInAuth: false,
+				adminInAuth: true,
 			},
 		},
 	}
 	for _, c := range cases {
-		u, err := UserFromReviewStatus(c.input, c.adminGroups)
+		u, err := UserFromReviewStatus(c.input, c.adminGroups, c.adminUsernames)
 		if c.expect.hasErr == true {
 			assert.NotNil(t, err)
 		} else {

--- a/src/server/middleware/security/auth_proxy.go
+++ b/src/server/middleware/security/auth_proxy.go
@@ -86,7 +86,7 @@ func (a *authProxy) Generate(req *http.Request) security.Context {
 			return nil
 		}
 	}
-	u2, err := authproxy.UserFromReviewStatus(tokenReviewStatus, httpAuthProxyConf.AdminGroups)
+	u2, err := authproxy.UserFromReviewStatus(tokenReviewStatus, httpAuthProxyConf.AdminGroups, httpAuthProxyConf.AdminUsernames)
 	if err != nil {
 		log.Errorf("failed to get user information from token review status: %v", err)
 		return nil

--- a/src/server/middleware/security/auth_proxy_test.go
+++ b/src/server/middleware/security/auth_proxy_test.go
@@ -58,6 +58,7 @@ func TestAuthProxy(t *testing.T) {
 		VerifyCert:          false,
 		TokenReviewEndpoint: server.URL,
 		AdminGroups:         []string{},
+		AdminUsernames:      []string{},
 	})
 
 	// No onboard


### PR DESCRIPTION
This commit adds the attribute "http_authproxy_admin_usernames", which
is string that contains usernames separated by comma, when a user logs
in and the username in the tokenreview status matches the setting of
this attribute, the user will have administrator permission.

Signed-off-by: Daniel Jiang <jiangd@vmware.com>