### PR TITLE
fix rbac project subject for robot accounts

### DIFF
--- a/src/server/middleware/security/robot2.go
+++ b/src/server/middleware/security/robot2.go
@@ -2,6 +2,7 @@ package security
 
 import (
 	"fmt"
+	"github.com/goharbor/harbor/src/common/rbac"
 	"github.com/goharbor/harbor/src/common/security"
 	robotCtx "github.com/goharbor/harbor/src/common/security/robot"
 	"github.com/goharbor/harbor/src/common/utils"
@@ -60,10 +61,17 @@ func (r *robot2) Generate(req *http.Request) security.Context {
 	var accesses []*types.Policy
 	for _, p := range robot.Permissions {
 		for _, a := range p.Access {
+			var resource string
+			if a.Resource == rbac.ResourceProject && p.Kind == "project" {
+				resource = p.Scope
+			} else {
+				resource = fmt.Sprintf("%s/%s", p.Scope, a.Resource)
+			}
+
 			accesses = append(accesses, &types.Policy{
 				Action:   a.Action,
 				Effect:   a.Effect,
-				Resource: types.Resource(fmt.Sprintf("%s/%s", p.Scope, a.Resource)),
+				Resource: types.Resource(resource),
 			})
 		}
 	}

--- a/src/server/middleware/security/robot2.go
+++ b/src/server/middleware/security/robot2.go
@@ -62,17 +62,17 @@ func (r *robot2) Generate(req *http.Request) security.Context {
 	for _, p := range robot.Permissions {
 		for _, a := range p.Access {
 			var resource string
-                        if a.Resource == rbac.ResourceProject && p.Kind == "project" {
-                                resource = p.Scope
-                        } else {
-                                resource = fmt.Sprintf("%s/%s", p.Scope, a.Resource)
-                        }
+			if a.Resource == rbac.ResourceProject && p.Kind == "project" {
+				resource = p.Scope
+			} else {
+				resource = fmt.Sprintf("%s/%s", p.Scope, a.Resource)
+			}
 
-                        accesses = append(accesses, &types.Policy{
-                                Action:   a.Action,
-                                Effect:   a.Effect,
-                                Resource: types.Resource(resource),
-                        })
+			accesses = append(accesses, &types.Policy{
+				Action:   a.Action,
+				Effect:   a.Effect,
+				Resource: types.Resource(resource),
+			})
 		}
 	}
 


### PR DESCRIPTION
as we began to use system level robot acocunt we could not list, delete or get projects from the api. we discoverd that the rbac subject for projects are wrong for robot accounts.

the the naming schema for subjects is:
```
/<system | project>/<resource id>/<subresource>
```

if a robot account has premissions to list all projects, the allowed subject looks like this:
```
/project/*/project
```

but harbor expects the following subject:
```
/project/*
```

These two subjects never match, so a robot account may never manage projects. For users, the subjects are created correctly. We checked this by changing the expected subject for projects. Now robot accounts were allowed to interact with projects, but users were not.

this pr fixes this issue by omitting the subresouce for project rbac subjects.

Related issues: #14145 #14512