### PR TITLE
fix project creation with robot account

### DIFF
--- a/src/common/security/robot/context.go
+++ b/src/common/security/robot/context.go
@@ -80,6 +80,12 @@ func (s *SecurityContext) IsSolutionUser() bool {
 	return false
 }
 
+// IsSystemLevel returns if a robot is system or project level
+// true if robot is system level otherwise false
+func (s *SecurityContext) IsSystemLevel() bool {
+	return s.robot.Level == robot.LEVELSYSTEM
+}
+
 // Can returns whether the robot can do action on resource
 func (s *SecurityContext) Can(ctx context.Context, action types.Action, resource types.Resource) bool {
 	if s.robot == nil {

--- a/src/server/v2.0/handler/project.go
+++ b/src/server/v2.0/handler/project.go
@@ -158,10 +158,10 @@ func (a *projectAPI) CreateProject(ctx context.Context, params operation.CreateP
 	// set the owner as the system admin when the API being called by replication
 	// it's a solution to workaround the restriction of project creation API:
 	// only normal users can create projects
-	ownerName := secCtx.GetUsername()
-	if secCtx.IsSolutionUser() || strings.HasPrefix(ownerName, config.RobotPrefix(ctx)) {
+	if secCtx.IsSolutionUser() || secCtx.Name() == "robot" {
 		ownerID = 1
 	} else {
+		ownerName := secCtx.GetUsername()
 		user, err := a.userMgr.GetByName(ctx, ownerName)
 		if err != nil {
 			return a.SendError(ctx, err)

--- a/src/server/v2.0/handler/project.go
+++ b/src/server/v2.0/handler/project.go
@@ -159,7 +159,7 @@ func (a *projectAPI) CreateProject(ctx context.Context, params operation.CreateP
 	// it's a solution to workaround the restriction of project creation API:
 	// only normal users can create projects
 	ownerName := secCtx.GetUsername()
-	if secCtx.IsSolutionUser() || strings.HasPrefix(ownerName, config.RobotPrefix()) {
+	if secCtx.IsSolutionUser() || strings.HasPrefix(ownerName, config.RobotPrefix(ctx)) {
 		ownerID = 1
 	} else {
 		user, err := a.userMgr.GetByName(ctx, ownerName)

--- a/src/server/v2.0/handler/project.go
+++ b/src/server/v2.0/handler/project.go
@@ -101,9 +101,15 @@ func (a *projectAPI) CreateProject(ctx context.Context, params operation.CreateP
 	}
 
 	secCtx, _ := security.FromContext(ctx)
-	if onlyAdmin && !(a.isSysAdmin(ctx, rbac.ActionCreate) || secCtx.IsSolutionUser()) {
+	if onlyAdmin && secCtx.Name() != "robot" && !(a.isSysAdmin(ctx, rbac.ActionCreate) || secCtx.IsSolutionUser()) {
 		log.Errorf("Only sys admin can create project")
 		return a.SendError(ctx, errors.ForbiddenError(nil).WithMessage("Only system admin can create project"))
+	}
+
+	// always check for robots if they have permissions to create projects
+	if secCtx.Name() == "robot" && !a.isSysAdmin(ctx, rbac.ActionCreate) {
+		log.Errorf("Only sys admin can create project")
+                return a.SendError(ctx, errors.ForbiddenError(nil).WithMessage("Only system admin or users can create project"))
 	}
 
 	req := params.Project

--- a/src/server/v2.0/handler/project.go
+++ b/src/server/v2.0/handler/project.go
@@ -158,10 +158,10 @@ func (a *projectAPI) CreateProject(ctx context.Context, params operation.CreateP
 	// set the owner as the system admin when the API being called by replication
 	// it's a solution to workaround the restriction of project creation API:
 	// only normal users can create projects
-	if secCtx.IsSolutionUser() {
+	ownerName := secCtx.GetUsername()
+	if secCtx.IsSolutionUser() || strings.HasPrefix(ownerName, config.RobotPrefix()) {
 		ownerID = 1
 	} else {
-		ownerName := secCtx.GetUsername()
 		user, err := a.userMgr.GetByName(ctx, ownerName)
 		if err != nil {
 			return a.SendError(ctx, err)

--- a/src/server/v2.0/handler/project.go
+++ b/src/server/v2.0/handler/project.go
@@ -106,7 +106,7 @@ func (a *projectAPI) CreateProject(ctx context.Context, params operation.CreateP
 		return a.SendError(ctx, errors.ForbiddenError(nil).WithMessage("Only system admin can create project"))
 	}
 
-	// always check for robots if they have permissions to create projects
+	// always check if robots have permissions to create projects
 	if secCtx.Name() == "robot" && !a.isSysAdmin(ctx, rbac.ActionCreate) {
 		log.Errorf("Only sys admin can create project")
                 return a.SendError(ctx, errors.ForbiddenError(nil).WithMessage("Only system admin or users can create project"))

--- a/src/server/v2.0/handler/project.go
+++ b/src/server/v2.0/handler/project.go
@@ -163,7 +163,9 @@ func (a *projectAPI) CreateProject(ctx context.Context, params operation.CreateP
 	// set the owner as the system admin when the API being called by replication
 	// it's a solution to workaround the restriction of project creation API:
 	// only normal users can create projects
-	if secCtx.IsSolutionUser() || secCtx.Name() == "robot" {
+	if secCtx.Name() == "robot" {
+		ownerID = 0
+	} else if secCtx.IsSolutionUser() {
 		ownerID = 1
 	} else {
 		ownerName := secCtx.GetUsername()

--- a/src/server/v2.0/handler/project.go
+++ b/src/server/v2.0/handler/project.go
@@ -109,7 +109,7 @@ func (a *projectAPI) CreateProject(ctx context.Context, params operation.CreateP
 	// always check if robots have permissions to create projects
 	if secCtx.Name() == "robot" && !a.isSysAdmin(ctx, rbac.ActionCreate) {
 		log.Errorf("Only sys admin can create project")
-                return a.SendError(ctx, errors.ForbiddenError(nil).WithMessage("Only system admin or users can create project"))
+		return a.SendError(ctx, errors.ForbiddenError(nil).WithMessage("Only system admin or users can create project"))
 	}
 
 	req := params.Project


### PR DESCRIPTION
we tried to create projects using a robot account, but the api call always fails with the message "user robot$<name> not found". it turns out that harbor is trying to get the id of the current authorized user when that user is not a "solution user". since a robot account is not a regular user, the api call always aborts with the error "user not found".

this pr fixes the issue by checking if the current authorized user starts with the robot prefix. if thats the case the owner id is set to one.

Related issues: #14145