### PR TITLE
Read upstream job ID as ID when it isn't null

### DIFF
--- a/src/pkg/task/hook.go
+++ b/src/pkg/task/hook.go
@@ -49,13 +49,10 @@ func (h *HookHandler) Handle(ctx context.Context, sc *job.StatusChange) error {
 	logger := log.GetLogger(ctx)
 
 	jobID := sc.JobID
-	// when a "KindScheduled" job is scheduled by a periodical job, it's "JobID" field
-	// is set as "87bbdee19bed5ce09c48a149@1605104520" which contains "@". In this case,
-	// read the parent periodical job ID from "sc.Metadata.UpstreamJobID"
-	if sc.Metadata.JobKind == job.KindScheduled {
-		if len(sc.Metadata.UpstreamJobID) > 0 {
-			jobID = sc.Metadata.UpstreamJobID
-		}
+	// the "JobID" field of some kinds of jobs are set as "87bbdee19bed5ce09c48a149@1605104520" which contains "@".
+	// In this case, read the parent periodical job ID from "sc.Metadata.UpstreamJobID"
+	if len(sc.Metadata.UpstreamJobID) > 0 {
+		jobID = sc.Metadata.UpstreamJobID
 	}
 	tasks, err := h.taskDAO.List(ctx, &q.Query{
 		Keywords: map[string]interface{}{


### PR DESCRIPTION
Read upstream job ID as ID when it isn't null to fix the job not found error

Signed-off-by: Wenkai Yin <yinw@vmware.com>