### PR TITLE
Fix duplicate execution record issue

### DIFF
--- a/make/migrations/postgresql/0052_2.2.2_schema.up.sql
+++ b/make/migrations/postgresql/0052_2.2.2_schema.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE schedule ADD COLUMN IF NOT EXISTS revision integer;
+UPDATE schedule set revision = 0;

--- a/src/controller/scan/callback.go
+++ b/src/controller/scan/callback.go
@@ -116,9 +116,9 @@ func scanTaskStatusChange(ctx context.Context, taskID int64, status string) (err
 }
 
 // scanTaskCheckInProcessor checkin processor handles the webhook of scan job
-func scanTaskCheckInProcessor(ctx context.Context, t *task.Task, data string) (err error) {
+func scanTaskCheckInProcessor(ctx context.Context, t *task.Task, sc *job.StatusChange) (err error) {
 	checkInReport := &scan.CheckInReport{}
-	if err := checkInReport.FromJSON(data); err != nil {
+	if err := checkInReport.FromJSON(sc.CheckIn); err != nil {
 		log.G(ctx).WithField("error", err).Errorf("failed to convert data to report")
 		return err
 	}

--- a/src/controller/scan/callback_test.go
+++ b/src/controller/scan/callback_test.go
@@ -135,7 +135,7 @@ func (suite *CallbackTestSuite) TestScanTaskStatusChange() {
 
 func (suite *CallbackTestSuite) TestScanTaskCheckInProcessor() {
 	{
-		suite.Error(scanTaskCheckInProcessor(context.TODO(), &task.Task{}, "report"))
+		suite.Error(scanTaskCheckInProcessor(context.TODO(), &task.Task{}, &job.StatusChange{CheckIn: "report"}))
 	}
 
 	{
@@ -156,7 +156,7 @@ func (suite *CallbackTestSuite) TestScanTaskCheckInProcessor() {
 		}
 
 		r, _ := json.Marshal(report)
-		suite.NoError(scanTaskCheckInProcessor(context.TODO(), &task.Task{}, string(r)))
+		suite.NoError(scanTaskCheckInProcessor(context.TODO(), &task.Task{}, &job.StatusChange{CheckIn: string(r)}))
 	}
 }
 

--- a/src/pkg/retention/callback.go
+++ b/src/pkg/retention/callback.go
@@ -19,18 +19,18 @@ func init() {
 
 }
 
-func retentionTaskCheckInProcessor(ctx context.Context, t *task.Task, data string) (err error) {
+func retentionTaskCheckInProcessor(ctx context.Context, t *task.Task, sc *job.StatusChange) (err error) {
 	taskID := t.ID
 	status := t.Status
 	log.Debugf("received retention task status update event: task-%d, status-%s", taskID, status)
 	// handle checkin
-	if data != "" {
+	if sc.CheckIn != "" {
 		var retainObj struct {
 			Total    int                `json:"total"`
 			Retained int                `json:"retained"`
 			Deleted  []*selector.Result `json:"deleted"`
 		}
-		if err := json.Unmarshal([]byte(data), &retainObj); err != nil {
+		if err := json.Unmarshal([]byte(sc.CheckIn), &retainObj); err != nil {
 			log.Errorf("failed to resolve checkin of retention task %d: %v", taskID, err)
 
 			return err

--- a/src/pkg/scheduler/mock_dao_test.go
+++ b/src/pkg/scheduler/mock_dao_test.go
@@ -115,3 +115,24 @@ func (_m *mockDAO) Update(ctx context.Context, s *schedule, props ...string) err
 
 	return r0
 }
+
+// UpdateRevision provides a mock function with given fields: ctx, id, revision
+func (_m *mockDAO) UpdateRevision(ctx context.Context, id int64, revision int64) (int64, error) {
+	ret := _m.Called(ctx, id, revision)
+
+	var r0 int64
+	if rf, ok := ret.Get(0).(func(context.Context, int64, int64) int64); ok {
+		r0 = rf(ctx, id, revision)
+	} else {
+		r0 = ret.Get(0).(int64)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, int64, int64) error); ok {
+		r1 = rf(ctx, id, revision)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}

--- a/src/pkg/task/hook.go
+++ b/src/pkg/task/hook.go
@@ -17,7 +17,6 @@ package task
 import (
 	"context"
 	"fmt"
-
 	"github.com/goharbor/harbor/src/jobservice/job"
 	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/lib/log"
@@ -80,7 +79,7 @@ func (h *HookHandler) Handle(ctx context.Context, sc *job.StatusChange) error {
 		}
 		t := &Task{}
 		t.From(task)
-		return processor(ctx, t, sc.CheckIn)
+		return processor(ctx, t, sc)
 	}
 
 	// update task status

--- a/src/pkg/task/hook_test.go
+++ b/src/pkg/task/hook_test.go
@@ -43,7 +43,7 @@ func (h *hookHandlerTestSuite) SetupTest() {
 
 func (h *hookHandlerTestSuite) TestHandle() {
 	// handle check in data
-	checkInProcessorRegistry["test"] = func(ctx context.Context, task *Task, data string) (err error) { return nil }
+	checkInProcessorRegistry["test"] = func(ctx context.Context, task *Task, sc *job.StatusChange) (err error) { return nil }
 	defer delete(checkInProcessorRegistry, "test")
 	h.taskDAO.On("List", mock.Anything, mock.Anything).Return([]*dao.Task{
 		{

--- a/src/pkg/task/registry.go
+++ b/src/pkg/task/registry.go
@@ -17,6 +17,8 @@ package task
 import (
 	"context"
 	"fmt"
+
+	"github.com/goharbor/harbor/src/jobservice/job"
 )
 
 var (
@@ -26,7 +28,7 @@ var (
 )
 
 // CheckInProcessor is the processor to process the check in data which is sent by jobservice via webhook
-type CheckInProcessor func(ctx context.Context, task *Task, data string) (err error)
+type CheckInProcessor func(ctx context.Context, task *Task, sc *job.StatusChange) (err error)
 
 // StatusChangePostFunc is the function called after the task status changed
 type StatusChangePostFunc func(ctx context.Context, taskID int64, status string) (err error)


### PR DESCRIPTION
When the core service cannot response the checkin request in time, duplicated execution records may be created, this commit introduces the revision column to make sure there is only one record for one schedule trigger

Signed-off-by: Wenkai Yin <yinw@vmware.com>