### PR TITLE
fix: using new ctx to scan artifact when scanAll

### DIFF
--- a/src/controller/scan/base_controller.go
+++ b/src/controller/scan/base_controller.go
@@ -327,7 +327,7 @@ func (bc *basicController) startScanAll(ctx context.Context, executionID int64) 
 			return bc.Scan(ctx, artifact, WithExecutionID(executionID))
 		}
 
-		if err := orm.WithTransaction(scan)(ctx); err != nil {
+		if err := orm.WithTransaction(scan)(bc.makeCtx()); err != nil {
 			// Just logged
 			log.Errorf("failed to scan artifact %s, error %v", artifact, err)
 

--- a/src/controller/scan/base_controller_test.go
+++ b/src/controller/scan/base_controller_test.go
@@ -278,7 +278,7 @@ func (suite *ControllerTestSuite) SetupSuite() {
 		},
 
 		cloneCtx: func(ctx context.Context) context.Context { return ctx },
-		makeCtx:  func() context.Context { return context.TODO() },
+		makeCtx:  func() context.Context { return orm.NewContext(nil, &ormtesting.FakeOrmer{}) },
 
 		execMgr:         suite.execMgr,
 		taskMgr:         suite.taskMgr,


### PR DESCRIPTION
DB transaction failure may break the loop query of the artifacts, the
result is that not all artifacts are scanned in one scan all job. Using
a new DB connection to call the Scan method of the controller to avoid
this problem.

Signed-off-by: He Weiwei <hweiwei@vmware.com>