### PR TITLE
perf: cache the metadata of the scanner

### DIFF
--- a/src/lib/cache/cache.go
+++ b/src/lib/cache/cache.go
@@ -25,6 +25,15 @@ import (
 	"github.com/goharbor/harbor/src/lib/log"
 )
 
+const (
+	// Memory the cache name of memory
+	Memory = "memory"
+	// Redis the cache name of redis
+	Redis = "redis"
+	// RedisSentinel the cache name of redis sentinel
+	RedisSentinel = "redis+sentinel"
+)
+
 var (
 	// ErrNotFound error returns when the key value not found in the cache
 	ErrNotFound = errors.New("key not found")

--- a/src/lib/cache/memory/memory.go
+++ b/src/lib/cache/memory/memory.go
@@ -116,5 +116,5 @@ func New(opts cache.Options) (cache.Cache, error) {
 }
 
 func init() {
-	cache.Register("memory", New)
+	cache.Register(cache.Memory, New)
 }

--- a/src/lib/cache/redis/redis.go
+++ b/src/lib/cache/redis/redis.go
@@ -127,6 +127,6 @@ func New(opts cache.Options) (cache.Cache, error) {
 }
 
 func init() {
-	cache.Register("redis", New)
-	cache.Register("redis+sentinel", New)
+	cache.Register(cache.Redis, New)
+	cache.Register(cache.RedisSentinel, New)
 }

--- a/src/pkg/scan/rest/v1/client.go
+++ b/src/pkg/scan/rest/v1/client.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"net"
 	"net/http"
 	"strconv"
 	"time"
@@ -82,15 +81,8 @@ type basicClient struct {
 // NewClient news a basic client
 func NewClient(url, authType, accessCredential string, skipCertVerify bool) (Client, error) {
 	transport := &http.Transport{
-		Proxy: http.ProxyFromEnvironment,
-		DialContext: (&net.Dialer{
-			Timeout:   30 * time.Second,
-			KeepAlive: 30 * time.Second,
-		}).DialContext,
-		MaxIdleConns:          100,
-		IdleConnTimeout:       90 * time.Second,
-		TLSHandshakeTimeout:   10 * time.Second,
-		ExpectContinueTimeout: 1 * time.Second,
+		Proxy:        http.ProxyFromEnvironment,
+		MaxIdleConns: 100,
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: skipCertVerify,
 		},
@@ -103,6 +95,7 @@ func NewClient(url, authType, accessCredential string, skipCertVerify bool) (Cli
 
 	return &basicClient{
 		httpClient: &http.Client{
+			Timeout:   time.Second * 5,
 			Transport: transport,
 			CheckRedirect: func(req *http.Request, via []*http.Request) error {
 				return http.ErrUseLastResponse


### PR DESCRIPTION
1. Cache the metadata of scanner 30s.
2. Change the scanner client request timeout to 5s.

Signed-off-by: He Weiwei <hweiwei@vmware.com>