### PR TITLE
[Cherry pick]perf: cache the metadata of the scanner

### DIFF
--- a/src/controller/scanner/base_controller.go
+++ b/src/controller/scanner/base_controller.go
@@ -16,8 +16,13 @@ package scanner
 
 import (
 	"context"
+	"fmt"
+	"sync"
+	"time"
 
 	"github.com/goharbor/harbor/src/jobservice/logger"
+	"github.com/goharbor/harbor/src/lib/cache"
+	_ "github.com/goharbor/harbor/src/lib/cache/memory" // memory cache
 	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/lib/log"
 	"github.com/goharbor/harbor/src/lib/q"
@@ -47,12 +52,24 @@ func New() Controller {
 
 // basicController is default implementation of api.Controller interface
 type basicController struct {
+	sync.Once
+
 	// Managers for managing the scanner registrations
 	manager rscanner.Manager
 	// For operating the project level configured scanner
 	proMetaMgr metadata.Manager
 	// Client pool for talking to adapters
 	clientPool v1.ClientPool
+	// Cache of the scanner metadata
+	cache cache.Cache
+}
+
+func (bc *basicController) Cache() cache.Cache {
+	bc.Do(func() {
+		bc.cache, _ = cache.New(cache.Memory, cache.Expiration(time.Second*30))
+	})
+
+	return bc.cache
 }
 
 // ListRegistrations ...
@@ -261,56 +278,28 @@ func (bc *basicController) Ping(registration *scanner.Registration) (*v1.Scanner
 		return nil, errors.New("nil registration to ping")
 	}
 
-	client, err := registration.Client(bc.clientPool)
+	var (
+		err  error
+		meta *v1.ScannerAdapterMetadata
+	)
+
+	if registration.ID > 0 {
+		meta, err = bc.getScannerAdapterMetadataWithCache(registration)
+	} else {
+		meta, err = bc.getScannerAdapterMetadata(registration)
+	}
+
 	if err != nil {
+		log.G(ctx).WithField("error", err).Error("failed to ping scanner")
+
 		return nil, errors.Wrap(err, "scanner controller: ping")
 	}
 
-	meta, err := client.GetMetadata()
-	if err != nil {
-		return nil, errors.Wrap(err, "scanner controller: ping")
+	if err := meta.Validate(); err != nil {
+		return nil, err
 	}
 
-	// Validate the required properties
-	if meta.Scanner == nil ||
-		len(meta.Scanner.Name) == 0 ||
-		len(meta.Scanner.Version) == 0 ||
-		len(meta.Scanner.Vendor) == 0 {
-		return nil, errors.New("invalid scanner in metadata")
-	}
-
-	if len(meta.Capabilities) == 0 {
-		return nil, errors.New("invalid capabilities in metadata")
-	}
-
-	for _, ca := range meta.Capabilities {
-		// v1.MimeTypeDockerArtifact is required now
-		found := false
-		for _, cm := range ca.ConsumesMimeTypes {
-			if cm == v1.MimeTypeDockerArtifact {
-				found = true
-				break
-			}
-		}
-		if !found {
-			return nil, errors.Errorf("missing %s in consumes_mime_types", v1.MimeTypeDockerArtifact)
-		}
-
-		// either of v1.MimeTypeNativeReport OR v1.MimeTypeGenericVulnerabilityReport is required
-		found = false
-		for _, pm := range ca.ProducesMimeTypes {
-			if pm == v1.MimeTypeNativeReport || pm == v1.MimeTypeGenericVulnerabilityReport {
-				found = true
-				break
-			}
-		}
-
-		if !found {
-			return nil, errors.Errorf("missing %s or %s in produces_mime_types", v1.MimeTypeNativeReport, v1.MimeTypeGenericVulnerabilityReport)
-		}
-	}
-
-	return meta, err
+	return meta, nil
 }
 
 // GetMetadata ...
@@ -327,6 +316,35 @@ func (bc *basicController) GetMetadata(registrationUUID string) (*v1.ScannerAdap
 	return bc.Ping(r)
 }
 
+func (bc *basicController) getScannerAdapterMetadata(registration *scanner.Registration) (*v1.ScannerAdapterMetadata, error) {
+	client, err := registration.Client(bc.clientPool)
+	if err != nil {
+		return nil, err
+	}
+
+	return client.GetMetadata()
+}
+
+func (bc *basicController) getScannerAdapterMetadataWithCache(registration *scanner.Registration) (*v1.ScannerAdapterMetadata, error) {
+	key := fmt.Sprintf("reg:%d:metadata", registration.ID)
+
+	var result MetadataResult
+	err := cache.FetchOrSave(bc.Cache(), key, &result, func() (interface{}, error) {
+		meta, err := bc.getScannerAdapterMetadata(registration)
+		if err != nil {
+			return &MetadataResult{Error: err.Error()}, nil
+		}
+
+		return &MetadataResult{Metadata: meta}, nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return result.Unpack()
+}
+
 var (
 	reservedNames = []string{"Trivy"}
 )
@@ -339,4 +357,20 @@ func isReservedName(name string) bool {
 	}
 
 	return false
+}
+
+// MetadataResult metadata or error saved in cache
+type MetadataResult struct {
+	Metadata *v1.ScannerAdapterMetadata
+	Error    string
+}
+
+// Unpack get ScannerAdapterMetadata and error from the result
+func (m *MetadataResult) Unpack() (*v1.ScannerAdapterMetadata, error) {
+	var err error
+	if m.Error != "" {
+		err = fmt.Errorf(m.Error)
+	}
+
+	return m.Metadata, err
 }

--- a/src/controller/scanner/base_controller.go
+++ b/src/controller/scanner/base_controller.go
@@ -290,7 +290,7 @@ func (bc *basicController) Ping(registration *scanner.Registration) (*v1.Scanner
 	}
 
 	if err != nil {
-		log.G(ctx).WithField("error", err).Error("failed to ping scanner")
+		log.Errorf("failed to ping scanner, error: %v", err)
 
 		return nil, errors.Wrap(err, "scanner controller: ping")
 	}

--- a/src/lib/cache/cache.go
+++ b/src/lib/cache/cache.go
@@ -25,6 +25,15 @@ import (
 	"github.com/goharbor/harbor/src/lib/log"
 )
 
+const (
+	// Memory the cache name of memory
+	Memory = "memory"
+	// Redis the cache name of redis
+	Redis = "redis"
+	// RedisSentinel the cache name of redis sentinel
+	RedisSentinel = "redis+sentinel"
+)
+
 var (
 	// ErrNotFound error returns when the key value not found in the cache
 	ErrNotFound = errors.New("key not found")

--- a/src/lib/cache/memory/memory.go
+++ b/src/lib/cache/memory/memory.go
@@ -116,5 +116,5 @@ func New(opts cache.Options) (cache.Cache, error) {
 }
 
 func init() {
-	cache.Register("memory", New)
+	cache.Register(cache.Memory, New)
 }

--- a/src/lib/cache/redis/redis.go
+++ b/src/lib/cache/redis/redis.go
@@ -127,6 +127,6 @@ func New(opts cache.Options) (cache.Cache, error) {
 }
 
 func init() {
-	cache.Register("redis", New)
-	cache.Register("redis+sentinel", New)
+	cache.Register(cache.Redis, New)
+	cache.Register(cache.RedisSentinel, New)
 }

--- a/src/pkg/scan/rest/v1/client.go
+++ b/src/pkg/scan/rest/v1/client.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"net"
 	"net/http"
 	"strconv"
 	"time"
@@ -82,15 +81,8 @@ type basicClient struct {
 // NewClient news a basic client
 func NewClient(url, authType, accessCredential string, skipCertVerify bool) (Client, error) {
 	transport := &http.Transport{
-		Proxy: http.ProxyFromEnvironment,
-		DialContext: (&net.Dialer{
-			Timeout:   30 * time.Second,
-			KeepAlive: 30 * time.Second,
-		}).DialContext,
-		MaxIdleConns:          100,
-		IdleConnTimeout:       90 * time.Second,
-		TLSHandshakeTimeout:   10 * time.Second,
-		ExpectContinueTimeout: 1 * time.Second,
+		Proxy:        http.ProxyFromEnvironment,
+		MaxIdleConns: 100,
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: skipCertVerify,
 		},
@@ -103,6 +95,7 @@ func NewClient(url, authType, accessCredential string, skipCertVerify bool) (Cli
 
 	return &basicClient{
 		httpClient: &http.Client{
+			Timeout:   time.Second * 5,
 			Transport: transport,
 			CheckRedirect: func(req *http.Request, via []*http.Request) error {
 				return http.ErrUseLastResponse


### PR DESCRIPTION
1. Cache the metadata of scanner 30s.
2. Change the scanner client request timeout to 5s.

Signed-off-by: He Weiwei <hweiwei@vmware.com>