### PR TITLE
Allows using robot accounts for Image replication

### DIFF
--- a/src/pkg/reg/adapter/harbor/base/chart_registry_test.go
+++ b/src/pkg/reg/adapter/harbor/base/chart_registry_test.go
@@ -29,6 +29,17 @@ func TestFetchCharts(t *testing.T) {
 	server := test.NewServer([]*test.RequestHandlerMapping{
 		{
 			Method:  http.MethodGet,
+			Pattern: "/api/projects/library",
+			Handler: func(w http.ResponseWriter, r *http.Request) {
+				data := `{
+					"name": "library",
+					"metadata": {"public":true}
+				}`
+				w.Write([]byte(data))
+			},
+		},
+		{
+			Method:  http.MethodGet,
 			Pattern: "/api/projects",
 			Handler: func(w http.ResponseWriter, r *http.Request) {
 				data := `[{

--- a/src/pkg/reg/adapter/harbor/base/client.go
+++ b/src/pkg/reg/adapter/harbor/base/client.go
@@ -114,16 +114,12 @@ func (c *Client) ListProjects(name string) ([]*Project, error) {
 
 // GetProject gets the specific project
 func (c *Client) GetProject(name string) (*Project, error) {
-	projects, err := c.ListProjects(name)
-	if err != nil {
+	project := &Project{}
+	url := fmt.Sprintf("%s/projects/%s", c.BasePath(), name)
+	if err := c.C.Get(url, project); err != nil {
 		return nil, err
 	}
-	for _, project := range projects {
-		if project.Name == name {
-			return project, nil
-		}
-	}
-	return nil, nil
+	return project, nil
 }
 
 // BasePath returns the API base path that contains version part


### PR DESCRIPTION
This patch (more of a bug fix) will allow using robot accounts for image replication. 

Currently, it is not possible to create a robot account that can replicate images from one Harbor registry to another. (You need a System Admin account, big no go in corp environments)

The patch only changes `getProject` to call the API directly, instead of filtering the list of `getProjects` because `getProjects` needs admin level permission and hence is not possible to be used with robot accounts. 


## Side Effects

The change has no or littel side effects: 
![image](https://user-images.githubusercontent.com/1492007/122196489-92033780-ce97-11eb-9171-9b6471b8343f.png)

its only called by `listProjects` and is always providing and expect a single result, 


This patch only works for Harbor => 2.2.0 and resolves a bunch of open issues.

resolves #14640, resolves #13384, resolves #13795
related #8723

## How to creaet a Robot Accounts for Replication

In order to a replication with robot accounts, a robot account with those permissions needs to be created.

Permissions needed for robot accounts.

```js
 [
        {
            'action': 'read',
            'resource': '?'
        },
        {
            'action': 'list',
            'resource': 'repository'
        },
        {
            'action': 'pull',
            'resource': 'repository'
        },
        {
            'action': 'list',
            'resource': 'artifact'
        },
        {
            'action': 'read',
            'resource': 'artifact'
        },
        {
            'action': 'list',
            'resource': 'helm-chart'
        },
        {
            'action': 'read',
            'resource': 'helm-chart'
        },
        {
            'action': 'list',
            'resource': 'helm-chart-version'
        },
        {
            'action': 'read',
            'resource': 'helm-chart-version'
        },
    ]
```

Signed-off-by: Vadim Bauer <vb@container-registry.com>