### PR TITLE
Provide detailed output about missing RBAC permissions in debug mode.

### DIFF
--- a/src/pkg/permission/evaluator/rbac/casbin.go
+++ b/src/pkg/permission/evaluator/rbac/casbin.go
@@ -17,6 +17,7 @@ package rbac
 import (
 	"github.com/casbin/casbin"
 	"github.com/casbin/casbin/model"
+	"github.com/goharbor/harbor/src/lib/log"
 	"github.com/goharbor/harbor/src/pkg/permission/types"
 )
 
@@ -47,7 +48,7 @@ func makeEnforcer(rbacUser types.RBACUser) *casbin.Enforcer {
 	m := model.Model{}
 	m.LoadModelFromText(modelText)
 
-	e := casbin.NewEnforcer(m, &adapter{rbacUser: rbacUser})
+	e := casbin.NewEnforcer(m, &adapter{rbacUser: rbacUser}, log.GetLevel() <= log.DebugLevel)
 	e.AddFunction("keyMatch2", keyMatch2Func)
 	return e
 }


### PR DESCRIPTION
This change displays missing RBAC permissions in the log when the debug mode is enabled. 
The functionality well help the normal user to craft permissions for robot accounts. This is especially useful if you want to perform API operations with robot accounts.

Signed-off-by: Vadim Bauer <vb@container-registry.com>