### PR TITLE
Check user in security context before getting the ID

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -37,7 +37,7 @@ jobs:
       - name: setup Docker
         uses: docker-practice/actions-setup-docker@0.0.1
         with:
-          docker_version: 18.09
+          docker_version: 20.04
           docker_channel: stable
       - uses: actions/checkout@v2
         with:

--- a/src/controller/user/controller.go
+++ b/src/controller/user/controller.go
@@ -113,7 +113,7 @@ func (c *controller) Get(ctx context.Context, id int, opt *Option) (*models.User
 		return nil, fmt.Errorf("can't find security context")
 	}
 	lsc, ok := sctx.(*local.SecurityContext)
-	if ok && lsc.User().UserID == id {
+	if ok && lsc.User() != nil && lsc.User().UserID == id {
 		u.AdminRoleInAuth = lsc.User().AdminRoleInAuth
 	}
 	if opt != nil && opt.WithOIDCInfo {


### PR DESCRIPTION
This commit fix a potential nil pointer issue when trying to read User
ID from security context

Signed-off-by: Daniel Jiang <jiangd@vmware.com>