### PR TITLE
Use system configuration resource for permission checking

### DIFF
--- a/src/common/rbac/const.go
+++ b/src/common/rbac/const.go
@@ -73,6 +73,4 @@ const (
 	ResourceReplicationPolicy  = Resource("replication-policy")
 	ResourceScanAll            = Resource("scan-all")
 	ResourceSystemVolumes      = Resource("system-volumes")
-	ResourceOIDCEndpoint       = Resource("oidc-endpoint")
-	ResourceSystemCVEAllowList = Resource("system-cve-allowlist")
 )

--- a/src/common/rbac/system/policies.go
+++ b/src/common/rbac/system/policies.go
@@ -61,11 +61,9 @@ var (
 
 		{Resource: rbac.ResourceSystemVolumes, Action: rbac.ActionRead},
 
-		{Resource: rbac.ResourceOIDCEndpoint, Action: rbac.ActionUpdate},
-		{Resource: rbac.ResourceOIDCEndpoint, Action: rbac.ActionRead},
 		{Resource: rbac.ResourceLdapUser, Action: rbac.ActionCreate},
 		{Resource: rbac.ResourceLdapUser, Action: rbac.ActionList},
-		{Resource: rbac.ResourceSystemCVEAllowList, Action: rbac.ActionRead},
-		{Resource: rbac.ResourceSystemCVEAllowList, Action: rbac.ActionUpdate},
+		{Resource: rbac.ResourceConfiguration, Action: rbac.ActionRead},
+		{Resource: rbac.ResourceConfiguration, Action: rbac.ActionUpdate},
 	}
 )

--- a/src/server/v2.0/handler/oidc.go
+++ b/src/server/v2.0/handler/oidc.go
@@ -20,7 +20,7 @@ func newOIDCAPI() *oidcAPI {
 }
 
 func (o oidcAPI) PingOIDC(ctx context.Context, params oidc.PingOIDCParams) middleware.Responder {
-	if err := o.RequireSystemAccess(ctx, rbac.ActionUpdate, rbac.ResourceOIDCEndpoint); err != nil {
+	if err := o.RequireSystemAccess(ctx, rbac.ActionUpdate, rbac.ResourceConfiguration); err != nil {
 		return o.SendError(ctx, err)
 	}
 	err := oidcpkg.TestEndpoint(oidcpkg.Conn{

--- a/src/server/v2.0/handler/sys_cve_allowlist.go
+++ b/src/server/v2.0/handler/sys_cve_allowlist.go
@@ -38,7 +38,7 @@ func newSystemCVEAllowListAPI() *systemCVEAllowListAPI {
 }
 
 func (s systemCVEAllowListAPI) PutSystemCVEAllowlist(ctx context.Context, params system_cve_allowlist.PutSystemCVEAllowlistParams) middleware.Responder {
-	if err := s.RequireSystemAccess(ctx, rbac.ActionUpdate, rbac.ResourceSystemCVEAllowList); err != nil {
+	if err := s.RequireSystemAccess(ctx, rbac.ActionUpdate, rbac.ResourceConfiguration); err != nil {
 		return s.SendError(ctx, err)
 	}
 	l := models.CVEAllowlist{}


### PR DESCRIPTION
This commit uses system configuration resource for permission check
against API to ping OIDC and update systen CVE allowlist.
Fixes #14386

Signed-off-by: Daniel Jiang <jiangd@vmware.com>