### PR TITLE
Add GUI support for chart label permissions

### DIFF
--- a/src/portal/src/app/base/left-side-nav/system-robot-accounts/system-robot-util.ts
+++ b/src/portal/src/app/base/left-side-nav/system-robot-accounts/system-robot-util.ts
@@ -107,6 +107,7 @@ export const ACTION_RESOURCE_I18N_MAP = {
     'helm-chart-version': 'SYSTEM_ROBOT.HELM_VERSION',
     'tag': 'REPLICATION.TAG',
     'artifact-label': 'SYSTEM_ROBOT.ARTIFACT_LABEL',
+    'helm-chart-version-label': 'SYSTEM_ROBOT.HELM_CHART_VERSION_LABEL',
     'scan': 'SYSTEM_ROBOT.SCAN',
     'scanner-pull': 'SYSTEM_ROBOT.SCANNER_PULL'
 };

--- a/src/portal/src/i18n/lang/de-de-lang.json
+++ b/src/portal/src/i18n/lang/de-de-lang.json
@@ -1675,6 +1675,7 @@
         "ENABLE_NEW_SECRET": "Aktiviere diese Option um das neue Secret selbst zu definieren",
         "DELETE": "Löschen",
         "ARTIFACT_LABEL": "Artefakt Label",
+        "HELM_CHART_VERSION_LABEL": "Helm Chart Version Label",
         "SCAN": "Scannen",
         "SCANNER_PULL": "Scanner Pull",
         "SEARCH_BY_NAME": "Robot-Account mittels Namen suchen (ohne Prefix)",

--- a/src/portal/src/i18n/lang/en-us-lang.json
+++ b/src/portal/src/i18n/lang/en-us-lang.json
@@ -1675,6 +1675,7 @@
         "ENABLE_NEW_SECRET": "Enable this option to manually specify a new secret",
         "DELETE": "Delete",
         "ARTIFACT_LABEL": "Artifact label",
+        "HELM_CHART_VERSION_LABEL": "Helm Chart Version label",
         "SCAN": "Scan",
         "SCANNER_PULL": "Scanner Pull",
         "SEARCH_BY_NAME": "Search by name(without prefix)",

--- a/src/portal/src/i18n/lang/es-es-lang.json
+++ b/src/portal/src/i18n/lang/es-es-lang.json
@@ -1673,6 +1673,7 @@
         "ENABLE_NEW_SECRET": "Enable this option to manually specify a new secret",
         "DELETE": "Delete",
         "ARTIFACT_LABEL": "Artifact label",
+        "HELM_CHART_VERSION_LABEL": "Helm Chart Version label",
         "SCAN": "Scan",
         "SCANNER_PULL": "Scanner Pull",
         "SEARCH_BY_NAME": "Search by name(without prefix)",

--- a/src/portal/src/i18n/lang/fr-fr-lang.json
+++ b/src/portal/src/i18n/lang/fr-fr-lang.json
@@ -1643,6 +1643,7 @@
         "ENABLE_NEW_SECRET": "Enable this option to manually specify a new secret",
         "DELETE": "Delete",
         "ARTIFACT_LABEL": "Artifact label",
+        "HELM_CHART_VERSION_LABEL": "Helm Chart Version label",
         "SCAN": "Scan",
         "SCANNER_PULL": "Scanner Pull",
         "SEARCH_BY_NAME": "Search by name(without prefix)",

--- a/src/portal/src/i18n/lang/pt-br-lang.json
+++ b/src/portal/src/i18n/lang/pt-br-lang.json
@@ -1671,6 +1671,7 @@
         "ENABLE_NEW_SECRET": "Enable this option to manually specify a new secret",
         "DELETE": "Delete",
         "ARTIFACT_LABEL": "Artifact label",
+        "HELM_CHART_VERSION_LABEL": "Helm Chart Version label",
         "SCAN": "Scan",
         "SCANNER_PULL": "Scanner Pull",
         "SEARCH_BY_NAME": "Search by name(without prefix)",

--- a/src/portal/src/i18n/lang/tr-tr-lang.json
+++ b/src/portal/src/i18n/lang/tr-tr-lang.json
@@ -1675,6 +1675,7 @@
         "ENABLE_NEW_SECRET": "Enable this option to manually specify a new secret",
         "DELETE": "Delete",
         "ARTIFACT_LABEL": "Artifact label",
+        "HELM_CHART_VERSION_LABEL": "Helm Chart Version label",
         "SCAN": "Scan",
         "SCANNER_PULL": "Scanner Pull",
         "SEARCH_BY_NAME": "Search by name(without prefix)",

--- a/src/portal/src/i18n/lang/zh-cn-lang.json
+++ b/src/portal/src/i18n/lang/zh-cn-lang.json
@@ -1673,6 +1673,7 @@
         "ENABLE_NEW_SECRET": "开启此项以便手动指定新令牌",
         "DELETE": "删除",
         "ARTIFACT_LABEL": "Artifact 标签",
+        "HELM_CHART_VERSION_LABEL": "Helm Chart Version 标签",
         "SCAN": "扫描",
         "SCANNER_PULL": "扫描器拉取",
         "SEARCH_BY_NAME": "按名称(不含前缀)搜索",

--- a/src/portal/src/i18n/lang/zh-tw-lang.json
+++ b/src/portal/src/i18n/lang/zh-tw-lang.json
@@ -1660,6 +1660,7 @@
     "ENABLE_NEW_SECRET": "Enable this option to manually specify a new secret",
     "DELETE": "Delete",
     "ARTIFACT_LABEL": "Artifact label",
+    "HELM_CHART_VERSION_LABEL": "Helm Chart Version label",
     "SCAN": "Scan",
     "SCANNER_PULL": "Scanner Pull",
     "SEARCH_BY_NAME": "Search by name(without prefix)",


### PR DESCRIPTION
If a `create` or `delete` permission for the `helm-chart-version-label`
resource is [added to a robot account using the REST API][1], it shows
up in the GUI as just "Create" or "Delete", respectively. So the
permissions for the robot account may look like this:

  * Push Artifact
  * Pull Artifact
  * Delete Artifact
  * Read Helm Chart
  * Create Helm Chart Version
  * Delete Helm Chart Version
  * Create Tag
  * Delete Tag
  * Create Artifact label
  * Create Scan
  * Create                    👈
  * Delete                    👈

This PR adds GUI support for said permissions, so that they are shown as
"Create Helm Chart Version label" and "Delete Helm Chart Version label",
respectively. The names are derived from "Create Helm Chart Version"
(title-case "Helm Chart Version") and "Create Artifact label"
(lower-case "label", except in German, which has "Artefakt Label").

[1]: https://github.com/goharbor/harbor/issues/8723#issuecomment-845719044

Signed-off-by: Simon Alling <alling.simon@gmail.com>