### PR TITLE
fix: delete robots by project id using raw sql

### DIFF
--- a/src/pkg/robot/dao/dao.go
+++ b/src/pkg/robot/dao/dao.go
@@ -2,11 +2,12 @@ package dao
 
 import (
 	"context"
+	"time"
+
 	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/lib/orm"
 	"github.com/goharbor/harbor/src/lib/q"
 	"github.com/goharbor/harbor/src/pkg/robot/model"
-	"time"
 )
 
 // DAO defines the interface to access the robot data model
@@ -121,14 +122,12 @@ func (d *dao) List(ctx context.Context, query *q.Query) ([]*model.Robot, error) 
 }
 
 func (d *dao) DeleteByProjectID(ctx context.Context, projectID int64) error {
-	qs, err := orm.QuerySetter(ctx, &model.Robot{}, &q.Query{
-		Keywords: map[string]interface{}{
-			"project_id": projectID,
-		},
-	})
+	ormer, err := orm.FromContext(ctx)
 	if err != nil {
 		return err
 	}
-	_, err = qs.Delete()
+
+	_, err = ormer.Raw("DELETE FROM robot WHERE project_id = ?", projectID).Exec()
+
 	return err
 }


### PR DESCRIPTION
QuerySeter.Delete will call two queies in the orm of beego. First it
will query all primary keys of the model by the QuerySeter, and then the
orm will delete the models using the IN statement of these primary keys.
This will be failed in the postgres when the records more than 65535.
This commit changes to use the raw query to delete the robots of the
project.

Closes #14678

Signed-off-by: He Weiwei <hweiwei@vmware.com>