### PR TITLE
refactor: convert scan report in scan job

### DIFF
--- a/src/controller/scan/base_controller_test.go
+++ b/src/controller/scan/base_controller_test.go
@@ -19,6 +19,9 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"testing"
+	"time"
+
 	"github.com/goharbor/harbor/src/common"
 	"github.com/goharbor/harbor/src/common/rbac"
 	"github.com/goharbor/harbor/src/controller/artifact"
@@ -47,8 +50,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"testing"
-	"time"
 )
 
 // ControllerTestSuite is the test suite for scan controller.
@@ -453,22 +454,6 @@ func (suite *ControllerTestSuite) TestScanControllerGetMultiScanLog() {
 		bytes, err := suite.c.GetScanLog(context.TODO(), base64.StdEncoding.EncodeToString([]byte("rp-uuid-001|rp-uuid-002")))
 		suite.Nil(err)
 		suite.Empty(bytes)
-	}
-}
-
-func (suite *ControllerTestSuite) TestUpdateReport() {
-	{
-		// get report failed
-		suite.reportMgr.On("GetBy", context.TODO(), "digest", "ruuid", []string{"mime"}).Return(nil, fmt.Errorf("failed")).Once()
-		report := &sca.CheckInReport{Digest: "digest", RegistrationUUID: "ruuid", MimeType: "mime"}
-		suite.Error(suite.c.UpdateReport(context.TODO(), report))
-	}
-
-	{
-		// report not found
-		suite.reportMgr.On("GetBy", context.TODO(), "digest", "ruuid", []string{"mime"}).Return(nil, nil).Once()
-		report := &sca.CheckInReport{Digest: "digest", RegistrationUUID: "ruuid", MimeType: "mime"}
-		suite.Error(suite.c.UpdateReport(context.TODO(), report))
 	}
 }
 

--- a/src/controller/scan/callback_test.go
+++ b/src/controller/scan/callback_test.go
@@ -22,8 +22,6 @@ import (
 
 	"github.com/goharbor/harbor/src/controller/artifact"
 	"github.com/goharbor/harbor/src/jobservice/job"
-	"github.com/goharbor/harbor/src/pkg/scan"
-	dscan "github.com/goharbor/harbor/src/pkg/scan/dao/scan"
 	"github.com/goharbor/harbor/src/pkg/task"
 	artifacttesting "github.com/goharbor/harbor/src/testing/controller/artifact"
 	robottesting "github.com/goharbor/harbor/src/testing/controller/robot"
@@ -130,33 +128,6 @@ func (suite *CallbackTestSuite) TestScanTaskStatusChange() {
 		).Once()
 		suite.artifactCtl.On("Get", context.TODO(), int64(1), (*artifact.Option)(nil)).Return(&artifact.Artifact{}, nil).Once()
 		suite.NoError(scanTaskStatusChange(context.TODO(), 1, job.SuccessStatus.String()))
-	}
-}
-
-func (suite *CallbackTestSuite) TestScanTaskCheckInProcessor() {
-	{
-		suite.Error(scanTaskCheckInProcessor(context.TODO(), &task.Task{}, &job.StatusChange{CheckIn: "report"}))
-	}
-
-	{
-		suite.reportMgr.On("GetBy", context.TODO(), "digest", "ruuid", []string{"mime_type"}).Return(
-			[]*dscan.Report{
-				{UUID: "uuid"},
-			},
-			nil,
-		).Once()
-
-		suite.reportMgr.On("UpdateReportData", context.TODO(), "uuid", "raw_report").Return(nil)
-
-		report := scan.CheckInReport{
-			Digest:           "digest",
-			RegistrationUUID: "ruuid",
-			MimeType:         "mime_type",
-			RawReport:        "raw_report",
-		}
-
-		r, _ := json.Marshal(report)
-		suite.NoError(scanTaskCheckInProcessor(context.TODO(), &task.Task{}, &job.StatusChange{CheckIn: string(r)}))
 	}
 }
 

--- a/src/controller/scan/controller.go
+++ b/src/controller/scan/controller.go
@@ -20,7 +20,6 @@ import (
 	"github.com/goharbor/harbor/src/controller/artifact"
 	"github.com/goharbor/harbor/src/jobservice/job"
 	allowlist "github.com/goharbor/harbor/src/pkg/allowlist/models"
-	sca "github.com/goharbor/harbor/src/pkg/scan"
 	"github.com/goharbor/harbor/src/pkg/scan/dao/scan"
 	"github.com/goharbor/harbor/src/pkg/scan/vuln"
 )
@@ -94,16 +93,6 @@ type Controller interface {
 	//  Returns:
 	//    error        : non nil error if any errors occurred
 	DeleteReports(ctx context.Context, digests ...string) error
-
-	// UpdateReport update the report
-	//
-	//   Arguments:
-	//     ctx context.Context : the context for this method
-	//     report *sca.CheckInReport : the scan report
-	//
-	//   Returns:
-	//     error  : non nil error if any errors occurred
-	UpdateReport(ctx context.Context, report *sca.CheckInReport) error
 
 	// Scan all the artifacts
 	//

--- a/src/lib/set.go
+++ b/src/lib/set.go
@@ -1,0 +1,42 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lib
+
+type void = struct{}
+
+// Set a simple set
+type Set map[interface{}]void
+
+// Add add item to set
+func (s Set) Add(item interface{}) {
+	s[item] = void{}
+}
+
+// Exists returns true when item in the set
+func (s Set) Exists(item interface{}) bool {
+	_, ok := s[item]
+
+	return ok
+}
+
+// Items returns the items in the set
+func (s Set) Items() []interface{} {
+	var items []interface{}
+	for item := range s {
+		items = append(items, item)
+	}
+
+	return items
+}

--- a/src/lib/set_test.go
+++ b/src/lib/set_test.go
@@ -1,0 +1,33 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lib
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSet(t *testing.T) {
+	assert := assert.New(t)
+
+	s := Set{}
+
+	s.Add(1)
+
+	assert.True(s.Exists(1))
+
+	assert.Len(s.Items(), 1)
+}

--- a/src/pkg/scan/dao/scan/model.go
+++ b/src/pkg/scan/dao/scan/model.go
@@ -14,7 +14,10 @@
 
 package scan
 
-import "time"
+import (
+	"fmt"
+	"time"
+)
 
 // Report of the scan.
 // Identified by the `digest`, `registration_uuid` and `mime_type`.
@@ -85,6 +88,11 @@ func (vr *VulnerabilityRecord) TableUnique() [][]string {
 // GetID returns the ID of the record
 func (vr *VulnerabilityRecord) GetID() int64 {
 	return vr.ID
+}
+
+// Key returns the uniq key of the vuln
+func (vr *VulnerabilityRecord) Key() string {
+	return fmt.Sprintf("%s-%s-%s", vr.CVEID, vr.Package, vr.PackageVersion)
 }
 
 // ReportVulnerabilityRecord is relation table required to optimize data storage for both the

--- a/src/pkg/scan/dao/scan/vulnerability.go
+++ b/src/pkg/scan/dao/scan/vulnerability.go
@@ -16,8 +16,9 @@ package scan
 
 import (
 	"context"
-	"fmt"
 
+	"github.com/goharbor/harbor/src/lib"
+	"github.com/goharbor/harbor/src/lib/log"
 	"github.com/goharbor/harbor/src/lib/orm"
 	"github.com/goharbor/harbor/src/lib/q"
 )
@@ -33,10 +34,12 @@ type VulnerabilityRecordDao interface {
 	Create(ctx context.Context, vr *VulnerabilityRecord) (int64, error)
 	// Delete deletes a vulnerability record
 	Delete(ctx context.Context, vr *VulnerabilityRecord) error
+	// Update updates a vulnerability record
+	Update(ctx context.Context, vr *VulnerabilityRecord, cols ...string) error
 	// List lists the vulnerability records
 	List(ctx context.Context, query *q.Query) ([]*VulnerabilityRecord, error)
 	// InsertForReport inserts vulnerability records for a report
-	InsertForReport(ctx context.Context, reportUUID string, vr *VulnerabilityRecord) (int64, error)
+	InsertForReport(ctx context.Context, reportUUID string, vulnerabilityRecordIDs ...int64) error
 	// GetForReport gets vulnerability records for a report
 	GetForReport(ctx context.Context, reportUUID string) ([]*VulnerabilityRecord, error)
 	// GetForScanner gets vulnerability records for a scanner
@@ -76,6 +79,16 @@ func (v *vulnerabilityRecordDao) Delete(ctx context.Context, vr *VulnerabilityRe
 	return err
 }
 
+func (v *vulnerabilityRecordDao) Update(ctx context.Context, vr *VulnerabilityRecord, cols ...string) error {
+	o, err := orm.FromContext(ctx)
+	if err != nil {
+		return err
+	}
+	_, err = o.Update(vr, cols...)
+
+	return err
+}
+
 // List lists the vulnerability records with given query parameters.
 // Keywords in query here will be enforced with `exact` way.
 // If the registration ID (which = the scanner ID is not specified), the results
@@ -84,52 +97,60 @@ func (v *vulnerabilityRecordDao) Delete(ctx context.Context, vr *VulnerabilityRe
 // responsibility of the calling code to de-duplicate the CVE records or bucket them
 // per registered scanner
 func (v *vulnerabilityRecordDao) List(ctx context.Context, query *q.Query) ([]*VulnerabilityRecord, error) {
-	o, err := orm.FromContext(ctx)
+	qs, err := orm.QuerySetter(ctx, &VulnerabilityRecord{}, query)
 	if err != nil {
 		return nil, err
 	}
-	qt := o.QueryTable(new(VulnerabilityRecord))
-
-	if query != nil {
-		if len(query.Keywords) > 0 {
-			for k, v := range query.Keywords {
-				if vv, ok := v.([]interface{}); ok {
-					qt = qt.Filter(fmt.Sprintf("%s__in", k), vv...)
-					continue
-				}
-
-				qt = qt.Filter(k, v)
-			}
-		}
-
-		if query.PageNumber > 0 && query.PageSize > 0 {
-			qt = qt.Limit(query.PageSize, (query.PageNumber-1)*query.PageSize)
-		}
-	}
 
 	l := make([]*VulnerabilityRecord, 0)
-	_, err = qt.All(&l)
+	_, err = qs.All(&l)
 
 	return l, err
 }
 
-// InsertForReport inserts a vulnerability record in the context of scan report
-func (v *vulnerabilityRecordDao) InsertForReport(ctx context.Context, reportUUID string, vr *VulnerabilityRecord) (int64, error) {
-
-	vrID, err := v.Create(ctx, vr)
-
-	if err != nil {
-		return 0, err
+// InsertForReport inserts the vulnerability records in the context of scan report
+func (v *vulnerabilityRecordDao) InsertForReport(ctx context.Context, reportUUID string, vulnerabilityRecordIDs ...int64) error {
+	if len(vulnerabilityRecordIDs) == 0 {
+		return nil
 	}
 
-	rvr := new(ReportVulnerabilityRecord)
-	rvr.Report = reportUUID
-	rvr.VulnRecordID = vrID
+	s := lib.Set{}
 
-	_, rvrID, err := orm.ReadOrCreate(ctx, rvr, "report_uuid", "vuln_record_id")
+	var records []*ReportVulnerabilityRecord
+	for _, vulnerabilityRecordID := range vulnerabilityRecordIDs {
+		if s.Exists(vulnerabilityRecordID) {
+			continue
+		}
 
-	return rvrID, err
+		s.Add(vulnerabilityRecordID)
 
+		records = append(records, &ReportVulnerabilityRecord{
+			Report:       reportUUID,
+			VulnRecordID: vulnerabilityRecordID,
+		})
+	}
+
+	h := func(ctx context.Context) error {
+		o, err := orm.FromContext(ctx)
+		if err != nil {
+			return err
+		}
+
+		_, err = o.InsertMulti(100, records)
+		return err
+	}
+
+	if err := orm.WithTransaction(h)(ctx); err != nil {
+		fields := log.Fields{
+			"error":  err,
+			"report": reportUUID,
+		}
+		log.G(ctx).WithFields(fields).Warningf("Could not associate vulnerability record to the report")
+
+		return err
+	}
+
+	return nil
 }
 
 // DeleteForReport deletes the vulnerability records for a single report

--- a/src/pkg/scan/dao/scan/vulnerability_test.go
+++ b/src/pkg/scan/dao/scan/vulnerability_test.go
@@ -19,13 +19,10 @@ import (
 	"testing"
 
 	"github.com/goharbor/harbor/src/jobservice/job"
-	"github.com/goharbor/harbor/src/lib/orm"
 	"github.com/goharbor/harbor/src/lib/q"
 	"github.com/goharbor/harbor/src/pkg/scan/dao/scanner"
 	v1 "github.com/goharbor/harbor/src/pkg/scan/rest/v1"
 	htesting "github.com/goharbor/harbor/src/testing"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -125,13 +122,13 @@ func (suite *VulnerabilityTestSuite) SetupTest() {
 // TearDownTest clears enf for test case.
 func (suite *VulnerabilityTestSuite) TearDownTest() {
 	registrations, err := scanner.ListRegistrations(suite.Context(), &q.Query{})
-	require.NoError(suite.T(), err, "Failed to cleanup scanner registrations")
+	suite.NoError(err, "Failed to cleanup scanner registrations")
 	for _, registration := range registrations {
 		err = scanner.DeleteRegistration(suite.Context(), registration.UUID)
-		require.NoError(suite.T(), err, "Error when cleaning up scanner registrations")
+		suite.NoError(err, "Error when cleaning up scanner registrations")
 	}
-	reports, err := suite.dao.List(orm.Context(), &q.Query{})
-	require.NoError(suite.T(), err)
+	reports, err := suite.dao.List(suite.Context(), &q.Query{})
+	suite.NoError(err)
 	for _, report := range reports {
 		suite.cleanUpAdditionalData(report.UUID, report.RegistrationUUID)
 	}
@@ -160,14 +157,14 @@ func (suite *VulnerabilityTestSuite) TestVulnerabilityRecordsListForReport() {
 	// fetch the records for the first report. Additionally assert that these records
 	// indeed belong to the same report being fetched and not to another report
 	{
-		vulns, err := suite.vulnerabilityRecordDao.GetForReport(orm.Context(), "uuid")
-		require.NoError(suite.T(), err, "Error when fetching vulnerability records for report")
-		require.True(suite.T(), len(vulns) > 0)
+		vulns, err := suite.vulnerabilityRecordDao.GetForReport(suite.Context(), "uuid")
+		suite.NoError(err, "Error when fetching vulnerability records for report")
+		suite.True(len(vulns) > 0)
 	}
 	{
-		vulns, err := suite.vulnerabilityRecordDao.GetForReport(orm.Context(), "uuid1")
-		require.NoError(suite.T(), err, "Error when fetching vulnerability records for report")
-		require.True(suite.T(), len(vulns) > 0)
+		vulns, err := suite.vulnerabilityRecordDao.GetForReport(suite.Context(), "uuid1")
+		suite.NoError(err, "Error when fetching vulnerability records for report")
+		suite.True(len(vulns) > 0)
 	}
 
 }
@@ -175,16 +172,16 @@ func (suite *VulnerabilityTestSuite) TestVulnerabilityRecordsListForReport() {
 // TestGetVulnerabilityRecordsForScanner gets vulnerability records for scanner
 func (suite *VulnerabilityTestSuite) TestGetVulnerabilityRecordsForScanner() {
 
-	vulns, err := suite.vulnerabilityRecordDao.GetForScanner(orm.Context(), "scannerId1")
-	require.NoError(suite.T(), err, "Error when fetching vulnerability records for report")
-	require.True(suite.T(), len(vulns) > 0)
+	vulns, err := suite.vulnerabilityRecordDao.GetForScanner(suite.Context(), "scannerId1")
+	suite.NoError(err, "Error when fetching vulnerability records for report")
+	suite.True(len(vulns) > 0)
 }
 
 // TestGetVulnerabilityRecordIdsForScanner gets vulnerability records for scanner
 func (suite *VulnerabilityTestSuite) TestGetVulnerabilityRecordIdsForScanner() {
-	vulns, err := suite.vulnerabilityRecordDao.GetRecordIdsForScanner(orm.Context(), "scannerId1")
-	require.NoError(suite.T(), err, "Error when fetching vulnerability records for report")
-	require.True(suite.T(), len(vulns) > 0)
+	vulns, err := suite.vulnerabilityRecordDao.GetRecordIdsForScanner(suite.Context(), "scannerId1")
+	suite.NoError(err, "Error when fetching vulnerability records for report")
+	suite.True(len(vulns) > 0)
 }
 
 // TestDeleteForDigest tests deleting vulnerability report for a specific digest
@@ -206,9 +203,9 @@ func (suite *VulnerabilityTestSuite) TestDeleteForDigest() {
 	for _, v := range vulns {
 		suite.insertVulnRecordForReport("uuid1", v)
 	}
-	delCount, err := suite.vulnerabilityRecordDao.DeleteForDigests(orm.Context(), "digest1")
-	require.NoError(suite.T(), err)
-	assert.Equal(suite.T(), int64(10), delCount)
+	delCount, err := suite.vulnerabilityRecordDao.DeleteForDigests(suite.Context(), "digest1")
+	suite.NoError(err)
+	suite.Equal(int64(10), delCount)
 }
 
 func (suite *VulnerabilityTestSuite) TestDuplicateRecords() {
@@ -230,46 +227,48 @@ func (suite *VulnerabilityTestSuite) TestDuplicateRecords() {
 // TestDeleteVulnerabilityRecord gets vulnerability records for scanner
 func (suite *VulnerabilityTestSuite) TestDeleteVulnerabilityRecord() {
 
-	vulns, err := suite.vulnerabilityRecordDao.GetForScanner(orm.Context(), "scannerId1")
-	require.NoError(suite.T(), err, "Error when fetching vulnerability records for report")
-	require.True(suite.T(), len(vulns) > 0)
+	vulns, err := suite.vulnerabilityRecordDao.GetForScanner(suite.Context(), "scannerId1")
+	suite.NoError(err, "Error when fetching vulnerability records for report")
+	suite.True(len(vulns) > 0)
 	for _, vuln := range vulns {
-		err = suite.vulnerabilityRecordDao.Delete(orm.Context(), vuln)
-		require.NoError(suite.T(), err)
+		err = suite.vulnerabilityRecordDao.Delete(suite.Context(), vuln)
+		suite.NoError(err)
 	}
 }
 
 // TestListVulnerabilityRecord gets vulnerability records for scanner
 func (suite *VulnerabilityTestSuite) TestListVulnerabilityRecord() {
 
-	vulns, err := suite.vulnerabilityRecordDao.List(orm.Context(), &q.Query{Keywords: map[string]interface{}{"CVEID": "CVE-ID1"}})
-	require.NoError(suite.T(), err, "Error when fetching vulnerability records for report")
-	require.True(suite.T(), len(vulns) > 0)
+	vulns, err := suite.vulnerabilityRecordDao.List(suite.Context(), &q.Query{Keywords: map[string]interface{}{"CVEID": "CVE-ID1"}})
+	suite.NoError(err, "Error when fetching vulnerability records for report")
+	suite.True(len(vulns) > 0)
 }
 
 func (suite *VulnerabilityTestSuite) createReport(r *Report) {
-	id, err := suite.dao.Create(orm.Context(), r)
-	require.NoError(suite.T(), err)
-	require.Condition(suite.T(), func() (success bool) {
+	id, err := suite.dao.Create(suite.Context(), r)
+	suite.NoError(err)
+	suite.Condition(func() (success bool) {
 		success = id > 0
 		return
 	})
 }
 
 func (suite *VulnerabilityTestSuite) insertVulnRecordForReport(reportUUID string, vr *VulnerabilityRecord) {
-	id, err := suite.vulnerabilityRecordDao.InsertForReport(orm.Context(), reportUUID, vr)
-	require.NoError(suite.T(), err)
-	require.True(suite.T(), id > 0, "Failed to insert vulnerability record row for report %s", reportUUID)
+	id, err := suite.vulnerabilityRecordDao.Create(suite.Context(), vr)
+	suite.NoError(err, "Failed to create vulnerability record")
+
+	err = suite.vulnerabilityRecordDao.InsertForReport(suite.Context(), reportUUID, id)
+	suite.NoError(err, "Failed to insert vulnerability record row for report %s", reportUUID)
 }
 
 func (suite *VulnerabilityTestSuite) cleanUpAdditionalData(reportID string, scannerID string) {
-	_, err := suite.dao.DeleteMany(orm.Context(), q.Query{Keywords: q.KeyWords{"uuid": reportID}})
+	_, err := suite.dao.DeleteMany(suite.Context(), q.Query{Keywords: q.KeyWords{"uuid": reportID}})
 
-	require.NoError(suite.T(), err)
-	_, err = suite.vulnerabilityRecordDao.DeleteForReport(orm.Context(), reportID)
-	require.NoError(suite.T(), err, "Failed to cleanup records")
-	_, err = suite.vulnerabilityRecordDao.DeleteForScanner(orm.Context(), scannerID)
-	require.NoError(suite.T(), err, "Failed to delete vulnerability records")
+	suite.NoError(err)
+	_, err = suite.vulnerabilityRecordDao.DeleteForReport(suite.Context(), reportID)
+	suite.NoError(err, "Failed to cleanup records")
+	_, err = suite.vulnerabilityRecordDao.DeleteForScanner(suite.Context(), scannerID)
+	suite.NoError(err, "Failed to delete vulnerability records")
 }
 
 func (suite *VulnerabilityTestSuite) registerScanner(registrationUUID string) {
@@ -281,7 +280,7 @@ func (suite *VulnerabilityTestSuite) registerScanner(registrationUUID string) {
 	}
 
 	_, err := scanner.AddRegistration(suite.Context(), r)
-	require.NoError(suite.T(), err, "add new registration")
+	suite.NoError(err, "add new registration")
 }
 
 func generateVulnerabilityRecordsForReport(reportUUID string, registrationUUID string, numRecords int) []*VulnerabilityRecord {

--- a/src/pkg/scan/job_test.go
+++ b/src/pkg/scan/job_test.go
@@ -16,12 +16,12 @@ package scan
 
 import (
 	"encoding/json"
-	"github.com/goharbor/harbor/src/controller/robot"
-	"github.com/goharbor/harbor/src/pkg/robot/model"
 	"testing"
 	"time"
 
+	"github.com/goharbor/harbor/src/controller/robot"
 	"github.com/goharbor/harbor/src/jobservice/job"
+	"github.com/goharbor/harbor/src/pkg/robot/model"
 	"github.com/goharbor/harbor/src/pkg/scan/dao/scanner"
 	v1 "github.com/goharbor/harbor/src/pkg/scan/rest/v1"
 	"github.com/goharbor/harbor/src/pkg/scan/vuln"
@@ -145,17 +145,6 @@ func (suite *JobTestSuite) TestJob() {
 	mc.On("GetScanReport", "scan_id", v1.MimeTypeNativeReport, v1.MimeTypeGenericVulnerabilityReport).Return(string(jRep), nil)
 	mocktesting.OnAnything(suite.mcp, "Get").Return(mc, nil)
 
-	crp := &CheckInReport{
-		Digest:           sr.Artifact.Digest,
-		RegistrationUUID: r.UUID,
-		MimeType:         v1.MimeTypeNativeReport,
-		RawReport:        string(jRep),
-	}
-
-	jsonData, err := crp.ToJSON()
-	require.NoError(suite.T(), err)
-
-	ctx.On("Checkin", string(jsonData)).Return(nil)
 	j := &Job{}
 	err = j.Run(ctx, jp)
 	require.NoError(suite.T(), err)

--- a/src/pkg/scan/report/manager.go
+++ b/src/pkg/scan/report/manager.go
@@ -24,6 +24,11 @@ import (
 	"github.com/google/uuid"
 )
 
+var (
+	// Mgr is the global report manager
+	Mgr = NewManager()
+)
+
 // Manager is used to manage the scan reports.
 type Manager interface {
 	// Create a new report record.

--- a/src/pkg/scan/vuln/report.go
+++ b/src/pkg/scan/vuln/report.go
@@ -148,6 +148,13 @@ func (l *VulnerabilityItemList) Add(items ...*VulnerabilityItem) {
 	}
 }
 
+// GetItem returns VulnerabilityItem by key
+func (l *VulnerabilityItemList) GetItem(key string) (*VulnerabilityItem, bool) {
+	item, ok := l.indexed[key]
+
+	return item, ok
+}
+
 // GetSeveritySummary returns the severity and summary of l
 func (l *VulnerabilityItemList) GetSeveritySummary() (Severity, *VulnerabilitySummary) {
 	if l == nil {

--- a/src/testing/controller/scan/controller.go
+++ b/src/testing/controller/scan/controller.go
@@ -13,8 +13,6 @@ import (
 
 	models "github.com/goharbor/harbor/src/pkg/allowlist/models"
 
-	pkgscan "github.com/goharbor/harbor/src/pkg/scan"
-
 	scan "github.com/goharbor/harbor/src/controller/scan"
 )
 
@@ -176,18 +174,4 @@ func (_m *Controller) ScanAll(ctx context.Context, trigger string, async bool) (
 	}
 
 	return r0, r1
-}
-
-// UpdateReport provides a mock function with given fields: ctx, report
-func (_m *Controller) UpdateReport(ctx context.Context, report *pkgscan.CheckInReport) error {
-	ret := _m.Called(ctx, report)
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, *pkgscan.CheckInReport) error); ok {
-		r0 = rf(ctx, report)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
 }


### PR DESCRIPTION
1. Refactor the process of updating the scan report. First tries to update the vulnerability records whose severity are changed, then creates the vulnerabilities which are not in the db, finally associates vulnerability records with the report.
2. Move the updating of the scan report in the scan job.

Closes #14851 #14745 #14585 #14461 #14430 

Signed-off-by: He Weiwei <hweiwei@vmware.com>