### PR TITLE
[Cherrypick - v2.2]: Make v2auth more strict

### DIFF
--- a/src/server/middleware/v2auth/auth.go
+++ b/src/server/middleware/v2auth/auth.go
@@ -17,12 +17,13 @@ package v2auth
 import (
 	"context"
 	"fmt"
-	rbac_project "github.com/goharbor/harbor/src/common/rbac/project"
-	"github.com/goharbor/harbor/src/common/rbac/system"
 	"net/http"
 	"net/url"
 	"strings"
 	"sync"
+
+	rbac_project "github.com/goharbor/harbor/src/common/rbac/project"
+	"github.com/goharbor/harbor/src/common/rbac/system"
 
 	"github.com/goharbor/harbor/src/common/rbac"
 	"github.com/goharbor/harbor/src/common/security"
@@ -49,7 +50,9 @@ func (rc *reqChecker) check(req *http.Request) (string, error) {
 		return "", fmt.Errorf("the security context got from request is nil")
 	}
 	al := accessList(req)
-
+	if len(al) == 0 {
+		return "", fmt.Errorf("un-recognized request: %s %s", req.Method, req.URL.Path)
+	}
 	for _, a := range al {
 		if a.target == login && !securityCtx.IsAuthenticated() {
 			return getChallenge(req, al), errors.New("unauthorized")

--- a/src/server/middleware/v2auth/auth_test.go
+++ b/src/server/middleware/v2auth/auth_test.go
@@ -154,6 +154,7 @@ func TestMiddleware(t *testing.T) {
 	req4, _ := http.NewRequest(http.MethodPost, "/v2/project_1/ubuntu/blobs/uploads/mount=?mount=sha256:08e4a417ff4e3913d8723a05cc34055db01c2fd165b588e049c5bad16ce6094f&from=project_2/ubuntu", nil)
 	req5, _ := http.NewRequest(http.MethodPost, "/v2/project_1/ubuntu/blobs/uploads/mount=?mount=sha256:08e4a417ff4e3913d8723a05cc34055db01c2fd165b588e049c5bad16ce6094f&from=project_3/ubuntu", nil)
 	req6, _ := http.NewRequest(http.MethodPost, "/v2/project_1/ubuntu/blobs/uploads/mount=?mount=sha256:08e4a417ff4e3913d8723a05cc34055db01c2fd165b588e049c5bad16ce6094f&from=project_0/ubuntu", nil)
+	req7, _ := http.NewRequest(http.MethodPost, "/v2/uploads/mount=?mount=sha256:08e4a417ff4e3913d8723a05cc34055db01c2fd165b588e049c5bad16ce6094f&from=project_0/ubuntu", nil)
 
 	cases := []struct {
 		input  *http.Request
@@ -189,6 +190,10 @@ func TestMiddleware(t *testing.T) {
 		},
 		{
 			input:  req6.WithContext(ctx5),
+			status: http.StatusUnauthorized,
+		},
+		{
+			input:  req7.WithContext(ctx5),
 			status: http.StatusUnauthorized,
 		},
 	}


### PR DESCRIPTION
This commit enhances the v2auth middleware, such that any un-recognized
request sent to /v2/ will be blocked.

Signed-off-by: Daniel Jiang <jiangd@vmware.com>