### PR TITLE
[Cherrypick v2.1] Make v2auth more strict

### DIFF
--- a/src/server/middleware/v2auth/auth.go
+++ b/src/server/middleware/v2auth/auth.go
@@ -16,8 +16,6 @@ package v2auth
 
 import (
 	"fmt"
-	"github.com/goharbor/harbor/src/lib"
-	lib_http "github.com/goharbor/harbor/src/lib/http"
 	"net/http"
 	"net/url"
 	"strings"
@@ -28,7 +26,9 @@ import (
 	"github.com/goharbor/harbor/src/core/config"
 	"github.com/goharbor/harbor/src/core/promgr"
 	"github.com/goharbor/harbor/src/core/service/token"
+	"github.com/goharbor/harbor/src/lib"
 	"github.com/goharbor/harbor/src/lib/errors"
+	lib_http "github.com/goharbor/harbor/src/lib/http"
 	"github.com/goharbor/harbor/src/lib/log"
 )
 
@@ -46,6 +46,9 @@ func (rc *reqChecker) check(req *http.Request) (string, error) {
 		return "", fmt.Errorf("the security context got from request is nil")
 	}
 	al := accessList(req)
+	if len(al) == 0 {
+		return "", fmt.Errorf("un-recognized request: %s %s", req.Method, req.URL.Path)
+	}
 
 	for _, a := range al {
 		if a.target == login && !securityCtx.IsAuthenticated() {


### PR DESCRIPTION
This commit enhances the v2auth middleware, such that any
un-recognized request sent to /v2/ will be blocked.

Signed-off-by: Daniel Jiang <jiangd@vmware.com>