### PR TITLE
(cherry-pick) Fall back to local registry when upstream registry is not working

### DIFF
--- a/src/server/middleware/repoproxy/proxy.go
+++ b/src/server/middleware/repoproxy/proxy.go
@@ -98,7 +98,12 @@ func preCheck(ctx context.Context) (art lib.ArtifactInfo, p *models.Project, ctl
 func ManifestMiddleware() func(http.Handler) http.Handler {
 	return middleware.New(func(w http.ResponseWriter, r *http.Request, next http.Handler) {
 		if err := handleManifest(w, r, next); err != nil {
-			httpLib.SendError(w, err)
+			if errors.IsNotFoundErr(err) {
+				httpLib.SendError(w, err)
+				return
+			}
+			log.Errorf("failed to proxy manifest, fallback to local, request uri: %v, error: %v", r.RequestURI, err)
+			next.ServeHTTP(w, r)
 		}
 	})
 }


### PR DESCRIPTION
Fixes #14822
When upstream registry not working, but status might stay healthy because the health check interval is 5 minutes, if a pull request comes before registry status turns to unhealthy, the proxy cache middleware might proxy the request to the upstream registry and get a 401 error and this 401 error might translate to a http 500 error to the client eventually.

To solve this issue, it fall back all error to local registry when proxying manifest except the NotFoundError from the local registry.

Signed-off-by: stonezdj <stonezdj@gmail.com>