### PR TITLE
update the log level of robot v1 context

### DIFF
--- a/src/server/middleware/security/robot.go
+++ b/src/server/middleware/security/robot.go
@@ -46,7 +46,7 @@ func (r *robot) Generate(req *http.Request) security.Context {
 	}
 	rtk, err := pkg_token.Parse(defaultOpt, robotTk, rClaims)
 	if err != nil {
-		log.Errorf("failed to decrypt robot token: %v", err)
+		log.Debugf("failed to decrypt robot token of v1 robot: %s, as: %v", robotName, err)
 		return nil
 	}
 	// Do authn for robot account, as Harbor only stores the token ID, just validate the ID and disable.


### PR DESCRIPTION
The robotv1 context uses the robot$ as a hardcoded prefix to identify robot account, it will raise error
for a valid robotv2 account with this prefix.

Update the log level to avoid the redundant logs for the default installation.

Signed-off-by: Wang Yan <wangyan@vmware.com>