### PR TITLE
set shm size of postgres

### DIFF
--- a/make/photon/prepare/templates/docker_compose/docker-compose.yml.jinja
+++ b/make/photon/prepare/templates/docker_compose/docker-compose.yml.jinja
@@ -144,6 +144,7 @@ services:
       options:
         syslog-address: "tcp://127.0.0.1:1514"
         tag: "postgresql"
+    shm_size: '1gb'
 {% endif %}
   core:
     image: goharbor/harbor-core:{{version}}


### PR DESCRIPTION
Fixed #15034, as for postgres 13, the default shm size is 64MB, set to 1gb to avoid could not resize shared memory segment error.

Signed-off-by: Wang Yan <wangyan@vmware.com>