### PR TITLE
enable policy checker for head manifest request

### DIFF
--- a/src/server/registry/route.go
+++ b/src/server/registry/route.go
@@ -59,6 +59,8 @@ func RegisterRoutes() {
 		Path("/*/manifests/:reference").
 		Middleware(metric.InjectOpIDMiddleware(metric.ManifestOperationID)).
 		Middleware(repoproxy.ManifestMiddleware()).
+		Middleware(contenttrust.Middleware()).
+		Middleware(vulnerable.Middleware()).
 		HandlerFunc(getManifest)
 	root.NewRoute().
 		Method(http.MethodDelete).


### PR DESCRIPTION
As from docker v20, the containerd leverages the cache when to pull a manifest, that leads to the
client doesn't send the get manifest request if the image exists in local.

The content trust and vul checker are only valid for get manifest request, the PR is to enable the checkers on
head manifest request to handle the containerd local cache scenario.

Signed-off-by: Wang Yan <wangyan@vmware.com>