### PR TITLE
Support project auto sync feature by pull-based replication mode

### DIFF
--- a/api/v2.0/swagger.yaml
+++ b/api/v2.0/swagger.yaml
@@ -6213,6 +6213,9 @@ definitions:
       cve_allowlist:
         description: The CVE allowlist of this project.
         $ref: '#/definitions/CVEAllowlist'
+      auto_synced:
+        type: boolean
+        description: Whether the project can be auto-synced with pull-based replication mode.
   ProjectDeletable:
     type: object
     properties:

--- a/make/migrations/postgresql/0061_2.3.0_schema.up.sql
+++ b/make/migrations/postgresql/0061_2.3.0_schema.up.sql
@@ -1,0 +1,1 @@
+alter table project add column auto_synced boolean not null default false;

--- a/src/common/models/project.go
+++ b/src/common/models/project.go
@@ -51,6 +51,7 @@ type Project struct {
 	Metadata     map[string]string   `orm:"-" json:"metadata"`
 	CVEAllowlist models.CVEAllowlist `orm:"-" json:"cve_allowlist"`
 	RegistryID   int64               `orm:"column(registry_id)" json:"registry_id"`
+	AutoSynced   bool                `orm:"column(auto_synced)" json:"auto_synced"`
 }
 
 // GetMetadata ...
@@ -81,8 +82,15 @@ func (p *Project) IsPublic() bool {
 }
 
 // IsProxy returns true when the project type is proxy cache
+// Because if project enabled auto sync, registry id is greater than zero,
+// so we should make sure that the project didn't enable auto sync.
 func (p *Project) IsProxy() bool {
-	return p.RegistryID > 0
+	return p.RegistryID > 0 && !p.AutoSynced
+}
+
+// IsAutoSynced returns true when the project type enabled auto sync
+func (p *Project) IsAutoSynced() bool {
+	return p.RegistryID > 0 && p.AutoSynced
 }
 
 // ContentTrustEnabled ...

--- a/src/controller/event/handler/init.go
+++ b/src/controller/event/handler/init.go
@@ -37,6 +37,7 @@ func init() {
 
 	// replication
 	notifier.Subscribe(event.TopicPushArtifact, &replication.Handler{})
+	notifier.Subscribe(event.TopicPullArtifact, &replication.Handler{})
 	notifier.Subscribe(event.TopicDeleteArtifact, &replication.Handler{})
 	notifier.Subscribe(event.TopicCreateTag, &replication.Handler{})
 	notifier.Subscribe(event.TopicDeleteTag, &replication.Handler{})

--- a/src/controller/event/handler/replication/event/event.go
+++ b/src/controller/event/handler/replication/event/event.go
@@ -18,6 +18,7 @@ import "github.com/goharbor/harbor/src/pkg/reg/model"
 
 // const definitions
 const (
+	EventTypeArtifactPull   = "artifact_pull"
 	EventTypeArtifactPush   = "artifact_push"
 	EventTypeArtifactDelete = "artifact_delete"
 	EventTypeTagDelete      = "tag_delete"

--- a/src/controller/registry/controller.go
+++ b/src/controller/registry/controller.go
@@ -196,8 +196,8 @@ func (c *controller) GetInfo(ctx context.Context, id int64) (*model.RegistryInfo
 		return nil, err
 	}
 
-	// currently, only the local Harbor registry supports the event based trigger, append it here
-	if id == 0 {
+	// currently, only the Harbor registry supports the event based trigger, append it here
+	if info.Type == model.RegistryTypeHarbor {
 		info.SupportedTriggers = append(info.SupportedTriggers, model.TriggerTypeEventBased)
 	}
 	info = process(info)

--- a/src/lib/context.go
+++ b/src/lib/context.go
@@ -22,10 +22,11 @@ type contextKey string
 
 // define all context key here to avoid conflict
 const (
-	contextKeyAPIVersion   contextKey = "apiVersion"
-	contextKeyArtifactInfo contextKey = "artifactInfo"
-	contextKeyAuthMode     contextKey = "authMode"
-	contextKeyCarrySession contextKey = "carrySession"
+	contextKeyAPIVersion    contextKey = "apiVersion"
+	contextKeyArtifactInfo  contextKey = "artifactInfo"
+	contextKeyAuthMode      contextKey = "authMode"
+	contextKeyCarrySession  contextKey = "carrySession"
+	contextKeyProxyPullMode contextKey = "proxyPullMode"
 )
 
 // ArtifactInfo wraps the artifact info extracted from the request to "/v2/"
@@ -111,4 +112,20 @@ func GetCarrySession(ctx context.Context) bool {
 		carrySession, _ = value.(bool)
 	}
 	return carrySession
+}
+
+// WithProxyPullMode returns a context with proxy pull mode
+// Proxy pull mode is similar to proxy cache except that there is no proxy project name prefix
+func WithProxyPullMode(ctx context.Context, enabled bool) context.Context {
+	return setToContext(ctx, contextKeyProxyPullMode, enabled)
+}
+
+// IsProxyPullMode return true if the proxy pull mode was enabled
+func IsProxyPullMode(ctx context.Context) bool {
+	enabled := false
+	value := getFromContext(ctx, contextKeyProxyPullMode)
+	if value != nil {
+		enabled, _ = value.(bool)
+	}
+	return enabled
 }

--- a/src/server/middleware/repoproxy/event.go
+++ b/src/server/middleware/repoproxy/event.go
@@ -1,0 +1,144 @@
+package repoproxy
+
+import (
+	"github.com/goharbor/harbor/src/lib/orm"
+	"net/http"
+
+	"github.com/goharbor/harbor/src/common/models"
+	"github.com/goharbor/harbor/src/controller/artifact"
+	"github.com/goharbor/harbor/src/controller/artifact/processor/image"
+	"github.com/goharbor/harbor/src/controller/event/operator"
+	"github.com/goharbor/harbor/src/controller/proxy"
+	"github.com/goharbor/harbor/src/controller/registry"
+	"github.com/goharbor/harbor/src/lib"
+	"github.com/goharbor/harbor/src/lib/errors"
+	httpLib "github.com/goharbor/harbor/src/lib/http"
+	"github.com/goharbor/harbor/src/lib/log"
+	"github.com/goharbor/harbor/src/pkg/reg/model"
+	reg "github.com/goharbor/harbor/src/pkg/registry"
+	"github.com/goharbor/harbor/src/server/middleware"
+	"github.com/goharbor/harbor/src/server/router"
+)
+
+func canAutoSync(p *models.Project) bool {
+	if p.RegistryID < 1 {
+		return false
+	}
+	reg, err := registry.Ctl.Get(orm.Context(), p.RegistryID)
+	if err != nil {
+		log.Errorf("failed to get registry, error:%v", err)
+		return false
+	}
+	if reg.Status != model.Healthy {
+		log.Errorf("current registry is unhealthy, regID:%v, Name:%v, Status: %v", reg.ID, reg.Name, reg.Status)
+	}
+	return reg.Status == model.Healthy && p.AutoSynced
+}
+
+// PullEventMiddleware middleware handle request for get or head manifest
+func PullEventMiddleware() func(http.Handler) http.Handler {
+	return middleware.New(func(w http.ResponseWriter, r *http.Request, next http.Handler) {
+		if err := handlePullEvent(w, r, next); err != nil {
+			httpLib.SendError(w, err)
+		}
+	})
+}
+
+func handlePullEvent(w http.ResponseWriter, r *http.Request, next http.Handler) error {
+
+	ctx := r.Context()
+	ctx = lib.WithProxyPullMode(ctx, true)
+
+	art, p, proxyCtl, err := preCheck(ctx)
+	if err != nil {
+		return err
+	}
+
+	if !canAutoSync(p) {
+		next.ServeHTTP(w, r)
+		return nil
+	}
+
+	remote, err := proxy.NewRemoteHelper(p.RegistryID)
+	if err != nil {
+		return err
+	}
+	useLocal, _, err := proxyCtl.UseLocalManifest(ctx, art, remote)
+	if err != nil {
+		return err
+	}
+	if useLocal {
+		next.ServeHTTP(w, r)
+		return nil
+	}
+	log.Debugf("the tag is %v, digest is %v", art.Tag, art.Digest)
+
+	if r.Method == http.MethodHead {
+		err = proxyManifestHead(ctx, w, proxyCtl, p, art, remote)
+	} else if r.Method == http.MethodGet {
+		err = proxyManifestGet(ctx, w, proxyCtl, p, art, remote)
+	}
+
+	if err != nil {
+		if errors.IsNotFoundErr(err) {
+			return err
+		}
+		log.Warningf("Proxy to remote failed, fallback to local repo, error: %v", err)
+		next.ServeHTTP(w, r)
+	}
+
+	if r.UserAgent() == reg.UserAgent {
+		return nil
+	}
+
+	return addPullArtifactEvent(r, art, p.ProjectID, remote)
+}
+
+func addPullArtifactEvent(r *http.Request, art lib.ArtifactInfo, projectID int64, remote proxy.RemoteInterface) error {
+	var ref string
+	if len(art.Tag) > 0 {
+		ref = art.Tag
+	} else {
+		ref = art.Digest
+	}
+
+	_, dig, err := remote.Manifest(art.Repository, ref)
+	if err != nil {
+		log.Error("repo %s:%s not found", art.Repository, art.Tag)
+		return err
+	}
+
+	var a = &artifact.Artifact{}
+	a.Type = image.ArtifactTypeImage
+	a.RepositoryName = router.Param(r.Context(), ":splat")
+	a.ProjectID = projectID
+	a.Digest = dig
+
+	proxy.SendPullEvent(a, art.Tag, operator.FromContext(r.Context()))
+	return nil
+}
+
+// PullEventBlobGetMiddleware handle get blob request
+func PullEventBlobGetMiddleware() func(http.Handler) http.Handler {
+	return middleware.New(func(w http.ResponseWriter, r *http.Request, next http.Handler) {
+
+		if err := handlePullEventBlob(w, r, next); err != nil {
+			httpLib.SendError(w, err)
+		}
+	})
+}
+
+func handlePullEventBlob(w http.ResponseWriter, r *http.Request, next http.Handler) error {
+	ctx := r.Context()
+	_, p, _, err := preCheck(ctx)
+	if err != nil {
+		return err
+	}
+
+	if p.AutoSynced {
+		r = r.WithContext(lib.WithProxyPullMode(ctx, true))
+	}
+
+	next.ServeHTTP(w, r)
+	return nil
+}

--- a/src/server/registry/route.go
+++ b/src/server/registry/route.go
@@ -50,6 +50,7 @@ func RegisterRoutes() {
 		Method(http.MethodGet).
 		Path("/*/manifests/:reference").
 		Middleware(metric.InjectOpIDMiddleware(metric.ManifestOperationID)).
+		Middleware(repoproxy.PullEventMiddleware()).
 		Middleware(repoproxy.ManifestMiddleware()).
 		Middleware(contenttrust.Middleware()).
 		Middleware(vulnerable.Middleware()).
@@ -58,6 +59,7 @@ func RegisterRoutes() {
 		Method(http.MethodHead).
 		Path("/*/manifests/:reference").
 		Middleware(metric.InjectOpIDMiddleware(metric.ManifestOperationID)).
+		Middleware(repoproxy.PullEventMiddleware()).
 		Middleware(repoproxy.ManifestMiddleware()).
 		HandlerFunc(getManifest)
 	root.NewRoute().
@@ -87,6 +89,7 @@ func RegisterRoutes() {
 		Method(http.MethodGet).
 		Path("/*/blobs/:digest").
 		Middleware(metric.InjectOpIDMiddleware(metric.BlobsOperationID)).
+		Middleware(repoproxy.PullEventBlobGetMiddleware()).
 		Middleware(repoproxy.BlobGetMiddleware()).
 		Handler(proxy)
 	// initiate blob upload

--- a/src/server/v2.0/handler/model/project.go
+++ b/src/server/v2.0/handler/model/project.go
@@ -70,6 +70,7 @@ func (p *Project) ToSwagger() *models.Project {
 		RegistryID:         p.RegistryID,
 		RepoCount:          p.RepoCount,
 		UpdateTime:         strfmt.DateTime(p.UpdateTime),
+		AutoSynced:         p.AutoSynced,
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: yunkunrao <yunkunrao@gmail.com>

### Summary
This PR adds event-based trigger mode for pull-based replication mode. This PR is related with #14736 .

### Background
Briefly, current replication policy doesn't support event-based trigger mode for pull-based replication mode.
And alternative solution proxy cache seems to have a similar function, but it has it's own limitation that docker image namespace has to be changed with a new proxy cache project as the prefix.

### Solution
Harbor admin can create a project with the same project name as the upsteam Harbor's project name with specified upstream registry_id and enable auto sync option.

When client run the docker pull cmd, local harbor will synchronize the docker image automically in the project. In other words it's totally transparent to docker client without any prefix in docker image full name.

For example, if we want to pull the latest image from downstream Harbor
- For proxy cache, we can run `docker pull <downstream_harbor:port>/proxy/<your ns>/<your image>:latest`
- For pull-based replication mode, we can run `docker run <downsteam_harbor:port>/<your ns>/<your image>:latest`. Only  prerequisites are project name should be the same as upstream's project name and project enable auto-synced option.
