### PR TITLE
[ Cherry-pick 2.2.0 ] Refind build base process in Makefile

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -49,9 +49,7 @@ jobs:
         if: contains(steps.changed-files.outputs.modified, 'Dockerfile.base') || contains(steps.changed-files.outputs.modified, 'VERSION')
         run: |
           set -x
-          base_image_tag=$(cat ./VERSION)
-          cd src/github.com/goharbor/harbor
-          sudo make build_base_docker -e BASEIMAGETAG=$base_image_tag -e REGISTRYUSER="${{ secrets.DOCKER_HUB_USERNAME }}" -e REGISTRYPASSWORD="${{ secrets.DOCKER_HUB_PASSWORD }}" -e PUSHBASEIMAGE=yes
+          echo "BUILD_BASE=true" >> $GITHUB_ENV
       - name: Build Package
         run: |
           set -x
@@ -83,9 +81,15 @@ jobs:
             Harbor_Build_Base_Tag=dev
           fi
 
+          build_base_params=" BUILD_BASE=false"
           cd src/github.com/goharbor/harbor
-          sudo make package_offline GOBUILDTAGS="include_oss include_gcs" BASEIMAGETAG=${Harbor_Build_Base_Tag} VERSIONTAG=${Harbor_Assets_Version} PKGVERSIONTAG=${Harbor_Package_Version} BUILDBIN=true NOTARYFLAG=true CHARTFLAG=true TRIVYFLAG=true HTTPPROXY=
-          sudo make package_online GOBUILDTAGS="include_oss include_gcs" BASEIMAGETAG=${Harbor_Build_Base_Tag} VERSIONTAG=${Harbor_Assets_Version} PKGVERSIONTAG=${Harbor_Package_Version} BUILDBIN=true NOTARYFLAG=true CHARTFLAG=true TRIVYFLAG=true HTTPPROXY=
+          if [ -z "$BUILD_BASE"  ] || [ "$BUILD_BASE" != "true"  ]; then
+            echo "Do not need to build base images!"
+          else
+            build_base_params=" BUILD_BASE=true PUSHBASEIMAGE=true REGISTRYUSER=\"${{ secrets.DOCKER_HUB_USERNAME }}\" REGISTRYPASSWORD=\"${{ secrets.DOCKER_HUB_PASSWORD }}\""
+          fi
+          sudo make package_offline GOBUILDTAGS="include_oss include_gcs" BASEIMAGETAG=${Harbor_Build_Base_Tag} VERSIONTAG=${Harbor_Assets_Version} PKGVERSIONTAG=${Harbor_Package_Version} BUILDBIN=true NOTARYFLAG=true CHARTFLAG=true TRIVYFLAG=true HTTPPROXY= ${build_base_params}
+          sudo make package_online GOBUILDTAGS="include_oss include_gcs" BASEIMAGETAG=${Harbor_Build_Base_Tag} VERSIONTAG=${Harbor_Assets_Version} PKGVERSIONTAG=${Harbor_Package_Version} BUILDBIN=true NOTARYFLAG=true CHARTFLAG=true TRIVYFLAG=true HTTPPROXY= ${build_base_params}
           harbor_offline_build_bundle=$(basename harbor-offline-installer-*.tgz)
           harbor_online_build_bundle=$(basename harbor-online-installer-*.tgz)
           echo "Package name is: $harbor_offline_build_bundle"

--- a/Makefile
+++ b/Makefile
@@ -91,10 +91,14 @@ GEN_TLS=
 # for docker image tag
 VERSIONTAG=dev
 # for base docker image tag
-PUSHBASEIMAGE=
+BUILD_BASE=true
+PUSHBASEIMAGE=false
 BASEIMAGETAG=dev
-BASEIMAGENAMESPACE=goharbor
 BUILDBASETARGET=chartserver trivy-adapter core db jobservice log nginx notary-server notary-signer portal prepare redis registry registryctl exporter
+BASEIMAGENAMESPACE=goharbor
+# #input true/false only
+PULL_BASE_FROM_DOCKERHUB=true
+
 # for harbor package name
 PKGVERSIONTAG=dev
 
@@ -249,9 +253,7 @@ ZIPCMD=$(shell which gzip)
 DOCKERIMGFILE=harbor
 HARBORPKG=harbor
 
-# pushimage
-PUSHSCRIPTPATH=$(MAKEPATH)
-PUSHSCRIPTNAME=pushimage.sh
+# pull/push image
 REGISTRYUSER=
 REGISTRYPASSWORD=
 
@@ -392,6 +394,19 @@ prepare: update_prepare_version
 	@$(MAKEPATH)/$(PREPARECMD) $(PREPARECMD_PARA)
 
 build:
+# PUSHBASEIMAGE should not be true if BUILD_BASE is not true
+	@if [ "$(PULL_BASE_FROM_DOCKERHUB)" != "true" ] && [ "$(PULL_BASE_FROM_DOCKERHUB)" != "false" ] ; then \
+		echo set PULL_BASE_FROM_DOCKERHUB to true or false.; exit 1; \
+	fi
+	@if [ "$(BUILD_BASE)" != "true" ]  && [ "$(PUSHBASEIMAGE)" = "true" ] ; then \
+		echo Do not push base images since no base images built. ; \
+		exit 1; \
+	fi
+# PULL_BASE_FROM_DOCKERHUB should be true if BUILD_BASE is not true
+	@if [ "$(BUILD_BASE)" != "true" ]  && [ "$(PULL_BASE_FROM_DOCKERHUB)" = "false" ] ; then \
+		echo Should pull base images from registry in docker configuration since no base images built. ; \
+		exit 1; \
+	fi
 	make -f $(MAKEFILEPATH_PHOTON)/Makefile $(BUILDTARGET) -e DEVFLAG=$(DEVFLAG) -e GOBUILDIMAGE=$(GOBUILDIMAGE) \
 	 -e REGISTRYVERSION=$(REGISTRYVERSION) -e REGISTRY_SRC_TAG=$(REGISTRY_SRC_TAG) \
 	 -e NOTARYVERSION=$(NOTARYVERSION) -e NOTARYMIGRATEVERSION=$(NOTARYMIGRATEVERSION) \
@@ -401,25 +416,13 @@ build:
 	 -e CHARTMUSEUMVERSION=$(CHARTMUSEUMVERSION) -e CHARTMUSEUM_SRC_TAG=$(CHARTMUSEUM_SRC_TAG) -e DOCKERIMAGENAME_CHART_SERVER=$(DOCKERIMAGENAME_CHART_SERVER) \
 	 -e NPM_REGISTRY=$(NPM_REGISTRY) -e BASEIMAGETAG=$(BASEIMAGETAG) -e BASEIMAGENAMESPACE=$(BASEIMAGENAMESPACE) \
 	 -e CHARTURL=$(CHARTURL) -e NORARYURL=$(NORARYURL) -e REGISTRYURL=$(REGISTRYURL) \
-	 -e TRIVY_DOWNLOAD_URL=$(TRIVY_DOWNLOAD_URL) -e TRIVY_ADAPTER_DOWNLOAD_URL=$(TRIVY_ADAPTER_DOWNLOAD_URL)
+	 -e TRIVY_DOWNLOAD_URL=$(TRIVY_DOWNLOAD_URL) -e TRIVY_ADAPTER_DOWNLOAD_URL=$(TRIVY_ADAPTER_DOWNLOAD_URL) \
+	 -e PULL_BASE_FROM_DOCKERHUB=$(PULL_BASE_FROM_DOCKERHUB) -e BUILD_BASE=$(BUILD_BASE) \
+	 -e REGISTRYUSER=$(REGISTRYUSER) -e REGISTRYPASSWORD=$(REGISTRYPASSWORD) \
+	 -e PUSHBASEIMAGE=$(PUSHBASEIMAGE)
 
 build_standalone_db_migrator: compile_standalone_db_migrator
 	make -f $(MAKEFILEPATH_PHOTON)/Makefile _build_standalone_db_migrator -e BASEIMAGETAG=$(BASEIMAGETAG) -e VERSIONTAG=$(VERSIONTAG)
-
-build_base_docker:
-	if [ -n "$(REGISTRYUSER)" ] && [ -n "$(REGISTRYPASSWORD)" ] ; then \
-		docker login -u $(REGISTRYUSER) -p $(REGISTRYPASSWORD) ; \
-	else \
-		echo "No docker credentials provided, please make sure enough priviledges to access docker hub!" ; \
-	fi
-	@for name in $(BUILDBASETARGET); do \
-		echo $$name ; \
-		sleep 30 ; \
-		$(DOCKERBUILD) --pull --no-cache -f $(MAKEFILEPATH_PHOTON)/$$name/Dockerfile.base -t $(BASEIMAGENAMESPACE)/harbor-$$name-base:$(BASEIMAGETAG) --label base-build-date=$(date +"%Y%m%d") . && \
-		if [ -n "$(PUSHBASEIMAGE)" ] ; then \
-			$(PUSHSCRIPTPATH)/$(PUSHSCRIPTNAME) $(BASEIMAGENAMESPACE)/harbor-$$name-base:$(BASEIMAGETAG) $(REGISTRYUSER) $(REGISTRYPASSWORD) || exit 1; \
-		fi ; \
-	done
 
 pull_base_docker:
 	@for name in $(BUILDBASETARGET); do \
@@ -573,7 +576,7 @@ cleanbinary:
 
 cleanbaseimage:
 	@echo "cleaning base image for photon..."
-	@for name in chartserver trivy-adapter core db jobservice log nginx notary-server notary-signer portal prepare redis registry registryctl; do \
+	@for name in $(BUILDBASETARGET); do \
 		$(DOCKERRMIMAGE) -f $(BASEIMAGENAMESPACE)/harbor-$$name-base:$(BASEIMAGETAG) ; \
 	done
 

--- a/make/photon/Makefile
+++ b/make/photon/Makefile
@@ -14,13 +14,19 @@ TOOLSPATH=$(CURDIR)/tools
 SEDCMD=$(shell which sed)
 WGET=$(shell which wget)
 CURL=$(shell which curl)
+TIMESTAMP=$(shell date +"%Y%m%d")
 
 # docker parameters
 DOCKERCMD=$(shell which docker)
-DOCKERBUILD=$(DOCKERCMD) build
+DOCKERBUILD=$(DOCKERCMD) build --no-cache
+DOCKERBUILD_WITH_PULL_PARA=$(DOCKERBUILD) --pull=$(PULL_BASE_FROM_DOCKERHUB)
 DOCKERRMIMAGE=$(DOCKERCMD) rmi
 DOCKERIMAGES=$(DOCKERCMD) images
 BASEIMAGENAMESPACE=goharbor
+
+# pushimage
+PUSHSCRIPTPATH=$(MAKEPATH)
+PUSHSCRIPTNAME=pushimage.sh
 
 # binary
 CORE_SOURCECODE=$(SRCPATH)/core
@@ -31,109 +37,132 @@ JOBSERVICEBINARYNAME=harbor_jobservice
 # photon dockerfile
 DOCKERFILEPATH=$(MAKEPATH)/photon
 
-DOCKERFILEPATH_PREPARE=$(DOCKERFILEPATH)/prepare
+PREPARE=prepare
+DOCKERFILEPATH_PREPARE=$(DOCKERFILEPATH)/$(PREPARE)
 DOCKERFILENAME_PREPARE=Dockerfile
-DOCKERIMAGENAME_PREPARE=goharbor/prepare
+DOCKERIMAGENAME_PREPARE=goharbor/$(PREPARE)
 
-DOCKERFILEPATH_PORTAL=$(DOCKERFILEPATH)/portal
+PORTAL=portal
+DOCKERFILEPATH_PORTAL=$(DOCKERFILEPATH)/$(PORTAL)
 DOCKERFILENAME_PORTAL=Dockerfile
-DOCKERIMAGENAME_PORTAL=goharbor/harbor-portal
+DOCKERIMAGENAME_PORTAL=goharbor/harbor-$(PORTAL)
 
-DOCKERFILEPATH_CORE=$(DOCKERFILEPATH)/core
+CORE=core
+DOCKERFILEPATH_CORE=$(DOCKERFILEPATH)/$(CORE)
 DOCKERFILENAME_CORE=Dockerfile
-DOCKERIMAGENAME_CORE=goharbor/harbor-core
+DOCKERIMAGENAME_CORE=goharbor/harbor-$(CORE)
 
-DOCKERFILEPATH_JOBSERVICE=$(DOCKERFILEPATH)/jobservice
+JOBSERVICE=jobservice
+DOCKERFILEPATH_JOBSERVICE=$(DOCKERFILEPATH)/$(JOBSERVICE)
 DOCKERFILENAME_JOBSERVICE=Dockerfile
-DOCKERIMAGENAME_JOBSERVICE=goharbor/harbor-jobservice
+DOCKERIMAGENAME_JOBSERVICE=goharbor/harbor-$(JOBSERVICE)
 
-DOCKERFILEPATH_LOG=$(DOCKERFILEPATH)/log
+LOG=log
+DOCKERFILEPATH_LOG=$(DOCKERFILEPATH)/$(LOG)
 DOCKERFILENAME_LOG=Dockerfile
-DOCKERIMAGENAME_LOG=goharbor/harbor-log
+DOCKERIMAGENAME_LOG=goharbor/harbor-$(LOG)
 
-DOCKERFILEPATH_DB=$(DOCKERFILEPATH)/db
+DB=db
+DOCKERFILEPATH_DB=$(DOCKERFILEPATH)/$(DB)
 DOCKERFILENAME_DB=Dockerfile
-DOCKERIMAGENAME_DB=goharbor/harbor-db
+DOCKERIMAGENAME_DB=goharbor/harbor-$(DB)
 
-DOCKERFILEPATH_POSTGRESQL=$(DOCKERFILEPATH)/postgresql
+POSTGRESQL=postgresql
+DOCKERFILEPATH_POSTGRESQL=$(DOCKERFILEPATH)/$(POSTGRESQL)
 DOCKERFILENAME_POSTGRESQL=Dockerfile
-DOCKERIMAGENAME_POSTGRESQL=goharbor/postgresql-photon
+DOCKERIMAGENAME_POSTGRESQL=goharbor/$(POSTGRESQL)-photon
 
-DOCKERFILEPATH_TRIVY_ADAPTER=$(DOCKERFILEPATH)/trivy-adapter
+TRIVY_ADAPTER=trivy-adapter
+DOCKERFILEPATH_TRIVY_ADAPTER=$(DOCKERFILEPATH)/$(TRIVY_ADAPTER)
 DOCKERFILENAME_TRIVY_ADAPTER=Dockerfile
-DOCKERIMAGENAME_TRIVY_ADAPTER=goharbor/trivy-adapter-photon
+DOCKERIMAGENAME_TRIVY_ADAPTER=goharbor/$(TRIVY_ADAPTER)-photon
 
-DOCKERFILEPATH_NGINX=$(DOCKERFILEPATH)/nginx
+NGINX=nginx
+DOCKERFILEPATH_NGINX=$(DOCKERFILEPATH)/$(NGINX)
 DOCKERFILENAME_NGINX=Dockerfile
-DOCKERIMAGENAME_NGINX=goharbor/nginx-photon
+DOCKERIMAGENAME_NGINX=goharbor/$(NGINX)-photon
 
-DOCKERFILEPATH_REG=$(DOCKERFILEPATH)/registry
+REGISTRY=registry
+DOCKERFILEPATH_REG=$(DOCKERFILEPATH)/$(REGISTRY)
 DOCKERFILENAME_REG=Dockerfile
-DOCKERIMAGENAME_REG=goharbor/registry-photon
+DOCKERIMAGENAME_REG=goharbor/$(REGISTRY)-photon
 
-DOCKERFILEPATH_REGISTRYCTL=$(DOCKERFILEPATH)/registryctl
+REGISTRYCTL=registryctl
+DOCKERFILEPATH_REGISTRYCTL=$(DOCKERFILEPATH)/$(REGISTRYCTL)
 DOCKERFILENAME_REGISTRYCTL=Dockerfile
-DOCKERIMAGENAME_REGISTRYCTL=goharbor/harbor-registryctl
+DOCKERIMAGENAME_REGISTRYCTL=goharbor/harbor-$(REGISTRYCTL)
 
+NOTARYSERVER=notary-server
+NOTARYSIGNER=notary-signer
 DOCKERFILEPATH_NOTARY=$(DOCKERFILEPATH)/notary
-DOCKERFILEPATH_NOTARYSERVER=$(DOCKERFILEPATH)/notary-server
-DOCKERFILENAME_NOTARYSIGNER=Dockerfile
-DOCKERIMAGENAME_NOTARYSIGNER=goharbor/notary-signer-photon
-DOCKERFILEPATH_NOTARYSIGNER=$(DOCKERFILEPATH)/notary-signer
+DOCKERFILEPATH_NOTARYSERVER=$(DOCKERFILEPATH)/$(NOTARYSERVER)
 DOCKERFILENAME_NOTARYSERVER=Dockerfile
-DOCKERIMAGENAME_NOTARYSERVER=goharbor/notary-server-photon
+DOCKERIMAGENAME_NOTARYSERVER=goharbor/$(NOTARYSERVER)-photon
+DOCKERFILEPATH_NOTARYSIGNER=$(DOCKERFILEPATH)/$(NOTARYSIGNER)
+DOCKERFILENAME_NOTARYSIGNER=Dockerfile
+DOCKERIMAGENAME_NOTARYSIGNER=goharbor/$(NOTARYSIGNER)-photon
 
-DOCKERFILEPATH_REDIS=$(DOCKERFILEPATH)/redis
+REDIS=redis
+DOCKERFILEPATH_REDIS=$(DOCKERFILEPATH)/$(REDIS)
 DOCKERFILENAME_REDIS=Dockerfile
-DOCKERIMAGENAME_REDIS=goharbor/redis-photon
+DOCKERIMAGENAME_REDIS=goharbor/$(REDIS)-photon
 
 DOCKERFILEPATH_STANDALONE_DB_MIGRATOR=$(DOCKERFILEPATH)/standalone-db-migrator
 DOCKERFILENAME_STANDALONE_DB_MIGRATOR=Dockerfile
 DOCKERIMAGENAME_STANDALONE_DB_MIGRATOR=goharbor/standalone-db-migrator
 
-DOCKERFILEPATH_EXPORTER=$(DOCKERFILEPATH)/exporter
+EXPORTER=exporter
+DOCKERFILEPATH_EXPORTER=$(DOCKERFILEPATH)/$(EXPORTER)
 DOCKERFILENAME_EXPORTER=Dockerfile
-DOCKERIMAGENAME_EXPORTER=goharbor/harbor-exporter
+DOCKERIMAGENAME_EXPORTER=goharbor/harbor-$(EXPORTER)
 
 # for chart server (chartmuseum)
-DOCKERFILEPATH_CHART_SERVER=$(DOCKERFILEPATH)/chartserver
+CHARTSERVER=chartserver
+DOCKERFILEPATH_CHART_SERVER=$(DOCKERFILEPATH)/$(CHARTSERVER)
 DOCKERFILENAME_CHART_SERVER=Dockerfile
 CHART_SERVER_CODE_BASE=https://github.com/helm/chartmuseum.git
 CHART_SERVER_MAIN_PATH=cmd/chartmuseum
 CHART_SERVER_BIN_NAME=chartm
 
 _build_prepare:
+	@$(call _build_base,$(PREPARE),$(DOCKERFILEPATH_PREPARE))
 	@echo "building prepare container for photon..."
-	@$(DOCKERBUILD) --build-arg harbor_base_image_version=$(BASEIMAGETAG) --build-arg harbor_base_namespace=$(BASEIMAGENAMESPACE) -f $(DOCKERFILEPATH_PREPARE)/$(DOCKERFILENAME_PREPARE) -t $(DOCKERIMAGENAME_PREPARE):$(VERSIONTAG) .
+	@$(DOCKERBUILD_WITH_PULL_PARA) --build-arg harbor_base_image_version=$(BASEIMAGETAG) --build-arg harbor_base_namespace=$(BASEIMAGENAMESPACE) -f $(DOCKERFILEPATH_PREPARE)/$(DOCKERFILENAME_PREPARE) -t $(DOCKERIMAGENAME_PREPARE):$(VERSIONTAG) .
 	@echo "Done."
 
 _build_db:
+	@$(call _build_base,$(DB),$(DOCKERFILEPATH_DB))
 	@echo "building db container for photon..."
-	@$(DOCKERBUILD) --build-arg harbor_base_image_version=$(BASEIMAGETAG) --build-arg harbor_base_namespace=$(BASEIMAGENAMESPACE) -f $(DOCKERFILEPATH_DB)/$(DOCKERFILENAME_DB) -t $(DOCKERIMAGENAME_DB):$(VERSIONTAG) .
+	@$(DOCKERBUILD_WITH_PULL_PARA) --build-arg harbor_base_image_version=$(BASEIMAGETAG) --build-arg harbor_base_namespace=$(BASEIMAGENAMESPACE) -f $(DOCKERFILEPATH_DB)/$(DOCKERFILENAME_DB) -t $(DOCKERIMAGENAME_DB):$(VERSIONTAG) .
 	@echo "Done."
 
 _build_portal:
+	@$(call _build_base,$(PORTAL),$(DOCKERFILEPATH_PORTAL))
 	@echo "building portal container for photon..."
-	$(DOCKERBUILD) --build-arg harbor_base_image_version=$(BASEIMAGETAG) --build-arg harbor_base_namespace=$(BASEIMAGENAMESPACE) --build-arg npm_registry=$(NPM_REGISTRY) -f $(DOCKERFILEPATH_PORTAL)/$(DOCKERFILENAME_PORTAL) -t $(DOCKERIMAGENAME_PORTAL):$(VERSIONTAG) .
+	$(DOCKERBUILD_WITH_PULL_PARA) --build-arg harbor_base_image_version=$(BASEIMAGETAG) --build-arg harbor_base_namespace=$(BASEIMAGENAMESPACE) --build-arg npm_registry=$(NPM_REGISTRY) -f $(DOCKERFILEPATH_PORTAL)/$(DOCKERFILENAME_PORTAL) -t $(DOCKERIMAGENAME_PORTAL):$(VERSIONTAG) .
 	@echo "Done."
 
 _build_core:
+	@$(call _build_base,$(CORE),$(DOCKERFILEPATH_CORE))
 	@echo "building core container for photon..."
-	@$(DOCKERBUILD) --build-arg harbor_base_image_version=$(BASEIMAGETAG) --build-arg harbor_base_namespace=$(BASEIMAGENAMESPACE) -f $(DOCKERFILEPATH_CORE)/$(DOCKERFILENAME_CORE) -t $(DOCKERIMAGENAME_CORE):$(VERSIONTAG) .
+	@$(DOCKERBUILD_WITH_PULL_PARA) --build-arg harbor_base_image_version=$(BASEIMAGETAG) --build-arg harbor_base_namespace=$(BASEIMAGENAMESPACE) -f $(DOCKERFILEPATH_CORE)/$(DOCKERFILENAME_CORE) -t $(DOCKERIMAGENAME_CORE):$(VERSIONTAG) .
 	@echo "Done."
 
 _build_jobservice:
+	@$(call _build_base,$(JOBSERVICE),$(DOCKERFILEPATH_JOBSERVICE))
 	@echo "building jobservice container for photon..."
-	@$(DOCKERBUILD) --build-arg harbor_base_image_version=$(BASEIMAGETAG) --build-arg harbor_base_namespace=$(BASEIMAGENAMESPACE) -f $(DOCKERFILEPATH_JOBSERVICE)/$(DOCKERFILENAME_JOBSERVICE) -t $(DOCKERIMAGENAME_JOBSERVICE):$(VERSIONTAG) .
+	@$(DOCKERBUILD_WITH_PULL_PARA) --build-arg harbor_base_image_version=$(BASEIMAGETAG) --build-arg harbor_base_namespace=$(BASEIMAGENAMESPACE) -f $(DOCKERFILEPATH_JOBSERVICE)/$(DOCKERFILENAME_JOBSERVICE) -t $(DOCKERIMAGENAME_JOBSERVICE):$(VERSIONTAG) .
 	@echo "Done."
 
 _build_log:
+	@$(call _build_base,$(LOG),$(DOCKERFILEPATH_LOG))
 	@echo "building log container for photon..."
-	$(DOCKERBUILD) --build-arg harbor_base_image_version=$(BASEIMAGETAG) --build-arg harbor_base_namespace=$(BASEIMAGENAMESPACE) -f $(DOCKERFILEPATH_LOG)/$(DOCKERFILENAME_LOG) -t $(DOCKERIMAGENAME_LOG):$(VERSIONTAG) .
+	$(DOCKERBUILD_WITH_PULL_PARA) --build-arg harbor_base_image_version=$(BASEIMAGETAG) --build-arg harbor_base_namespace=$(BASEIMAGENAMESPACE) -f $(DOCKERFILEPATH_LOG)/$(DOCKERFILENAME_LOG) -t $(DOCKERIMAGENAME_LOG):$(VERSIONTAG) .
 	@echo "Done."
 
 _build_trivy_adapter:
 	@if [ "$(TRIVYFLAG)" = "true" ] ; then \
+		$(call _build_base,$(TRIVY_ADAPTER),$(DOCKERFILEPATH_TRIVY_ADAPTER)) ; \
 		rm -rf $(DOCKERFILEPATH_TRIVY_ADAPTER)/binary && mkdir -p $(DOCKERFILEPATH_TRIVY_ADAPTER)/binary ; \
 		echo "Downloading Trivy scanner $(TRIVYVERSION)..." ; \
 		$(call _extract_archive, $(TRIVY_DOWNLOAD_URL), $(DOCKERFILEPATH_TRIVY_ADAPTER)/binary/) ; \
@@ -145,7 +174,7 @@ _build_trivy_adapter:
 			cd $(DOCKERFILEPATH_TRIVY_ADAPTER) && $(DOCKERFILEPATH_TRIVY_ADAPTER)/builder.sh $(TRIVYADAPTERVERSION) && cd - ; \
 		fi ; \
 		echo "Building Trivy adapter container for photon..." ; \
-		$(DOCKERBUILD) --build-arg harbor_base_image_version=$(BASEIMAGETAG) \
+		$(DOCKERBUILD_WITH_PULL_PARA) --build-arg harbor_base_image_version=$(BASEIMAGETAG) \
 			--build-arg harbor_base_namespace=$(BASEIMAGENAMESPACE) \
 			--build-arg trivy_version=$(TRIVYVERSION) \
 			-f $(DOCKERFILEPATH_TRIVY_ADAPTER)/$(DOCKERFILENAME_TRIVY_ADAPTER) \
@@ -156,6 +185,7 @@ _build_trivy_adapter:
 
 _build_chart_server:
 	@if [ "$(CHARTFLAG)" = "true" ] ; then \
+		$(call _build_base,$(CHARTSERVER),$(DOCKERFILEPATH_CHART_SERVER)); \
 		if [ "$(BUILDBIN)" != "true" ] ; then \
 			rm -rf $(DOCKERFILEPATH_CHART_SERVER)/binary && mkdir -p $(DOCKERFILEPATH_CHART_SERVER)/binary && \
 			$(call _get_binary, $(CHARTURL), $(DOCKERFILEPATH_CHART_SERVER)/binary/chartm); \
@@ -163,18 +193,21 @@ _build_chart_server:
 			cd $(DOCKERFILEPATH_CHART_SERVER) && $(DOCKERFILEPATH_CHART_SERVER)/builder $(GOBUILDIMAGE) $(CHART_SERVER_CODE_BASE) $(CHARTMUSEUM_SRC_TAG) $(CHART_SERVER_MAIN_PATH) $(CHART_SERVER_BIN_NAME) && cd - ; \
 		fi ; \
 		echo "building chartmuseum container for photon..." ; \
-		$(DOCKERBUILD) --build-arg harbor_base_image_version=$(BASEIMAGETAG) --build-arg harbor_base_namespace=$(BASEIMAGENAMESPACE) -f $(DOCKERFILEPATH_CHART_SERVER)/$(DOCKERFILENAME_CHART_SERVER) -t $(DOCKERIMAGENAME_CHART_SERVER):$(VERSIONTAG) . ; \
+		$(DOCKERBUILD_WITH_PULL_PARA) --build-arg harbor_base_image_version=$(BASEIMAGETAG) --build-arg harbor_base_namespace=$(BASEIMAGENAMESPACE) -f $(DOCKERFILEPATH_CHART_SERVER)/$(DOCKERFILENAME_CHART_SERVER) -t $(DOCKERIMAGENAME_CHART_SERVER):$(VERSIONTAG) . ; \
 		rm -rf $(DOCKERFILEPATH_CHART_SERVER)/binary; \
 		echo "Done." ; \
 	fi
 
 _build_nginx:
+	@$(call _build_base,$(NGINX),$(DOCKERFILEPATH_NGINX))
 	@echo "building nginx container for photon..."
-	@$(DOCKERBUILD) --build-arg harbor_base_image_version=$(BASEIMAGETAG) --build-arg harbor_base_namespace=$(BASEIMAGENAMESPACE) -f $(DOCKERFILEPATH_NGINX)/$(DOCKERFILENAME_NGINX) -t $(DOCKERIMAGENAME_NGINX):$(VERSIONTAG) .
+	@$(DOCKERBUILD_WITH_PULL_PARA) --build-arg harbor_base_image_version=$(BASEIMAGETAG) --build-arg harbor_base_namespace=$(BASEIMAGENAMESPACE) -f $(DOCKERFILEPATH_NGINX)/$(DOCKERFILENAME_NGINX) -t $(DOCKERIMAGENAME_NGINX):$(VERSIONTAG) .
 	@echo "Done."
 
 _build_notary:
 	@if [ "$(NOTARYFLAG)" = "true" ] ; then \
+		$(call _build_base,$(NOTARYSERVER),$(DOCKERFILEPATH_NOTARYSERVER)) ; \
+		$(call _build_base,$(NOTARYSIGNER),$(DOCKERFILEPATH_NOTARYSIGNER)) ; \
 		if [ "$(BUILDBIN)" != "true" ] ; then \
 			rm -rf $(DOCKERFILEPATH_NOTARY)/binary && mkdir -p $(DOCKERFILEPATH_NOTARY)/binary && \
 			$(call _get_binary, $(NORARYURL), $(DOCKERFILEPATH_NOTARY)/binary-bundle.tgz); \
@@ -183,13 +216,14 @@ _build_notary:
 			cd $(DOCKERFILEPATH_NOTARY) && $(DOCKERFILEPATH_NOTARY)/builder $(NOTARYVERSION) $(NOTARYMIGRATEVERSION) && cd - ; \
 		fi ; \
 		echo "building notary container for photon..."; \
-		chmod 655 $(DOCKERFILEPATH_NOTARY)/binary/notary-signer && $(DOCKERBUILD) --build-arg harbor_base_image_version=$(BASEIMAGETAG) --build-arg harbor_base_namespace=$(BASEIMAGENAMESPACE) -f $(DOCKERFILEPATH_NOTARYSIGNER)/$(DOCKERFILENAME_NOTARYSIGNER) -t $(DOCKERIMAGENAME_NOTARYSIGNER):$(VERSIONTAG) . ; \
-		chmod 655 $(DOCKERFILEPATH_NOTARY)/binary/notary-server && $(DOCKERBUILD) --build-arg harbor_base_image_version=$(BASEIMAGETAG) --build-arg harbor_base_namespace=$(BASEIMAGENAMESPACE) -f $(DOCKERFILEPATH_NOTARYSERVER)/$(DOCKERFILENAME_NOTARYSERVER) -t $(DOCKERIMAGENAME_NOTARYSERVER):$(VERSIONTAG) . ; \
+		chmod 655 $(DOCKERFILEPATH_NOTARY)/binary/notary-signer && $(DOCKERBUILD_WITH_PULL_PARA) --build-arg harbor_base_image_version=$(BASEIMAGETAG) --build-arg harbor_base_namespace=$(BASEIMAGENAMESPACE) -f $(DOCKERFILEPATH_NOTARYSIGNER)/$(DOCKERFILENAME_NOTARYSIGNER) -t $(DOCKERIMAGENAME_NOTARYSIGNER):$(VERSIONTAG) . ; \
+		chmod 655 $(DOCKERFILEPATH_NOTARY)/binary/notary-server && $(DOCKERBUILD_WITH_PULL_PARA) --build-arg harbor_base_image_version=$(BASEIMAGETAG) --build-arg harbor_base_namespace=$(BASEIMAGENAMESPACE) -f $(DOCKERFILEPATH_NOTARYSERVER)/$(DOCKERFILENAME_NOTARYSERVER) -t $(DOCKERIMAGENAME_NOTARYSERVER):$(VERSIONTAG) . ; \
 		rm -rf $(DOCKERFILEPATH_NOTARY)/binary; \
 		echo "Done."; \
 	fi
 
 _build_registry:
+	@$(call _build_base,$(REGISTRY),$(DOCKERFILEPATH_REG))
 	@if [ "$(BUILDBIN)" != "true" ] ; then \
 		rm -rf $(DOCKERFILEPATH_REG)/binary && mkdir -p $(DOCKERFILEPATH_REG)/binary && \
 		$(call _get_binary, $(REGISTRYURL), $(DOCKERFILEPATH_REG)/binary/registry); \
@@ -197,26 +231,29 @@ _build_registry:
 		cd $(DOCKERFILEPATH_REG) && $(DOCKERFILEPATH_REG)/builder $(REGISTRY_SRC_TAG) && cd - ; \
 	fi
 	@echo "building registry container for photon..."
-	@chmod 655 $(DOCKERFILEPATH_REG)/binary/registry && $(DOCKERBUILD) --build-arg harbor_base_image_version=$(BASEIMAGETAG) --build-arg harbor_base_namespace=$(BASEIMAGENAMESPACE) -f $(DOCKERFILEPATH_REG)/$(DOCKERFILENAME_REG) -t $(DOCKERIMAGENAME_REG):$(VERSIONTAG) .
+	@chmod 655 $(DOCKERFILEPATH_REG)/binary/registry && $(DOCKERBUILD_WITH_PULL_PARA) --build-arg harbor_base_image_version=$(BASEIMAGETAG) --build-arg harbor_base_namespace=$(BASEIMAGENAMESPACE) -f $(DOCKERFILEPATH_REG)/$(DOCKERFILENAME_REG) -t $(DOCKERIMAGENAME_REG):$(VERSIONTAG) .
 	@echo "Done."
 
 _build_registryctl:
+	@$(call _build_base,$(REGISTRYCTL),$(DOCKERFILEPATH_REGISTRYCTL))
 	@echo "building registry controller for photon..."
-	@$(DOCKERBUILD) --build-arg harbor_base_image_version=$(BASEIMAGETAG) --build-arg harbor_base_namespace=$(BASEIMAGENAMESPACE) -f $(DOCKERFILEPATH_REGISTRYCTL)/$(DOCKERFILENAME_REGISTRYCTL) -t $(DOCKERIMAGENAME_REGISTRYCTL):$(VERSIONTAG) .
+	@$(DOCKERBUILD_WITH_PULL_PARA) --build-arg harbor_base_image_version=$(BASEIMAGETAG) --build-arg harbor_base_namespace=$(BASEIMAGENAMESPACE) -f $(DOCKERFILEPATH_REGISTRYCTL)/$(DOCKERFILENAME_REGISTRYCTL) -t $(DOCKERIMAGENAME_REGISTRYCTL):$(VERSIONTAG) .
 	@rm -rf $(DOCKERFILEPATH_REG)/binary
 	@echo "Done."
 
 _build_redis:
+	@$(call _build_base,$(REDIS),$(DOCKERFILEPATH_REDIS))
 	@echo "building redis container for photon..."
-	@$(DOCKERBUILD) --build-arg harbor_base_image_version=$(BASEIMAGETAG) --build-arg harbor_base_namespace=$(BASEIMAGENAMESPACE) -f $(DOCKERFILEPATH_REDIS)/$(DOCKERFILENAME_REDIS) -t $(DOCKERIMAGENAME_REDIS):$(VERSIONTAG) .
+	@$(DOCKERBUILD_WITH_PULL_PARA) --build-arg harbor_base_image_version=$(BASEIMAGETAG) --build-arg harbor_base_namespace=$(BASEIMAGENAMESPACE) -f $(DOCKERFILEPATH_REDIS)/$(DOCKERFILENAME_REDIS) -t $(DOCKERIMAGENAME_REDIS):$(VERSIONTAG) .
 	@echo "Done."
 
 _build_standalone_db_migrator:
 	@echo "building standalone db migrator image for photon..."
-	@$(DOCKERBUILD) --build-arg harbor_base_image_version=$(BASEIMAGETAG) --build-arg harbor_base_namespace=$(BASEIMAGENAMESPACE) -f $(DOCKERFILEPATH_STANDALONE_DB_MIGRATOR)/$(DOCKERFILENAME_STANDALONE_DB_MIGRATOR) -t $(DOCKERIMAGENAME_STANDALONE_DB_MIGRATOR):$(VERSIONTAG) .
+	@$(DOCKERBUILD_WITH_PULL_PARA) --build-arg harbor_base_image_version=$(BASEIMAGETAG) --build-arg harbor_base_namespace=$(BASEIMAGENAMESPACE) -f $(DOCKERFILEPATH_STANDALONE_DB_MIGRATOR)/$(DOCKERFILENAME_STANDALONE_DB_MIGRATOR) -t $(DOCKERIMAGENAME_STANDALONE_DB_MIGRATOR):$(VERSIONTAG) .
 	@echo "Done."
 
 _compile_and_build_exporter:
+	@$(call _build_base,$(EXPORTER),$(DOCKERFILEPATH_EXPORTER))
 	@echo "compiling and building image for exporter..."
 	@$(DOCKERCMD) build --build-arg harbor_base_image_version=$(BASEIMAGETAG) --build-arg harbor_base_namespace=$(BASEIMAGENAMESPACE) --build-arg build_image=$(GOBUILDIMAGE) -f ${DOCKERFILEPATH_EXPORTER}/${DOCKERFILENAME_EXPORTER} -t $(DOCKERIMAGENAME_EXPORTER):$(VERSIONTAG) .
 	@echo "Done."
@@ -231,7 +268,20 @@ define _get_binary
 	$(CURL) --connect-timeout 30 -f -k -L $1 -o $2 || exit 1
 endef
 
-
+define _build_base
+	if [ "$(BUILD_BASE)" = "true" ] ; then \
+		echo "building base image for $(1)...";\
+		if [ -n "$(REGISTRYUSER)"  ] && [ -n "$(REGISTRYPASSWORD)" ] ; then \
+			docker login -u $(REGISTRYUSER) -p $(REGISTRYPASSWORD) ; \
+		else \
+			echo "No docker credentials provided, please be aware of priviledges to access docker hub!" ; \
+		fi ;\
+		$(DOCKERBUILD) -f $(2)/Dockerfile.base -t $(BASEIMAGENAMESPACE)/harbor-$(1)-base:$(BASEIMAGETAG) --label base-build-date=$(TIMESTAMP) . ;\
+		if [ "$(PUSHBASEIMAGE)" = "true" ] ; then \
+			$(PUSHSCRIPTPATH)/$(PUSHSCRIPTNAME) $(BASEIMAGENAMESPACE)/harbor-$(1)-base:$(BASEIMAGETAG) $(REGISTRYUSER) $(REGISTRYPASSWORD) $(PULL_BASE_FROM_DOCKERHUB) || exit 1; \
+		fi ; \
+	fi
+endef
 
 build: _build_prepare _build_db _build_portal _build_core _build_jobservice _build_log _build_nginx _build_registry _build_registryctl _build_notary _build_trivy_adapter _build_redis _build_chart_server _compile_and_build_exporter
 

--- a/make/pushimage.sh
+++ b/make/pushimage.sh
@@ -89,7 +89,7 @@ IMAGE="$1"
 USERNAME="$2"
 PASSWORD="$3"
 REGISTRY="$4"
-
+PULL_BASE_FROM_DOCKERHUB="$5"
 set -e
 
 # ----- Pushing image(s) -----
@@ -98,6 +98,19 @@ set -e
 #  - https://docs.docker.com/reference/commandline/cli/#push
 #  - https://docs.docker.com/reference/commandline/cli/#logout
 # ---------------------------
+
+# Login docker
+h2 "Login to the Docker registry"
+DOCKER_LOGIN="docker login --username $USERNAME --password $PASSWORD $REGISTRY"
+info "docker login --username $USERNAME --password *******"
+DOCKER_LOGIN_OUTPUT=$($DOCKER_LOGIN)
+if [ $? -ne 0 ]; then
+  warn "$DOCKER_LOGIN_OUTPUT"
+  error "Login to Docker registry $REGISTRY failed"
+  exit 1
+else
+  success "Login to Docker registry $REGISTRY succeeded";
+fi
 
 # Push the docker image
 h2 "Pushing image to Docker registry"
@@ -113,15 +126,29 @@ else
   success "Pushing image $IMAGE succeeded";
 fi
 
-h2 "Remove local goharbor images"
-DOCKER_RMI="docker rmi -f $(docker images | grep "goharbor" | awk '{print $3}')"
-info "$DOCKER_RMI"
-DOCKER_RMI_OUTPUT=$($DOCKER_RMI)
+# Logout from the registry
+h2 "Logout from the docker registry"
+DOCKER_LOGOUT="docker logout $REGISTRY"
+DOCKER_LOGOUT_OUTPUT=$($DOCKER_LOGOUT)
 
-if [ $? -ne 0 ];then
-  warn $DOCKER_RMI_OUTPUT
-  error "Clean local goharbor images failed";
+if [ $? -ne 0 ]; then
+  warn "$DOCKER_LOGOUT_OUTPUT"
+  error "Logout from Docker registry $REGISTRY failed"
+  exit 1
 else
-  success "Clean local goharbor images succeeded";
+  success "Logout from Docker registry $REGISTRY succeeded"
+fi
+
+if [ "$PULL_BASE_FROM_DOCKERHUB" == "true" ];then
+  h2 "Remove local goharbor images"
+  DOCKER_RMI="docker rmi $(docker images | grep "goharbor" | awk '{print $3}') -f"
+  info "$DOCKER_RMI"
+  DOCKER_RMI_OUTPUT=$($DOCKER_RMI)
+  if [ $? -ne 0 ];then
+    warn $DOCKER_RMI_OUTPUT
+    error "Clean local goharbor images failed";
+  else
+    success "Clean local goharbor images succeeded";
+  fi
 fi
 

--- a/tests/ci/api_common_install.sh
+++ b/tests/ci/api_common_install.sh
@@ -62,7 +62,7 @@ sed "s|#   enabled: false|  enabled: true|" -i make/harbor.yml
 sed "s|#   port: 9090|  port: 9090|" -i make/harbor.yml
 sed "s|#   path: /metrics|  path: /metrics|" -i make/harbor.yml
 
-sudo make build_base_docker compile build prepare COMPILETAG=compile_golangimage GOBUILDTAGS="include_oss include_gcs" BUILDBIN=true NOTARYFLAG=true TRIVYFLAG=true CHARTFLAG=true GEN_TLS=true
+sudo make compile build prepare COMPILETAG=compile_golangimage GOBUILDTAGS="include_oss include_gcs" BUILDBIN=true NOTARYFLAG=true TRIVYFLAG=true CHARTFLAG=true GEN_TLS=true PULL_BASE_FROM_DOCKERHUB=false
 
 # set the debugging env
 echo "GC_TIME_WINDOW_HOURS=0" | sudo tee -a ./make/common/config/core/env

--- a/tests/ci/ut_install.sh
+++ b/tests/ci/ut_install.sh
@@ -21,8 +21,7 @@ sudo rm -rf /data/*
 sudo -E env "PATH=$PATH" make go_check
 sudo ./tests/hostcfg.sh
 sudo ./tests/generateCerts.sh
-sudo make build_base_docker -e BUILDBASETARGET="db registry prepare"
-sudo make build -e BUILDTARGET="_build_db _build_registry _build_prepare"
+sudo make build -e BUILDTARGET="_build_db _build_registry _build_prepare" -e PULL_BASE_FROM_DOCKERHUB=false
 docker run --rm -v /:/hostfs:z goharbor/prepare:dev gencert -p /etc/harbor/tls/internal
 sudo MAKEPATH=$(pwd)/make ./make/prepare
 sudo mkdir -p "/data/redis"


### PR DESCRIPTION
Remove build base executable in Makefile by replacing it as an input parameter.
Add add more input parameters for controlling docker pull/push to make
build base process flexible for users.

Signed-off-by: danfengliu <danfengl@vmware.com>