### PR TITLE
Set "x-omitempty" as "false" for the pull count and artifact count of…

### DIFF
--- a/api/v2.0/swagger.yaml
+++ b/api/v2.0/swagger.yaml
@@ -5656,10 +5656,12 @@ definitions:
         type: integer
         format: int64
         description: The count of the artifacts inside the repository
+        x-omitempty: false
       pull_count:
         type: integer
         format: int64
         description: The count that the artifact inside the repository pulled
+        x-omitempty: false
       creation_time:
         type: string
         format: date-time


### PR DESCRIPTION
… repository

Set "x-omitempty" as "false" for the pull count and artifact count of repository to avoid the missing of these properties in API response

Signed-off-by: Wenkai Yin <yinw@vmware.com>