### PR TITLE
Fix the concurrent pushing the same image issue

### DIFF
--- a/src/controller/repository/controller.go
+++ b/src/controller/repository/controller.go
@@ -104,22 +104,21 @@ func (c *controller) Ensure(ctx context.Context, name string) (bool, int64, erro
 			Name:      name,
 		})
 		if err != nil {
-			// if got conflict error, try to get again
-			if errors.IsConflictErr(err) {
-				var e error
-				repository, e = c.repoMgr.GetByName(ctx, name)
-				if e != nil {
-					err = e
-				} else {
-					id = repository.RepositoryID
-				}
-			}
 			return err
 		}
 		created = true
 		return nil
-	})(ctx); err != nil && !errors.IsConflictErr(err) {
-		return false, 0, err
+	})(ctx); err != nil {
+		// isn't conflict error, return directly
+		if !errors.IsConflictErr(err) {
+			return false, 0, err
+		}
+		// if got conflict error, try to get again
+		repository, err = c.repoMgr.GetByName(ctx, name)
+		if err != nil {
+			return false, 0, err
+		}
+		id = repository.RepositoryID
 	}
 
 	return created, id, nil


### PR DESCRIPTION
The transaction will be aborted when get errors during the execution which causes the following sqls report error.
This commit moves the re-getting artifact logic out of the second transaction to avoid the concurrent pushing issue

Signed-off-by: Wenkai Yin <yinw@vmware.com>