### PR TITLE
perf: configurations for perf improvement

### DIFF
--- a/make/harbor.yml.tmpl
+++ b/make/harbor.yml.tmpl
@@ -38,10 +38,10 @@ database:
   # The password for the root user of Harbor DB. Change this before any production use.
   password: root123
   # The maximum number of connections in the idle connection pool. If it <=0, no idle connections are retained.
-  max_idle_conns: 50
+  max_idle_conns: 100
   # The maximum number of open connections to the database. If it <= 0, then there is no limit on the number of open connections.
   # Note: the default number of connections is 1024 for postgres of harbor.
-  max_open_conns: 1000
+  max_open_conns: 900
 
 # The default data volume
 data_volume: /data

--- a/make/photon/prepare/migrations/version_2_3_0/__init__.py
+++ b/make/photon/prepare/migrations/version_2_3_0/__init__.py
@@ -6,6 +6,15 @@ revision = '2.3.0'
 down_revisions = ['2.2.0']
 
 def migrate(input_cfg, output_cfg):
+    def db_conn_need_update(db_conf):
+        if not db_conf:
+            return False
+
+        max_idle_conns = db_conf.get('max_idle_conns', 0)
+        max_open_conns = db_conf.get('max_open_conns', 0)
+
+        return max_idle_conns == 50 and max_open_conns == 1000
+
     current_dir = os.path.dirname(__file__)
     tpl = Environment(
         loader=FileSystemLoader(current_dir),
@@ -15,6 +24,10 @@ def migrate(input_cfg, output_cfg):
         ).get_template('harbor.yml.jinja')
 
     config_dict = read_conf(input_cfg)
+
+    if db_conn_need_update(config_dict.get('database')):
+        config_dict['database']['max_idle_conns'] = 100
+        config_dict['database']['max_open_conns'] = 900
 
     with open(output_cfg, 'w') as f:
         f.write(tpl.render(**config_dict))

--- a/make/photon/prepare/migrations/version_2_3_0/harbor.yml.jinja
+++ b/make/photon/prepare/migrations/version_2_3_0/harbor.yml.jinja
@@ -73,16 +73,16 @@ database:
   # The maximum number of connections in the idle connection pool. If it <=0, no idle connections are retained.
   max_idle_conns: {{ database.max_idle_conns }}
   # The maximum number of open connections to the database. If it <= 0, then there is no limit on the number of open connections.
-  # Note: the default number of connections is 100 for postgres.
+  # Note: the default number of connections is 1024 for postgres of harbor.
   max_open_conns: {{ database.max_open_conns }}
 {% else %}
   # The password for the root user of Harbor DB. Change this before any production use.
   password: root123
   # The maximum number of connections in the idle connection pool. If it <=0, no idle connections are retained.
-  max_idle_conns: 50
+  max_idle_conns: 100
   # The maximum number of open connections to the database. If it <= 0, then there is no limit on the number of open connections.
-  # Note: the default number of connections is 100 for postgres.
-  max_open_conns: 100
+  # Note: the default number of connections is 1024 for postgres of harbor.
+  max_open_conns: 900
 {% endif %}
 
 {% if data_volume is defined %}

--- a/make/photon/prepare/templates/nginx/nginx.http.conf.jinja
+++ b/make/photon/prepare/templates/nginx/nginx.http.conf.jinja
@@ -2,7 +2,7 @@ worker_processes auto;
 pid /tmp/nginx.pid;
 
 events {
-  worker_connections 1024;
+  worker_connections 3096;
   use epoll;
   multi_accept on;
 }
@@ -76,7 +76,7 @@ http {
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header X-Forwarded-Proto $x_forwarded_proto;
-      
+
       proxy_buffering off;
       proxy_request_buffering off;
     }
@@ -98,7 +98,7 @@ http {
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header X-Forwarded-Proto $x_forwarded_proto;
-      
+
       proxy_buffering off;
       proxy_request_buffering off;
     }
@@ -120,7 +120,7 @@ http {
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header X-Forwarded-Proto $x_forwarded_proto;
-      
+
       proxy_buffering off;
       proxy_request_buffering off;
     }
@@ -142,7 +142,7 @@ http {
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header X-Forwarded-Proto $x_forwarded_proto;
-      
+
       proxy_buffering off;
       proxy_request_buffering off;
     }

--- a/make/photon/prepare/templates/nginx/nginx.https.conf.jinja
+++ b/make/photon/prepare/templates/nginx/nginx.https.conf.jinja
@@ -2,7 +2,7 @@ worker_processes auto;
 pid /tmp/nginx.pid;
 
 events {
-  worker_connections 1024;
+  worker_connections 3096;
   use epoll;
   multi_accept on;
 }
@@ -56,16 +56,16 @@ http {
     # SSL
     ssl_certificate {{ssl_cert}};
     ssl_certificate_key {{ssl_cert_key}};
-  
+
     # Recommendations from https://raymii.org/s/tutorials/Strong_SSL_Security_On_nginx.html
     ssl_protocols TLSv1.2;
     ssl_ciphers '!aNULL:kECDH+AESGCM:ECDH+AESGCM:RSA+AESGCM:kECDH+AES:ECDH+AES:RSA+AES:';
     ssl_prefer_server_ciphers on;
     ssl_session_cache shared:SSL:10m;
-  
+
     # disable any limits to avoid HTTP 413 for large image uploads
     client_max_body_size 0;
-  
+
     # required to avoid HTTP 411: see Issue #1486 (https://github.com/docker/docker/issues/1486)
     chunked_transfer_encoding on;
 
@@ -73,7 +73,7 @@ http {
     add_header Strict-Transport-Security "max-age=31536000; includeSubdomains; preload";
     add_header X-Frame-Options DENY;
     add_header Content-Security-Policy "frame-ancestors 'none'";
-  
+
     # customized location config file can place to /etc/nginx dir with prefix harbor.https. and suffix .conf
     include /etc/nginx/conf.d/harbor.https.*.conf;
 
@@ -124,7 +124,7 @@ http {
       proxy_buffering off;
       proxy_request_buffering off;
     }
-  
+
     location /api/ {
 {% if internal_tls.enabled %}
       proxy_pass https://core/api/;
@@ -144,7 +144,7 @@ http {
       proxy_set_header X-Forwarded-Proto $x_forwarded_proto;
 
       proxy_cookie_path / "/; Secure";
-      
+
       proxy_buffering off;
       proxy_request_buffering off;
     }
@@ -168,7 +168,7 @@ http {
       proxy_set_header X-Forwarded-Proto $x_forwarded_proto;
 
       proxy_cookie_path / "/; Secure";
-      
+
       proxy_buffering off;
       proxy_request_buffering off;
     }

--- a/make/photon/prepare/templates/registry/config.yml.jinja
+++ b/make/photon/prepare/templates/registry/config.yml.jinja
@@ -29,6 +29,10 @@ redis:
   dialtimeout: 10s
   password: {{redis_password}}
   db: {{redis_db_index_reg}}
+  pool:
+    maxidle: 100
+    maxactive: 500
+    idletimeout: 60s
 http:
 {% if internal_tls.enabled %}
   addr: :5443


### PR DESCRIPTION
Increasing the `worker_connections` of Nginx to resolve the `Connection refused` problem.

Increasing the `max_idle_conns` in the core to resolve the `connect: cannot assign requested address` in the core component.

Add the `pool` configuration to the registry to resolve the `connect: cannot assign requested address` in the registry component.

Closes #15041

Signed-off-by: He Weiwei <hweiwei@vmware.com>