### PR TITLE
Support for specifing token service url by TOKEN_SERVICE_URL

### DIFF
--- a/src/lib/config/metadata/metadatalist.go
+++ b/src/lib/config/metadata/metadatalist.go
@@ -122,7 +122,7 @@ var (
 		{Name: common.RegistryControllerURL, Scope: SystemScope, Group: BasicGroup, EnvKey: "REGISTRY_CONTROLLER_URL", DefaultValue: "http://registryctl:8080", ItemType: &StringType{}, Editable: false},
 		{Name: common.SelfRegistration, Scope: UserScope, Group: BasicGroup, EnvKey: "SELF_REGISTRATION", DefaultValue: "false", ItemType: &BoolType{}, Editable: false, Description: `Whether the Harbor instance supports self-registration.  If it''s set to false, admin need to add user to the instance.`},
 		{Name: common.TokenExpiration, Scope: UserScope, Group: BasicGroup, EnvKey: "TOKEN_EXPIRATION", DefaultValue: "30", ItemType: &IntType{}, Editable: false, Description: `The expiration time of the token for internal Registry, in minutes.`},
-		{Name: common.TokenServiceURL, Scope: SystemScope, Group: BasicGroup, EnvKey: "TOKEN_SERVICE_URL", DefaultValue: "http://core:8080/service/token", ItemType: &StringType{}, Editable: false},
+		{Name: common.TokenServiceURL, Scope: SystemScope, Group: BasicGroup, EnvKey: "TOKEN_SERVICE_URL", DefaultValue: "", ItemType: &StringType{}, Editable: false},
 
 		{Name: common.UAAClientID, Scope: UserScope, Group: UAAGroup, EnvKey: "UAA_CLIENTID", DefaultValue: "", ItemType: &StringType{}, Editable: false, Description: `The client id of UAA`},
 		{Name: common.UAAClientSecret, Scope: UserScope, Group: UAAGroup, EnvKey: "UAA_CLIENTSECRET", DefaultValue: "", ItemType: &StringType{}, Editable: false, Description: `The client secret of the UAA`},

--- a/src/lib/config/systemconfig.go
+++ b/src/lib/config/systemconfig.go
@@ -166,6 +166,12 @@ func GetChartMuseumEndpoint() (string, error) {
 	return chartEndpoint, nil
 }
 
+// TokenServiceURL returns the token service URL of Harbor: protocol://host:port/service/token
+func TokenServiceURL() (string, error) {
+	return defaultMgr().Get(backgroundCtx, common.TokenServiceURL).GetString(), nil
+}
+
+
 // ExtEndpoint returns the external URL of Harbor: protocol://host:port
 func ExtEndpoint() (string, error) {
 	return defaultMgr().Get(backgroundCtx, common.ExtEndpoint).GetString(), nil

--- a/src/server/middleware/v2auth/auth_test.go
+++ b/src/server/middleware/v2auth/auth_test.go
@@ -75,6 +75,7 @@ func TestMain(m *testing.M) {
 	}
 	conf := map[string]interface{}{
 		common.ExtEndpoint: "https://harbor.test",
+		common.TokenServiceURL: "https://core-service/service/token",
 		common.CoreURL:     "https://harbor.core:8443",
 	}
 	config.InitWithSettings(conf)
@@ -254,7 +255,7 @@ func TestGetChallenge(t *testing.T) {
 	}{
 		{
 			request:   req1,
-			challenge: `Bearer realm="https://harbor.test/service/token",service="harbor-registry"`,
+			challenge: `Bearer realm="https://core-service/service/token",service="harbor-registry"`,
 		},
 		{
 			request:   req1x,
@@ -270,7 +271,7 @@ func TestGetChallenge(t *testing.T) {
 		},
 		{
 			request:   req3,
-			challenge: `Bearer realm="https://harbor.test/service/token",service="harbor-registry",scope="repository:project_1/ubuntu:pull,push repository:project_2/ubuntu:pull"`,
+			challenge: `Bearer realm="https://core-service/service/token",service="harbor-registry",scope="repository:project_1/ubuntu:pull,push repository:project_2/ubuntu:pull"`,
 		},
 		{
 			request:   req3x,


### PR DESCRIPTION
When an external client makes a  pull or push request to Harbor, Harbor will respond extEndpoint as service token authorization URL.
https://github.com/goharbor/harbor/blob/b789674ada2ed21fb5277daeb55657c20788de6b/src/server/middleware/v2auth/auth.go#L120-L125

This is great for most situation; however, there're still some limits.
1. In our container platform, we deploy harbor as container registry service within it. The platform requests extEndpoint of harbor service. And there're multiple platforms installed by the one installer package, and To keep the platform's configuration simple, we set a fixed FQDN to harbor's extEndpoint.So If I  try to push the image from one client to serveral platform's harbor, I was always struck by the token service since all these harbor return the same FQDN token service URL even though the request's HOST was set to different IP.
2. If I try to set harbor's token service Url to another standalone service, there's no entry to doing this.

IMHO, we could define a configurable item for service token URL. 

Luckily, I found there is TOKEN_SERVICE_URL defined in config but no reference on it, so I take it for granted to bypass the limits.
https://github.com/goharbor/harbor/blob/b789674ada2ed21fb5277daeb55657c20788de6b/src/lib/config/metadata/metadatalist.go#L125

Wish I do it in the right direction~

Signed-off-by: 屈骏 <qujun@tiduyun.com>