### PR TITLE
Add ldap_group_dn parameter to search group with ldap group dn

### DIFF
--- a/api/v2.0/swagger.yaml
+++ b/api/v2.0/swagger.yaml
@@ -2697,6 +2697,11 @@ paths:
         - usergroup
       parameters:
         - $ref: '#/parameters/requestId'
+        - name: ldap_group_dn
+          in: query
+          type: string
+          required: false
+          description: search with ldap group DN
       responses:
         '200':
           description: Get user group successfully.

--- a/src/server/v2.0/handler/usergroup.go
+++ b/src/server/v2.0/handler/usergroup.go
@@ -109,6 +109,9 @@ func (u *userGroupAPI) ListUserGroups(ctx context.Context, params operation.List
 	switch authMode {
 	case common.LDAPAuth:
 		query.GroupType = common.LDAPGroupType
+		if params.LdapGroupDn != nil && len(*params.LdapGroupDn) > 0 {
+			query.LdapGroupDN = *params.LdapGroupDn
+		}
 	case common.HTTPAuth:
 		query.GroupType = common.HTTPGroupType
 	}


### PR DESCRIPTION
 Fixes #15171
 Cannot use q.Query because ldap_group_dn contains comma(,) and equal(=), which are reserved characters in q.Query

Signed-off-by: stonezdj <stonezdj@gmail.com>