### PR TITLE
Fix refreshing oidc access token breaks users subiss in database

### DIFF
--- a/src/pkg/oidc/dao/meta.go
+++ b/src/pkg/oidc/dao/meta.go
@@ -43,7 +43,7 @@ func NewMetaDao() MetaDAO {
 type metaDAO struct{}
 
 func (md *metaDAO) GetByUsername(ctx context.Context, username string) (*models.OIDCUser, error) {
-	sql := `SELECT oidc_user.id, oidc_user.user_id, oidc_user.secret, oidc_user.token,
+	sql := `SELECT oidc_user.id, oidc_user.user_id, oidc_user.secret, oidc_user.subiss, oidc_user.token,
 				oidc_user.creation_time, oidc_user.update_time FROM oidc_user
 			JOIN harbor_user ON oidc_user.user_id = harbor_user.user_id 
 			WHERE harbor_user.username = ?`

--- a/src/pkg/oidc/dao/meta_test.go
+++ b/src/pkg/oidc/dao/meta_test.go
@@ -63,6 +63,7 @@ func (suite *MetaDaoTestSuite) TestGetByUsername() {
 	ou, err := suite.dao.GetByUsername(ctx, suite.username)
 	suite.Nil(err)
 	suite.Equal(suite.userID, ou.UserID)
+	suite.Equal("ca4bb144-4b5c-4d1b-9469-69cb3768af8fhttps://sso.andrea.muellerpublic.de/auth/realms/harbor", ou.SubIss)
 	suite.Equal("xxxx", ou.Token)
 }
 


### PR DESCRIPTION
### Summary of your change
Ensures that `subiss` field is fetched from the database. Otherwise this field is empty and will cause several issues when working with the user object. Eg. when writing it back to the database it resets the `subiss` in the database.

### Issue being fixed

Fixes #15241

### Please indicate you've done the following:

- [x] [Accepted the DCO](https://github.com/goharbor/harbor/blob/master/CONTRIBUTING.md#commit). Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
