### PR TITLE
if username is not available in remote, fall back to username from token

### DIFF
--- a/src/pkg/oidc/helper.go
+++ b/src/pkg/oidc/helper.go
@@ -350,7 +350,6 @@ func userInfoFromClaims(c claimsProvider, setting cfgModels.OIDCSetting) (*UserI
 		if username, ok := allClaims[setting.UserClaim].(string); ok {
 			res.Username = username
 		} else {
-			log.Debugf("OIDC. Failed to recover Username from claims: %+v", allClaims)
 			log.Warningf("OIDC. Failed to recover Username from claim. Claim '%s' is invalid or not a string", setting.UserClaim)
 		}
 	}

--- a/src/pkg/oidc/helper.go
+++ b/src/pkg/oidc/helper.go
@@ -289,8 +289,12 @@ func mergeUserInfo(remote, local *UserInfo) *UserInfo {
 		Subject: local.Subject,
 		Issuer:  local.Issuer,
 		// Used data from userinfo
-		Username: remote.Username,
-		Email:    remote.Email,
+		Email: remote.Email,
+	}
+	if remote.Username != "" {
+		res.Username = remote.Username
+	} else {
+		res.Username = local.Username
 	}
 	if remote.hasGroupClaim {
 		res.Groups = remote.Groups
@@ -346,6 +350,7 @@ func userInfoFromClaims(c claimsProvider, setting cfgModels.OIDCSetting) (*UserI
 		if username, ok := allClaims[setting.UserClaim].(string); ok {
 			res.Username = username
 		} else {
+			log.Debugf("OIDC. Failed to recover Username from claims: %+v", allClaims)
 			log.Warningf("OIDC. Failed to recover Username from claim. Claim '%s' is invalid or not a string", setting.UserClaim)
 		}
 	}

--- a/src/pkg/oidc/helper_test.go
+++ b/src/pkg/oidc/helper_test.go
@@ -379,6 +379,32 @@ func TestMergeUserInfo(t *testing.T) {
 				hasGroupClaim: true,
 			},
 		},
+		{
+			fromInfo: &UserInfo{
+				Issuer:        "",
+				Subject:       "",
+				Username:      "",
+				Email:         "kevin@whatever.com",
+				Groups:        []string{},
+				hasGroupClaim: false,
+			},
+			fromIDToken: &UserInfo{
+				Issuer:        "issuer-whatever",
+				Subject:       "subject-kevin",
+				Username:      "kevin",
+				Email:         "kevin@whatever.com",
+				Groups:        []string{"g1", "g2"},
+				hasGroupClaim: true,
+			},
+			expected: &UserInfo{
+				Issuer:        "issuer-whatever",
+				Subject:       "subject-kevin",
+				Username:      "kevin",
+				Email:         "kevin@whatever.com",
+				Groups:        []string{"g1", "g2"},
+				hasGroupClaim: true,
+			},
+		},
 	}
 
 	for _, tc := range s {


### PR DESCRIPTION
### Summary of your change
Ensures that username is used from token if not present in remote. Otherwise username is always fetched from userinfo endpoint even though the configured username claim does not exist in userinfo endpoint (more details in #15290).

### Issue being fixed

Fixes #15290

### Please indicate you've done the following:

- [x] [Accepted the DCO](https://github.com/goharbor/harbor/blob/master/CONTRIBUTING.md#commit). Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
