### PR TITLE
🎈 perf(migrations/postgresql): index of quota table

### DIFF
--- a/make/migrations/postgresql/0010_1.9.0_schema.up.sql
+++ b/make/migrations/postgresql/0010_1.9.0_schema.up.sql
@@ -71,7 +71,7 @@ CREATE TABLE quota
   hard          JSONB              NOT NULL,
   creation_time timestamp default CURRENT_TIMESTAMP,
   update_time   timestamp default CURRENT_TIMESTAMP,
-  UNIQUE (reference, reference_id)
+  UNIQUE (reference_id,reference)
 );
 
 /* add quota usage table */
@@ -83,7 +83,7 @@ CREATE TABLE quota_usage
   used          JSONB              NOT NULL,
   creation_time timestamp default CURRENT_TIMESTAMP,
   update_time   timestamp default CURRENT_TIMESTAMP,
-  UNIQUE (reference, reference_id)
+  UNIQUE (reference_id,reference)
 );
 
 /* only set quota and usage for 'library', and let the sync quota handling others. */


### PR DESCRIPTION
Because the values of the reference field in the quota table are basically the same, the reference field is not the same_ ID is more distinguishable. Index query follows forward matching rule. So the reference_ If Id is put in front of index, the query efficiency will be higher.