### PR TITLE
Adjust "flattening" tooltip quotes to be consistent

### DIFF
--- a/src/portal/src/i18n/lang/de-de-lang.json
+++ b/src/portal/src/i18n/lang/de-de-lang.json
@@ -645,7 +645,7 @@
         "FLATTEN_LEVEL_TIP_1": "'Flatten 1 Level'(Default): 'a/b/c/d/img' -> 'ns/b/c/d/img'",
         "FLATTEN_LEVEL_TIP_2": "'Flatten 2 Levels': 'a/b/c/d/img' -> 'ns/c/d/img'",
         "FLATTEN_LEVEL_TIP_3": "'Flatten 3 Levels': 'a/b/c/d/img' -> 'ns/d/img'",
-        "NOTE": "Notes: The Chartmuseum Charts only support the repository structure with 2 path components: `a/chart`"
+        "NOTE": "Notes: The Chartmuseum Charts only support the repository structure with 2 path components: 'a/chart'"
     },
     "DESTINATION": {
         "NEW_ENDPOINT": "Neuer Endpunkt",

--- a/src/portal/src/i18n/lang/en-us-lang.json
+++ b/src/portal/src/i18n/lang/en-us-lang.json
@@ -645,7 +645,7 @@
         "FLATTEN_LEVEL_TIP_1": "'Flatten 1 Level'(Default): 'a/b/c/d/img' -> 'ns/b/c/d/img'",
         "FLATTEN_LEVEL_TIP_2": "'Flatten 2 Levels': 'a/b/c/d/img' -> 'ns/c/d/img'",
         "FLATTEN_LEVEL_TIP_3": "'Flatten 3 Levels': 'a/b/c/d/img' -> 'ns/d/img'",
-        "NOTE": "Notes: The Chartmuseum Charts only support the repository structure with 2 path components: `a/chart`"
+        "NOTE": "Notes: The Chartmuseum Charts only support the repository structure with 2 path components: 'a/chart'"
     },
     "DESTINATION": {
         "NEW_ENDPOINT": "New Endpoint",

--- a/src/portal/src/i18n/lang/es-es-lang.json
+++ b/src/portal/src/i18n/lang/es-es-lang.json
@@ -647,7 +647,7 @@
         "FLATTEN_LEVEL_TIP_1": "'Flatten 1 Level'(Default): 'a/b/c/d/img' -> 'ns/b/c/d/img'",
         "FLATTEN_LEVEL_TIP_2": "'Flatten 2 Levels': 'a/b/c/d/img' -> 'ns/c/d/img'",
         "FLATTEN_LEVEL_TIP_3": "'Flatten 3 Levels': 'a/b/c/d/img' -> 'ns/d/img'",
-        "NOTE": "Notes: The Chartmuseum Charts only support the repository structure with 2 path components: `a/chart`"
+        "NOTE": "Notes: The Chartmuseum Charts only support the repository structure with 2 path components: 'a/chart'"
     },
     "DESTINATION": {
         "NEW_ENDPOINT": "Nuevo Endpoint",

--- a/src/portal/src/i18n/lang/fr-fr-lang.json
+++ b/src/portal/src/i18n/lang/fr-fr-lang.json
@@ -635,7 +635,7 @@
         "FLATTEN_LEVEL_TIP_1": "'Flatten 1 Level'(Default): 'a/b/c/d/img' -> 'ns/b/c/d/img'",
         "FLATTEN_LEVEL_TIP_2": "'Flatten 2 Levels': 'a/b/c/d/img' -> 'ns/c/d/img'",
         "FLATTEN_LEVEL_TIP_3": "'Flatten 3 Levels': 'a/b/c/d/img' -> 'ns/d/img'",
-        "NOTE": "Notes: The Chartmuseum Charts only support the repository structure with 2 path components: `a/chart`"
+        "NOTE": "Notes: The Chartmuseum Charts only support the repository structure with 2 path components: 'a/chart'"
     },
     "DESTINATION": {
         "NEW_ENDPOINT": "Nouveau Point Final",

--- a/src/portal/src/i18n/lang/pt-br-lang.json
+++ b/src/portal/src/i18n/lang/pt-br-lang.json
@@ -645,7 +645,7 @@
         "FLATTEN_LEVEL_TIP_1": "'Flatten 1 Level'(Default): 'a/b/c/d/img' -> 'ns/b/c/d/img'",
         "FLATTEN_LEVEL_TIP_2": "'Flatten 2 Levels': 'a/b/c/d/img' -> 'ns/c/d/img'",
         "FLATTEN_LEVEL_TIP_3": "'Flatten 3 Levels': 'a/b/c/d/img' -> 'ns/d/img'",
-        "NOTE": "Notes: The Chartmuseum Charts only support the repository structure with 2 path components: `a/chart`"
+        "NOTE": "Notes: The Chartmuseum Charts only support the repository structure with 2 path components: 'a/chart'"
     },
     "DESTINATION": {
         "NEW_ENDPOINT": "Novo Endpoint",

--- a/src/portal/src/i18n/lang/tr-tr-lang.json
+++ b/src/portal/src/i18n/lang/tr-tr-lang.json
@@ -645,7 +645,7 @@
         "FLATTEN_LEVEL_TIP_1": "'Flatten 1 Level'(Default): 'a/b/c/d/img' -> 'ns/b/c/d/img'",
         "FLATTEN_LEVEL_TIP_2": "'Flatten 2 Levels': 'a/b/c/d/img' -> 'ns/c/d/img'",
         "FLATTEN_LEVEL_TIP_3": "'Flatten 3 Levels': 'a/b/c/d/img' -> 'ns/d/img'",
-        "NOTE": "Notes: The Chartmuseum Charts only support the repository structure with 2 path components: `a/chart`"
+        "NOTE": "Notes: The Chartmuseum Charts only support the repository structure with 2 path components: 'a/chart'"
     },
     "DESTINATION": {
         "NEW_ENDPOINT": "Yeni Uç Nokta",

--- a/src/portal/src/i18n/lang/zh-cn-lang.json
+++ b/src/portal/src/i18n/lang/zh-cn-lang.json
@@ -647,7 +647,7 @@
         "FLATTEN_LEVEL_TIP_1": "'替换1级'(默认项): 'a/b/c/d/img' -> 'ns/b/c/d/img'",
         "FLATTEN_LEVEL_TIP_2": "'替换2级': 'a/b/c/d/img' -> 'ns/c/d/img'",
         "FLATTEN_LEVEL_TIP_3": "'替换3级': 'a/b/c/d/img' -> 'ns/d/img'",
-        "NOTE": "注意: Chartmuseum Charts 仅支持2层的仓库结构：如 `a/chart`"
+        "NOTE": "注意: Chartmuseum Charts 仅支持2层的仓库结构：如 'a/chart'"
     },
     "DESTINATION": {
         "NEW_ENDPOINT": "新建目标",

--- a/src/portal/src/i18n/lang/zh-tw-lang.json
+++ b/src/portal/src/i18n/lang/zh-tw-lang.json
@@ -642,7 +642,7 @@
     "FLATTEN_LEVEL_TIP_1": "'Flatten 1 Level'(Default): 'a/b/c/d/img' -> 'ns/b/c/d/img'",
     "FLATTEN_LEVEL_TIP_2": "'Flatten 2 Levels': 'a/b/c/d/img' -> 'ns/c/d/img'",
     "FLATTEN_LEVEL_TIP_3": "'Flatten 3 Levels': 'a/b/c/d/img' -> 'ns/d/img'",
-    "NOTE": "Notes: The Chartmuseum Charts only support the repository structure with 2 path components: `a/chart`"
+    "NOTE": "Notes: The Chartmuseum Charts only support the repository structure with 2 path components: 'a/chart'"
   },
   "DESTINATION":{
     "NEW_ENDPOINT": "新建目標",


### PR DESCRIPTION
This is a minor consistency issue, but it also turns into a minor rendering issue where something is converting "backtick + a" into "à"