### PR TITLE
missing syslog home directory breaks logrotate

### DIFF
--- a/make/photon/log/Dockerfile.base
+++ b/make/photon/log/Dockerfile.base
@@ -2,6 +2,6 @@ FROM photon:4.0
 
 RUN tdnf install -y cronie rsyslog logrotate shadow tar gzip sudo >> /dev/null\
     && mkdir /var/spool/rsyslog \
-    && groupadd -r -g 10000 syslog && useradd --no-log-init -r -g 10000 -u 10000 syslog \
+    && groupadd -r -g 10000 syslog && useradd --no-log-init -r -g 10000 -u 10000 -m syslog \
     && tdnf clean all \
     && chage -M 99999 root


### PR DESCRIPTION
Logrotate is run with sudo as the syslog user by cron.hourly 
Without the syslog home directory, the job fails. Currently the following stderr is being thrown away by the cron script:
```
error: cannot open current directory: Permission denied 
```

Fixes #15468