### PR TITLE
remove the internal legacy API to switch quota

### DIFF
--- a/src/core/api/harborapi_test.go
+++ b/src/core/api/harborapi_test.go
@@ -115,7 +115,6 @@ func init() {
 	beego.Router("/api/"+api.APIVersion+"/chartrepo/:repo/charts/:name/:version/labels", chartLabelAPIType, "get:GetLabels;post:MarkLabel")
 	beego.Router("/api/"+api.APIVersion+"/chartrepo/:repo/charts/:name/:version/labels/:id([0-9]+)", chartLabelAPIType, "delete:RemoveLabel")
 
-	beego.Router("/api/internal/switchquota", &InternalAPI{}, "put:SwitchQuota")
 	beego.Router("/api/internal/syncquota", &InternalAPI{}, "post:SyncQuota")
 
 	// Init user Info

--- a/src/core/api/internal_test.go
+++ b/src/core/api/internal_test.go
@@ -20,42 +20,6 @@ import (
 )
 
 // cannot verify the real scenario here
-func TestSwitchQuota(t *testing.T) {
-	cases := []*codeCheckingCase{
-		// 401
-		{
-			request: &testingRequest{
-				method: http.MethodPut,
-				url:    "/api/internal/switchquota",
-			},
-			code: http.StatusUnauthorized,
-		},
-		// 200
-		{
-			request: &testingRequest{
-				method:     http.MethodPut,
-				url:        "/api/internal/switchquota",
-				credential: sysAdmin,
-				bodyJSON: &QuotaSwitcher{
-					Enabled: true,
-				},
-			},
-			code: http.StatusOK,
-		},
-		// 403
-		{
-			request: &testingRequest{
-				url:        "/api/internal/switchquota",
-				method:     http.MethodPut,
-				credential: nonSysAdmin,
-			},
-			code: http.StatusForbidden,
-		},
-	}
-	runCodeCheckingCases(t, cases...)
-}
-
-// cannot verify the real scenario here
 func TestSyncQuota(t *testing.T) {
 	cases := []*codeCheckingCase{
 		// 401

--- a/src/server/route.go
+++ b/src/server/route.go
@@ -46,7 +46,6 @@ func registerRoutes() {
 	beego.Router(common.AuthProxyRediretPath, &controllers.AuthProxyController{}, "get:HandleRedirect")
 
 	beego.Router("/api/internal/renameadmin", &api.InternalAPI{}, "post:RenameAdmin")
-	beego.Router("/api/internal/switchquota", &api.InternalAPI{}, "put:SwitchQuota")
 	beego.Router("/api/internal/syncquota", &api.InternalAPI{}, "post:SyncQuota")
 
 	beego.Router("/service/notifications/jobs/webhook/:id([0-9]+)", &jobs.Handler{}, "post:HandleNotificationJob")


### PR DESCRIPTION
The init design of this API is to avoid the quota error leads to system disaster.
As quota has been refineded and redis lock has been removed, the API can be deprecated safely.

And this API is only call the DB to refresh quota data, user can call the SyncQuota API to handle this.

Signed-off-by: Wang Yan <wangyan@vmware.com>