### PR TITLE
fix(replication) gitlab filters may not work

### DIFF
--- a/src/pkg/reg/adapter/gitlab/adapter.go
+++ b/src/pkg/reg/adapter/gitlab/adapter.go
@@ -90,10 +90,8 @@ func (a *adapter) FetchArtifacts(filters []*model.Filter) ([]*model.Resource, er
 	for _, filter := range filters {
 		if filter.Type == model.FilterTypeName {
 			nameFilter = filter.Value.(string)
-			break
 		} else if filter.Type == model.FilterTypeTag {
 			tagFilter = filter.Value.(string)
-			break
 		}
 	}
 
@@ -142,7 +140,7 @@ func (a *adapter) FetchArtifacts(filters []*model.Filter) ([]*model.Resource, er
 			tags := []string{}
 			for _, vTag := range vTags {
 				if len(tagFilter) > 0 {
-					if ok, _ := util.Match(strings.ToLower(vTag.Name), strings.ToLower(tagFilter)); !ok {
+					if ok, _ := util.Match(strings.ToLower(tagFilter), strings.ToLower(vTag.Name)); !ok {
 						continue
 					}
 				}

--- a/src/pkg/reg/adapter/gitlab/adapter_test.go
+++ b/src/pkg/reg/adapter/gitlab/adapter_test.go
@@ -122,4 +122,17 @@ func TestFetchImages(t *testing.T) {
 		assertions.Len(resources, v, k, v)
 	}
 
+	resources, err := adapter.FetchArtifacts([]*model.Filter{
+		{
+			Type:  model.FilterTypeName,
+			Value: "library/dockers",
+		},
+		{
+			Type:  model.FilterTypeTag,
+			Value: "{late*,v2}",
+		},
+	})
+	require.Nil(t, err)
+	require.Equal(t, 1, len(resources))
+	require.Equal(t, 2, len(resources[0].Metadata.Vtags))
 }


### PR DESCRIPTION
close #15385
in gitlab replication adapter, if set name and tag filters together, the tag filter is not work