### PR TITLE
Logrotate fails when cwd is not accessible

### DIFF
--- a/make/photon/log/logrotate
+++ b/make/photon/log/logrotate
@@ -2,5 +2,6 @@
 
 # run the logrotate with user 10000, the state file "/var/lib/logrotate/logrotate.status"
 # is specified to avoid the permission error
+cd /
 sudo -u \#10000 -E /usr/sbin/logrotate -s /var/lib/logrotate/logrotate.status /etc/logrotate.conf
 exit 0


### PR DESCRIPTION
Logrotate is run with sudo as the syslog user by cron.hourly
The current working directory is `/root` which is inaccessible to the syslog
user so the logrotate command fails. Currently the following stderr is being
thrown away by the cron script:
```
error: cannot open current directory: Permission denied
```

Fixes #15468

Signed-off-by: Christopher Jenkins <christj@gmail.com>