### PR TITLE
[Cherrypick - v2.3]Do not check security context in Get of user controller

### DIFF
--- a/src/controller/user/controller.go
+++ b/src/controller/user/controller.go
@@ -16,7 +16,6 @@ package user
 
 import (
 	"context"
-	"fmt"
 
 	commonmodels "github.com/goharbor/harbor/src/common/models"
 	"github.com/goharbor/harbor/src/common/security"
@@ -144,10 +143,7 @@ func (c *controller) Get(ctx context.Context, id int, opt *Option) (*models.User
 	if err != nil {
 		return nil, err
 	}
-	sctx, ok := security.FromContext(ctx)
-	if !ok {
-		return nil, fmt.Errorf("can't find security context")
-	}
+	sctx, _ := security.FromContext(ctx)
 	lsc, ok := sctx.(*local.SecurityContext)
 	if ok && lsc.User() != nil && lsc.User().UserID == id {
 		u.AdminRoleInAuth = lsc.User().AdminRoleInAuth


### PR DESCRIPTION
This commit make sure when security context is not found the `Get`
function in user controller should not return error.
Because this func will be called by security middleware, at which point
of time the security context is not generated.
Additionally, checking security context is not necessary because the
permission checking is already done in the API handler layer.

fixes #15535

Signed-off-by: Daniel Jiang <jiangd@vmware.com>