### PR TITLE
Add trigger file for building base

### DIFF
--- a/.buildbaselog
+++ b/.buildbaselog
@@ -1,0 +1,12 @@
+# Please add memo for logging the reason to trigger build base images action.
+# Note: 
+#    Any modifiction of this file will trigger base images build action.
+
+
+%changelog
+
+*   Add date here... Add signature here...
+-   Add your reason here...
+
+*   Jul 15 2021 <danfengl@vmware.com>
+-   Create this file to trigger build base action in buld-package workflow 

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -46,7 +46,10 @@ jobs:
         with:
           path: src/github.com/goharbor/harbor
       - name: Build Base Image
-        if: contains(steps.changed-files.outputs.modified, 'Dockerfile.base') || contains(steps.changed-files.outputs.modified, 'VERSION')
+        if: |
+            contains(steps.changed-files.outputs.modified, 'Dockerfile.base') ||
+            contains(steps.changed-files.outputs.modified, 'VERSION') ||
+            contains(steps.changed-files.outputs.modified, '.buildbaselog')
         run: |
           set -x
           echo "BUILD_BASE=true" >> $GITHUB_ENV


### PR DESCRIPTION
If build base images is needed in a unexpected situation, build base images action will be triggered by making a modification of .buildbaselog.

Signed-off-by: danfengliu <danfengl@vmware.com>