### PR TITLE
freeze fix during bzip2  presense check

### DIFF
--- a/make/photon/db/rpm_builder.sh
+++ b/make/photon/db/rpm_builder.sh
@@ -12,7 +12,7 @@ function checkdep {
 		exit 1
 	fi
 
-	if ! bzip2 --version &> /dev/null
+	if ! [ -x "$(command -v bzip2)" ]
 	then
 		echo "Need to install bzip2 first and run this script again."
 		exit 1


### PR DESCRIPTION
For some reason this script hangs on checking bzip2 presense. Tested on several environments.
Steps to reproduce:
* clone repo
* run  make install COMPILETAG=compile_golangimage
* wait until script will check that bzip2 is installed