### PR TITLE
fix(scanners): Vulnerability report v1.0 might override v1.1

### DIFF
--- a/api/v2.0/swagger.yaml
+++ b/api/v2.0/swagger.yaml
@@ -5389,7 +5389,7 @@ parameters:
     name: X-Accept-Vulnerabilities
     in: header
     type: string
-    default: 'application/vnd.scanner.adapter.vuln.report.harbor+json; version=1.0'
+    default: 'application/vnd.security.vulnerability.report; version=1.1'
     description: |-
       A comma-separated lists of MIME types for the scan report or scan summary. The first mime type will be used when the report found for it.
       Currently the mime type supports 'application/vnd.scanner.adapter.vuln.report.harbor+json; version=1.0' and 'application/vnd.security.vulnerability.report; version=1.1'

--- a/src/pkg/scan/dao/scanner/model.go
+++ b/src/pkg/scan/dao/scanner/model.go
@@ -159,12 +159,30 @@ func (r *Registration) GetProducesMimeTypes(mimeType string) []string {
 	for _, capability := range r.Metadata.Capabilities {
 		for _, mt := range capability.ConsumesMimeTypes {
 			if mt == mimeType {
-				return capability.ProducesMimeTypes
+				return r.ignoreDuplicateMimeType(capability.ProducesMimeTypes)
 			}
 		}
 	}
 
 	return nil
+}
+
+// ignoreDuplicateMimeType removes deprecated v1.MimeTypeNativeReport if it's
+// specified along with v1.MimeTypeGenericVulnerabilityReport.
+func (r *Registration) ignoreDuplicateMimeType(mimeTypes []string) []string {
+	set := make(map[string]bool)
+	for _, mt := range mimeTypes {
+		set[mt] = true
+	}
+
+	var out []string
+	for mt := range set {
+		if mt == v1.MimeTypeNativeReport && set[v1.MimeTypeGenericVulnerabilityReport] {
+			continue
+		}
+		out = append(out, mt)
+	}
+	return out
 }
 
 // GetCapability returns capability for the mime type

--- a/src/pkg/scan/dao/scanner/model_test.go
+++ b/src/pkg/scan/dao/scanner/model_test.go
@@ -17,6 +17,7 @@ package scanner
 import (
 	"testing"
 
+	v1 "github.com/goharbor/harbor/src/pkg/scan/rest/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -78,4 +79,96 @@ func (suite *ModelTestSuite) TestValidate() {
 
 	err = r.Validate(true)
 	require.NoError(suite.T(), err)
+}
+
+func TestRegistration_GetProducesMimeTypes(t *testing.T) {
+	testCases := []struct {
+		name              string
+		metadata          *v1.ScannerAdapterMetadata
+		expectedMimeTypes []string
+	}{
+		{
+			name: "Should return native report mime type",
+			metadata: &v1.ScannerAdapterMetadata{
+				Capabilities: []*v1.ScannerCapability{
+					{
+						ConsumesMimeTypes: []string{
+							v1.MimeTypeOCIArtifact,
+							v1.MimeTypeDockerArtifact,
+						},
+						ProducesMimeTypes: []string{
+							v1.MimeTypeNativeReport,
+						},
+					},
+				},
+			},
+			expectedMimeTypes: []string{
+				v1.MimeTypeNativeReport,
+			},
+		},
+		{
+			name: "Should return generic mime type when both are returned by scanner",
+			metadata: &v1.ScannerAdapterMetadata{
+				Capabilities: []*v1.ScannerCapability{
+					{
+						ConsumesMimeTypes: []string{
+							v1.MimeTypeOCIArtifact,
+							v1.MimeTypeDockerArtifact,
+						},
+						ProducesMimeTypes: []string{
+							v1.MimeTypeNativeReport,
+							v1.MimeTypeGenericVulnerabilityReport,
+						},
+					},
+				},
+			},
+			expectedMimeTypes: []string{
+				v1.MimeTypeGenericVulnerabilityReport,
+			},
+		},
+		{
+			name: "Should return generic report mime type",
+			metadata: &v1.ScannerAdapterMetadata{
+				Capabilities: []*v1.ScannerCapability{
+					{
+						ConsumesMimeTypes: []string{
+							v1.MimeTypeOCIArtifact,
+							v1.MimeTypeDockerArtifact,
+						},
+						ProducesMimeTypes: []string{
+							v1.MimeTypeGenericVulnerabilityReport,
+						},
+					},
+				},
+			},
+			expectedMimeTypes: []string{
+				v1.MimeTypeGenericVulnerabilityReport,
+			},
+		},
+		{
+			name: "Should return empty list when consumes mime types don't match",
+			metadata: &v1.ScannerAdapterMetadata{
+				Capabilities: []*v1.ScannerCapability{
+					{
+						ConsumesMimeTypes: []string{
+							v1.MimeTypeDockerArtifact,
+						},
+						ProducesMimeTypes: []string{
+							v1.MimeTypeGenericVulnerabilityReport,
+						},
+					},
+				},
+			},
+			expectedMimeTypes: []string(nil),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &Registration{
+				Metadata: tc.metadata,
+			}
+			assert.Equal(t, tc.expectedMimeTypes, r.GetProducesMimeTypes(v1.MimeTypeOCIArtifact))
+		})
+	}
 }

--- a/tests/apitests/python/library/artifact.py
+++ b/tests/apitests/python/library/artifact.py
@@ -115,7 +115,7 @@ class Artifact(base.Base, object):
                 else:
                     raise Exception("Artifact should not be scanned {}.".format(artifact.scan_overview))
 
-            scan_status = artifact.scan_overview['application/vnd.scanner.adapter.vuln.report.harbor+json; version=1.0'].scan_status
+            scan_status = artifact.scan_overview['application/vnd.security.vulnerability.report; version=1.1'].scan_status
             if scan_status == expected_scan_status:
                 return
         raise Exception("Scan image result is {}, not as expected {}.".format(scan_status, expected_scan_status))


### PR DESCRIPTION
When both application/vnd.scanner.adapter.vuln.report.harbor+json; version=1.0
and application/vnd.security.vulnerability.report; version=1.1 mime types
are returned by a scanner we may end up with data inconsistency.
The root cause is that two reports pulled down by Harbor may override records
stored in the vulnerability_record table.

Resolves: #15623

Signed-off-by: Daniel Pacak <pacak.daniel@gmail.com>