### PR TITLE
Add autoescape parameter to jinja environments

### DIFF
--- a/make/photon/prepare/migrations/version_1_10_0/__init__.py
+++ b/make/photon/prepare/migrations/version_1_10_0/__init__.py
@@ -1,5 +1,5 @@
 import os
-from jinja2 import Environment, FileSystemLoader, StrictUndefined
+from jinja2 import Environment, FileSystemLoader, StrictUndefined, select_autoescape
 from utils.migration import read_conf
 
 revision = '1.10.0'
@@ -13,7 +13,8 @@ def migrate(input_cfg, output_cfg):
         loader=FileSystemLoader(current_dir),
         undefined=StrictUndefined,
         trim_blocks=True,
-        lstrip_blocks=True
+        lstrip_blocks=True,
+        autoescape = select_autoescape()
         ).get_template('harbor.yml.jinja')
 
     with open(output_cfg, 'w') as f:

--- a/make/photon/prepare/migrations/version_1_9_0/__init__.py
+++ b/make/photon/prepare/migrations/version_1_9_0/__init__.py
@@ -1,5 +1,5 @@
 import os
-from jinja2 import Environment, FileSystemLoader, StrictUndefined
+from jinja2 import Environment, FileSystemLoader, StrictUndefined, select_autoescape
 from utils.migration import read_conf
 
 revision = '1.9.0'
@@ -13,7 +13,8 @@ def migrate(input_cfg, output_cfg):
         loader=FileSystemLoader(current_dir),
         undefined=StrictUndefined,
         trim_blocks=True,
-        lstrip_blocks=True
+        lstrip_blocks=True,
+        autoescape = select_autoescape()
         ).get_template('harbor.yml.jinja')
 
     with open(output_cfg, 'w') as f:

--- a/make/photon/prepare/migrations/version_2_0_0/__init__.py
+++ b/make/photon/prepare/migrations/version_2_0_0/__init__.py
@@ -1,5 +1,5 @@
 import os
-from jinja2 import Environment, FileSystemLoader, StrictUndefined
+from jinja2 import Environment, FileSystemLoader, StrictUndefined, select_autoescape
 from utils.migration import read_conf
 
 revision = '2.0.0'
@@ -13,7 +13,8 @@ def migrate(input_cfg, output_cfg):
         loader=FileSystemLoader(current_dir),
         undefined=StrictUndefined,
         trim_blocks=True,
-        lstrip_blocks=True
+        lstrip_blocks=True,
+        autoescape = select_autoescape()
         ).get_template('harbor.yml.jinja')
 
     with open(output_cfg, 'w') as f:

--- a/make/photon/prepare/migrations/version_2_1_0/__init__.py
+++ b/make/photon/prepare/migrations/version_2_1_0/__init__.py
@@ -1,5 +1,5 @@
 import os
-from jinja2 import Environment, FileSystemLoader, StrictUndefined
+from jinja2 import Environment, FileSystemLoader, StrictUndefined, select_autoescape
 from utils.migration import read_conf
 
 revision = '2.1.0'
@@ -18,7 +18,8 @@ def migrate(input_cfg, output_cfg):
         loader=FileSystemLoader(current_dir),
         undefined=StrictUndefined,
         trim_blocks=True,
-        lstrip_blocks=True
+        lstrip_blocks=True,
+        autoescape = select_autoescape()
         ).get_template('harbor.yml.jinja')
 
     config_dict = read_conf(input_cfg)

--- a/make/photon/prepare/migrations/version_2_2_0/__init__.py
+++ b/make/photon/prepare/migrations/version_2_2_0/__init__.py
@@ -1,5 +1,5 @@
 import os
-from jinja2 import Environment, FileSystemLoader, StrictUndefined
+from jinja2 import Environment, FileSystemLoader, StrictUndefined, select_autoescape
 from utils.migration import read_conf
 
 revision = '2.2.0'
@@ -11,7 +11,8 @@ def migrate(input_cfg, output_cfg):
         loader=FileSystemLoader(current_dir),
         undefined=StrictUndefined,
         trim_blocks=True,
-        lstrip_blocks=True
+        lstrip_blocks=True,
+        autoescape = select_autoescape()
         ).get_template('harbor.yml.jinja')
 
     config_dict = read_conf(input_cfg)

--- a/make/photon/prepare/migrations/version_2_3_0/__init__.py
+++ b/make/photon/prepare/migrations/version_2_3_0/__init__.py
@@ -1,5 +1,5 @@
 import os
-from jinja2 import Environment, FileSystemLoader, StrictUndefined
+from jinja2 import Environment, FileSystemLoader, StrictUndefined, select_autoescape
 from utils.migration import read_conf
 
 revision = '2.3.0'
@@ -20,7 +20,8 @@ def migrate(input_cfg, output_cfg):
         loader=FileSystemLoader(current_dir),
         undefined=StrictUndefined,
         trim_blocks=True,
-        lstrip_blocks=True
+        lstrip_blocks=True,
+        autoescape = select_autoescape()
         ).get_template('harbor.yml.jinja')
 
     config_dict = read_conf(input_cfg)

--- a/make/photon/prepare/migrations/version_2_4_0/__init__.py
+++ b/make/photon/prepare/migrations/version_2_4_0/__init__.py
@@ -1,5 +1,5 @@
 import os
-from jinja2 import Environment, FileSystemLoader, StrictUndefined
+from jinja2 import Environment, FileSystemLoader, StrictUndefined, select_autoescape
 from utils.migration import read_conf
 
 revision = '2.4.0'
@@ -11,7 +11,8 @@ def migrate(input_cfg, output_cfg):
         loader=FileSystemLoader(current_dir),
         undefined=StrictUndefined,
         trim_blocks=True,
-        lstrip_blocks=True
+        lstrip_blocks=True,
+        autoescape = select_autoescape()
         ).get_template('harbor.yml.jinja')
 
     config_dict = read_conf(input_cfg)

--- a/make/photon/prepare/utils/jinja.py
+++ b/make/photon/prepare/utils/jinja.py
@@ -1,9 +1,9 @@
 import json
 
-from jinja2 import Environment, FileSystemLoader
+from jinja2 import Environment, FileSystemLoader, select_autoescape
 from .misc import mark_file
 
-jinja_env = Environment(loader=FileSystemLoader('/'), trim_blocks=True, lstrip_blocks=True)
+jinja_env = Environment(loader=FileSystemLoader('/'), trim_blocks=True, lstrip_blocks=True, autoescape = select_autoescape())
 
 def to_json(value):
     return json.dumps(value)


### PR DESCRIPTION
This resolves the bugs observed [here](https://lift.sonatype.com/result/bhamail/harbor/01FHG1B5AJ8MXCH0A05BMBNWWT?t=CustomTool%20%22Bandit%22%7Cjinja2_autoescape_false) by Sonatype Lift.
