### PR TITLE
Fix semgrep sprintf-host-port

### DIFF
--- a/src/common/dao/pgsql.go
+++ b/src/common/dao/pgsql.go
@@ -16,11 +16,13 @@ package dao
 
 import (
 	"fmt"
-	"github.com/goharbor/harbor/src/common/models"
+	"net"
 	"net/url"
 	"os"
 	"strconv"
 	"time"
+
+	"github.com/goharbor/harbor/src/common/models"
 
 	"github.com/astaxie/beego/orm"
 	"github.com/goharbor/harbor/src/common/utils"
@@ -74,7 +76,7 @@ func NewPGSQL(host string, port string, usr string, pwd string, database string,
 
 // Register registers pgSQL to orm with the info wrapped by the instance.
 func (p *pgsql) Register(alias ...string) error {
-	if err := utils.TestTCPConn(fmt.Sprintf("%s:%s", p.host, p.port), 60, 2); err != nil {
+	if err := utils.TestTCPConn(net.JoinHostPort(p.host, p.port), 60, 2); err != nil {
 		return err
 	}
 
@@ -142,7 +144,7 @@ func NewMigrator(database *models.PostGreSQL) (*migrate.Migrate, error) {
 	dbURL := url.URL{
 		Scheme:   "postgres",
 		User:     url.UserPassword(database.Username, database.Password),
-		Host:     fmt.Sprintf("%s:%d", database.Host, database.Port),
+		Host:     net.JoinHostPort(database.Host, strconv.Itoa(database.Port)),
 		Path:     database.Database,
 		RawQuery: fmt.Sprintf("sslmode=%s", database.SSLMode),
 	}

--- a/src/pkg/exporter/harbor_cli.go
+++ b/src/pkg/exporter/harbor_cli.go
@@ -1,9 +1,10 @@
 package exporter
 
 import (
-	"fmt"
+	"net"
 	"net/http"
 	"net/url"
+	"strconv"
 )
 
 var hbrCli *HarborClient
@@ -19,7 +20,7 @@ type HarborClient struct {
 func (hc HarborClient) harborURL(p string) url.URL {
 	return url.URL{
 		Scheme: hc.HarborScheme,
-		Host:   fmt.Sprintf("%s:%d", hc.HarborHost, hc.HarborPort),
+		Host:   net.JoinHostPort(hc.HarborHost, strconv.Itoa(hc.HarborPort)),
 		Path:   p,
 	}
 }


### PR DESCRIPTION
Fixes semgrep warning observed on Sonatype Lift over [here](https://lift.sonatype.com/result/bhamail/harbor/01FHG1B5AJ8MXCH0A05BMBNWWT?t=CustomTool%20%22Semgrep%22%7Copt.semgrep.sprintf-host-port). 

Excluded [this](https://github.com/bhamail/harbor/blob/f57c42640950d7e0a3621f170abe000ecf0c72cd/src/jobservice/common/utils/utils.go#L133) as it does not seem to be a `host:port` pattern though `net.JoinHostPort()` works in this scenario.