### PR TITLE
Fix semgrep use-of-weak-crypto error

### DIFF
--- a/src/lib/cache/redis/redis.go
+++ b/src/lib/cache/redis/redis.go
@@ -15,7 +15,7 @@
 package redis
 
 import (
-	"crypto/md5"
+	"crypto/sha256"
 	"fmt"
 	"time"
 
@@ -107,7 +107,7 @@ func New(opts cache.Options) (cache.Cache, error) {
 		opts.Address = "redis://localhost:6379/0"
 	}
 
-	name := fmt.Sprintf("%x", md5.Sum([]byte(opts.Address)))
+	name := fmt.Sprintf("%x", sha256.Sum256([]byte(opts.Address)))
 
 	param := &libredis.PoolParam{
 		PoolMaxIdle:           100,


### PR DESCRIPTION
Signed-off-by: Soumik Majumder <soumikm@vmware.com>

Use `SHA256` sum to generate Redis pool names instead of `MD5` hashes.
- Resolves `semgrep` warning : `go.lang.security.audit.crypto.use_of_weak_crypto.use-of-md5` (seen [here](https://lift.sonatype.com/result/bhamail/harbor/01FHG1B5AJ8MXCH0A05BMBNWWT?t=CustomTool%20%22Semgrep%22%7Copt.semgrep.go.lang.security.audit.crypto.use_of_weak_crypto.use-of-md5)) 
- `SHA256`  hashes are collision resistant.

Note:
- Will this lead to older caches being inaccessible? 
- Will the caches be reinitialised? 
- Is backwards compatibility an issue?