### PR TITLE
roll back the runner count

### DIFF
--- a/src/pkg/reg/adapter/adapter.go
+++ b/src/pkg/reg/adapter/adapter.go
@@ -26,7 +26,7 @@ import (
 
 // const definition
 const (
-	MaxConcurrency = 30
+	MaxConcurrency = 100
 )
 
 var registry = map[string]Factory{}


### PR DESCRIPTION
It takes about 1 hour to perform data for 40000 repositories per performance testing.

Roll back the runner count to 100 could speed the data preparation time.
It's safe since it only takes 100 DB connection counts at most per execution per core.

Signed-off-by: Wang Yan <wangyan@vmware.com>