### PR TITLE
Add configurable timeout for Trivy scans

### DIFF
--- a/make/photon/prepare/migrations/version_2_4_0/harbor.yml.jinja
+++ b/make/photon/prepare/migrations/version_2_4_0/harbor.yml.jinja
@@ -147,6 +147,12 @@ trivy:
   {% else %}
   ignore_unfixed: false
   {% endif %}
+  # timeout The duration to wait for scan completion
+  {% if trivy.timeout is defined %}
+  timeout: {{ trivy.timeout }}
+  {% else %}
+  timeout: 5m0s
+  {% endif %}
   # skipUpdate The flag to enable or disable Trivy DB downloads from GitHub
   #
   # You might want to enable this flag in test or CI/CD environments to avoid GitHub rate limiting issues.

--- a/make/photon/prepare/templates/trivy-adapter/env.jinja
+++ b/make/photon/prepare/templates/trivy-adapter/env.jinja
@@ -12,6 +12,7 @@ SCANNER_TRIVY_IGNORE_UNFIXED={{trivy_ignore_unfixed}}
 SCANNER_TRIVY_SKIP_UPDATE={{trivy_skip_update}}
 SCANNER_TRIVY_GITHUB_TOKEN={{trivy_github_token}}
 SCANNER_TRIVY_INSECURE={{trivy_insecure}}
+SCANNER_TRIVY_TIMEOUT={{trivy_timeout}}
 HTTP_PROXY={{trivy_http_proxy}}
 HTTPS_PROXY={{trivy_https_proxy}}
 NO_PROXY={{trivy_no_proxy}}

--- a/make/photon/prepare/utils/configs.py
+++ b/make/photon/prepare/utils/configs.py
@@ -221,6 +221,7 @@ def parse_yaml_config(config_file_path, with_notary, with_trivy, with_chartmuseu
     config_dict['trivy_skip_update'] = trivy_configs.get("skip_update") or False
     config_dict['trivy_ignore_unfixed'] = trivy_configs.get("ignore_unfixed") or False
     config_dict['trivy_insecure'] = trivy_configs.get("insecure") or False
+    config_dict['trivy_timeout'] = trivy_configs.get("timeout") or '5m0s'
 
     # Chart configs
     chart_configs = configs.get("chart") or {}


### PR DESCRIPTION
Signed-off-by: Rolf Ahrenberg <Rolf.Ahrenberg@saunalahti.fi>

I've been getting timeout problems with Trivy scanner lately and configurable timeout might benefit for others as well:
```
Oct 13 11:12:36 172.19.0.1 trivy-adapter[952]: {"error":"running trivy wrapper: running trivy: exit status 1: 2021-10-13T08:12:34.101Z\t\u001b[33mWARN\u001b[0m\tIncrease --timeout value\n2021-10-13T08:12:34.101Z\t\u001b[31
mFATAL\u001b[0m\tscan error: image scan failed: failed analysis: analyze error: timeout: context deadline exceeded\n","level":"error","msg":"Scan job failed","scan_job_id":"a9103a7502ea8d33059095e0","time":"2021-10-13T08:1
2:36Z"}
```
https://github.com/aquasecurity/harbor-scanner-trivy#configuration