### PR TITLE
fixes gc dry run issue

### DIFF
--- a/src/pkg/blob/dao/dao_test.go
+++ b/src/pkg/blob/dao/dao_test.go
@@ -457,6 +457,31 @@ func (suite *DaoTestSuite) TestGetBlobsNotRefedByProjectBlob() {
 	suite.Require().Equal(0, len(blobs))
 }
 
+func (suite *DaoTestSuite) GetBlobsByArtDigest() {
+	ctx := suite.Context()
+	afDigest := suite.DigestString()
+	blobs, err := suite.dao.GetBlobsByArtDigest(ctx, afDigest)
+	suite.Nil(err)
+	suite.Require().Equal(0, len(blobs))
+
+	suite.dao.CreateBlob(ctx, &models.Blob{Digest: afDigest})
+	blobDigest1 := suite.DigestString()
+	blobDigest2 := suite.DigestString()
+	suite.dao.CreateBlob(ctx, &models.Blob{Digest: blobDigest1})
+	suite.dao.CreateBlob(ctx, &models.Blob{Digest: blobDigest2})
+
+	_, err = suite.dao.CreateArtifactAndBlob(ctx, afDigest, afDigest)
+	suite.Nil(err)
+	_, err = suite.dao.CreateArtifactAndBlob(ctx, afDigest, blobDigest1)
+	suite.Nil(err)
+	_, err = suite.dao.CreateArtifactAndBlob(ctx, afDigest, blobDigest2)
+	suite.Nil(err)
+
+	blobs, err = suite.dao.GetBlobsByArtDigest(ctx, afDigest)
+	suite.Nil(err)
+	suite.Require().Equal(3, len(blobs))
+}
+
 func TestDaoTestSuite(t *testing.T) {
 	suite.Run(t, &DaoTestSuite{})
 }

--- a/src/pkg/blob/manager.go
+++ b/src/pkg/blob/manager.go
@@ -59,6 +59,9 @@ type Manager interface {
 	// Get get blob by digest
 	Get(ctx context.Context, digest string) (*Blob, error)
 
+	// Get get blob by artifact digest
+	GetByArt(ctx context.Context, digest string) ([]*models.Blob, error)
+
 	// Update the blob
 	Update(ctx context.Context, blob *Blob) error
 
@@ -123,6 +126,10 @@ func (m *manager) FindBlobsShouldUnassociatedWithProject(ctx context.Context, pr
 
 func (m *manager) Get(ctx context.Context, digest string) (*Blob, error) {
 	return m.dao.GetBlobByDigest(ctx, digest)
+}
+
+func (m *manager) GetByArt(ctx context.Context, digest string) ([]*models.Blob, error) {
+	return m.dao.GetBlobsByArtDigest(ctx, digest)
 }
 
 func (m *manager) Update(ctx context.Context, blob *Blob) error {

--- a/src/pkg/blob/manager_test.go
+++ b/src/pkg/blob/manager_test.go
@@ -439,6 +439,31 @@ func (suite *ManagerTestSuite) TestUselessBlobs() {
 	suite.Require().Equal(0, len(blobs))
 }
 
+func (suite *ManagerTestSuite) GetBlobsByArtDigest() {
+	ctx := suite.Context()
+	afDigest := suite.DigestString()
+	blobs, err := Mgr.GetByArt(ctx, afDigest)
+	suite.Nil(err)
+	suite.Require().Equal(0, len(blobs))
+
+	Mgr.Create(ctx, suite.DigestString(), "media type", 100)
+	blobDigest1 := suite.DigestString()
+	blobDigest2 := suite.DigestString()
+	Mgr.Create(ctx, blobDigest1, "media type", 100)
+	Mgr.Create(ctx, blobDigest2, "media type", 100)
+
+	_, err = Mgr.AssociateWithArtifact(ctx, afDigest, afDigest)
+	suite.Nil(err)
+	_, err = Mgr.AssociateWithArtifact(ctx, afDigest, blobDigest1)
+	suite.Nil(err)
+	_, err = Mgr.AssociateWithArtifact(ctx, afDigest, blobDigest2)
+	suite.Nil(err)
+
+	blobs, err = Mgr.List(ctx, q.New(q.KeyWords{"artifactDigest": afDigest}))
+	suite.Nil(err)
+	suite.Require().Equal(3, len(blobs))
+}
+
 func TestManagerTestSuite(t *testing.T) {
 	suite.Run(t, &ManagerTestSuite{})
 }

--- a/src/testing/pkg/blob/manager.go
+++ b/src/testing/pkg/blob/manager.go
@@ -209,6 +209,29 @@ func (_m *Manager) Get(ctx context.Context, digest string) (*models.Blob, error)
 	return r0, r1
 }
 
+// GetByArt provides a mock function with given fields: ctx, digest
+func (_m *Manager) GetByArt(ctx context.Context, digest string) ([]*models.Blob, error) {
+	ret := _m.Called(ctx, digest)
+
+	var r0 []*models.Blob
+	if rf, ok := ret.Get(0).(func(context.Context, string) []*models.Blob); ok {
+		r0 = rf(ctx, digest)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*models.Blob)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, digest)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // List provides a mock function with given fields: ctx, query
 func (_m *Manager) List(ctx context.Context, query *q.Query) ([]*models.Blob, error) {
 	ret := _m.Called(ctx, query)


### PR DESCRIPTION
fixes #15332, for the dry run mode, gc job should not remove the untagged candidates.
To fix it, use the simulate untagged artifact deletion for dry-run.

Signed-off-by: Wang Yan <wangyan@vmware.com>