### PR TITLE
fix check dragionfly response status

### DIFF
--- a/src/pkg/p2p/preheat/provider/dragonfly.go
+++ b/src/pkg/p2p/preheat/provider/dragonfly.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -11,6 +10,7 @@ import (
 	"github.com/goharbor/harbor/src/pkg/p2p/preheat/models/provider"
 	"github.com/goharbor/harbor/src/pkg/p2p/preheat/provider/auth"
 	"github.com/goharbor/harbor/src/pkg/p2p/preheat/provider/client"
+	"github.com/goharbor/harbor/src/lib/errors"
 )
 
 const (
@@ -18,6 +18,7 @@ const (
 	preheatEndpoint     = "/preheats"
 	preheatTaskEndpoint = "/preheats/{task_id}"
 	dragonflyPending    = "WAITING"
+	dragonflyFailed     = "FAILED"
 )
 
 type dragonflyPreheatCreateResp struct {
@@ -28,6 +29,7 @@ type dragonflyPreheatInfo struct {
 	ID         string `json:"ID"`
 	StartTime  string `json:"startTime,omitempty"`
 	FinishTime string `json:"finishTime,omitempty"`
+	ErrorMsg   string `json:"errorMsg"`
 	Status     string
 }
 
@@ -104,6 +106,51 @@ func (dd *DragonflyDriver) Preheat(preheatingImage *PreheatImage) (*PreheatingSt
 
 // CheckProgress implements @Driver.CheckProgress.
 func (dd *DragonflyDriver) CheckProgress(taskID string) (*PreheatingStatus, error) {
+	status, err := dd.getProgressStatus(taskID)
+	if err != nil {
+		return nil, err
+	}
+
+	// If preheat job already exists
+	if strings.Index(status.ErrorMsg, "preheat task already exists, id:") >= 0 {
+		if taskID, err = getTaskExistedFromErrMsg(status.ErrorMsg); err != nil {
+			return nil, err
+		}
+		if status, err = dd.getProgressStatus(taskID); err != nil {
+			return nil, err
+		}
+	}
+
+	if status.Status == dragonflyPending {
+		status.Status = provider.PreheatingStatusPending
+	} else if status.Status == dragonflyFailed {
+		status.Status = provider.PreheatingStatusFail
+	}
+
+	res := &PreheatingStatus{
+		Status: status.Status,
+		TaskID: taskID,
+	}
+	if status.StartTime != "" {
+		res.StartTime = status.StartTime
+	}
+	if status.FinishTime != "" {
+		res.FinishTime = status.FinishTime
+	}
+
+	return res, nil
+}
+
+func getTaskExistedFromErrMsg(msg string) (string, error) {
+	begin := strings.Index(msg, "preheat task already exists, id:") + 32
+	end := strings.LastIndex(msg, "\"}")
+	if end - begin <= 0 {
+		return "", errors.Errorf("can't find existed task id by error msg:%s", msg)
+	}
+	return msg[begin:end], nil
+}
+
+func (dd *DragonflyDriver) getProgressStatus(taskID string) (*dragonflyPreheatInfo, error) {
 	if dd.instance == nil {
 		return nil, errors.New("missing instance metadata")
 	}
@@ -123,23 +170,7 @@ func (dd *DragonflyDriver) CheckProgress(taskID string) (*PreheatingStatus, erro
 	if err := json.Unmarshal(bytes, status); err != nil {
 		return nil, err
 	}
-
-	if status.Status == dragonflyPending {
-		status.Status = provider.PreheatingStatusPending
-	}
-
-	res := &PreheatingStatus{
-		Status: status.Status,
-		TaskID: taskID,
-	}
-	if status.StartTime != "" {
-		res.StartTime = status.StartTime
-	}
-	if status.FinishTime != "" {
-		res.FinishTime = status.FinishTime
-	}
-
-	return res, nil
+	return status, nil
 }
 
 func (dd *DragonflyDriver) getCred() *auth.Credential {


### PR DESCRIPTION
**reason**
when I use preheat by dragonfly (1.0.6) while checking process from dragonfly it resp that :
``````
{
    "ID":"b0227c0ba41938d25abad4df1e9b57a1e7d113086cc77d047f7acb6e73916fa9",
    "finishTime":"2021-10-25T07:53:44.162Z",
    "startTime":"2021-10-25T07:53:44.143Z",
    "status":"FAILED",
    "errorMsg":"{\"Code\":208,\"Msg\":\"preheat task already exists, id:02b0d5c6e1cd99b5fa9f730b0a8d96696ca965898233ad68b4f26267b8016ce1\"}"
}
``````
but here is status defined on git:
``````
const (
	// PreheatingImageTypeImage defines the 'image' type of preheating images
	PreheatingImageTypeImage = "image"
	// PreheatingStatusPending means the preheating is waiting for starting
	PreheatingStatusPending = "PENDING"
	// PreheatingStatusRunning means the preheating is ongoing
	PreheatingStatusRunning = "RUNNING"
	// PreheatingStatusSuccess means the preheating is success
	PreheatingStatusSuccess = "SUCCESS"
	// PreheatingStatusFail means the preheating is failed
	PreheatingStatusFail = "FAIL"
)
``````
so I fix that and add retry when dragonfly job already exists.

**what I changed**

- fix check dragionfly response status;
- add handle when dragonfly preheat job existed;

Signed-off-by: mr_002 <anyiwei123@sina.com>