### PR TITLE
Support right click to open a link in a new tab

### DIFF
--- a/src/portal/src/app/base/left-side-nav/projects/list-project/list-project.component.html
+++ b/src/portal/src/app/base/left-side-nav/projects/list-project/list-project.component.html
@@ -15,7 +15,7 @@
     <clr-dg-column [clrDgSortBy]="'creation_time'">{{'PROJECT.CREATION_TIME' | translate}}</clr-dg-column>
     <clr-dg-row *ngFor="let p of projects" [clrDgItem]="p">
         <clr-dg-cell>
-            <a href="javascript:void(0)" (click)="goToLink(p.project_id)">{{p.name}}</a>
+            <a href="javascript:void(0)" [routerLink]="getLink(p.project_id)" (click)="clickLink(p.project_id)">{{p.name}}</a>
         </clr-dg-cell>
         <clr-dg-cell>{{ (p.metadata.public === 'true' ? 'PROJECT.PUBLIC' : 'PROJECT.PRIVATE') | translate}}</clr-dg-cell>
         <clr-dg-cell>{{ roleInfo[p.current_user_role_id]? (roleInfo[p.current_user_role_id] | translate): "-"}}</clr-dg-cell>

--- a/src/portal/src/app/base/left-side-nav/projects/list-project/list-project.component.ts
+++ b/src/portal/src/app/base/left-side-nav/projects/list-project/list-project.component.ts
@@ -130,11 +130,11 @@ export class ListProjectComponent implements OnDestroy {
         this.addProject.emit();
     }
 
-    goToLink(proId: number): void {
+    clickLink(proId: number): void {
         this.searchTrigger.closeSearch(true);
-
-        let linkUrl = ["harbor", "projects", proId];
-        this.router.navigate(linkUrl);
+    }
+    getLink(proId: number) {
+        return `/harbor/projects/${proId}/repositories`;
     }
 
     clrLoad(state: ClrDatagridStateInterface) {

--- a/src/portal/src/app/base/left-side-nav/system-robot-accounts/list-all-projects/list-all-projects.component.html
+++ b/src/portal/src/app/base/left-side-nav/system-robot-accounts/list-all-projects/list-all-projects.component.html
@@ -22,7 +22,7 @@
     <clr-dg-column>{{"SYSTEM_ROBOT.PERMISSION_COLUMN" | translate}}</clr-dg-column>
     <clr-dg-row *clrDgItems="let p of projects; let projectIndex = index;" [clrDgItem]="p">
         <clr-dg-cell>
-            <a href="javascript:void(0)" (click)="goToLink(p.project_id)">{{p.name}}</a>
+            <a href="javascript:void(0)" [routerLink]="getLink(p.project_id)">{{p.name}}</a>
         </clr-dg-cell>
         <clr-dg-cell>{{p.creation_time | harborDatetime: 'short'}}</clr-dg-cell>
         <clr-dg-cell>

--- a/src/portal/src/app/base/left-side-nav/system-robot-accounts/list-all-projects/list-all-projects.component.ts
+++ b/src/portal/src/app/base/left-side-nav/system-robot-accounts/list-all-projects/list-all-projects.component.ts
@@ -80,8 +80,8 @@ export class ListAllProjectsComponent implements OnInit {
     });
     return count;
   }
-  goToLink(proId: number): void {
-    this.router.navigate(["harbor", "projects", proId]);
+  getLink(proId: number): string {
+    return `/harbor/projects/${proId}`;
   }
   selectAllOrUnselectAll() {
     if (this.showSelectAll) {

--- a/src/portal/src/app/base/project/repository/repository-gridview.component.html
+++ b/src/portal/src/app/base/project/repository/repository-gridview.component.html
@@ -33,7 +33,9 @@
                 <clr-dg-column [clrDgSortBy]="'update_time'">{{'REPOSITORY.LAST_MODIFIED' | translate}}</clr-dg-column>
                 <clr-dg-placeholder>{{'REPOSITORY.PLACEHOLDER' | translate }}</clr-dg-placeholder>
                 <clr-dg-row *ngFor="let r of repositories"  [clrDgItem]="r">
-                    <clr-dg-cell><a href="javascript:void(0)" (click)="goIntoRepo(r)"><span *ngIf="withAdmiral" class="list-img"><img [src]="getImgLink(r)"/></span>{{r.name}}</a></clr-dg-cell>
+                    <clr-dg-cell>
+                        <a href="javascript:void(0)" [routerLink]="getLink(r)">
+                            <span *ngIf="withAdmiral" class="list-img"><img [src]="getImgLink(r)"/></span>{{r.name}}</a></clr-dg-cell>
                     <!-- to do -->
                     <clr-dg-cell>{{r.artifact_count}}</clr-dg-cell>
                     <clr-dg-cell>{{r.pull_count}}</clr-dg-cell>
@@ -60,7 +62,7 @@
     [withAdmiral]="withAdmiral"
     (loadNextPageEvent)="loadNextPage()">
         <ng-template let-item="item">
-            <a class="card clickable" (click)="goIntoRepo(item)">
+            <a class="card clickable" [routerLink]="getLink(item)">
                 <div class="card-header">
                     <div [ngClass]="{'card-media-block': true, 'wrap': !withAdmiral }">
                         <img *ngIf="withAdmiral" [src]="getImgLink(item)"/>

--- a/src/portal/src/app/base/project/repository/repository-gridview.component.ts
+++ b/src/portal/src/app/base/project/repository/repository-gridview.component.ts
@@ -113,9 +113,8 @@ export class RepositoryGridviewComponent implements OnChanges, OnInit, OnDestroy
     return this.systemInfo && this.systemInfo.has_ca_root;
   }
 
-  goIntoRepo(repoEvt: NewRepository): void {
-    let linkUrl = ['harbor', 'projects', repoEvt.project_id, 'repositories', repoEvt.name.substr(this.projectName.length + 1)];
-    this.router.navigate(linkUrl);
+  getLink(repoEvt: NewRepository): string {
+    return `/harbor/projects/${repoEvt.project_id}/repositories/${repoEvt.name.substr(this.projectName.length + 1)}`;
   }
 
   ngOnChanges(changes: SimpleChanges): void {

--- a/src/portal/src/index.html
+++ b/src/portal/src/index.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="utf-8">
     <title>Harbor</title>
-    <base href="/">
+    <base href="/test">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/x-icon" href="favicon.ico?v=2">
     <link rel="preload" as="style" href="./light-theme.css">


### PR DESCRIPTION
Fixes #15893

1. Enable  right-click to open in a new tab for "project links" and "repository links" (other links have extra logic, so can not enable it)


Signed-off-by: AllForNothing <sshijun@vmware.com>