### PR TITLE
Not allow space in replication rule filters

### DIFF
--- a/src/portal/src/app/base/left-side-nav/replication/replication/create-edit-rule/create-edit-rule.component.html
+++ b/src/portal/src/app/base/left-side-nav/replication/replication/create-edit-rule/create-edit-rule.component.html
@@ -108,7 +108,7 @@
                   <clr-dropdown class="width-tag-label">
                     <button type="button" class="width-100 dropdown-toggle btn btn-link statistic-data label-text" clrDropdownTrigger>
                       <ng-template ngFor let-label [ngForOf]="filter.value.value" let-m="index">
-                        <span class="label" *ngIf="m<1"> {{label}} </span>
+                        <hbr-label-piece [hasIcon]="false" [label]="getLabel(label)" [labelWidth]="84"></hbr-label-piece>
                       </ng-template>
                       <span class="ellipsis color-white-dark" *ngIf="filter.value.value.length>1">···</span>
                       <div *ngFor="let label1 of filter.value.value;let k = index" hidden="true">

--- a/src/portal/src/app/base/left-side-nav/replication/replication/create-edit-rule/create-edit-rule.component.ts
+++ b/src/portal/src/app/base/left-side-nav/replication/replication/create-edit-rule/create-edit-rule.component.ts
@@ -181,7 +181,7 @@ export class CreateEditRuleComponent implements OnInit, OnDestroy {
   }
   trimText(event) {
     if (event.target.value) {
-      event.target.value = event.target.value.trim();
+      event.target.value = event.target.value.replace(/\s+/g, '');
     }
   }
   equals(c1: any, c2: any): boolean {
@@ -704,6 +704,17 @@ export class CreateEditRuleComponent implements OnInit, OnDestroy {
     } else {
       this.selectedUnit = BandwidthUnit.KB;
       return realSpeed ? realSpeed : -1;
+    }
+  }
+  getLabel(labelName: string): Label {
+    if (this.supportedFilterLabels?.length) {
+      let label: Label;
+      this.supportedFilterLabels.forEach(item => {
+        if (item.name === labelName) {
+          label = item;
+        }
+      });
+      return label;
     }
   }
 }

--- a/src/portal/src/app/shared/components/label/label-piece/label-piece.component.html
+++ b/src/portal/src/app/shared/components/label/label-piece/label-piece.component.html
@@ -1,5 +1,5 @@
 <label class="label" [ngStyle]="{'background-color': labelColor?.color, 'color': labelColor?.textColor, 'border': labelColor?.color == '#FFFFFF'? '1px solid #A1A1A1': 'none'}" [style.max-width.px]="labelWidth">
-    <clr-icon *ngIf="label.scope=='p'" shape="organization"></clr-icon>
-    <clr-icon *ngIf="label.scope=='g'" shape="administrator"></clr-icon>
+    <clr-icon *ngIf="hasIcon && label.scope=='p'" shape="organization"></clr-icon>
+    <clr-icon *ngIf="hasIcon && label.scope=='g'" shape="administrator"></clr-icon>
      {{label.name}}
 </label>

--- a/src/portal/src/app/shared/components/label/label-piece/label-piece.component.ts
+++ b/src/portal/src/app/shared/components/label/label-piece/label-piece.component.ts
@@ -25,6 +25,7 @@ import { Label } from "../../../../../../ng-swagger-gen/models/label";
 export class LabelPieceComponent implements OnInit, OnChanges {
     @Input() label: Label;
     @Input() labelWidth: number;
+    @Input() hasIcon: boolean = true;
     labelColor: {[key: string]: string};
 
     ngOnChanges(): void {


### PR DESCRIPTION
Related issue #15973
Replace spaces with "", so users can not input any space in filters
Signed-off-by: AllForNothing <sshijun@vmware.com>