### PR TITLE
set default permissions to false

### DIFF
--- a/src/portal/src/app/base/left-side-nav/system-robot-accounts/system-robot-util.ts
+++ b/src/portal/src/app/base/left-side-nav/system-robot-accounts/system-robot-util.ts
@@ -50,82 +50,82 @@ export const INITIAL_ACCESSES: FrontAccess[] = [
     {
         "resource": "repository",
         "action": "push",
-        "checked": true
+        "checked": false
     },
     {
         "resource": "repository",
         "action": "pull",
-        "checked": true
+        "checked": false
     },
     {
         "resource": "artifact",
         "action": "delete",
-        "checked": true
+        "checked": false
     },
     {
         "resource": "helm-chart",
         "action": "read",
-        "checked": true
+        "checked": false
     },
     {
         "resource": "helm-chart-version",
         "action": "create",
-        "checked": true
+        "checked": false
     },
     {
         "resource": "helm-chart-version",
         "action": "delete",
-        "checked": true
+        "checked": false
     },
     {
         "resource": "tag",
         "action": "create",
-        "checked": true
+        "checked": false
     },
     {
         "resource": "tag",
         "action": "delete",
-        "checked": true
+        "checked": false
     },
     {
         "resource": "artifact-label",
         "action": "create",
-        "checked": true
+        "checked": false
     },
     {
         "resource": "artifact-label",
         "action": "delete",
-        "checked": true
+        "checked": false
     },
     {
         "resource": "scan",
         "action": "create",
-        "checked": true
+        "checked": false
     },
     {
         "resource": "scan",
         "action": "stop",
-        "checked": true
+        "checked": false
     },
     {
         "resource": "artifact",
         "action": "list",
-        "checked": true
+        "checked": false
     },
     {
         "resource": "repository",
         "action": "list",
-        "checked": true
+        "checked": false
     },
     {
         "resource": "helm-chart-version-label",
         "action": "create",
-        "checked": true
+        "checked": false
     },
     {
         "resource": "helm-chart-version-label",
         "action": "delete",
-        "checked": true
+        "checked": false
     },
 ];
 


### PR DESCRIPTION
Security wise, it is best to have the robot permissions
all set to false and if the users wish to enable a
certain permission to expressely do it. The other way
around loses the permission policy enforcement from
lazy/unknowing users.

Fixes: #15988

Signed-off-by: Diogo Guerra <diogo.filipe.tomas.guerra@cern.ch>