### PR TITLE
Specify test redis image tag

### DIFF
--- a/tests/resources/TestCaseBody.robot
+++ b/tests/resources/TestCaseBody.robot
@@ -86,14 +86,15 @@ Body Of Scan Image With Empty Vul
 Body Of Manual Scan All
     [Arguments]  @{vulnerability_levels}
     Init Chrome Driver
-    Push Image  ${ip}  ${HARBOR_ADMIN}  ${HARBOR_PASSWORD}  library  redis
+    ${sha256}=  Set Variable  e4b315ad03a1d1d9ff0c111e648a1a91066c09ead8352d3d6a48fa971a82922c
+    Push Image  ${ip}  ${HARBOR_ADMIN}  ${HARBOR_PASSWORD}  library  redis  sha256=${sha256}
     Sign In Harbor  ${HARBOR_URL}  ${HARBOR_ADMIN}  ${HARBOR_PASSWORD}
     Switch To Vulnerability Page
     Trigger Scan Now And Wait Until The Result Appears
     Navigate To Projects
     Go Into Project  library
     Go Into Repo  redis
-    Scan Result Should Display In List Row  latest
+    Scan Result Should Display In List Row  ${sha256}
     View Repo Scan Details  @{vulnerability_levels}
     Close Browser
 

--- a/tests/robot-cases/Group1-Nightly/Common_GC.robot
+++ b/tests/robot-cases/Group1-Nightly/Common_GC.robot
@@ -29,7 +29,7 @@ Test Case - Garbage Collection
 
     Sign In Harbor  ${HARBOR_URL}  ${HARBOR_ADMIN}  ${HARBOR_PASSWORD}
     Create An New Project And Go Into Project  project${d}
-    Push Image  ${ip}  ${HARBOR_ADMIN}  ${HARBOR_PASSWORD}  project${d}  redis
+    Push Image  ${ip}  ${HARBOR_ADMIN}  ${HARBOR_PASSWORD}  project${d}  redis  sha256=e4b315ad03a1d1d9ff0c111e648a1a91066c09ead8352d3d6a48fa971a82922c
     Sleep  2
     Go Into Project  project${d}
     Delete Repo  project${d}  redis


### PR DESCRIPTION
Specify the test redis mirror tag. If not specified, the default tag is latest. If the latest tag changes, it will cause false positives in the test case.
Signed-off-by: Yang Jiao <jiaoya@vmware.com>