### PR TITLE
fix harbor-registry client authentication

### DIFF
--- a/src/pkg/registry/auth/basic/authorizer.go
+++ b/src/pkg/registry/auth/basic/authorizer.go
@@ -35,6 +35,8 @@ type authorizer struct {
 func (a *authorizer) Modify(req *http.Request) error {
 	if len(a.username) > 0 {
 		req.SetBasicAuth(a.username, a.password)
+	} else if len(a.password) > 0 {
+		req.Header.Set("Authorization", "Harbor-Secret "+a.password)
 	}
 	return nil
 }


### PR DESCRIPTION
Adds the option to authenticate with a Harbor-Secret authorization header in case no username is set for registry access.

This case happens for example when configuring a 'pull-based' replication. In this case the jobservice needs to fetch a service token from harbor-core with the jobservice secret.

### Without this change
When trying to replicate an image to the target registry (local harbor, because it's a pull-based replication), a service token to access the registry must be fetched.

This call to `http://harbor-core/service/token` will not complete successfully, because no Authorization header is added (`a.username` is empty, only `a.password` is filled with the jobservice secret)

### With this change
Adding an `Authorization: Harbor-Secret THESECRET` header, in case only a password is set. This allows the request for a service token to successfully complete.