### PR TITLE
Update replication.go

### DIFF
--- a/src/controller/event/handler/webhook/artifact/replication.go
+++ b/src/controller/event/handler/webhook/artifact/replication.go
@@ -201,7 +201,8 @@ func constructReplicationPayload(event *event.ReplicationEvent) (*model.Payload,
 
 func getMetadataFromResource(resource string) (namespace, nameAndTag string) {
 	// Usually resource format likes 'library/busybox:v1', but it could be 'busybox:v1' in docker registry
-	meta := strings.Split(resource, "/")
+	// It also could be 'library/bitnami/fluentd:1.13.3-debian-10-r0' so we need to split to only 2 parts
+	meta := strings.SplitN(resource, "/", 2)
 	if len(meta) == 1 {
 		return "", meta[0]
 	}


### PR DESCRIPTION
It also could be 'library/bitnami/fluentd:1.13.3-debian-10-r0' so we need to split to only 2 parts