### PR TITLE
add pull update control env

### DIFF
--- a/src/common/const.go
+++ b/src/common/const.go
@@ -186,4 +186,14 @@ const (
 	TraceOtelCompression = "trace_otel_compression"
 	TraceOtelInsecure    = "trace_otel_insecure"
 	TraceOtelTimeout     = "trace_otel_timeout"
+
+	//  These variables are temporary solution for issue: https://github.com/goharbor/harbor/issues/16039
+	//  When user disable the pull count/time/audit log, it will decrease the database access, especially in large concurrency pull scenarios.
+	// TODO: Once we have a complete solution, delete these variables.
+	// PullCountUpdateDisable indicate if pull count is disable for pull request.
+	PullCountUpdateDisable = "pull_count_update_disable"
+	// PullTimeUpdateDisable indicate if pull time is disable for pull request.
+	PullTimeUpdateDisable = "pull_time_update_disable"
+	// PullAuditLogDisable indicate if pull audit log is disable for pull request.
+	PullAuditLogDisable = "pull_audit_log_disable"
 )

--- a/src/controller/event/handler/internal/artifact.go
+++ b/src/controller/event/handler/internal/artifact.go
@@ -16,6 +16,7 @@ package internal
 
 import (
 	"context"
+	"github.com/goharbor/harbor/src/lib/config"
 	"time"
 
 	"github.com/goharbor/harbor/src/controller/artifact"
@@ -54,8 +55,12 @@ func (a *Handler) IsStateful() bool {
 }
 
 func (a *Handler) onPull(ctx context.Context, event *event.ArtifactEvent) error {
-	go func() { a.updatePullTime(ctx, event) }()
-	go func() { a.addPullCount(ctx, event) }()
+	if !config.PullTimeUpdateDisable(ctx) {
+		go func() { a.updatePullTime(ctx, event) }()
+	}
+	if !config.PullCountUpdateDisable(ctx) {
+		go func() { a.addPullCount(ctx, event) }()
+	}
 	return nil
 }
 

--- a/src/lib/config/metadata/metadatalist.go
+++ b/src/lib/config/metadata/metadatalist.go
@@ -179,5 +179,9 @@ var (
 		{Name: common.TraceOtelCompression, Scope: SystemScope, Group: BasicGroup, EnvKey: "TRACE_OTEL_COMPRESSION", DefaultValue: "", ItemType: &BoolType{}, Editable: false, Description: `The compression of the Otel`},
 		{Name: common.TraceOtelInsecure, Scope: SystemScope, Group: BasicGroup, EnvKey: "TRACE_OTEL_INSECURE", DefaultValue: "", ItemType: &BoolType{}, Editable: false, Description: `The insecure of the Otel`},
 		{Name: common.TraceOtelTimeout, Scope: SystemScope, Group: BasicGroup, EnvKey: "TRACE_OTEL_TIMEOUT", DefaultValue: "", ItemType: &IntType{}, Editable: false, Description: `The timeout of the Otel`},
+
+		{Name: common.PullTimeUpdateDisable, Scope: UserScope, Group: BasicGroup, EnvKey: "PULL_TIME_UPDATE_DISABLE", DefaultValue: "false", ItemType: &BoolType{}, Editable: false, Description: `The flag to indicate if pull time is disable for pull request.`},
+		{Name: common.PullCountUpdateDisable, Scope: UserScope, Group: BasicGroup, EnvKey: "PULL_COUNT_UPDATE_DISABLE", DefaultValue: "false", ItemType: &BoolType{}, Editable: false, Description: `The flag to indicate if pull count is disable for pull request.`},
+		{Name: common.PullAuditLogDisable, Scope: UserScope, Group: BasicGroup, EnvKey: "PULL_AUDIT_LOG_DISABLE", DefaultValue: "false", ItemType: &BoolType{}, Editable: false, Description: `The flag to indicate if pull audit log is disable for pull request.`},
 	}
 )

--- a/src/lib/config/userconfig.go
+++ b/src/lib/config/userconfig.go
@@ -226,3 +226,18 @@ func SplitAndTrim(s, sep string) []string {
 	}
 	return res
 }
+
+// PullCountUpdateDisable returns a bool to indicate if pull count is disable for pull request.
+func PullCountUpdateDisable(ctx context.Context) bool {
+	return defaultMgr().Get(ctx, common.PullCountUpdateDisable).GetBool()
+}
+
+// PullTimeUpdateDisable returns a bool to indicate if pull time is disable for pull request.
+func PullTimeUpdateDisable(ctx context.Context) bool {
+	return defaultMgr().Get(ctx, common.PullTimeUpdateDisable).GetBool()
+}
+
+// PullAuditLogDisable returns a bool to indicate if pull audit log is disable for pull request.
+func PullAuditLogDisable(ctx context.Context) bool {
+	return defaultMgr().Get(ctx, common.PullAuditLogDisable).GetBool()
+}


### PR DESCRIPTION
These variables are temporary solution for issue: https://github.com/goharbor/harbor/issues/16039
When user disable the pull count/time/audit log, it will decrease the database access, especially in large concurrency pull scenarios.

1, PULL_TIME_UPDATE_DISABLE : The flag to indicate if pull time is disable for pull request.
2, PULL_COUNT_UPDATE_DISABLE : The flag to indicate if pull count is disable for pull request.
3, pull audit log will not create on disabling pull time.

Signed-off-by: Wang Yan <wangyan@vmware.com>