### PR TITLE
Fix: using traditional `PKCS#1` format RSA key

### DIFF
--- a/make/photon/prepare/utils/cert.py
+++ b/make/photon/prepare/utils/cert.py
@@ -46,7 +46,7 @@ def get_alias(path):
 
 @stat_decorator
 def create_root_cert(subj, key_path="./k.key", cert_path="./cert.crt"):
-   rc = subprocess.call(["/usr/bin/openssl", "genrsa", "-out", key_path, "4096"], stdout=DEVNULL, stderr=subprocess.STDOUT)
+   rc = subprocess.call(["/usr/bin/openssl", "genrsa", "-traditional", "-out", key_path, "4096"], stdout=DEVNULL, stderr=subprocess.STDOUT)
    if rc != 0:
         return rc
    return subprocess.call(["/usr/bin/openssl", "req", "-new", "-x509", "-key", key_path,\

--- a/tests/ci/api_common_install.sh
+++ b/tests/ci/api_common_install.sh
@@ -64,8 +64,6 @@ sudo make compile build prepare COMPILETAG=compile_golangimage GOBUILDTAGS="incl
 
 # set the debugging env
 echo "GC_TIME_WINDOW_HOURS=0" | sudo tee -a ./make/common/config/core/env
- # TODO This is a temporary solution to core private_key
-sudo openssl rsa -in /data/secret/core/private_key.pem -out /data/secret/core/private_key.pem
 
 sudo make start
 


### PR DESCRIPTION
The openssl 3.0.0 using newer `PKCS#8` format.
But it's not compatitable with harbor core
So using tradictional format instead

Signed-off-by: Qian Deng <dengq@vmware.com>