### PR TITLE
Remove os.Kill in signal handling

### DIFF
--- a/src/jobservice/runtime/bootstrap.go
+++ b/src/jobservice/runtime/bootstrap.go
@@ -219,7 +219,7 @@ func (bs *Bootstrap) LoadAndRun(ctx context.Context, cancel context.CancelFunc) 
 
 	// Listen to the system signals
 	sig := make(chan os.Signal, 1)
-	signal.Notify(sig, os.Interrupt, syscall.SIGTERM, os.Kill)
+	signal.Notify(sig, os.Interrupt, syscall.SIGTERM)
 	terminated := false
 	go func(errChan chan error) {
 		defer func() {

--- a/src/pkg/scan/rest/v1/client_pool.go
+++ b/src/pkg/scan/rest/v1/client_pool.go
@@ -128,7 +128,7 @@ func (bcp *basicClientPool) deadCheck(key string, item *poolItem) {
 		// As we do not have a global context, let's watch the system signal to
 		// exit the goroutine correctly.
 		sig := make(chan os.Signal, 1)
-		signal.Notify(sig, os.Interrupt, syscall.SIGTERM, os.Kill)
+		signal.Notify(sig, os.Interrupt, syscall.SIGTERM)
 
 		tk := time.NewTicker(bcp.config.DeadCheckInterval)
 		defer tk.Stop()


### PR DESCRIPTION
os.Kill cannot be trapped. May refer to [SA1016](https://staticcheck.io/docs/checks#SA1016)

Signed-off-by: heylongdacoder <heylongdacoder@gmail.com>