### PR TITLE
fix the postgresql version to 13

### DIFF
--- a/make/photon/db/Dockerfile.base
+++ b/make/photon/db/Dockerfile.base
@@ -2,7 +2,7 @@ FROM photon:4.0
 
 ENV PGDATA /var/lib/postgresql/data
 
-RUN tdnf install -y shadow gzip postgresql findutils bc >> /dev/null \
+RUN tdnf install -y shadow gzip postgresql-13.5-2.ph4 findutils bc >> /dev/null \
     && groupadd -r postgres --gid=999 \
     && useradd -m -r -g postgres --uid=999 postgres \
     && mkdir -p /docker-entrypoint-initdb.d \


### PR DESCRIPTION
As the Photon 4.0 has updated PG to major version 14 and it may not compatible with notary, we temp fix the pg to 13 now.

Signed-off-by: Wang Yan <wangyan@vmware.com>