### PR TITLE
Store Username in auto-onboard flow (resolves #16180)

### DIFF
--- a/src/pkg/oidc/helper.go
+++ b/src/pkg/oidc/helper.go
@@ -355,7 +355,10 @@ func userInfoFromClaims(c claimsProvider, setting cfgModels.OIDCSetting) (*UserI
 		}
 
 		if username, ok := allClaims[setting.UserClaim].(string); ok {
-			res.autoOnboardUsername = username
+			// res.Username and autoOnboardUsername both need to be set to create a fallback when mergeUserInfo has not been successfully called.
+			// This can for example occur when remote fails and only a local token is available for onboarding.
+			// Otherwise the onboard flow only has a fallback when "name" is set in the token, which is not always the case as a custom Username Claim could be configured.
+			res.autoOnboardUsername, res.Username = username, username
 		} else {
 			log.Warningf("OIDC. Failed to recover Username from claim. Claim '%s' is invalid or not a string", setting.UserClaim)
 		}

--- a/src/pkg/oidc/helper_test.go
+++ b/src/pkg/oidc/helper_test.go
@@ -284,7 +284,7 @@ func TestUserInfoFromClaims(t *testing.T) {
 				Issuer:              "",
 				Subject:             "",
 				autoOnboardUsername: "airadier@gmail.com",
-				Username:            "Alvaro",
+				Username:            "airadier@gmail.com", // Set Username based on configured UserClaim
 				Email:               "airadier@gmail.com",
 				Groups:              []string{},
 				hasGroupClaim:       false,


### PR DESCRIPTION
This PR resolves #16180, which seems to come down to the username not being set properly whenever `userInfoFromRemote` fails in `UserInfoFromToken`:
https://github.com/goharbor/harbor/blob/5cd5bcaee44e9f57c96ac8327009bcffb95ac7a5/src/pkg/oidc/helper.go#L269

When above fails, [mergeUserInfo](https://github.com/goharbor/harbor/blob/5cd5bcaee44e9f57c96ac8327009bcffb95ac7a5/src/pkg/oidc/helper.go#L287) is never called, which leads to `local.Username` to remain empty (as this is handled by `mergeUserInfo`).
https://github.com/goharbor/harbor/blob/5cd5bcaee44e9f57c96ac8327009bcffb95ac7a5/src/pkg/oidc/helper.go#L273-L277
What I'd like to suggest is setting the Username if it's still empty, after setting the autoOnboardUsername, as it was prior to #15625 :
https://github.com/goharbor/harbor/blob/03b7b01f77faab31d9205f1dfbb129b2272242ea/src/pkg/oidc/helper.go#L350-L351

The change has been tested and resolved our issue entirely.