### PR TITLE
Upgrade distribution to 2.8

### DIFF
--- a/src/go.mod
+++ b/src/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.1.1
 	github.com/coreos/go-oidc/v3 v3.0.0
 	github.com/dghubble/sling v1.1.0
-	github.com/docker/distribution v2.7.2-0.20211123191640-3b7b53456922+incompatible
+	github.com/docker/distribution v2.8.0+incompatible
 	github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-asn1-ber/asn1-ber v1.5.1

--- a/src/go.mod
+++ b/src/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.1.1
 	github.com/coreos/go-oidc/v3 v3.0.0
 	github.com/dghubble/sling v1.1.0
-	github.com/docker/distribution v2.7.1+incompatible
+	github.com/docker/distribution v2.7.2-0.20211123191640-3b7b53456922+incompatible
 	github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-asn1-ber/asn1-ber v1.5.1

--- a/src/go.sum
+++ b/src/go.sum
@@ -434,6 +434,8 @@ github.com/docker/distribution v2.7.1+incompatible h1:a5mlkVzth6W5A4fOsS3D2EO5BU
 github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/distribution v2.7.2-0.20211123191640-3b7b53456922+incompatible h1:F2KlCExCtw1TY7fg2+JWZU9gBLckHoZbeWhmbOwmDYA=
 github.com/docker/distribution v2.7.2-0.20211123191640-3b7b53456922+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
+github.com/docker/distribution v2.8.0+incompatible h1:l9EaZDICImO1ngI+uTifW+ZYvvz7fKISBAKpg+MbWbY=
+github.com/docker/distribution v2.8.0+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/docker v1.4.2-0.20200213202729-31a86c4ab209/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker v17.12.0-ce-rc1.0.20200618181300-9dc6525e6118+incompatible h1:iWPIG7pWIsCwT6ZtHnTUpoVMnete7O/pzd9HFE3+tn8=
 github.com/docker/docker v17.12.0-ce-rc1.0.20200618181300-9dc6525e6118+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=

--- a/src/go.sum
+++ b/src/go.sum
@@ -432,6 +432,10 @@ github.com/docker/distribution v0.0.0-20190905152932-14b96e55d84c/go.mod h1:0+TT
 github.com/docker/distribution v2.7.1-0.20190205005809-0d3efadf0154+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/distribution v2.7.1+incompatible h1:a5mlkVzth6W5A4fOsS3D2EO5BUmsJpcB+cRlLU7cSug=
 github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
+github.com/docker/distribution v2.7.2-0.20211123191640-3b7b53456922+incompatible h1:F2KlCExCtw1TY7fg2+JWZU9gBLckHoZbeWhmbOwmDYA=
+github.com/docker/distribution v2.7.2-0.20211123191640-3b7b53456922+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
+github.com/docker/docker v1.4.2-0.20200213202729-31a86c4ab209/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v17.12.0-ce-rc1.0.20200618181300-9dc6525e6118+incompatible h1:iWPIG7pWIsCwT6ZtHnTUpoVMnete7O/pzd9HFE3+tn8=
 github.com/docker/docker v17.12.0-ce-rc1.0.20200618181300-9dc6525e6118+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker v20.10.9+incompatible h1:JlsVnETOjM2RLQa0Cc1XCIspUdXW3Zenq9P54uXBm6k=
 github.com/docker/docker v20.10.9+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=


### PR DESCRIPTION
## what

Upgrade the [distribution package to 2.8](https://github.com/distribution/distribution/releases/tag/v2.8.0)

## why

Harbor is currently on 2.7.1 which was released in 2019. Full release notes available here https://github.com/distribution/distribution/releases/tag/v2.8.0

## EDIT: IRSA support not included in this release

See https://github.com/distribution/distribution/pull/3552#issuecomment-1018761583

~The 2.7 release uses an out of date AWS SDK which does not support the AWS AssumeRoleWithWebIdentity required for deployments under Kubernetes that use IRSA. This was fixed in the 2.8 release, see https://github.com/distribution/distribution/issues/3097. Support for IRSA is of growing importance. It is the recommended solution when running Kubernetes on AWS~

~Unfortunately while distribution has a 2.8 branch they have not made a release. I pinned the upgrade to the last commit of the 2.8 release branch~

~IRSA Documentation:~
- ~Overview https://aws.amazon.com/blogs/opensource/introducing-fine-grained-iam-roles-service-accounts/~
- ~Required AWS SDK versions https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts-minimum-sdk.html~

~This fixes https://github.com/goharbor/harbor-helm/issues/725~
