### PR TITLE
feature: Use RegisteredClaims instead of deprecated staruct StandardClaims

### DIFF
--- a/src/core/service/token/authutils.go
+++ b/src/core/service/token/authutils.go
@@ -121,14 +121,14 @@ func MakeToken(ctx context.Context, username, service string, access []*token.Re
 	now := time.Now().UTC()
 
 	claims := &v2.Claims{
-		StandardClaims: jwt.StandardClaims{
+		RegisteredClaims: jwt.RegisteredClaims{
 			Issuer:    options.Issuer,
 			Subject:   username,
-			Audience:  service,
-			ExpiresAt: now.Add(time.Duration(expiration) * time.Minute).Unix(),
-			NotBefore: now.Unix(),
-			IssuedAt:  now.Unix(),
-			Id:        utils.GenerateRandomStringWithLen(16),
+			Audience:  jwt.ClaimStrings([]string{service}),
+			ExpiresAt: jwt.NewNumericDate(now.Add(time.Duration(expiration) * time.Minute)),
+			NotBefore: jwt.NewNumericDate(now),
+			IssuedAt:  jwt.NewNumericDate(now),
+			ID:        utils.GenerateRandomStringWithLen(16),
 		},
 		Access: access,
 	}

--- a/src/core/service/token/token_test.go
+++ b/src/core/service/token/token_test.go
@@ -122,7 +122,7 @@ func getPublicKey(crtPath string) (*rsa.PublicKey, error) {
 }
 
 type harborClaims struct {
-	jwt.StandardClaims
+	jwt.RegisteredClaims
 	// Private claims
 	Access []*token.ResourceActions `json:"access"`
 }
@@ -159,7 +159,7 @@ func TestMakeToken(t *testing.T) {
 	}
 	claims := tok.Claims.(*harborClaims)
 	assert.Equal(t, *(claims.Access[0]), *(ra[0]), "Access mismatch")
-	assert.Equal(t, claims.Audience, svc, "Audience mismatch")
+	assert.Equal(t, claims.Audience, jwt.ClaimStrings([]string{svc}), "Audience mismatch")
 }
 
 type parserTestRec struct {

--- a/src/pkg/token/claims/robot/robot.go
+++ b/src/pkg/token/claims/robot/robot.go
@@ -7,9 +7,13 @@ import (
 	"github.com/golang-jwt/jwt/v4"
 )
 
+func init() {
+	jwt.MarshalSingleStringAsArray = false
+}
+
 // Claim implements the interface of jwt.Claims
 type Claim struct {
-	jwt.StandardClaims
+	jwt.RegisteredClaims
 	TokenID   int64           `json:"id"`
 	ProjectID int64           `json:"pid"`
 	Access    []*types.Policy `json:"access"`
@@ -26,7 +30,7 @@ func (rc Claim) Valid() error {
 	if rc.Access == nil {
 		return errors.New("the access info cannot be nil")
 	}
-	stdErr := rc.StandardClaims.Valid()
+	stdErr := rc.RegisteredClaims.Valid()
 	if stdErr != nil {
 		return stdErr
 	}

--- a/src/pkg/token/claims/v2/claims.go
+++ b/src/pkg/token/claims/v2/claims.go
@@ -1,11 +1,16 @@
 package v2
 
 import (
+	"crypto/subtle"
 	"fmt"
 
 	"github.com/docker/distribution/registry/auth/token"
 	"github.com/golang-jwt/jwt/v4"
 )
+
+func init() {
+	jwt.MarshalSingleStringAsArray = false
+}
 
 const (
 	// Issuer is the only valid issuer for jwt token sent to /v2/xxxx
@@ -14,16 +19,16 @@ const (
 
 // Claims represents the token claims that encapsulated in a JWT token for registry/notary resources
 type Claims struct {
-	jwt.StandardClaims
+	jwt.RegisteredClaims
 	Access []*token.ResourceActions `json:"access"`
 }
 
 // Valid checks if the issuer is harbor
 func (c *Claims) Valid() error {
-	if err := c.StandardClaims.Valid(); err != nil {
+	if err := c.RegisteredClaims.Valid(); err != nil {
 		return err
 	}
-	if !c.VerifyIssuer(Issuer, true) {
+	if subtle.ConstantTimeCompare([]byte(c.Issuer), []byte(Issuer)) == 0 {
 		return fmt.Errorf("invalid token issuer: %s", c.Issuer)
 	}
 	return nil

--- a/src/pkg/token/claims/v2/claims_test.go
+++ b/src/pkg/token/claims/v2/claims_test.go
@@ -15,7 +15,7 @@ func TestValid(t *testing.T) {
 	}{
 		{
 			claims: Claims{
-				StandardClaims: jwt.StandardClaims{
+				RegisteredClaims: jwt.RegisteredClaims{
 					Issuer: "anonymous",
 				},
 				Access: []*token.ResourceActions{},
@@ -24,7 +24,7 @@ func TestValid(t *testing.T) {
 		},
 		{
 			claims: Claims{
-				StandardClaims: jwt.StandardClaims{
+				RegisteredClaims: jwt.RegisteredClaims{
 					Issuer: Issuer,
 				},
 				Access: []*token.ResourceActions{},

--- a/src/pkg/token/token_test.go
+++ b/src/pkg/token/token_test.go
@@ -32,13 +32,13 @@ func TestNew(t *testing.T) {
 	tokenID := int64(123)
 	projectID := int64(321)
 	tokenExpiration := time.Duration(10) * 24 * time.Hour
-	expiresAt := time.Now().UTC().Add(tokenExpiration).Unix()
+	expiresAt := time.Now().UTC().Add(tokenExpiration)
 	robot := robot_claim.Claim{
 		TokenID:   tokenID,
 		ProjectID: projectID,
 		Access:    policies,
-		StandardClaims: jwt.StandardClaims{
-			ExpiresAt: expiresAt,
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(expiresAt),
 		},
 	}
 	defaultOpt := DefaultTokenOptions()
@@ -59,20 +59,20 @@ func TestRaw(t *testing.T) {
 		Resource: "/project/library/repository",
 		Action:   "pull",
 	}
-	policies := []*types.Policy{}
+	var policies []*types.Policy
 	policies = append(policies, rbacPolicy)
 
 	tokenID := int64(123)
 	projectID := int64(321)
 
 	tokenExpiration := time.Duration(10) * 24 * time.Hour
-	expiresAt := time.Now().UTC().Add(tokenExpiration).Unix()
+	expiresAt := time.Now().UTC().Add(tokenExpiration)
 	robot := robot_claim.Claim{
 		TokenID:   tokenID,
 		ProjectID: projectID,
 		Access:    policies,
-		StandardClaims: jwt.StandardClaims{
-			ExpiresAt: expiresAt,
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(expiresAt),
 		},
 	}
 	defaultOpt := DefaultTokenOptions()


### PR DESCRIPTION
StandardClaims are Deprecated and may might lead to incompatibilities with other JWT implementations. The use of this is discouraged.
Use RegisteredClaims instead for a forward-compatible way to access registered claims in a struct.
Signed-off-by: wujunwei <wjw3323@live.com>