### PR TITLE
feat: gc sweep in parallel

### DIFF
--- a/src/jobservice/job/impl/gc/garbage_collection.go
+++ b/src/jobservice/job/impl/gc/garbage_collection.go
@@ -15,15 +15,19 @@
 package gc
 
 import (
+	"context"
 	"os"
+	"sync"
 	"time"
 
 	"github.com/goharbor/harbor/src/common/registryctl"
+	"github.com/goharbor/harbor/src/common/utils"
 	"github.com/goharbor/harbor/src/controller/artifact"
 	"github.com/goharbor/harbor/src/controller/project"
 	"github.com/goharbor/harbor/src/jobservice/job"
 	"github.com/goharbor/harbor/src/jobservice/logger"
 	"github.com/goharbor/harbor/src/lib/errors"
+	"github.com/goharbor/harbor/src/lib/orm"
 	"github.com/goharbor/harbor/src/lib/q"
 	redisLib "github.com/goharbor/harbor/src/lib/redis"
 	"github.com/goharbor/harbor/src/lib/retry"
@@ -238,118 +242,135 @@ func (gc *GarbageCollector) mark(ctx job.Context) error {
 	return nil
 }
 
+const (
+	BatchSize = 5
+)
+
 func (gc *GarbageCollector) sweep(ctx job.Context) error {
 	gc.logger = ctx.GetLogger()
-	sweepSize := int64(0)
-	blobCnt := 0
-	mfCnt := 0
-	for _, blob := range gc.deleteSet {
-		// set the status firstly, if the blob is updated by any HEAD/PUT request, it should be fail and skip.
-		blob.Status = blobModels.StatusDeleting
-		count, err := gc.blobMgr.UpdateBlobStatus(ctx.SystemContext(), blob)
-		if err != nil {
-			gc.logger.Errorf("failed to mark gc candidate deleting, skip: %s, %s", blob.Digest, blob.Status)
-			continue
-		}
-		if count == 0 {
-			gc.logger.Warningf("no blob found to mark gc candidate deleting, ID:%d, digest:%s", blob.ID, blob.Digest)
-			continue
-		}
 
-		// remove tags and revisions of a manifest
-		skippedBlob := false
-		if _, exist := gc.trashedArts[blob.Digest]; exist && blob.IsManifest() {
-			for _, art := range gc.trashedArts[blob.Digest] {
-				// Harbor cannot know the existing tags in the backend from its database, so let the v2 DELETE manifest to remove all of them.
-				gc.logger.Infof("delete the manifest with registry v2 API: %s, %s, %s",
-					art.RepositoryName, blob.ContentType, blob.Digest)
-				if err := v2DeleteManifest(gc.logger, art.RepositoryName, blob.Digest); err != nil {
-					gc.logger.Errorf("failed to delete manifest with v2 API, %s, %s, %v", art.RepositoryName, blob.Digest, err)
+	// the mutex used when computing blobCnt, mfCnt, sweepSize
+	var mu sync.Mutex
+	blobCnt, mfCnt, sweepSize := int64(0), int64(0), int64(0)
+	runner := utils.NewLimitedConcurrentRunner(BatchSize)
+	for _, blob := range gc.deleteSet {
+		// copy !
+		curBlob := blob
+		newCtx := orm.Clone(ctx.SystemContext())
+		runner.AddTask(func() error {
+			// set the status firstly, if the blob is updated by any HEAD/PUT request, it should be fail and skip.
+			curBlob.Status = blobModels.StatusDeleting
+			count, err := gc.blobMgr.UpdateBlobStatus(newCtx, curBlob)
+			if err != nil {
+				gc.logger.Errorf("failed to mark gc candidate deleting, skip: %s, %s", curBlob.Digest, curBlob.Status)
+				return nil
+			}
+			if count == 0 {
+				gc.logger.Warningf("no blob found to mark gc candidate deleting, ID:%d, digest:%s", curBlob.ID, curBlob.Digest)
+				return nil
+			}
+
+			// remove tags and revisions of a manifest
+			if _, exist := gc.trashedArts[curBlob.Digest]; exist && curBlob.IsManifest() {
+				for _, art := range gc.trashedArts[curBlob.Digest] {
+					// Harbor cannot know the existing tags in the backend from its database, so let the v2 DELETE manifest to remove all of them.
+					gc.logger.Infof("delete the manifest with registry v2 API: %s, %s, %s",
+						art.RepositoryName, curBlob.ContentType, curBlob.Digest)
+					if err := v2DeleteManifest(gc.logger, art.RepositoryName, curBlob.Digest); err != nil {
+						gc.logger.Errorf("failed to delete manifest with v2 API, %s, %s, %v", art.RepositoryName, curBlob.Digest, err)
+						if err := ignoreNotFound(func() error {
+							return gc.markDeleteFailed(newCtx, curBlob)
+						}); err != nil {
+							gc.logger.Errorf("failed to call gc.markDeleteFailed() after v2DeleteManifest() error out: %s, %v", curBlob.Digest, err)
+							runner.Cancel(err)
+							return err
+						}
+						return nil
+					}
+					// for manifest, it has to delete the revisions folder of each repository
+					gc.logger.Infof("delete manifest from storage: %s", curBlob.Digest)
+					if err := retry.Retry(func() error {
+						return ignoreNotFound(func() error {
+							return gc.registryCtlClient.DeleteManifest(art.RepositoryName, curBlob.Digest)
+						})
+					}, retry.Callback(func(err error, sleep time.Duration) {
+						gc.logger.Infof("failed to exec DeleteManifest, error: %v, will retry again after: %s", err, sleep)
+					})); err != nil {
+						gc.logger.Errorf("failed to remove manifest from storage: %s, %s, errMsg=%v", art.RepositoryName, curBlob.Digest, err)
+						if err := ignoreNotFound(func() error {
+							return gc.markDeleteFailed(newCtx, curBlob)
+						}); err != nil {
+							gc.logger.Errorf("failed to call gc.markDeleteFailed() after gc.registryCtlClient.DeleteManifest() error out: %s, %s, %v", art.RepositoryName, curBlob.Digest, err)
+							runner.Cancel(err)
+							return err
+						}
+						return nil
+					}
+
+					gc.logger.Infof("delete artifact trash record from database: %d, %s, %s", art.ID, art.RepositoryName, art.Digest)
 					if err := ignoreNotFound(func() error {
-						return gc.markDeleteFailed(ctx, blob)
+						return gc.artrashMgr.Delete(newCtx, art.ID)
 					}); err != nil {
-						gc.logger.Errorf("failed to call gc.markDeleteFailed() after v2DeleteManifest() error out: %s, %v", blob.Digest, err)
+						gc.logger.Errorf("failed to call gc.artrashMgr.Delete(): %v, errMsg=%v", art.ID, err)
+						runner.Cancel(err)
 						return err
 					}
-					skippedBlob = true
-					continue
 				}
-				// for manifest, it has to delete the revisions folder of each repository
-				gc.logger.Infof("delete manifest from storage: %s", blob.Digest)
+			}
+
+			// delete all of blobs, which include config, layer and manifest
+			// for the foreign layer, as it's not stored in the storage, no need to call the delete api and count size, but still have to delete the DB record.
+			if !curBlob.IsForeignLayer() {
+				gc.logger.Infof("delete blob from storage: %s", curBlob.Digest)
 				if err := retry.Retry(func() error {
 					return ignoreNotFound(func() error {
-						return gc.registryCtlClient.DeleteManifest(art.RepositoryName, blob.Digest)
+						return gc.registryCtlClient.DeleteBlob(curBlob.Digest)
 					})
 				}, retry.Callback(func(err error, sleep time.Duration) {
-					gc.logger.Infof("failed to exec DeleteManifest, error: %v, will retry again after: %s", err, sleep)
+					gc.logger.Infof("failed to exec DeleteBlob, error: %v, will retry again after: %s", err, sleep)
 				})); err != nil {
-					gc.logger.Errorf("failed to remove manifest from storage: %s, %s, errMsg=%v", art.RepositoryName, blob.Digest, err)
+					gc.logger.Errorf("failed to delete blob from storage: %s, %s, errMsg=%v", curBlob.Digest, curBlob.Status, err)
 					if err := ignoreNotFound(func() error {
-						return gc.markDeleteFailed(ctx, blob)
+						return gc.markDeleteFailed(newCtx, curBlob)
 					}); err != nil {
-						gc.logger.Errorf("failed to call gc.markDeleteFailed() after gc.registryCtlClient.DeleteManifest() error out: %s, %s, %v", art.RepositoryName, blob.Digest, err)
+						gc.logger.Errorf("failed to call gc.markDeleteFailed() after gc.registryCtlClient.DeleteBlob() error out: %s, %v", curBlob.Digest, err)
+						runner.Cancel(err)
 						return err
 					}
-					skippedBlob = true
-					continue
+					return nil
 				}
-
-				gc.logger.Infof("delete artifact trash record from database: %d, %s, %s", art.ID, art.RepositoryName, art.Digest)
-				if err := ignoreNotFound(func() error {
-					return gc.artrashMgr.Delete(ctx.SystemContext(), art.ID)
-				}); err != nil {
-					gc.logger.Errorf("failed to call gc.artrashMgr.Delete(): %v, errMsg=%v", art.ID, err)
-					return err
-				}
+				mu.Lock()
+				sweepSize = sweepSize + curBlob.Size
+				mu.Unlock()
 			}
-		}
 
-		// skip deleting the blob if the manifest's tag/revision is not deleted
-		if skippedBlob {
-			continue
-		}
-
-		// delete all of blobs, which include config, layer and manifest
-		// for the foreign layer, as it's not stored in the storage, no need to call the delete api and count size, but still have to delete the DB record.
-		if !blob.IsForeignLayer() {
-			gc.logger.Infof("delete blob from storage: %s", blob.Digest)
-			if err := retry.Retry(func() error {
-				return ignoreNotFound(func() error {
-					return gc.registryCtlClient.DeleteBlob(blob.Digest)
-				})
-			}, retry.Callback(func(err error, sleep time.Duration) {
-				gc.logger.Infof("failed to exec DeleteBlob, error: %v, will retry again after: %s", err, sleep)
-			})); err != nil {
-				gc.logger.Errorf("failed to delete blob from storage: %s, %s, errMsg=%v", blob.Digest, blob.Status, err)
-				if err := ignoreNotFound(func() error {
-					return gc.markDeleteFailed(ctx, blob)
-				}); err != nil {
-					gc.logger.Errorf("failed to call gc.markDeleteFailed() after gc.registryCtlClient.DeleteBlob() error out: %s, %v", blob.Digest, err)
-					return err
-				}
-				continue
-			}
-			sweepSize = sweepSize + blob.Size
-		}
-
-		gc.logger.Infof("delete blob record from database: %d, %s", blob.ID, blob.Digest)
-		if err := ignoreNotFound(func() error {
-			return gc.blobMgr.Delete(ctx.SystemContext(), blob.ID)
-		}); err != nil {
-			gc.logger.Errorf("failed to delete blob from database: %s, %s, errMsg=%v", blob.Digest, blob.Status, err)
+			gc.logger.Infof("delete blob record from database: %d, %s", curBlob.ID, curBlob.Digest)
 			if err := ignoreNotFound(func() error {
-				return gc.markDeleteFailed(ctx, blob)
+				return gc.blobMgr.Delete(newCtx, curBlob.ID)
 			}); err != nil {
-				gc.logger.Errorf("failed to call gc.markDeleteFailed() after gc.blobMgr.Delete() error out, %d, %s %v", blob.ID, blob.Digest, err)
+				gc.logger.Errorf("failed to delete blob from database: %s, %s, errMsg=%v", curBlob.Digest, curBlob.Status, err)
+				if err := ignoreNotFound(func() error {
+					return gc.markDeleteFailed(newCtx, curBlob)
+				}); err != nil {
+					gc.logger.Errorf("failed to call gc.markDeleteFailed() after gc.blobMgr.Delete() error out, %d, %s %v", curBlob.ID, curBlob.Digest, err)
+					runner.Cancel(err)
+					return err
+				}
+				runner.Cancel(err)
 				return err
 			}
-			return err
-		}
-		if blob.IsManifest() {
-			mfCnt++
-		} else {
-			blobCnt++
-		}
+			mu.Lock()
+			if curBlob.IsManifest() {
+				mfCnt++
+			} else {
+				blobCnt++
+			}
+			mu.Unlock()
+			return nil
+		})
+	}
+	if err := runner.Wait(); err != nil {
+		return err
 	}
 	gc.logger.Infof("%d blobs and %d manifests are actually deleted", blobCnt, mfCnt)
 	gc.logger.Infof("The GC job actual frees up %d MB space.", sweepSize/1024/1024)
@@ -557,9 +578,9 @@ func (gc *GarbageCollector) uselessBlobs(ctx job.Context) ([]*blobModels.Blob, e
 }
 
 // markDeleteFailed set the blob status to StatusDeleteFailed
-func (gc *GarbageCollector) markDeleteFailed(ctx job.Context, blob *blobModels.Blob) error {
+func (gc *GarbageCollector) markDeleteFailed(ctx context.Context, blob *blobModels.Blob) error {
 	blob.Status = blobModels.StatusDeleteFailed
-	count, err := gc.blobMgr.UpdateBlobStatus(ctx.SystemContext(), blob)
+	count, err := gc.blobMgr.UpdateBlobStatus(ctx, blob)
 	if err != nil {
 		gc.logger.Errorf("failed to mark gc candidate delete failed: %s, %s", blob.Digest, blob.Status)
 		return errors.Wrapf(err, "failed to mark gc candidate delete failed: %s, %s", blob.Digest, blob.Status)


### PR DESCRIPTION
issue reference:
https://github.com/goharbor/harbor/issues/16010
https://github.com/goharbor/harbor/issues/15807

[ Test ]
case 1: normal gc with sweep in parallel, the untagged artifacts in harbor portal are deleted, both manifests' tag/revision and blobs are deleted in registry storage.

case 2: use a proxy to only have `v2DeleteManifest()` error out, the tag, revision and blob of the manifest are not deleted; then have `v2DeleteManifest()` worked normally, the tag, revision and blob of the manifest are deleted.

case 3: use a proxy to only have `gc.registryCtlClient.DeleteManifest()` error out, the manifest tag is deleted while the revision and blob of this manifest are not deleted; then have `gc.registryCtlClient.DeleteManifest()` worked normally, the revision and blob of this manifest are deleted.

case 4: use a proxy to only have `gc.registryCtlClient.DeleteBlob()` error out, the tag and revision of manifest are deleted while the blob of the manifest is not deleted, and other non-manifest blobs are not deleted either; then have `gc.registryCtlClient.DeleteBlob()` worked normally, the blob of the manifest along with other blob are deleted.

[ Performance Improvement ]
logs when run gc in parallel:
```
Jan 20 10:09:23 ubuntu-2021-12-22 jobservice[958]: 2022-01-20T10:09:23Z [INFO] [/jobservice/job/impl/gc/garbage_collection.go:393]: 77 blobs and 10 manifests are actually deleted
Jan 20 10:09:23 ubuntu-2021-12-22 jobservice[958]: 2022-01-20T10:09:23Z [INFO] [/jobservice/job/impl/gc/garbage_collection.go:394]: The GC job actual frees up 1194 MB space.
Jan 20 10:09:23 ubuntu-2021-12-22 jobservice[958]: 2022-01-20T10:09:23Z [INFO] [/jobservice/job/impl/gc/garbage_collection.go:177]: success to run gc in job.
Jan 20 10:09:23 ubuntu-2021-12-22 jobservice[958]: 2022-01-20T10:09:23Z [INFO] [/jobservice/job/impl/gc/garbage_collection.go:178]: gc time spent - in parallel: 16.610936567s
Jan 20 10:09:23 ubuntu-2021-12-22 jobservice[958]: 2022-01-20T10:09:23Z [INFO] [/jobservice/runner/redis.go:151]: Job 'GARBAGE_COLLECTION:083ad18761a8568b0c573e11' exit with success
```
logs when run gc in single thread:
```
Jan 20 10:45:48 ubuntu-2021-12-22 jobservice[958]: 2022-01-20T10:45:48Z [INFO] [/jobservice/job/impl/gc/garbage_collection.go:356]: 77 blobs and 10 manifests are actually deleted
Jan 20 10:45:48 ubuntu-2021-12-22 jobservice[958]: 2022-01-20T10:45:48Z [INFO] [/jobservice/job/impl/gc/garbage_collection.go:357]: The GC job actual frees up 1194 MB space.
Jan 20 10:45:48 ubuntu-2021-12-22 jobservice[958]: 2022-01-20T10:45:48Z [INFO] [/jobservice/job/impl/gc/garbage_collection.go:175]: success to run gc in job.
Jan 20 10:45:48 ubuntu-2021-12-22 jobservice[958]: 2022-01-20T10:45:48Z [INFO] [/jobservice/job/impl/gc/garbage_collection.go:176]: gc time spent - in sequence: 1m3.466013494s
Jan 20 10:45:48 ubuntu-2021-12-22 jobservice[958]: 2022-01-20T10:45:48Z [INFO] [/jobservice/runner/redis.go:151]: Job 'GARBAGE_COLLECTION:48314ca4173d4bd8cac338ad' exit with success
```
gc time improvement: (63.5 - 16.6) / 63.5 = 73.86%

Signed-off-by: Shengwen Yu <yshengwen@vmware.com>