### PR TITLE
fix: Clean old version scan reports of trivy

### DIFF
--- a/make/migrations/postgresql/0080_2.5.0_schema.up.sql
+++ b/make/migrations/postgresql/0080_2.5.0_schema.up.sql
@@ -20,3 +20,5 @@ CREATE TABLE IF NOT EXISTS artifact_accessory (
     FOREIGN KEY (subject_artifact_id) REFERENCES artifact(id),
     CONSTRAINT unique_artifact_accessory UNIQUE (artifact_id, subject_artifact_id)
 );
+
+DELETE FROM scan_report WHERE mime_type='application/vnd.scanner.adapter.vuln.report.harbor+json; version=1.0' AND registration_uuid IN (SELECT uuid FROM scanner_registration WHERE name='Trivy' AND immutable='true');


### PR DESCRIPTION
From harbor 2.4, the trivy does not support scan report v1.0, we need to remove the old version scan reports from the DB.

Closes #16221

Signed-off-by: He Weiwei <hweiwei@vmware.com>