### PR TITLE
Move removing old version scan reports of trivy to 2.4.2

### DIFF
--- a/make/migrations/postgresql/0071_2.4.2_schema.up.sql
+++ b/make/migrations/postgresql/0071_2.4.2_schema.up.sql
@@ -1,0 +1,2 @@
+/* Remove old version scan reports of trivy */
+DELETE FROM scan_report WHERE mime_type='application/vnd.scanner.adapter.vuln.report.harbor+json; version=1.0' AND registration_uuid IN (SELECT uuid FROM scanner_registration WHERE name='Trivy' AND immutable='true');

--- a/make/migrations/postgresql/0080_2.5.0_schema.up.sql
+++ b/make/migrations/postgresql/0080_2.5.0_schema.up.sql
@@ -21,4 +21,3 @@ CREATE TABLE IF NOT EXISTS artifact_accessory (
     CONSTRAINT unique_artifact_accessory UNIQUE (artifact_id, subject_artifact_id)
 );
 
-DELETE FROM scan_report WHERE mime_type='application/vnd.scanner.adapter.vuln.report.harbor+json; version=1.0' AND registration_uuid IN (SELECT uuid FROM scanner_registration WHERE name='Trivy' AND immutable='true');


### PR DESCRIPTION
Signed-off-by: He Weiwei <hweiwei@vmware.com>