### PR TITLE
[FIX] avoid spam debug message in logs (Update unauthorized.go)

### DIFF
--- a/src/server/middleware/security/unauthorized.go
+++ b/src/server/middleware/security/unauthorized.go
@@ -25,6 +25,6 @@ import (
 type unauthorized struct{}
 
 func (u *unauthorized) Generate(req *http.Request) security.Context {
-	log.G(req.Context()).Debugf("an unauthorized security context generated for request %s %s", req.Method, req.URL.Path)
+	//log.G(req.Context()).Debugf("an unauthorized security context generated for request %s %s", req.Method, req.URL.Path)
 	return local.NewSecurityContext(nil)
 }


### PR DESCRIPTION
avoid spam debug message about  "an unauthorized security context generated for request GET /api/v2.0/ping"  when liveness probe is set to  /api/v2.0/ping on the helm charts

Signed-off-by: gabriel cuadros gabrielcuadros@gmail.com