### PR TITLE
update 2.5.0 migration script harbor.yml.jinja

### DIFF
--- a/make/photon/prepare/migrations/version_2_5_0/harbor.yml.jinja
+++ b/make/photon/prepare/migrations/version_2_5_0/harbor.yml.jinja
@@ -372,11 +372,6 @@ external_redis:
   #  <host_sentinel1>:<port_sentinel1>,<host_sentinel2>:<port_sentinel2>,<host_sentinel3>:<port_sentinel3>
   host: {{ external_redis.host }}
   password: {{ external_redis.password }}
-  {% if external_redis.username is defined %}
-  username: {{ external_redis.username }}
-  {% else %}
-  # username:
-  {% endif %}
   # sentinel_master_set must be set to support redis+sentinel
   #sentinel_master_set:
   # db_index 0 is for core, it's unchangeable
@@ -394,9 +389,6 @@ external_redis:
 #   #  <host_sentinel1>:<port_sentinel1>,<host_sentinel2>:<port_sentinel2>,<host_sentinel3>:<port_sentinel3>
 #   host: redis:6379
 #   password:
-#   # Redis AUTH command was extended in Redis 6, it is possible to use it in the two-arguments AUTH <username> <password> form.
-#   # implicit username is "default", provide compatibility with past version of old AUTH <password> form
-#   username: 
 #   # sentinel_master_set must be set to support redis+sentinel
 #   #sentinel_master_set:
 #   # db_index 0 is for core, it's unchangeable


### PR DESCRIPTION
Signed-off-by: yminer <yminer@vmmware.com>

Harbor 2.5.0 will not support `username` for external redis currently.