### PR TITLE
Fix resource when call /projects/<project>

### DIFF
--- a/src/server/v2.0/handler/project.go
+++ b/src/server/v2.0/handler/project.go
@@ -580,7 +580,7 @@ func (a *projectAPI) ListScannerCandidatesOfProject(ctx context.Context, params 
 	}
 
 	projectNameOrID := parseProjectNameOrID(params.ProjectNameOrID, params.XIsResourceName)
-	if err := a.RequireProjectAccess(ctx, projectNameOrID, rbac.ActionCreate, rbac.ResourceScanner); err != nil {
+	if err := a.RequireProjectAccess(ctx, projectNameOrID, rbac.ActionList, rbac.ResourceScanner); err != nil {
 		return a.SendError(ctx, err)
 	}
 

--- a/src/server/v2.0/handler/repository.go
+++ b/src/server/v2.0/handler/repository.go
@@ -17,6 +17,7 @@ package handler
 import (
 	"context"
 	"fmt"
+
 	"github.com/goharbor/harbor/src/common/security/robot"
 	robotCtr "github.com/goharbor/harbor/src/controller/robot"
 	pkgModels "github.com/goharbor/harbor/src/pkg/project/models"
@@ -198,7 +199,7 @@ func (r *repositoryAPI) ListRepositories(ctx context.Context, params operation.L
 }
 
 func (r *repositoryAPI) GetRepository(ctx context.Context, params operation.GetRepositoryParams) middleware.Responder {
-	if err := r.RequireProjectAccess(ctx, params.ProjectName, rbac.ActionList, rbac.ResourceRepository); err != nil {
+	if err := r.RequireProjectAccess(ctx, params.ProjectName, rbac.ActionRead, rbac.ResourceRepository); err != nil {
 		return r.SendError(ctx, err)
 	}
 	repository, err := r.repoCtl.GetByName(ctx, fmt.Sprintf("%s/%s", params.ProjectName, params.RepositoryName))


### PR DESCRIPTION
Hello,
This PR fix resource when we call the root project url like `/projects/{project_name_or_id}`.
This is an update of #14753 because this issue is still present.

**Affected issues** : #14512

**Affected endpoints** :
- [GET,DELETE,PUT] /projects/{project_name_or_id}
- [GET] /projects/{project_name_or_id}/_deletable
- [GET] /projects/{project_name_or_id}/summary

## Problem explanation

The bellowing code request resource `/project/*`
https://github.com/goharbor/harbor/blob/fd92efe1400d4be45dee8427f8ee9bfd2e8214ce/src/server/v2.0/handler/project.go#L324
But this following line generate `/project/*/project`
https://github.com/goharbor/harbor/blob/fd92efe1400d4be45dee8427f8ee9bfd2e8214ce/src/common/security/robot/context.go#L96

## Solution

So that PR fix that by creating custom case when we have request `project` resource and we have `project` kind.

Eg of permission enter in this case :
```json
{
  "access": [
    { "action": "read", "resource": "project" }
  ],
  "kind": "project",
  "namespace": "*"
}
```
