### PR TITLE
fix: ignore untagged artifact when perform immutable policy

### DIFF
--- a/src/pkg/immutable/match/rule/match.go
+++ b/src/pkg/immutable/match/rule/match.go
@@ -2,6 +2,7 @@ package rule
 
 import (
 	"context"
+
 	"github.com/goharbor/harbor/src/controller/immutable"
 	"github.com/goharbor/harbor/src/lib/q"
 	iselector "github.com/goharbor/harbor/src/lib/selector"
@@ -54,8 +55,9 @@ func (rm *Matcher) Match(ctx context.Context, pid int64, c iselector.Candidate) 
 			continue
 		}
 		tagSelector := r.TagSelectors[0]
+		// for immutable policy, should not keep untagged artifacts by default.
 		selector, err = index.Get(tagSelector.Kind, tagSelector.Decoration,
-			tagSelector.Pattern, "")
+			tagSelector.Pattern, "{\"untagged\": false}")
 		if err != nil {
 			return false, err
 		}

--- a/src/pkg/immutable/match/rule/match_test.go
+++ b/src/pkg/immutable/match/rule/match_test.go
@@ -1,6 +1,9 @@
 package rule
 
 import (
+	"os"
+	"testing"
+
 	"github.com/goharbor/harbor/src/common/dao"
 	"github.com/goharbor/harbor/src/controller/immutable"
 	"github.com/goharbor/harbor/src/lib/orm"
@@ -9,8 +12,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"os"
-	"testing"
 )
 
 // MatchTestSuite ...
@@ -128,6 +129,19 @@ func (s *MatchTestSuite) TestImmuMatch() {
 		Kind:        selector.Image,
 	}
 	isMatch, err = match.Match(orm.Context(), 1, c4)
+	s.require.Equal(isMatch, false)
+	s.require.Nil(err)
+
+	// untagged case
+	c5 := selector.Candidate{
+		NamespaceID: 1,
+		Namespace:   "library",
+		Repository:  "redis",
+		// no tags
+		Tags: []string{},
+		Kind: selector.Image,
+	}
+	isMatch, err = match.Match(orm.Context(), 1, c5)
 	s.require.Equal(isMatch, false)
 	s.require.Nil(err)
 }


### PR DESCRIPTION
Fixes: https://github.com/goharbor/harbor/issues/16335

Signed-off-by: chlins <chenyuzh@vmware.com>