### PR TITLE
jobservice/job: fix dropped error

### DIFF
--- a/src/jobservice/job/tracker.go
+++ b/src/jobservice/job/tracker.go
@@ -232,13 +232,14 @@ func (bt *basicTracker) CheckIn(message string) error {
 
 	bt.refresh(current, message)
 	err := bt.fireHookEvent(current, message)
-	err = bt.Update(
+	if err != nil {
+		return err
+	}
+	return bt.Update(
 		// skip checkin data here
 		"check_in_at", now,
 		"update_time", now,
 	)
-
-	return err
 }
 
 // Run job


### PR DESCRIPTION
This fixes a dropped `err` variable in `src/jobservice/job`.

Signed-off-by: Lars Lehtonen <lars.lehtonen@gmail.com>