### PR TITLE
fix: oidc token is not respected in /service/token endpoint

### DIFF
--- a/src/server/middleware/security/idtoken.go
+++ b/src/server/middleware/security/idtoken.go
@@ -36,7 +36,7 @@ func (i *idToken) Generate(req *http.Request) security.Context {
 	if lib.GetAuthMode(ctx) != common.OIDCAuth {
 		return nil
 	}
-	if !strings.HasPrefix(req.URL.Path, "/api") {
+	if !strings.HasPrefix(req.URL.Path, "/api") && req.URL.Path != "/service/token" {
 		return nil
 	}
 	token := bearerToken(req)

--- a/src/server/middleware/security/idtoken_test.go
+++ b/src/server/middleware/security/idtoken_test.go
@@ -46,4 +46,11 @@ func TestIDToken(t *testing.T) {
 	req = req.WithContext(lib.WithAuthMode(req.Context(), common.OIDCAuth))
 	ctx = idToken.Generate(req)
 	assert.Nil(t, ctx)
+
+	// contains no authorization header
+	req, err = http.NewRequest(http.MethodGet, "http://127.0.0.1/service/token?service=harbor-registry&scope=repository:foo/bar:pull", nil)
+	require.Nil(t, err)
+	req = req.WithContext(lib.WithAuthMode(req.Context(), common.OIDCAuth))
+	ctx = idToken.Generate(req)
+	assert.Nil(t, ctx)
 }


### PR DESCRIPTION
I can query the harbor API with my OIDC token, but unfortunately I cannot get a distribution token.

This PR fixes that. 

This PR enables us to build facades/proxies to harbor that act as custom PHP composer or JS npm registries over OCI Artifacts with OIDC Token support instead of CLI secrets. 