### PR TITLE
fix 16418

### DIFF
--- a/src/controller/tag/controller_test.go
+++ b/src/controller/tag/controller_test.go
@@ -15,6 +15,7 @@
 package tag
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -37,6 +38,7 @@ import (
 type controllerTestSuite struct {
 	suite.Suite
 	ctl          *controller
+	ctx          context.Context
 	repoMgr      *repository.Manager
 	artMgr       *artifact.Manager
 	tagMgr       *tagtesting.FakeManager
@@ -54,10 +56,8 @@ func (c *controllerTestSuite) SetupTest() {
 		immutableMtr: c.immutableMtr,
 	}
 
-	var tagCtlTestConfig = map[string]interface{}{
-		common.WithNotary: false,
-	}
-	config.InitWithSettings(tagCtlTestConfig)
+	cfgMgr, _ := config.GetManager(common.InMemoryCfgManager)
+	c.ctx = config.NewContext(context.Background(), cfgMgr)
 }
 
 func (c *controllerTestSuite) TestEnsureTag() {
@@ -158,7 +158,7 @@ func (c *controllerTestSuite) TestDelete() {
 	}, nil)
 	c.immutableMtr.On("Match").Return(false, nil)
 	c.tagMgr.On("Delete").Return(nil)
-	err := c.ctl.Delete(nil, 1)
+	err := c.ctl.Delete(c.ctx, 1)
 	c.Require().Nil(err)
 }
 
@@ -172,7 +172,7 @@ func (c *controllerTestSuite) TestDeleteImmutable() {
 	}, nil)
 	c.immutableMtr.On("Match").Return(true, nil)
 	c.tagMgr.On("Delete").Return(nil)
-	err := c.ctl.Delete(nil, 1)
+	err := c.ctl.Delete(c.ctx, 1)
 	c.Require().NotNil(err)
 	c.True(errors.IsErr(err, errors.PreconditionCode))
 }
@@ -199,7 +199,7 @@ func (c *controllerTestSuite) TestDeleteTags() {
 	c.immutableMtr.On("Match").Return(false, nil)
 	c.tagMgr.On("Delete").Return(nil)
 	ids := []int64{1, 2, 3, 4}
-	err := c.ctl.DeleteTags(nil, ids)
+	err := c.ctl.DeleteTags(c.ctx, ids)
 	c.Require().Nil(err)
 }
 

--- a/src/core/middlewares/middlewares.go
+++ b/src/core/middlewares/middlewares.go
@@ -22,6 +22,7 @@ import (
 	"github.com/goharbor/harbor/src/pkg/distribution"
 	"github.com/goharbor/harbor/src/server/middleware"
 	"github.com/goharbor/harbor/src/server/middleware/artifactinfo"
+	"github.com/goharbor/harbor/src/server/middleware/config"
 	"github.com/goharbor/harbor/src/server/middleware/csrf"
 	"github.com/goharbor/harbor/src/server/middleware/log"
 	"github.com/goharbor/harbor/src/server/middleware/mergeslash"
@@ -87,6 +88,7 @@ func MiddleWares() []beego.MiddleWare {
 		session.Middleware(),
 		csrf.Middleware(),
 		orm.Middleware(pingSkipper),
+		config.Middleware(),
 		notification.Middleware(pingSkipper), // notification must ahead of transaction ensure the DB transaction execution complete
 		transaction.Middleware(dbTxSkippers...),
 		artifactinfo.Middleware(),

--- a/src/lib/config/config.go
+++ b/src/lib/config/config.go
@@ -77,7 +77,7 @@ func GetManager(name string) (Manager, error) {
 func defaultMgr() Manager {
 	manager, err := GetManager(DefaultCfgManager)
 	if err != nil {
-		log.Error("failed to get config manager")
+		log.Errorf("failed to get config manager, %v", err)
 	}
 	return manager
 }

--- a/src/pkg/signature/manager.go
+++ b/src/pkg/signature/manager.go
@@ -15,8 +15,10 @@
 package signature
 
 import (
+	"github.com/goharbor/harbor/src/common"
 	"github.com/goharbor/harbor/src/common/security"
 	"github.com/goharbor/harbor/src/lib/config"
+	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/lib/log"
 	"github.com/goharbor/harbor/src/pkg/signature/notary"
 	"github.com/goharbor/harbor/src/pkg/signature/notary/model"
@@ -58,7 +60,11 @@ type mgr struct {
 
 // GetCheckerByRepo ...
 func (m *mgr) GetCheckerByRepo(ctx context.Context, repo string) (*Checker, error) {
-	if !config.WithNotary() { // return a checker that always return false
+	cfgMgr, ok := config.FromContext(ctx)
+	if !ok {
+		return nil, errors.Errorf("failed to get config manager")
+	}
+	if !cfgMgr.Get(context.Background(), common.WithNotary).GetBool() { // return a checker that always return false
 		return &Checker{}, nil
 	}
 	s := make(map[string]string)

--- a/src/pkg/signature/manager_test.go
+++ b/src/pkg/signature/manager_test.go
@@ -94,8 +94,9 @@ func TestGetCheckerByRepo(t *testing.T) {
 			},
 		},
 	}
+	cfgMgr, _ := config.GetManager(common.InMemoryCfgManager)
 	for _, c := range cases {
-		checker, err := m.GetCheckerByRepo(context.Background(), c.input.repo)
+		checker, err := m.GetCheckerByRepo(config.NewContext(context.Background(), cfgMgr), c.input.repo)
 		assert.Nil(t, err)
 		assert.Equal(t, c.expect.tagSigned, checker.IsTagSigned(c.input.tag, c.input.digest),
 			"Unexpected tagSigned value for input: %#v", c.input)

--- a/src/server/middleware/config/config.go
+++ b/src/server/middleware/config/config.go
@@ -1,0 +1,21 @@
+package config
+
+import (
+	libCfg "github.com/goharbor/harbor/src/lib/config"
+	lib_http "github.com/goharbor/harbor/src/lib/http"
+	"github.com/goharbor/harbor/src/server/middleware"
+	"net/http"
+)
+
+// Middleware returns a middleware that set the config manager into the context
+func Middleware() func(http.Handler) http.Handler {
+	return middleware.New(func(rw http.ResponseWriter, req *http.Request, next http.Handler) {
+		cfgMgr, err := libCfg.GetManager(libCfg.DefaultCfgManager)
+		if err != nil {
+			lib_http.SendError(rw, err)
+			return
+		}
+		ctx := libCfg.NewContext(req.Context(), cfgMgr)
+		next.ServeHTTP(rw, req.WithContext(ctx))
+	})
+}

--- a/src/server/middleware/config/config_test.go
+++ b/src/server/middleware/config/config_test.go
@@ -1,0 +1,56 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"github.com/goharbor/harbor/src/common"
+	"github.com/goharbor/harbor/src/pkg/config/db"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/goharbor/harbor/src/lib/config"
+	"github.com/stretchr/testify/suite"
+)
+
+type MiddlewareTestSuite struct {
+	suite.Suite
+}
+
+func (suite *MiddlewareTestSuite) TestMiddleware() {
+	next := func() http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, ok := config.FromContext(r.Context())
+			if !ok {
+				w.WriteHeader(http.StatusInternalServerError)
+			} else {
+				w.WriteHeader(http.StatusOK)
+			}
+		})
+	}
+
+	{
+		config.Register(common.DBCfgManager, db.NewDBCfgManager())
+		req := httptest.NewRequest("GET", "/v1/library/photon/manifests/2.0", nil)
+		rr := httptest.NewRecorder()
+		Middleware()(next()).ServeHTTP(rr, req)
+		suite.Equal(http.StatusOK, rr.Code)
+	}
+
+}
+
+func TestMiddlewareTestSuite(t *testing.T) {
+	suite.Run(t, &MiddlewareTestSuite{})
+}


### PR DESCRIPTION
The DB config manager is not inited on jobservice to call core, but it was injected into jobservice context.
Update the signature manager to load config from contex.

Signed-off-by: Wang Yan <wangyan@vmware.com>