### PR TITLE
Create index on task with job_id

### DIFF
--- a/make/migrations/postgresql/0080_2.5.0_schema.up.sql
+++ b/make/migrations/postgresql/0080_2.5.0_schema.up.sql
@@ -30,3 +30,5 @@ ALTER TABLE vulnerability_record ALTER COLUMN id TYPE BIGINT;
 ALTER SEQUENCE vulnerability_record_id_seq AS BIGINT;
 ALTER TABLE report_vulnerability_record ALTER COLUMN id TYPE BIGINT;
 ALTER SEQUENCE report_vulnerability_record_id_seq AS BIGINT;
+
+CREATE INDEX IF NOT EXISTS idx_task_job_id ON task (job_id);


### PR DESCRIPTION
  Missing index with job_id, when query task with job_id, it cause a full table scan, caused performance issue
  Fixes #15271

Signed-off-by: stonezdj <stonezdj@gmail.com>