### PR TITLE
The DB config manager is not init on jobservice call config.WithNotary

### DIFF
--- a/src/jobservice/main.go
+++ b/src/jobservice/main.go
@@ -34,6 +34,9 @@ import (
 )
 
 func main() {
+	cfgLib.DefaultCfgManager = common.RestCfgManager
+	cfgLib.DefaultMgr().Load(context.Background())
+
 	// Get parameters
 	configPath := flag.String("c", "", "Specify the yaml config file path")
 	flag.Parse()
@@ -69,11 +72,8 @@ func main() {
 		if utils.IsEmptyStr(secret) {
 			return nil, errors.New("empty auth secret")
 		}
-		cfgMgr, err := cfgLib.GetManager(common.RestCfgManager)
-		if err != nil {
-			return nil, err
-		}
-		jobCtx := impl.NewContext(ctx, cfgMgr)
+
+		jobCtx := impl.NewContext(ctx, cfgLib.DefaultMgr())
 
 		if err := jobCtx.Init(); err != nil {
 			return nil, err

--- a/src/lib/config/config.go
+++ b/src/lib/config/config.go
@@ -74,7 +74,8 @@ func GetManager(name string) (Manager, error) {
 	return mgr, nil
 }
 
-func defaultMgr() Manager {
+// DefaultMgr get default config manager
+func DefaultMgr() Manager {
 	manager, err := GetManager(DefaultCfgManager)
 	if err != nil {
 		log.Error("failed to get config manager")
@@ -100,7 +101,7 @@ func Init() {
 func InitWithSettings(cfgs map[string]interface{}, kp ...encrypt.KeyProvider) {
 	Init()
 	DefaultCfgManager = common.InMemoryCfgManager
-	mgr := defaultMgr()
+	mgr := DefaultMgr()
 	mgr.UpdateConfig(backgroundCtx, cfgs)
 	if len(kp) > 0 {
 		keyProvider = kp[0]
@@ -109,15 +110,15 @@ func InitWithSettings(cfgs map[string]interface{}, kp ...encrypt.KeyProvider) {
 
 // GetCfgManager return the current config manager
 func GetCfgManager(ctx context.Context) Manager {
-	return defaultMgr()
+	return DefaultMgr()
 }
 
 // Load configurations
 func Load(ctx context.Context) error {
-	return defaultMgr().Load(ctx)
+	return DefaultMgr().Load(ctx)
 }
 
 // Upload save all configurations, used by testing
 func Upload(cfg map[string]interface{}) error {
-	return defaultMgr().UpdateConfig(orm.Context(), cfg)
+	return DefaultMgr().UpdateConfig(orm.Context(), cfg)
 }

--- a/src/lib/config/systemconfig.go
+++ b/src/lib/config/systemconfig.go
@@ -143,23 +143,23 @@ func GetGCTimeWindow() int64 {
 
 // WithNotary returns a bool value to indicate if Harbor's deployed with Notary
 func WithNotary() bool {
-	return defaultMgr().Get(backgroundCtx, common.WithNotary).GetBool()
+	return DefaultMgr().Get(backgroundCtx, common.WithNotary).GetBool()
 }
 
 // WithTrivy returns a bool value to indicate if Harbor's deployed with Trivy.
 func WithTrivy() bool {
-	return defaultMgr().Get(backgroundCtx, common.WithTrivy).GetBool()
+	return DefaultMgr().Get(backgroundCtx, common.WithTrivy).GetBool()
 }
 
 // WithChartMuseum returns a bool to indicate if chartmuseum is deployed with Harbor.
 func WithChartMuseum() bool {
-	return defaultMgr().Get(backgroundCtx, common.WithChartMuseum).GetBool()
+	return DefaultMgr().Get(backgroundCtx, common.WithChartMuseum).GetBool()
 }
 
 // GetChartMuseumEndpoint returns the endpoint of the chartmuseum service
 // otherwise an non nil error is returned
 func GetChartMuseumEndpoint() (string, error) {
-	chartEndpoint := strings.TrimSpace(defaultMgr().Get(backgroundCtx, common.ChartRepoURL).GetString())
+	chartEndpoint := strings.TrimSpace(DefaultMgr().Get(backgroundCtx, common.ChartRepoURL).GetString())
 	if len(chartEndpoint) == 0 {
 		return "", errors.New("empty chartmuseum endpoint")
 	}
@@ -168,7 +168,7 @@ func GetChartMuseumEndpoint() (string, error) {
 
 // ExtEndpoint returns the external URL of Harbor: protocol://host:port
 func ExtEndpoint() (string, error) {
-	return defaultMgr().Get(backgroundCtx, common.ExtEndpoint).GetString(), nil
+	return DefaultMgr().Get(backgroundCtx, common.ExtEndpoint).GetString(), nil
 }
 
 // ExtURL returns the external URL: host:port
@@ -206,12 +206,12 @@ func initSecretStore() {
 
 // InternalCoreURL returns the local harbor core url
 func InternalCoreURL() string {
-	return strings.TrimSuffix(defaultMgr().Get(backgroundCtx, common.CoreURL).GetString(), "/")
+	return strings.TrimSuffix(DefaultMgr().Get(backgroundCtx, common.CoreURL).GetString(), "/")
 }
 
 // LocalCoreURL returns the local harbor core url
 func LocalCoreURL() string {
-	return defaultMgr().Get(backgroundCtx, common.CoreLocalURL).GetString()
+	return DefaultMgr().Get(backgroundCtx, common.CoreLocalURL).GetString()
 }
 
 // InternalTokenServiceEndpoint returns token service endpoint for internal communication between Harbor containers
@@ -222,41 +222,41 @@ func InternalTokenServiceEndpoint() string {
 // InternalNotaryEndpoint returns notary server endpoint for internal communication between Harbor containers
 // This is currently a conventional value and can be unaccessible when Harbor is not deployed with Notary.
 func InternalNotaryEndpoint() string {
-	return defaultMgr().Get(backgroundCtx, common.NotaryURL).GetString()
+	return DefaultMgr().Get(backgroundCtx, common.NotaryURL).GetString()
 }
 
 // TrivyAdapterURL returns the endpoint URL of a Trivy adapter instance, by default it's the one deployed within Harbor.
 func TrivyAdapterURL() string {
-	return defaultMgr().Get(backgroundCtx, common.TrivyAdapterURL).GetString()
+	return DefaultMgr().Get(backgroundCtx, common.TrivyAdapterURL).GetString()
 }
 
 // Metric returns the overall metric settings
 func Metric() *models.Metric {
 	return &models.Metric{
-		Enabled: defaultMgr().Get(backgroundCtx, common.MetricEnable).GetBool(),
-		Port:    defaultMgr().Get(backgroundCtx, common.MetricPort).GetInt(),
-		Path:    defaultMgr().Get(backgroundCtx, common.MetricPath).GetString(),
+		Enabled: DefaultMgr().Get(backgroundCtx, common.MetricEnable).GetBool(),
+		Port:    DefaultMgr().Get(backgroundCtx, common.MetricPort).GetInt(),
+		Path:    DefaultMgr().Get(backgroundCtx, common.MetricPath).GetString(),
 	}
 }
 
 // InitialAdminPassword returns the initial password for administrator
 func InitialAdminPassword() (string, error) {
-	return defaultMgr().Get(backgroundCtx, common.AdminInitialPassword).GetString(), nil
+	return DefaultMgr().Get(backgroundCtx, common.AdminInitialPassword).GetString(), nil
 }
 
 // Database returns database settings
 func Database() (*models.Database, error) {
 	database := &models.Database{}
-	database.Type = defaultMgr().Get(backgroundCtx, common.DatabaseType).GetString()
+	database.Type = DefaultMgr().Get(backgroundCtx, common.DatabaseType).GetString()
 	postgresql := &models.PostGreSQL{
-		Host:         defaultMgr().Get(backgroundCtx, common.PostGreSQLHOST).GetString(),
-		Port:         defaultMgr().Get(backgroundCtx, common.PostGreSQLPort).GetInt(),
-		Username:     defaultMgr().Get(backgroundCtx, common.PostGreSQLUsername).GetString(),
-		Password:     defaultMgr().Get(backgroundCtx, common.PostGreSQLPassword).GetPassword(),
-		Database:     defaultMgr().Get(backgroundCtx, common.PostGreSQLDatabase).GetString(),
-		SSLMode:      defaultMgr().Get(backgroundCtx, common.PostGreSQLSSLMode).GetString(),
-		MaxIdleConns: defaultMgr().Get(backgroundCtx, common.PostGreSQLMaxIdleConns).GetInt(),
-		MaxOpenConns: defaultMgr().Get(backgroundCtx, common.PostGreSQLMaxOpenConns).GetInt(),
+		Host:         DefaultMgr().Get(backgroundCtx, common.PostGreSQLHOST).GetString(),
+		Port:         DefaultMgr().Get(backgroundCtx, common.PostGreSQLPort).GetInt(),
+		Username:     DefaultMgr().Get(backgroundCtx, common.PostGreSQLUsername).GetString(),
+		Password:     DefaultMgr().Get(backgroundCtx, common.PostGreSQLPassword).GetPassword(),
+		Database:     DefaultMgr().Get(backgroundCtx, common.PostGreSQLDatabase).GetString(),
+		SSLMode:      DefaultMgr().Get(backgroundCtx, common.PostGreSQLSSLMode).GetString(),
+		MaxIdleConns: DefaultMgr().Get(backgroundCtx, common.PostGreSQLMaxIdleConns).GetInt(),
+		MaxOpenConns: DefaultMgr().Get(backgroundCtx, common.PostGreSQLMaxOpenConns).GetInt(),
 	}
 	database.PostGreSQL = postgresql
 

--- a/src/lib/config/userconfig.go
+++ b/src/lib/config/userconfig.go
@@ -28,7 +28,7 @@ import (
 
 // GetSystemCfg returns the all configurations
 func GetSystemCfg(ctx context.Context) (map[string]interface{}, error) {
-	sysCfg := defaultMgr().GetAll(ctx)
+	sysCfg := DefaultMgr().GetAll(ctx)
 	if len(sysCfg) == 0 {
 		return nil, errors.New("can not load system config, the database might be down")
 	}
@@ -37,7 +37,7 @@ func GetSystemCfg(ctx context.Context) (map[string]interface{}, error) {
 
 // AuthMode ...
 func AuthMode(ctx context.Context) (string, error) {
-	mgr := defaultMgr()
+	mgr := DefaultMgr()
 	err := mgr.Load(ctx)
 	if err != nil {
 		log.Errorf("failed to load config, error %v", err)
@@ -48,7 +48,7 @@ func AuthMode(ctx context.Context) (string, error) {
 
 // LDAPConf returns the setting of ldap server
 func LDAPConf(ctx context.Context) (*cfgModels.LdapConf, error) {
-	mgr := defaultMgr()
+	mgr := DefaultMgr()
 	err := mgr.Load(ctx)
 	if err != nil {
 		return nil, err
@@ -68,7 +68,7 @@ func LDAPConf(ctx context.Context) (*cfgModels.LdapConf, error) {
 
 // LDAPGroupConf returns the setting of ldap group search
 func LDAPGroupConf(ctx context.Context) (*cfgModels.GroupConf, error) {
-	mgr := defaultMgr()
+	mgr := DefaultMgr()
 	err := mgr.Load(ctx)
 	if err != nil {
 		return nil, err
@@ -85,31 +85,31 @@ func LDAPGroupConf(ctx context.Context) (*cfgModels.GroupConf, error) {
 
 // TokenExpiration returns the token expiration time (in minute)
 func TokenExpiration(ctx context.Context) (int, error) {
-	return defaultMgr().Get(ctx, common.TokenExpiration).GetInt(), nil
+	return DefaultMgr().Get(ctx, common.TokenExpiration).GetInt(), nil
 }
 
 // RobotTokenDuration returns the token expiration time of robot account (in minute)
 func RobotTokenDuration(ctx context.Context) int {
-	return defaultMgr().Get(ctx, common.RobotTokenDuration).GetInt()
+	return DefaultMgr().Get(ctx, common.RobotTokenDuration).GetInt()
 }
 
 // SelfRegistration returns the enablement of self registration
 func SelfRegistration(ctx context.Context) (bool, error) {
-	return defaultMgr().Get(ctx, common.SelfRegistration).GetBool(), nil
+	return DefaultMgr().Get(ctx, common.SelfRegistration).GetBool(), nil
 }
 
 // OnlyAdminCreateProject returns the flag to restrict that only sys admin can create project
 func OnlyAdminCreateProject(ctx context.Context) (bool, error) {
-	err := defaultMgr().Load(ctx)
+	err := DefaultMgr().Load(ctx)
 	if err != nil {
 		return true, err
 	}
-	return defaultMgr().Get(ctx, common.ProjectCreationRestriction).GetString() == common.ProCrtRestrAdmOnly, nil
+	return DefaultMgr().Get(ctx, common.ProjectCreationRestriction).GetString() == common.ProCrtRestrAdmOnly, nil
 }
 
 // Email returns email server settings
 func Email(ctx context.Context) (*cfgModels.Email, error) {
-	mgr := defaultMgr()
+	mgr := DefaultMgr()
 	err := mgr.Load(ctx)
 	if err != nil {
 		return nil, err
@@ -128,7 +128,7 @@ func Email(ctx context.Context) (*cfgModels.Email, error) {
 
 // UAASettings returns the UAASettings to access UAA service.
 func UAASettings(ctx context.Context) (*models.UAASettings, error) {
-	mgr := defaultMgr()
+	mgr := DefaultMgr()
 	err := mgr.Load(ctx)
 	if err != nil {
 		return nil, err
@@ -144,13 +144,13 @@ func UAASettings(ctx context.Context) (*models.UAASettings, error) {
 
 // ReadOnly returns a bool to indicates if Harbor is in read only mode.
 func ReadOnly(ctx context.Context) bool {
-	return defaultMgr().Get(ctx, common.ReadOnly).GetBool()
+	return DefaultMgr().Get(ctx, common.ReadOnly).GetBool()
 }
 
 // HTTPAuthProxySetting returns the setting of HTTP Auth proxy.  the settings are only meaningful when the auth_mode is
 // set to http_auth
 func HTTPAuthProxySetting(ctx context.Context) (*cfgModels.HTTPAuthProxy, error) {
-	mgr := defaultMgr()
+	mgr := DefaultMgr()
 	if err := mgr.Load(ctx); err != nil {
 		return nil, err
 	}
@@ -168,7 +168,7 @@ func HTTPAuthProxySetting(ctx context.Context) (*cfgModels.HTTPAuthProxy, error)
 // OIDCSetting returns the setting of OIDC provider, currently there's only one OIDC provider allowed for Harbor and it's
 // only effective when auth_mode is set to oidc_auth
 func OIDCSetting(ctx context.Context) (*cfgModels.OIDCSetting, error) {
-	mgr := defaultMgr()
+	mgr := DefaultMgr()
 	if err := mgr.Load(ctx); err != nil {
 		return nil, err
 	}
@@ -193,27 +193,27 @@ func OIDCSetting(ctx context.Context) (*cfgModels.OIDCSetting, error) {
 
 // NotificationEnable returns a bool to indicates if notification enabled in harbor
 func NotificationEnable(ctx context.Context) bool {
-	return defaultMgr().Get(ctx, common.NotificationEnable).GetBool()
+	return DefaultMgr().Get(ctx, common.NotificationEnable).GetBool()
 }
 
 // QuotaPerProjectEnable returns a bool to indicates if quota per project enabled in harbor
 func QuotaPerProjectEnable(ctx context.Context) bool {
-	return defaultMgr().Get(ctx, common.QuotaPerProjectEnable).GetBool()
+	return DefaultMgr().Get(ctx, common.QuotaPerProjectEnable).GetBool()
 }
 
 // QuotaSetting returns the setting of quota.
 func QuotaSetting(ctx context.Context) (*cfgModels.QuotaSetting, error) {
-	if err := defaultMgr().Load(ctx); err != nil {
+	if err := DefaultMgr().Load(ctx); err != nil {
 		return nil, err
 	}
 	return &cfgModels.QuotaSetting{
-		StoragePerProject: defaultMgr().Get(ctx, common.StoragePerProject).GetInt64(),
+		StoragePerProject: DefaultMgr().Get(ctx, common.StoragePerProject).GetInt64(),
 	}, nil
 }
 
 // RobotPrefix user defined robot name prefix.
 func RobotPrefix(ctx context.Context) string {
-	return defaultMgr().Get(ctx, common.RobotNamePrefix).GetString()
+	return DefaultMgr().Get(ctx, common.RobotNamePrefix).GetString()
 }
 
 // SplitAndTrim ...
@@ -229,15 +229,15 @@ func SplitAndTrim(s, sep string) []string {
 
 // PullCountUpdateDisable returns a bool to indicate if pull count is disable for pull request.
 func PullCountUpdateDisable(ctx context.Context) bool {
-	return defaultMgr().Get(ctx, common.PullCountUpdateDisable).GetBool()
+	return DefaultMgr().Get(ctx, common.PullCountUpdateDisable).GetBool()
 }
 
 // PullTimeUpdateDisable returns a bool to indicate if pull time is disable for pull request.
 func PullTimeUpdateDisable(ctx context.Context) bool {
-	return defaultMgr().Get(ctx, common.PullTimeUpdateDisable).GetBool()
+	return DefaultMgr().Get(ctx, common.PullTimeUpdateDisable).GetBool()
 }
 
 // PullAuditLogDisable returns a bool to indicate if pull audit log is disable for pull request.
 func PullAuditLogDisable(ctx context.Context) bool {
-	return defaultMgr().Get(ctx, common.PullAuditLogDisable).GetBool()
+	return DefaultMgr().Get(ctx, common.PullAuditLogDisable).GetBool()
 }


### PR DESCRIPTION
  Make func defaultMgr() public
  Set DefaultCfgManager to RestCfgManager and Load it in the jobservice main
  config.WithNotary call DefaultMgr(), it wil get the RestCfgManager
  Fixes #16418

Signed-off-by: stonezdj <stonezdj@gmail.com>