### PR TITLE
lib/q: fix dropped test error

### DIFF
--- a/src/lib/q/builder_test.go
+++ b/src/lib/q/builder_test.go
@@ -75,6 +75,7 @@ func TestParseRange(t *testing.T) {
 	// valid value
 	value = "[~2]"
 	v, err = parseRange(value)
+	require.NoError(t, err)
 	assert.Equal(t, int64(2), v.Max.(int64))
 	assert.Nil(t, v.Min)
 


### PR DESCRIPTION
This fixes a dropped test `err` variable in `lib/q`.

Signed-off-by: Lars Lehtonen <lars.lehtonen@gmail.com>