### PR TITLE
[cherry-pick]add transaction for artifact delete

### DIFF
--- a/src/controller/artifact/controller.go
+++ b/src/controller/artifact/controller.go
@@ -311,7 +311,9 @@ func (c *controller) Delete(ctx context.Context, id int64) error {
 	if err != nil {
 		return err
 	}
-	return c.deleteDeeply(ctx, id, true, len(accs) > 0)
+	return orm.WithTransaction(func(ctx context.Context) error {
+		return c.deleteDeeply(ctx, id, true, len(accs) > 0)
+	})(orm.SetTransactionOpNameToContext(ctx, "tx-delete-artifact-delete"))
 }
 
 // "isRoot" is used to specify whether the artifact is the root parent artifact


### PR DESCRIPTION
Add transaction for artifact deletion, given API has the transaction when to call artifact controller but other object may not, for example jobservice job.
Here, force add the tx to ensure all the things can be rolled back.

Signed-off-by: Wang Yan <wangyan@vmware.com>