### PR TITLE
[cherry-pick]add transaction for artifact delete

### DIFF
--- a/src/controller/artifact/controller.go
+++ b/src/controller/artifact/controller.go
@@ -283,7 +283,9 @@ func (c *controller) getByTag(ctx context.Context, repository, tag string, optio
 }
 
 func (c *controller) Delete(ctx context.Context, id int64) error {
-	return c.deleteDeeply(ctx, id, true)
+	return orm.WithTransaction(func(ctx context.Context) error {
+		return c.deleteDeeply(ctx, id, true)
+	})(orm.SetTransactionOpNameToContext(ctx, "tx-delete-artifact-delete"))
 }
 
 // "isRoot" is used to specify whether the artifact is the root parent artifact


### PR DESCRIPTION
Add transaction for artifact deletion, given API has the transaction when to call artifact controller but other object may not, for example jobservice job.
Here, force add the tx to ensure all the things can be rolled back.

Signed-off-by: Wang Yan <wangyan@vmware.com>