### PR TITLE
Update usergroups API to support search by group_name

### DIFF
--- a/api/v2.0/swagger.yaml
+++ b/api/v2.0/swagger.yaml
@@ -2768,7 +2768,7 @@ paths:
   /usergroups:
     get:
       summary: Get all user groups information
-      description: Get all user groups information
+      description: Get all user groups information, it is open for system admin
       operationId: listUserGroups
       tags:
         - usergroup
@@ -2781,6 +2781,11 @@ paths:
           type: string
           required: false
           description: search with ldap group DN
+        - name: group_name
+          in: query
+          type: string
+          required: false
+          description: group name need to search, fuzzy matches
       responses:
         '200':
           description: Get user group successfully.

--- a/src/server/v2.0/handler/usergroup.go
+++ b/src/server/v2.0/handler/usergroup.go
@@ -110,6 +110,9 @@ func (u *userGroupAPI) ListUserGroups(ctx context.Context, params operation.List
 	if err != nil {
 		return u.SendError(ctx, err)
 	}
+	if params.GroupName != nil && len(*params.GroupName) > 0 {
+		query.Keywords["GroupName"] = &q.FuzzyMatchValue{Value: *params.GroupName}
+	}
 	switch authMode {
 	case common.LDAPAuth:
 		query.Keywords["GroupType"] = common.LDAPGroupType


### PR DESCRIPTION
  Add group_name parameter to GET usergroups API
  Related to issue #16408
  UI should also switch from search api to usergroups list api

Signed-off-by: stonezdj <stonezdj@gmail.com>