### PR TITLE
Add python-dateutil module in api e2e image

### DIFF
--- a/tests/ci/api_run.sh
+++ b/tests/ci/api_run.sh
@@ -8,7 +8,7 @@ sudo gsutil version -l
 harbor_logs_bucket="harbor-ci-logs"
 
 DIR="$(cd "$(dirname "$0")" && pwd)"
-E2E_IMAGE="goharbor/harbor-e2e-engine:4.2.0-api"
+E2E_IMAGE="goharbor/harbor-e2e-engine:4.2.1-api"
 
 # GS util
 function uploader {

--- a/tests/test-engine-image/Dockerfile.api_test
+++ b/tests/test-engine-image/Dockerfile.api_test
@@ -22,7 +22,7 @@ RUN tdnf install -y \
     gzip && \
     tdnf erase -y toybox && \
     tdnf install -y python3 python3-pip python3-setuptools httpd && \
-    pip3 install --upgrade pip pyasn1 google-apitools==0.5.31 gsutil \
+    pip3 install --upgrade pip pyasn1 google-apitools==0.5.31 gsutil python-dateutil \
     robotframework==3.2.1 robotframework-sshlibrary robotframework-httplibrary \
     requests dbbot robotframework-seleniumlibrary==4.3.0 robotframework-pabot \
     robotframework-JSONLibrary hurry.filesize --upgrade && \


### PR DESCRIPTION
Because swagger_client adds dependency on python-dateutil module

Signed-off-by: Yang Jiao <jiaoya@vmware.com>