### PR TITLE
feat: add cache layer for artifact

### DIFF
--- a/make/harbor.yml.tmpl
+++ b/make/harbor.yml.tmpl
@@ -245,3 +245,8 @@ upload_purging:
   # the interval of the purge operations
   interval: 24h
   dryrun: false
+
+# Cache related config
+cache:
+  enabled: false
+  expire_hours: 24

--- a/make/photon/prepare/models.py
+++ b/make/photon/prepare/models.py
@@ -7,6 +7,7 @@ from g import internal_tls_dir, DEFAULT_GID, DEFAULT_UID, PG_GID, PG_UID
 from utils.misc import check_permission, owner_can_read, get_realpath, port_number_valid
 from utils.cert import san_existed
 
+
 class InternalTLS:
 
     harbor_certs_filename = {
@@ -137,8 +138,9 @@ class InternalTLS:
             else:
                 os.chown(file, DEFAULT_UID, DEFAULT_GID)
 
+
 class Metric:
-    def __init__(self, enabled: bool = False, port: int = 8080, path: str = "metrics" ):
+    def __init__(self, enabled: bool = False, port: int = 8080, path: str = "metrics"):
         self.enabled = enabled
         self.port = port
         self.path = path
@@ -166,6 +168,7 @@ class JaegerExporter:
         if self.endpoint and self.agent_host:
             raise Exception('Jaeger Colector Endpoint and Agent host both set, only can set one')
 
+
 class OtelExporter:
     def __init__(self, config: dict):
         if not config:
@@ -183,6 +186,7 @@ class OtelExporter:
             raise Exception('Trace endpoint not set')
         if not self.url_path:
             raise Exception('Trace url path not set')
+
 
 class Trace:
     def __init__(self, config: dict):
@@ -205,6 +209,7 @@ class Trace:
         elif self.otel.enabled:
             self.otel.validate()
 
+
 class PurgeUpload:
     def __init__(self, config: dict):
         if not config:
@@ -223,14 +228,30 @@ class PurgeUpload:
             raise Exception('purge upload age should set with with nh, n is the number of hour')
         # interval should larger than 2h
         age = self.age[:-1]
-        if not age.isnumeric() or int(age) < 2 :
+        if not age.isnumeric() or int(age) < 2:
             raise Exception('purge upload age should set with with nh, n is the number of hour and n should not be less than 2')
-        
+
         # interval should end with h
         if not isinstance(self.interval, str) or not self.interval.endswith('h'):
             raise Exception('purge upload interval should set with with nh, n is the number of hour')
         # interval should larger than 2h
         interval = self.interval[:-1]
-        if not interval.isnumeric() or int(interval) < 2 :
+        if not interval.isnumeric() or int(interval) < 2:
             raise Exception('purge upload interval should set with with nh, n is the number of hour and n should not beless than 2')
+        return
+
+
+class Cache:
+    def __init__(self, config: dict):
+        if not config:
+            self.enabled = False
+        self.enabled = config.get('enabled')
+        self.expire_hours = config.get('expire_hours')
+
+    def validate(self):
+        if not self.enabled:
+            return
+
+        if not self.expire_hours.isnumeric():
+            raise Exception('cache expire hours should be number')
         return

--- a/make/photon/prepare/templates/core/env.jinja
+++ b/make/photon/prepare/templates/core/env.jinja
@@ -84,3 +84,8 @@ TRACE_OTEL_TIMEOUT={{ trace.otel.timeout }}
 TRACE_OTEL_INSECURE={{ trace.otel.insecure }}
 {% endif %}
 {% endif %}
+
+{% if cache.enabled %}
+CACHE_ENABLED=true
+CACHE_EXPIRE_HOURS={{ cache.expire_hours }}
+{% endif %}

--- a/src/common/const.go
+++ b/src/common/const.go
@@ -196,4 +196,13 @@ const (
 	PullTimeUpdateDisable = "pull_time_update_disable"
 	// PullAuditLogDisable indicate if pull audit log is disable for pull request.
 	PullAuditLogDisable = "pull_audit_log_disable"
+
+	// Cache layer settings
+	// CacheEnabled indicate whether enable cache layer.
+	CacheEnabled = "cache_enabled"
+	// CacheExpireHours is the cache expiration time, unit is hour.
+	CacheExpireHours = "cache_expire_hours"
+	// DefaultCacheExpireHours is the default cache expire hours, default is
+	// 24h.
+	DefaultCacheExpireHours = 24
 )

--- a/src/controller/artifact/abstractor.go
+++ b/src/controller/artifact/abstractor.go
@@ -18,7 +18,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+
 	"github.com/goharbor/harbor/src/lib/q"
+	"github.com/goharbor/harbor/src/pkg"
 
 	"github.com/docker/distribution/manifest/manifestlist"
 	"github.com/docker/distribution/manifest/schema1"
@@ -40,7 +42,7 @@ type Abstractor interface {
 // NewAbstractor creates a new abstractor
 func NewAbstractor() Abstractor {
 	return &abstractor{
-		artMgr:  artifact.Mgr,
+		artMgr:  pkg.ArtifactMgr,
 		blobMgr: blob.Mgr,
 		regCli:  registry.Cli,
 	}

--- a/src/controller/artifact/controller.go
+++ b/src/controller/artifact/controller.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/goharbor/harbor/src/pkg"
 	accessorymodel "github.com/goharbor/harbor/src/pkg/accessory/model"
 
 	"github.com/goharbor/harbor/src/controller/artifact/processor/chart"
@@ -116,7 +117,7 @@ func NewController() Controller {
 	return &controller{
 		tagCtl:       tag.Ctl,
 		repoMgr:      repository.Mgr,
-		artMgr:       artifact.Mgr,
+		artMgr:       pkg.ArtifactMgr,
 		artrashMgr:   artifactrash.Mgr,
 		blobMgr:      blob.Mgr,
 		sigMgr:       signature.GetManager(),

--- a/src/controller/icon/controller.go
+++ b/src/controller/icon/controller.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"encoding/base64"
 	"image"
+
 	// import the gif format
 	_ "image/gif"
 	// import the jpeg format
@@ -31,6 +32,7 @@ import (
 	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/lib/icon"
 	"github.com/goharbor/harbor/src/lib/q"
+	"github.com/goharbor/harbor/src/pkg"
 	"github.com/goharbor/harbor/src/pkg/artifact"
 	"github.com/goharbor/harbor/src/pkg/registry"
 	"github.com/nfnt/resize"
@@ -83,7 +85,7 @@ type Controller interface {
 // NewController creates a new instance of the icon controller
 func NewController() Controller {
 	return &controller{
-		artMgr: artifact.Mgr,
+		artMgr: pkg.ArtifactMgr,
 		regCli: registry.Cli,
 		cache:  sync.Map{},
 	}

--- a/src/controller/repository/controller.go
+++ b/src/controller/repository/controller.go
@@ -23,6 +23,7 @@ import (
 	"github.com/goharbor/harbor/src/lib/log"
 	"github.com/goharbor/harbor/src/lib/orm"
 	"github.com/goharbor/harbor/src/lib/q"
+	"github.com/goharbor/harbor/src/pkg"
 	art "github.com/goharbor/harbor/src/pkg/artifact"
 	"github.com/goharbor/harbor/src/pkg/project"
 	"github.com/goharbor/harbor/src/pkg/repository"
@@ -61,7 +62,7 @@ func NewController() Controller {
 	return &controller{
 		proMgr:  project.Mgr,
 		repoMgr: repository.Mgr,
-		artMgr:  art.Mgr,
+		artMgr:  pkg.ArtifactMgr,
 		artCtl:  artifact.Ctl,
 	}
 }

--- a/src/controller/tag/controller.go
+++ b/src/controller/tag/controller.go
@@ -24,6 +24,7 @@ import (
 	"github.com/goharbor/harbor/src/lib/orm"
 	"github.com/goharbor/harbor/src/lib/q"
 	"github.com/goharbor/harbor/src/lib/selector"
+	"github.com/goharbor/harbor/src/pkg"
 	"github.com/goharbor/harbor/src/pkg/artifact"
 	"github.com/goharbor/harbor/src/pkg/immutable/match"
 	"github.com/goharbor/harbor/src/pkg/immutable/match/rule"
@@ -61,7 +62,7 @@ type Controller interface {
 func NewController() Controller {
 	return &controller{
 		tagMgr:       tag.Mgr,
-		artMgr:       artifact.Mgr,
+		artMgr:       pkg.ArtifactMgr,
 		immutableMtr: rule.NewRuleMatcher(),
 	}
 }

--- a/src/lib/cache/cache.go
+++ b/src/lib/cache/cache.go
@@ -56,6 +56,9 @@ type Cache interface {
 
 	// Save cache the value by key
 	Save(ctx context.Context, key string, value interface{}, expiration ...time.Duration) error
+
+	// Keys returns the key matched by prefixes
+	Keys(ctx context.Context, prefixes ...string) ([]string, error)
 }
 
 var (

--- a/src/lib/cache/memory/memory.go
+++ b/src/lib/cache/memory/memory.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"strings"
 	"sync"
 	"time"
 
@@ -109,6 +110,29 @@ func (c *Cache) Save(ctx context.Context, key string, value interface{}, expirat
 	})
 
 	return nil
+}
+
+// Keys returns the key matched by prefixes.
+func (c *Cache) Keys(ctx context.Context, prefixes ...string) ([]string, error) {
+	// if no prefix, means match all keys.
+	matchAll := len(prefixes) == 0
+	// range map to get all keys
+	keys := make([]string, 0)
+	c.storage.Range(func(k, v interface{}) bool {
+		ks := k.(string)
+		if matchAll {
+			keys = append(keys, ks)
+		} else {
+			for _, p := range prefixes {
+				if strings.HasPrefix(ks, c.opts.Key(p)) {
+					keys = append(keys, ks)
+				}
+			}
+		}
+		return true
+	})
+
+	return keys, nil
 }
 
 // New returns memory cache

--- a/src/lib/cache/memory/memory_test.go
+++ b/src/lib/cache/memory/memory_test.go
@@ -108,6 +108,30 @@ func (suite *CacheTestSuite) TestPing() {
 	suite.NoError(suite.cache.Ping(suite.ctx))
 }
 
+func (suite *CacheTestSuite) TestKeys() {
+	key1 := "p1"
+	key2 := "p2"
+
+	var err error
+	err = suite.cache.Save(suite.ctx, key1, "hello, p1")
+	suite.Nil(err)
+	err = suite.cache.Save(suite.ctx, key2, "hello, p2")
+	suite.Nil(err)
+
+	// should match all
+	keys, err := suite.cache.Keys(suite.ctx, "p")
+	suite.Nil(err)
+	suite.ElementsMatch([]string{"p1", "p2"}, keys)
+	// only get p1
+	keys, err = suite.cache.Keys(suite.ctx, key1)
+	suite.Nil(err)
+	suite.Equal([]string{"p1"}, keys)
+	// only get p2
+	keys, err = suite.cache.Keys(suite.ctx, key2)
+	suite.Nil(err)
+	suite.Equal([]string{"p2"}, keys)
+}
+
 func TestCacheTestSuite(t *testing.T) {
 	suite.Run(t, new(CacheTestSuite))
 }

--- a/src/lib/cache/redis/redis.go
+++ b/src/lib/cache/redis/redis.go
@@ -87,6 +87,30 @@ func (c *Cache) Save(ctx context.Context, key string, value interface{}, expirat
 	return c.Client.Set(ctx, c.opts.Key(key), data, exp).Err()
 }
 
+// Keys returns the key matched by prefixes.
+func (c *Cache) Keys(ctx context.Context, prefixes ...string) ([]string, error) {
+	patterns := make([]string, 0, len(prefixes))
+	if len(prefixes) == 0 {
+		patterns = append(patterns, "*")
+	} else {
+		for _, p := range prefixes {
+			patterns = append(patterns, c.opts.Key(p)+"*")
+		}
+	}
+
+	keys := make([]string, 0)
+	for _, pattern := range patterns {
+		cmd := c.Client.Keys(ctx, pattern)
+		if err := cmd.Err(); err != nil {
+			return nil, err
+		}
+
+		keys = append(keys, cmd.Val()...)
+	}
+
+	return keys, nil
+}
+
 // New returns redis cache
 func New(opts cache.Options) (cache.Cache, error) {
 	if opts.Address == "" {

--- a/src/lib/cache/redis/redis_test.go
+++ b/src/lib/cache/redis/redis_test.go
@@ -109,6 +109,30 @@ func (suite *CacheTestSuite) TestPing() {
 	suite.NoError(suite.cache.Ping(suite.ctx))
 }
 
+func (suite *CacheTestSuite) TestKeys() {
+	key1 := "p1"
+	key2 := "p2"
+
+	var err error
+	err = suite.cache.Save(suite.ctx, key1, "hello, p1")
+	suite.Nil(err)
+	err = suite.cache.Save(suite.ctx, key2, "hello, p2")
+	suite.Nil(err)
+
+	// should match all
+	keys, err := suite.cache.Keys(suite.ctx, "p")
+	suite.Nil(err)
+	suite.ElementsMatch([]string{"p1", "p2"}, keys)
+	// only get p1
+	keys, err = suite.cache.Keys(suite.ctx, key1)
+	suite.Nil(err)
+	suite.Equal([]string{"p1"}, keys)
+	// only get p2
+	keys, err = suite.cache.Keys(suite.ctx, key2)
+	suite.Nil(err)
+	suite.Equal([]string{"p2"}, keys)
+}
+
 func TestCacheTestSuite(t *testing.T) {
 	suite.Run(t, new(CacheTestSuite))
 }

--- a/src/lib/config/metadata/metadatalist.go
+++ b/src/lib/config/metadata/metadatalist.go
@@ -183,5 +183,8 @@ var (
 		{Name: common.PullTimeUpdateDisable, Scope: UserScope, Group: BasicGroup, EnvKey: "PULL_TIME_UPDATE_DISABLE", DefaultValue: "false", ItemType: &BoolType{}, Editable: false, Description: `The flag to indicate if pull time is disable for pull request.`},
 		{Name: common.PullCountUpdateDisable, Scope: UserScope, Group: BasicGroup, EnvKey: "PULL_COUNT_UPDATE_DISABLE", DefaultValue: "false", ItemType: &BoolType{}, Editable: false, Description: `The flag to indicate if pull count is disable for pull request.`},
 		{Name: common.PullAuditLogDisable, Scope: UserScope, Group: BasicGroup, EnvKey: "PULL_AUDIT_LOG_DISABLE", DefaultValue: "false", ItemType: &BoolType{}, Editable: false, Description: `The flag to indicate if pull audit log is disable for pull request.`},
+
+		{Name: common.CacheEnabled, Scope: SystemScope, Group: BasicGroup, EnvKey: "CACHE_ENABLED", DefaultValue: "false", ItemType: &BoolType{}, Editable: false, Description: `Enable cache`},
+		{Name: common.CacheExpireHours, Scope: SystemScope, Group: BasicGroup, EnvKey: "CACHE_EXPIRE_HOURS", DefaultValue: "24", ItemType: &IntType{}, Editable: false, Description: `The expire hours for cache`},
 	}
 )

--- a/src/lib/config/systemconfig.go
+++ b/src/lib/config/systemconfig.go
@@ -31,14 +31,15 @@ package config
 import (
 	"context"
 	"errors"
+	"os"
+	"strconv"
+	"strings"
+
 	"github.com/goharbor/harbor/src/common"
 	"github.com/goharbor/harbor/src/common/models"
 	"github.com/goharbor/harbor/src/common/secret"
 	"github.com/goharbor/harbor/src/lib/encrypt"
 	"github.com/goharbor/harbor/src/lib/log"
-	"os"
-	"strconv"
-	"strings"
 )
 
 var (
@@ -242,6 +243,30 @@ func Metric() *models.Metric {
 // InitialAdminPassword returns the initial password for administrator
 func InitialAdminPassword() (string, error) {
 	return DefaultMgr().Get(backgroundCtx, common.AdminInitialPassword).GetString(), nil
+}
+
+// CacheEnabled returns whether enable cache layer.
+func CacheEnabled() bool {
+	if DefaultMgr() != nil {
+		return DefaultMgr().Get(backgroundCtx, common.CacheEnabled).GetBool()
+	}
+	// backoff read from env.
+	return os.Getenv("CACHE_ENABLED") == "true"
+}
+
+// CacheExpireHours returns the cache expire hours for cache layer.
+func CacheExpireHours() int {
+	if DefaultMgr() != nil {
+		return DefaultMgr().Get(backgroundCtx, common.CacheExpireHours).GetInt()
+	}
+	// backoff read from env.
+	hours, err := strconv.Atoi(os.Getenv("CACHE_EXPIRE_HOURS"))
+	if err != nil {
+		// use default if parse error.
+		hours = common.DefaultCacheExpireHours
+	}
+
+	return hours
 }
 
 // Database returns database settings

--- a/src/migration/artifact.go
+++ b/src/migration/artifact.go
@@ -20,6 +20,7 @@ import (
 	art "github.com/goharbor/harbor/src/controller/artifact"
 	"github.com/goharbor/harbor/src/lib/log"
 	"github.com/goharbor/harbor/src/lib/q"
+	"github.com/goharbor/harbor/src/pkg"
 	"github.com/goharbor/harbor/src/pkg/artifact"
 	"github.com/goharbor/harbor/src/pkg/project"
 	"github.com/goharbor/harbor/src/pkg/repository"
@@ -43,7 +44,7 @@ func abstractArtData(ctx context.Context) error {
 		}
 		for _, repo := range repos {
 			log.Infof("abstracting artifact metadata under repository %s ....", repo.Name)
-			arts, err := artifact.Mgr.List(ctx, &q.Query{
+			arts, err := pkg.ArtifactMgr.List(ctx, &q.Query{
 				Keywords: map[string]interface{}{
 					"RepositoryID": repo.RepositoryID,
 				},
@@ -57,7 +58,7 @@ func abstractArtData(ctx context.Context) error {
 					log.Errorf("failed to abstract the artifact %s@%s: %v, skip", a.RepositoryName, a.Digest, err)
 					continue
 				}
-				if err = artifact.Mgr.Update(ctx, a); err != nil {
+				if err = pkg.ArtifactMgr.Update(ctx, a); err != nil {
 					log.Errorf("failed to update the artifact %s@%s: %v, skip", repo.Name, a.Digest, err)
 					continue
 				}
@@ -73,7 +74,7 @@ func abstractArtData(ctx context.Context) error {
 func abstract(ctx context.Context, abstractor art.Abstractor, art *artifact.Artifact) error {
 	// abstract the children
 	for _, reference := range art.References {
-		child, err := artifact.Mgr.Get(ctx, reference.ChildID)
+		child, err := pkg.ArtifactMgr.Get(ctx, reference.ChildID)
 		if err != nil {
 			log.Errorf("failed to get the artifact %d: %v, skip", reference.ChildID, err)
 			continue

--- a/src/pkg/artifact/manager.go
+++ b/src/pkg/artifact/manager.go
@@ -22,11 +22,6 @@ import (
 	"github.com/goharbor/harbor/src/pkg/artifact/dao"
 )
 
-var (
-	// Mgr is a global artifact manager instance
-	Mgr = NewManager()
-)
-
 // Manager is the only interface of artifact module to provide the management functions for artifacts
 type Manager interface {
 	// Count returns the total count of artifacts according to the query.

--- a/src/pkg/cached/artifact/redis/manager.go
+++ b/src/pkg/cached/artifact/redis/manager.go
@@ -1,0 +1,257 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package redis
+
+import (
+	"context"
+	"time"
+
+	libcache "github.com/goharbor/harbor/src/lib/cache"
+	"github.com/goharbor/harbor/src/lib/config"
+	"github.com/goharbor/harbor/src/lib/errors"
+	"github.com/goharbor/harbor/src/lib/log"
+	"github.com/goharbor/harbor/src/lib/q"
+	"github.com/goharbor/harbor/src/lib/retry"
+	"github.com/goharbor/harbor/src/pkg/artifact"
+	"github.com/goharbor/harbor/src/pkg/cached"
+)
+
+var _ CachedManager = &manager{}
+
+// CachedManager is the interface combines raw resource manager and cached manager for better extension.
+type CachedManager interface {
+	// Manager is the raw resource manager.
+	artifact.Manager
+	// Manager is the common interface for resource cache.
+	cached.Manager
+}
+
+// manager is the cached manager implemented by redis.
+type manager struct {
+	// delegator delegates the raw crud to DAO.
+	delegator artifact.Manager
+	// client returns the redis cache client.
+	client func() libcache.Cache
+	// keyBuilder builds cache object key.
+	keyBuilder *cached.ObjectKey
+	// lifetime is the cache life time.
+	lifetime time.Duration
+}
+
+// NewManager returns the redis cache manager.
+func NewManager(m artifact.Manager) *manager {
+	return &manager{
+		delegator:  m,
+		client:     func() libcache.Cache { return libcache.Default() },
+		keyBuilder: cached.NewObjectKey(cached.ResourceTypeArtifact),
+		lifetime:   time.Duration(config.CacheExpireHours()) * time.Hour,
+	}
+}
+
+func (m *manager) Count(ctx context.Context, query *q.Query) (int64, error) {
+	return m.delegator.Count(ctx, query)
+}
+
+func (m *manager) List(ctx context.Context, query *q.Query) ([]*artifact.Artifact, error) {
+	return m.delegator.List(ctx, query)
+}
+
+func (m *manager) Create(ctx context.Context, artifact *artifact.Artifact) (int64, error) {
+	return m.delegator.Create(ctx, artifact)
+}
+
+func (m *manager) ListReferences(ctx context.Context, query *q.Query) ([]*artifact.Reference, error) {
+	return m.delegator.ListReferences(ctx, query)
+}
+
+func (m *manager) DeleteReference(ctx context.Context, id int64) error {
+	return m.delegator.DeleteReference(ctx, id)
+}
+
+func (m *manager) Get(ctx context.Context, id int64) (*artifact.Artifact, error) {
+	key, err := m.keyBuilder.Format("id", id)
+	if err != nil {
+		return nil, err
+	}
+
+	art := &artifact.Artifact{}
+	if err = m.client().Fetch(ctx, key, art); err == nil {
+		return art, nil
+	}
+
+	log.Debugf("get artifact %d from cache error: %v, will query from database.", id, err)
+
+	art, err = m.delegator.Get(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	if err = m.client().Save(ctx, key, art, m.lifetime); err != nil {
+		// log error if save to cache failed
+		log.Debugf("save artifact %s to cache error: %v", art.String(), err)
+	}
+
+	return art, nil
+}
+
+func (m *manager) GetByDigest(ctx context.Context, repository, digest string) (*artifact.Artifact, error) {
+	key, err := m.keyBuilder.Format("digest", digest)
+	if err != nil {
+		return nil, err
+	}
+
+	art := &artifact.Artifact{}
+	if err = m.client().Fetch(ctx, key, art); err == nil {
+		return art, nil
+	}
+
+	art, err = m.delegator.GetByDigest(ctx, repository, digest)
+	if err != nil {
+		return nil, err
+	}
+
+	if err = m.client().Save(ctx, key, art, m.lifetime); err != nil {
+		// log error if save to cache failed
+		log.Debugf("save artifact %s to cache error: %v", art.String(), err)
+	}
+
+	return art, nil
+}
+
+func (m *manager) Delete(ctx context.Context, id int64) error {
+	art, err := m.Get(ctx, id)
+	if err != nil {
+		return err
+	}
+	// pass on delete operation
+	if err := m.delegator.Delete(ctx, id); err != nil {
+		return err
+	}
+	// clean cache
+	m.cleanUp(ctx, art)
+	return nil
+}
+
+func (m *manager) Update(ctx context.Context, artifact *artifact.Artifact, props ...string) error {
+	// pass on update operation
+	if err := m.delegator.Update(ctx, artifact, props...); err != nil {
+		return err
+	}
+	// clean cache
+	m.cleanUp(ctx, artifact)
+	return nil
+}
+
+func (m *manager) UpdatePullTime(ctx context.Context, id int64, pullTime time.Time) error {
+	art, err := m.Get(ctx, id)
+	if err != nil {
+		return err
+	}
+	// pass on updatePullTime operation
+	if err = m.delegator.UpdatePullTime(ctx, id, pullTime); err != nil {
+		return err
+	}
+	// refresh cache
+	m.refreshCache(ctx, art)
+	return nil
+}
+
+// cleanUp cleans up data in cache.
+func (m *manager) cleanUp(ctx context.Context, art *artifact.Artifact) {
+	// clean index by id
+	idIdx, err := m.keyBuilder.Format("id", art.ID)
+	if err != nil {
+		log.Errorf("format artifact id key error: %v", err)
+	} else {
+		// retry to avoid dirty data
+		if err = retry.Retry(func() error { return m.client().Delete(ctx, idIdx) }); err != nil {
+			log.Errorf("delete artifact cache key %s error: %v", idIdx, err)
+		}
+	}
+
+	// clean index by digest
+	digestIdx, err := m.keyBuilder.Format("digest", art.Digest)
+	if err != nil {
+		log.Errorf("format artifact digest key error: %v", err)
+	} else {
+		if err = retry.Retry(func() error { return m.client().Delete(ctx, digestIdx) }); err != nil {
+			log.Errorf("delete artifact cache key %s error: %v", digestIdx, err)
+		}
+	}
+}
+
+// refreshCache refreshes cache.
+func (m *manager) refreshCache(ctx context.Context, art *artifact.Artifact) {
+	// refreshCache used for UpdatePullTime, because we have a background goroutine to
+	// update per artifact pull_time in period time, in that case, we don't want to lose
+	// cache every fixed interval, so prefer to use refreshCache instead of cleanUp.
+	// no need to consider lock because we only have one goroutine do this work one by one.
+
+	// refreshCache includes 2 steps:
+	//   1. cleanUp
+	//   2. re-get
+	m.cleanUp(ctx, art)
+
+	var err error
+	// re-get by id
+	_, err = m.Get(ctx, art.ID)
+	if err != nil {
+		log.Errorf("refresh cache by artifact id %d error: %v", art.ID, err)
+	}
+	// re-get by digest
+	_, err = m.GetByDigest(ctx, art.RepositoryName, art.Digest)
+	if err != nil {
+		log.Errorf("refresh cache by artifact digest %s error: %v", art.Digest, err)
+	}
+}
+
+func (m *manager) ResourceType(ctx context.Context) string {
+	return cached.ResourceTypeArtifact
+}
+
+func (m *manager) CountCache(ctx context.Context) (int64, error) {
+	// prefix is resource type
+	keys, err := m.client().Keys(ctx, m.ResourceType(ctx))
+	if err != nil {
+		return 0, err
+	}
+
+	return int64(len(keys)), nil
+}
+
+func (m *manager) DeleteCache(ctx context.Context, key string) error {
+	return m.client().Delete(ctx, key)
+}
+
+func (m *manager) FlushAll(ctx context.Context) error {
+	// prefix is resource type
+	keys, err := m.client().Keys(ctx, m.ResourceType(ctx))
+	if err != nil {
+		return err
+	}
+
+	var errs errors.Errors
+	for _, key := range keys {
+		if err = m.client().Delete(ctx, key); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	if errs.Len() > 0 {
+		return errs
+	}
+
+	return nil
+}

--- a/src/pkg/cached/artifact/redis/manager_test.go
+++ b/src/pkg/cached/artifact/redis/manager_test.go
@@ -1,0 +1,202 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package redis
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/goharbor/harbor/src/lib/cache"
+	"github.com/goharbor/harbor/src/pkg/artifact"
+	testcache "github.com/goharbor/harbor/src/testing/lib/cache"
+	"github.com/goharbor/harbor/src/testing/mock"
+	testArt "github.com/goharbor/harbor/src/testing/pkg/artifact"
+	"github.com/stretchr/testify/suite"
+)
+
+type managerTestSuite struct {
+	suite.Suite
+	cachedManager CachedManager
+	artMgr        *testArt.Manager
+	cache         *testcache.Cache
+	ctx           context.Context
+}
+
+func (m *managerTestSuite) SetupTest() {
+	m.artMgr = &testArt.Manager{}
+	m.cache = &testcache.Cache{}
+	m.cachedManager = NewManager(
+		m.artMgr,
+	)
+	m.cachedManager.(*manager).client = func() cache.Cache { return m.cache }
+	m.ctx = context.TODO()
+}
+
+func (m *managerTestSuite) TestGet() {
+	// get from cache directly
+	m.cache.On("Fetch", mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
+	_, err := m.cachedManager.Get(m.ctx, 100)
+	m.NoError(err, "should get from cache")
+	m.artMgr.AssertNotCalled(m.T(), "Get", mock.Anything, mock.Anything)
+
+	// not found in cache, read from dao
+	m.cache.On("Fetch", mock.Anything, mock.Anything, mock.Anything).Return(cache.ErrNotFound).Once()
+	m.cache.On("Save", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
+	m.artMgr.On("Get", mock.Anything, mock.Anything).Return(&artifact.Artifact{}, nil).Once()
+	_, err = m.cachedManager.Get(m.ctx, 100)
+	m.NoError(err, "should get from artMgr")
+	m.artMgr.AssertCalled(m.T(), "Get", mock.Anything, mock.Anything)
+}
+
+func (m *managerTestSuite) TestGetByDigest() {
+	// get from cache directly
+	m.cache.On("Fetch", mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
+	_, err := m.cachedManager.GetByDigest(m.ctx, "repo", "sha256:418fb88ec412e340cdbef913b8ca1bbe8f9e8dc705f9617414c1f2c8db980180")
+	m.NoError(err, "should get from cache")
+	m.artMgr.AssertNotCalled(m.T(), "Get", mock.Anything, mock.Anything)
+
+	// not found in cache, read from dao
+	m.cache.On("Fetch", mock.Anything, mock.Anything, mock.Anything).Return(cache.ErrNotFound).Once()
+	m.cache.On("Save", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
+	m.artMgr.On("Get", mock.Anything, mock.Anything).Return(&artifact.Artifact{}, nil).Once()
+	_, err = m.cachedManager.Get(m.ctx, 100)
+	m.NoError(err, "should get from artMgr")
+	m.artMgr.AssertCalled(m.T(), "Get", mock.Anything, mock.Anything)
+}
+
+func (m *managerTestSuite) TestDelete() {
+	// delete from artMgr error
+	errDelete := errors.New("delete failed")
+	m.artMgr.On("Delete", mock.Anything, mock.Anything).Return(errDelete).Once()
+	m.artMgr.On("DeleteReferences", mock.Anything, mock.Anything).Return(nil).Once()
+	m.cache.On("Fetch", mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
+	err := m.cachedManager.Delete(m.ctx, 100)
+	m.ErrorIs(err, errDelete, "delete should error")
+	m.cache.AssertNotCalled(m.T(), "Delete", mock.Anything, mock.Anything)
+
+	// delete from artMgr success
+	m.artMgr.On("Delete", mock.Anything, mock.Anything).Return(nil).Once()
+	m.artMgr.On("DeleteReferences", mock.Anything, mock.Anything).Return(nil).Once()
+	m.cache.On("Fetch", mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
+	m.cache.On("Delete", mock.Anything, mock.Anything).Return(nil).Twice()
+	err = m.cachedManager.Delete(m.ctx, 100)
+	m.NoError(err, "delete should success")
+	m.cache.AssertCalled(m.T(), "Delete", mock.Anything, mock.Anything)
+}
+
+func (m *managerTestSuite) TestUpdate() {
+	// update from artMgr error
+	errUpdate := errors.New("update failed")
+	m.artMgr.On("Update", mock.Anything, mock.Anything).Return(errUpdate).Once()
+	err := m.cachedManager.Update(m.ctx, &artifact.Artifact{})
+	m.ErrorIs(err, errUpdate, "update should error")
+	m.cache.AssertNotCalled(m.T(), "Delete", mock.Anything, mock.Anything)
+
+	// update from artMgr success
+	m.artMgr.On("Update", mock.Anything, mock.Anything).Return(nil).Once()
+	m.cache.On("Delete", mock.Anything, mock.Anything).Return(nil).Twice()
+	err = m.cachedManager.Update(m.ctx, &artifact.Artifact{})
+	m.NoError(err, "update should success")
+	m.cache.AssertCalled(m.T(), "Delete", mock.Anything, mock.Anything)
+}
+
+func (m *managerTestSuite) TestUpdatePullTime() {
+	// update pull time from artMgr error
+	errUpdate := errors.New("update pull time failed")
+	m.artMgr.On("UpdatePullTime", mock.Anything, mock.Anything, mock.Anything).Return(errUpdate).Once()
+	m.cache.On("Fetch", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	err := m.cachedManager.UpdatePullTime(m.ctx, 100, time.Now())
+	m.ErrorIs(err, errUpdate, "update pull time should error")
+	m.cache.AssertNotCalled(m.T(), "Delete", mock.Anything, mock.Anything)
+
+	// update pull time from artMgr success
+	m.artMgr.On("UpdatePullTime", mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
+	m.cache.On("Delete", mock.Anything, mock.Anything).Return(nil).Twice()
+	err = m.cachedManager.UpdatePullTime(m.ctx, 100, time.Now())
+	m.NoError(err, "update pull time should success")
+	m.cache.AssertCalled(m.T(), "Delete", mock.Anything, mock.Anything)
+}
+
+func (m *managerTestSuite) TestCount() {
+	m.artMgr.On("Count", mock.Anything, mock.Anything).Return(int64(1), nil)
+	c, err := m.cachedManager.Count(m.ctx, nil)
+	m.NoError(err)
+	m.Equal(int64(1), c)
+	m.artMgr.AssertCalled(m.T(), "Count", mock.Anything, mock.Anything)
+}
+
+func (m *managerTestSuite) TestList() {
+	arts := []*artifact.Artifact{}
+	m.artMgr.On("List", mock.Anything, mock.Anything).Return(arts, nil)
+	as, err := m.cachedManager.List(m.ctx, nil)
+	m.NoError(err)
+	m.Equal(arts, as)
+	m.artMgr.AssertCalled(m.T(), "List", mock.Anything, mock.Anything)
+}
+
+func (m *managerTestSuite) TestCreate() {
+	m.artMgr.On("Create", mock.Anything, mock.Anything).Return(int64(1), nil)
+	id, err := m.cachedManager.Create(m.ctx, nil)
+	m.NoError(err)
+	m.Equal(int64(1), id)
+	m.artMgr.AssertCalled(m.T(), "Create", mock.Anything, mock.Anything)
+}
+
+func (m *managerTestSuite) TestListReferences() {
+	refs := []*artifact.Reference{}
+	m.artMgr.On("ListReferences", mock.Anything, mock.Anything).Return(refs, nil)
+	rs, err := m.cachedManager.ListReferences(m.ctx, nil)
+	m.NoError(err)
+	m.Equal(refs, rs)
+	m.artMgr.AssertCalled(m.T(), "ListReferences", mock.Anything, mock.Anything)
+}
+
+func (m *managerTestSuite) TestDeleteReference() {
+	m.artMgr.On("DeleteReference", mock.Anything, mock.Anything).Return(nil)
+	err := m.cachedManager.DeleteReference(m.ctx, 1)
+	m.NoError(err)
+	m.artMgr.AssertCalled(m.T(), "DeleteReference", mock.Anything, mock.Anything)
+}
+
+func (m *managerTestSuite) TestResourceType() {
+	t := m.cachedManager.ResourceType(m.ctx)
+	m.Equal("artifact", t)
+}
+
+func (m *managerTestSuite) TestCountCache() {
+	m.cache.On("Keys", mock.Anything, mock.Anything).Return([]string{"1"}, nil).Once()
+	c, err := m.cachedManager.CountCache(m.ctx)
+	m.NoError(err)
+	m.Equal(int64(1), c)
+}
+
+func (m *managerTestSuite) TestDeleteCache() {
+	m.cache.On("Delete", mock.Anything, mock.Anything).Return(nil).Once()
+	err := m.cachedManager.DeleteCache(m.ctx, "key")
+	m.NoError(err)
+}
+
+func (m *managerTestSuite) TestFlushAll() {
+	m.cache.On("Keys", mock.Anything, mock.Anything).Return([]string{"1"}, nil).Once()
+	m.cache.On("Delete", mock.Anything, mock.Anything).Return(nil).Once()
+	err := m.cachedManager.FlushAll(m.ctx)
+	m.NoError(err)
+}
+
+func TestManager(t *testing.T) {
+	suite.Run(t, &managerTestSuite{})
+}

--- a/src/pkg/cached/manager.go
+++ b/src/pkg/cached/manager.go
@@ -1,0 +1,89 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cached
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/goharbor/harbor/src/lib/errors"
+)
+
+const (
+	// Resource type definitions
+	// ResourceTypeArtifact defines artifact type.
+	ResourceTypeArtifact = "artifact"
+)
+
+// Manager is the interface for resource cache manager.
+// Provides common interfaces for admin to view and manage resource cache.
+type Manager interface {
+	//  ResourceType returns the resource type.
+	//  eg. artifact、project、tag、repository
+	ResourceType(ctx context.Context) string
+	// CountCache returns current this resource occupied cache count.
+	CountCache(ctx context.Context) (int64, error)
+	// DeleteCache deletes specific cache by key.
+	DeleteCache(ctx context.Context, key string) error
+	// FlushAll flush this resource's all cache.
+	FlushAll(ctx context.Context) error
+
+	// TODO for more extensions like metrics.
+}
+
+// ObjectKey normalizes cache object key.
+type ObjectKey struct {
+	// namespace as group or prefix, eg. artifact:id
+	namespace string
+}
+
+// NewObjectKey returns object key with namespace.
+func NewObjectKey(ns string) *ObjectKey {
+	return &ObjectKey{namespace: ns}
+}
+
+// Format formats fields to string.
+// eg. namespace: 'artifact'
+// Format("id", 100, "digest", "aaa"): "artifact:id:100:digest:aaa"
+func (ok *ObjectKey) Format(keysAndValues ...interface{}) (string, error) {
+	// keysAndValues must be paired.
+	if len(keysAndValues)%2 != 0 {
+		return "", errors.Errorf("invalid keysAndValues: %v", keysAndValues...)
+	}
+
+	s := ok.namespace
+	for i := 0; i < len(keysAndValues); i++ {
+		// even is key
+		if i%2 == 0 {
+			key, match := keysAndValues[i].(string)
+			if !match {
+				return "", errors.Errorf("key must be string, invalid key type: %#v", keysAndValues[i])
+			}
+
+			s += fmt.Sprintf(":%s", key)
+		} else {
+			switch keysAndValues[i].(type) {
+			case int, int16, int32, int64:
+				s += fmt.Sprintf(":%d", keysAndValues[i])
+			case string:
+				s += fmt.Sprintf(":%s", keysAndValues[i])
+			default:
+				return "", errors.Errorf("unsupported value type: %#v", keysAndValues[i])
+			}
+		}
+	}
+
+	return s, nil
+}

--- a/src/pkg/cached/manager_test.go
+++ b/src/pkg/cached/manager_test.go
@@ -1,0 +1,36 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cached
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestObjectKey(t *testing.T) {
+	ok := NewObjectKey("artifact")
+	// valid case
+	s, err := ok.Format("id", 100, "digest", "9834876dcfb05cb167a5c24953eba58c4ac89b1adf57f28f2f9d09af107ee8f0")
+	assert.NoError(t, err, "format should not error")
+	assert.Equal(t, "artifact:id:100:digest:9834876dcfb05cb167a5c24953eba58c4ac89b1adf57f28f2f9d09af107ee8f0", s)
+	// invalid case
+	_, err = ok.Format("id")
+	assert.Error(t, err, "invalid length should error")
+	_, err = ok.Format(1, 1)
+	assert.Error(t, err, "invalid key type should error")
+	_, err = ok.Format("id", struct{}{})
+	assert.Error(t, err, "invalid value type should error")
+}

--- a/src/pkg/exporter/project_collector_test.go
+++ b/src/pkg/exporter/project_collector_test.go
@@ -1,10 +1,12 @@
 package exporter
 
 import (
-	proModels "github.com/goharbor/harbor/src/pkg/project/models"
 	"strconv"
 	"testing"
 	"time"
+
+	"github.com/goharbor/harbor/src/pkg"
+	proModels "github.com/goharbor/harbor/src/pkg/project/models"
 
 	"github.com/stretchr/testify/suite"
 
@@ -93,7 +95,7 @@ func setupTest(t *testing.T) {
 	art1.ProjectID = testPro1.ProjectID
 	art1.RepositoryID = repo1ID
 	art1.PushTime = time.Now()
-	_, err = artifact.Mgr.Create(ctx, &art1)
+	_, err = pkg.ArtifactMgr.Create(ctx, &art1)
 	if err != nil {
 		t.Errorf("add repo error %v", err)
 	}
@@ -101,7 +103,7 @@ func setupTest(t *testing.T) {
 	art2.ProjectID = testPro2.ProjectID
 	art2.RepositoryID = repo2ID
 	art2.PushTime = time.Now()
-	_, err = artifact.Mgr.Create(ctx, &art2)
+	_, err = pkg.ArtifactMgr.Create(ctx, &art2)
 	if err != nil {
 		t.Errorf("add repo error %v", err)
 	}

--- a/src/pkg/factory.go
+++ b/src/pkg/factory.go
@@ -1,0 +1,49 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pkg
+
+import (
+	"sync"
+
+	"github.com/goharbor/harbor/src/lib/config"
+	"github.com/goharbor/harbor/src/pkg/artifact"
+	"github.com/goharbor/harbor/src/pkg/cached/artifact/redis"
+)
+
+// Define global resource manager.
+var (
+	// once for only init one time.
+	once sync.Once
+	// ArtifactMgr is the manager for artifact.
+	ArtifactMgr artifact.Manager
+)
+
+// init initialize mananger for resources
+func init() {
+	once.Do(func() {
+		cacheEnabled := config.CacheEnabled()
+		initArtifactManager(cacheEnabled)
+	})
+}
+
+func initArtifactManager(cacheEnabled bool) {
+	artMgr := artifact.NewManager()
+	// check cache enable
+	if cacheEnabled {
+		ArtifactMgr = redis.NewManager(artMgr)
+	} else {
+		ArtifactMgr = artMgr
+	}
+}

--- a/src/pkg/factory_test.go
+++ b/src/pkg/factory_test.go
@@ -1,0 +1,36 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pkg
+
+import (
+	"testing"
+
+	"github.com/goharbor/harbor/src/pkg/artifact"
+	"github.com/goharbor/harbor/src/pkg/cached/artifact/redis"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInit(t *testing.T) {
+	// cache not enable
+	// artifact
+	assert.NotNil(t, ArtifactMgr)
+	assert.IsType(t, artifact.NewManager(), ArtifactMgr)
+
+	// cache enable
+	initArtifactManager(true)
+	// artifact
+	assert.NotNil(t, ArtifactMgr)
+	assert.IsType(t, redis.NewManager(artifact.NewManager()), ArtifactMgr)
+}

--- a/src/server/middleware/cosign/cosign_test.go
+++ b/src/server/middleware/cosign/cosign_test.go
@@ -2,9 +2,16 @@ package cosign
 
 import (
 	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
 	"github.com/goharbor/harbor/src/controller/repository"
 	"github.com/goharbor/harbor/src/lib"
 	"github.com/goharbor/harbor/src/lib/q"
+	"github.com/goharbor/harbor/src/pkg"
 	"github.com/goharbor/harbor/src/pkg/accessory"
 	"github.com/goharbor/harbor/src/pkg/accessory/model"
 	accessorymodel "github.com/goharbor/harbor/src/pkg/accessory/model"
@@ -12,11 +19,6 @@ import (
 	"github.com/goharbor/harbor/src/pkg/distribution"
 	htesting "github.com/goharbor/harbor/src/testing"
 	"github.com/stretchr/testify/suite"
-	"net/http"
-	"net/http/httptest"
-	"strings"
-	"testing"
-	"time"
 )
 
 type MiddlewareTestSuite struct {
@@ -77,7 +79,7 @@ func (suite *MiddlewareTestSuite) addArt(pid, repositoryID int64, repositoryName
 		PushTime:       time.Now(),
 		PullTime:       time.Now(),
 	}
-	afid, err := artifact.Mgr.Create(suite.Context(), af)
+	afid, err := pkg.ArtifactMgr.Create(suite.Context(), af)
 	suite.Nil(err, fmt.Sprintf("Add artifact failed for %d", repositoryID))
 	return afid
 }
@@ -93,7 +95,7 @@ func (suite *MiddlewareTestSuite) addArtAcc(pid, repositoryID int64, repositoryN
 		PushTime:       time.Now(),
 		PullTime:       time.Now(),
 	}
-	subafid, err := artifact.Mgr.Create(suite.Context(), subaf)
+	subafid, err := pkg.ArtifactMgr.Create(suite.Context(), subaf)
 	suite.Nil(err, fmt.Sprintf("Add artifact failed for %d", repositoryID))
 
 	af := &artifact.Artifact{
@@ -106,7 +108,7 @@ func (suite *MiddlewareTestSuite) addArtAcc(pid, repositoryID int64, repositoryN
 		PushTime:       time.Now(),
 		PullTime:       time.Now(),
 	}
-	afid, err := artifact.Mgr.Create(suite.Context(), af)
+	afid, err := pkg.ArtifactMgr.Create(suite.Context(), af)
 	suite.Nil(err, fmt.Sprintf("Add artifact failed for %d", repositoryID))
 
 	accid, err := accessory.Mgr.Create(suite.Context(), accessorymodel.AccessoryData{

--- a/src/server/middleware/immutable/pushmf_test.go
+++ b/src/server/middleware/immutable/pushmf_test.go
@@ -3,15 +3,17 @@ package immutable
 import (
 	"context"
 	"fmt"
-	"github.com/goharbor/harbor/src/controller/immutable"
-	"github.com/goharbor/harbor/src/pkg/project"
-	proModels "github.com/goharbor/harbor/src/pkg/project/models"
 	"math/rand"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"testing"
 	"time"
+
+	"github.com/goharbor/harbor/src/controller/immutable"
+	"github.com/goharbor/harbor/src/pkg"
+	"github.com/goharbor/harbor/src/pkg/project"
+	proModels "github.com/goharbor/harbor/src/pkg/project/models"
 
 	"github.com/goharbor/harbor/src/common/dao"
 	"github.com/goharbor/harbor/src/lib"
@@ -92,7 +94,7 @@ func (suite *HandlerSuite) addArt(ctx context.Context, pid, repositoryID int64, 
 		PushTime:       time.Now(),
 		PullTime:       time.Now(),
 	}
-	afid, err := artifact.Mgr.Create(ctx, af)
+	afid, err := pkg.ArtifactMgr.Create(ctx, af)
 	suite.Nil(err, fmt.Sprintf("Add artifact failed for %d", repositoryID))
 	return afid
 }
@@ -162,7 +164,7 @@ func (suite *HandlerSuite) TestPutDeleteManifestCreated() {
 
 	defer func() {
 		project.Mgr.Delete(ctx, projectID)
-		artifact.Mgr.Delete(ctx, afID)
+		pkg.ArtifactMgr.Delete(ctx, afID)
 		repository.Mgr.Delete(ctx, repoID)
 		tag.Mgr.Delete(ctx, tagID)
 		immutable.Ctr.DeleteImmutableRule(internal_orm.Context(), immuRuleID)

--- a/src/testing/lib/cache/cache.go
+++ b/src/testing/lib/cache/cache.go
@@ -56,6 +56,36 @@ func (_m *Cache) Fetch(ctx context.Context, key string, value interface{}) error
 	return r0
 }
 
+// Keys provides a mock function with given fields: ctx, prefixes
+func (_m *Cache) Keys(ctx context.Context, prefixes ...string) ([]string, error) {
+	_va := make([]interface{}, len(prefixes))
+	for _i := range prefixes {
+		_va[_i] = prefixes[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	var r0 []string
+	if rf, ok := ret.Get(0).(func(context.Context, ...string) []string); ok {
+		r0 = rf(ctx, prefixes...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, ...string) error); ok {
+		r1 = rf(ctx, prefixes...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // Ping provides a mock function with given fields: ctx
 func (_m *Cache) Ping(ctx context.Context) error {
 	ret := _m.Called(ctx)


### PR DESCRIPTION
Implement cache layer for resource artifact and define common
cache manager and workflow. Also add cache related options to
configuration yaml.

Closes: https://github.com/goharbor/harbor/issues/16739

Signed-off-by: chlins <chenyuzh@vmware.com>

## Comparison

### Get the specific artifact

`/projects/{project_name}/repositories/{repository_name}/artifacts/{reference}`


#### Get by digest

script: `hey -c 2000 -z 1m -H "Authorization: Basic YWRtaW46SGFyYm9yMTIzNDUK" http://harbor.domain/api/v2.0/projects/library/repositories/busybox/artifacts/sha256:14d4f50961544fdb669075c442509f194bdc4c0e344bde06e35dbd55af842a38`

2.5:
```bash
Summary:
  Total:	62.0148 secs
  Slowest:	16.1262 secs
  Fastest:	0.1568 secs
  Average:	1.9981 secs
  Requests/sec:	980.0083

  Total data:	68736525 bytes
  Size/request:	1131 bytes

Response time histogram:
  0.157 [1]	|
  1.754 [32982]	|■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  3.351 [21843]	|■■■■■■■■■■■■■■■■■■■■■■■■■■
  4.948 [3915]	|■■■■■
  6.545 [1165]	|■
  8.141 [490]	|■
  9.738 [229]	|
  11.335 [106]	|
  12.932 [31]	|
  14.529 [6]	|
  16.126 [7]	|


Latency distribution:
  10% in 0.9956 secs
  25% in 1.2842 secs
  50% in 1.6807 secs
  75% in 2.2534 secs
  90% in 3.3216 secs
  95% in 4.3125 secs
  99% in 7.2571 secs

Details (average, fastest, slowest):
  DNS+dialup:	0.0019 secs, 0.1568 secs, 16.1262 secs
  DNS-lookup:	0.0000 secs, 0.0000 secs, 0.0000 secs
  req write:	0.0000 secs, 0.0000 secs, 0.0360 secs
  resp wait:	1.9959 secs, 0.1468 secs, 16.1262 secs
  resp read:	0.0000 secs, 0.0000 secs, 0.0131 secs

Status code distribution:
  [200]	60775 responses
```

after:
```bash
Summary:
  Total:	61.6996 secs
  Slowest:	4.3489 secs
  Fastest:	0.0143 secs
  Average:	0.5151 secs
  Requests/sec:	3786.3100

  Total data:	264217434 bytes
  Size/request:	1131 bytes

Response time histogram:
  0.014 [1]	|
  0.448 [154944]	|■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  0.881 [41623]	|■■■■■■■■■■■
  1.315 [19779]	|■■■■■
  1.748 [8368]	|■■
  2.182 [3642]	|■
  2.615 [3284]	|■
  3.049 [1445]	|
  3.482 [512]	|
  3.915 [5]	|
  4.349 [11]	|


Latency distribution:
  10% in 0.1628 secs
  25% in 0.2302 secs
  50% in 0.3355 secs
  75% in 0.5766 secs
  90% in 1.1193 secs
  95% in 1.5810 secs
  99% in 2.5418 secs

Details (average, fastest, slowest):
  DNS+dialup:	0.0004 secs, 0.0143 secs, 4.3489 secs
  DNS-lookup:	0.0000 secs, 0.0000 secs, 0.0000 secs
  req write:	0.0001 secs, 0.0000 secs, 0.0250 secs
  resp wait:	0.5146 secs, 0.0142 secs, 4.3254 secs
  resp read:	0.0000 secs, 0.0000 secs, 0.0156 secs

Status code distribution:
  [200]	233614 responses
```

In conclusion, QPS improvement is about **3.8X**  and P99 latency is **2.8X** faster than 2.5.

#### Get by tag

script: `hey -c 2000 -z 1m -H "Authorization: Basic YWRtaW46SGFyYm9yMTIzNDUK" http://harbor.domain/api/v2.0/projects/library/repositories/busybox/artifacts/latest`

2.5:
```bash
Summary:
  Total:	62.1554 secs
  Slowest:	6.1563 secs
  Fastest:	0.0137 secs
  Average:	0.7875 secs
  Requests/sec:	2478.1917

  Total data:	178593918 bytes
  Size/request:	1159 bytes

Response time histogram:
  0.014 [1]	|
  0.628 [100809]	|■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  1.242 [25355]	|■■■■■■■■■■
  1.856 [11940]	|■■■■■
  2.471 [10592]	|■■■■
  3.085 [3322]	|■
  3.699 [1500]	|■
  4.314 [385]	|
  4.928 [97]	|
  5.542 [25]	|
  6.156 [6]	|


Latency distribution:
  10% in 0.3182 secs
  25% in 0.3990 secs
  50% in 0.5095 secs
  75% in 0.8389 secs
  90% in 1.8815 secs
  95% in 2.2722 secs
  99% in 3.2261 secs

Details (average, fastest, slowest):
  DNS+dialup:	0.0005 secs, 0.0137 secs, 6.1563 secs
  DNS-lookup:	0.0000 secs, 0.0000 secs, 0.0000 secs
  req write:	0.0001 secs, 0.0000 secs, 0.0232 secs
  resp wait:	0.7868 secs, 0.0136 secs, 6.1563 secs
  resp read:	0.0000 secs, 0.0000 secs, 0.0114 secs

Status code distribution:
  [200]	148699 responses
  [503]	5333 responses
```

after:
```bash
Summary:
  Total:	61.8543 secs
  Slowest:	3.5923 secs
  Fastest:	0.0316 secs
  Average:	0.5456 secs
  Requests/sec:	3573.9795

  Total data:	250025646 bytes
  Size/request:	1131 bytes

Response time histogram:
  0.032 [1]	|
  0.388 [87192]	|■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  0.744 [90451]	|■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  1.100 [26736]	|■■■■■■■■■■■■
  1.456 [11829]	|■■■■■
  1.812 [2834]	|■
  2.168 [1513]	|■
  2.524 [330]	|
  2.880 [121]	|
  3.236 [50]	|
  3.592 [9]	|


Latency distribution:
  10% in 0.2686 secs
  25% in 0.3328 secs
  50% in 0.4337 secs
  75% in 0.6489 secs
  90% in 1.0068 secs
  95% in 1.2196 secs
  99% in 1.7883 secs

Details (average, fastest, slowest):
  DNS+dialup:	0.0006 secs, 0.0316 secs, 3.5923 secs
  DNS-lookup:	0.0000 secs, 0.0000 secs, 0.0000 secs
  req write:	0.0001 secs, 0.0000 secs, 0.0634 secs
  resp wait:	0.5447 secs, 0.0316 secs, 3.4957 secs
  resp read:	0.0000 secs, 0.0000 secs, 0.0169 secs

Status code distribution:
  [200]	221066 responses
```

In conclusion, QPS improvement is about **1.4X** and P99 latency is **1.8X** faster than 2.5, and also success rate improve to **100%**.
 
