### PR TITLE
Use exec in registryctl so signals are passed properly

### DIFF
--- a/make/photon/registryctl/start.sh
+++ b/make/photon/registryctl/start.sh
@@ -10,4 +10,4 @@ set -e
 
 /home/harbor/install_cert.sh
 
-/home/harbor/harbor_registryctl -c /etc/registryctl/config.yml
+exec /home/harbor/harbor_registryctl -c /etc/registryctl/config.yml


### PR DESCRIPTION
When containers are terminated in Kubernetes, Kubernetes will send a SIGTERM to PID1, wait for terminationGracePeriodSeconds, then SIGKILL it.

But since PID1 in registryctl is `bash`, that SIGTERM signal is not automatically passed to the registryctl process, forcing Kubernetes to wait the whole terminationGracePeriodSeconds to update the registry Pod.

This PR fixes that issue by using `exec`, which makes `registryctl` itself be PID1 so that it receives the SIGTERM signal.

Wasn't able to test this locally, I think the build system needs some TLC, especially for testing individual components. Like for example, I need a local copy of `registry` to build the registryctl image which is downloaded from `https://storage.googleapis.com/harbor-builds/bin/registry/release-v2.8.0-patch-redis/registry`, but that URL 404s.