### PR TITLE
skip policy check on pull cosign signature

### DIFF
--- a/src/server/middleware/contenttrust/cosign.go
+++ b/src/server/middleware/contenttrust/cosign.go
@@ -29,11 +29,6 @@ func Cosign() func(http.Handler) http.Handler {
 			return err
 		}
 
-		if util.SkipPolicyChecking(r, pro.ProjectID) {
-			logger.Debugf("artifact %s@%s is pulling by the scanner/cosign, skip the checking", af.Repository, af.Digest)
-			return nil
-		}
-
 		// If cosign policy enabled, it has to at least have one cosign signature.
 		if pro.ContentTrustCosignEnabled() {
 			art, err := artifact.Ctl.GetByReference(ctx, af.Repository, af.Reference, &artifact.Option{
@@ -41,6 +36,15 @@ func Cosign() func(http.Handler) http.Handler {
 			})
 			if err != nil {
 				return err
+			}
+
+			ok, err := util.SkipPolicyChecking(r, pro.ProjectID, art.ID)
+			if err != nil {
+				return err
+			}
+			if ok {
+				logger.Debugf("artifact %s@%s is pulling by the scanner/cosign, skip the checking", af.Repository, af.Digest)
+				return nil
 			}
 
 			if len(art.Accessories) == 0 {

--- a/src/server/middleware/contenttrust/cosign_test.go
+++ b/src/server/middleware/contenttrust/cosign_test.go
@@ -16,7 +16,11 @@ package contenttrust
 
 import (
 	"fmt"
+	"github.com/goharbor/harbor/src/pkg/accessory"
+	accessorymodel "github.com/goharbor/harbor/src/pkg/accessory/model"
+	basemodel "github.com/goharbor/harbor/src/pkg/accessory/model/base"
 	proModels "github.com/goharbor/harbor/src/pkg/project/models"
+	accessorytesting "github.com/goharbor/harbor/src/testing/pkg/accessory"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -42,6 +46,9 @@ type CosignMiddlewareTestSuite struct {
 	originalProjectController project.Controller
 	projectController         *projecttesting.Controller
 
+	originalAccessMgr accessory.Manager
+	accessMgr         *accessorytesting.Manager
+
 	artifact *artifact.Artifact
 	project  *proModels.Project
 
@@ -56,6 +63,10 @@ func (suite *CosignMiddlewareTestSuite) SetupTest() {
 	suite.originalProjectController = project.Ctl
 	suite.projectController = &projecttesting.Controller{}
 	project.Ctl = suite.projectController
+
+	suite.originalAccessMgr = accessory.Mgr
+	suite.accessMgr = &accessorytesting.Manager{}
+	accessory.Mgr = suite.accessMgr
 
 	suite.artifact = &artifact.Artifact{}
 	suite.artifact.Type = image.ArtifactTypeImage
@@ -80,6 +91,7 @@ func (suite *CosignMiddlewareTestSuite) SetupTest() {
 func (suite *CosignMiddlewareTestSuite) TearDownTest() {
 	artifact.Ctl = suite.originalArtifactController
 	project.Ctl = suite.originalProjectController
+	accessory.Mgr = suite.originalAccessMgr
 }
 
 func (suite *CosignMiddlewareTestSuite) makeRequest(setHeader ...bool) *http.Request {
@@ -143,6 +155,7 @@ func (suite *CosignMiddlewareTestSuite) TestNoneArtifact() {
 func (suite *CosignMiddlewareTestSuite) TestAuthenticatedUserPulling() {
 	mock.OnAnything(suite.artifactController, "GetByReference").Return(suite.artifact, nil)
 	mock.OnAnything(suite.projectController, "GetByName").Return(suite.project, nil)
+	mock.OnAnything(suite.accessMgr, "List").Return([]accessorymodel.Accessory{}, nil)
 	securityCtx := &securitytesting.Context{}
 	mock.OnAnything(securityCtx, "Name").Return("local")
 	mock.OnAnything(securityCtx, "Can").Return(true, nil)
@@ -159,6 +172,7 @@ func (suite *CosignMiddlewareTestSuite) TestAuthenticatedUserPulling() {
 func (suite *CosignMiddlewareTestSuite) TestScannerPulling() {
 	mock.OnAnything(suite.artifactController, "GetByReference").Return(suite.artifact, nil)
 	mock.OnAnything(suite.projectController, "GetByName").Return(suite.project, nil)
+	mock.OnAnything(suite.accessMgr, "List").Return([]accessorymodel.Accessory{}, nil)
 	securityCtx := &securitytesting.Context{}
 	mock.OnAnything(securityCtx, "Name").Return("v2token")
 	mock.OnAnything(securityCtx, "Can").Return(true, nil)
@@ -175,6 +189,7 @@ func (suite *CosignMiddlewareTestSuite) TestScannerPulling() {
 func (suite *CosignMiddlewareTestSuite) TestCosignPulling() {
 	mock.OnAnything(suite.artifactController, "GetByReference").Return(suite.artifact, nil)
 	mock.OnAnything(suite.projectController, "GetByName").Return(suite.project, nil)
+	mock.OnAnything(suite.accessMgr, "List").Return([]accessorymodel.Accessory{}, nil)
 	securityCtx := &securitytesting.Context{}
 	mock.OnAnything(securityCtx, "Name").Return("v2token")
 	mock.OnAnything(securityCtx, "Can").Return(true, nil)
@@ -192,6 +207,7 @@ func (suite *CosignMiddlewareTestSuite) TestCosignPulling() {
 func (suite *CosignMiddlewareTestSuite) TestUnAuthenticatedUserPulling() {
 	mock.OnAnything(suite.artifactController, "GetByReference").Return(suite.artifact, nil)
 	mock.OnAnything(suite.projectController, "GetByName").Return(suite.project, nil)
+	mock.OnAnything(suite.accessMgr, "List").Return([]accessorymodel.Accessory{}, nil)
 	securityCtx := &securitytesting.Context{}
 	mock.OnAnything(securityCtx, "Name").Return("local")
 	mock.OnAnything(securityCtx, "Can").Return(true, nil)
@@ -202,6 +218,29 @@ func (suite *CosignMiddlewareTestSuite) TestUnAuthenticatedUserPulling() {
 
 	Cosign()(suite.next).ServeHTTP(rr, req)
 	suite.Equal(rr.Code, http.StatusPreconditionFailed)
+}
+
+// pull cosign signature when policy checker is enabled.
+func (suite *CosignMiddlewareTestSuite) TestSignaturePulling() {
+	mock.OnAnything(suite.artifactController, "GetByReference").Return(suite.artifact, nil)
+	mock.OnAnything(suite.projectController, "GetByName").Return(suite.project, nil)
+	acc := &basemodel.Default{
+		Data: accessorymodel.AccessoryData{
+			ID:            1,
+			ArtifactID:    2,
+			SubArtifactID: 1,
+			Type:          accessorymodel.TypeCosignSignature,
+		},
+	}
+	mock.OnAnything(suite.accessMgr, "List").Return([]accessorymodel.Accessory{
+		acc,
+	}, nil)
+
+	req := suite.makeRequest()
+	rr := httptest.NewRecorder()
+
+	Cosign()(suite.next).ServeHTTP(rr, req)
+	suite.Equal(rr.Code, http.StatusOK)
 }
 
 func TestCosignMiddlewareTestSuite(t *testing.T) {

--- a/src/server/middleware/contenttrust/notary_test.go
+++ b/src/server/middleware/contenttrust/notary_test.go
@@ -16,7 +16,11 @@ package contenttrust
 
 import (
 	"fmt"
+	"github.com/goharbor/harbor/src/pkg/accessory"
+	accessorymodel "github.com/goharbor/harbor/src/pkg/accessory/model"
+	basemodel "github.com/goharbor/harbor/src/pkg/accessory/model/base"
 	proModels "github.com/goharbor/harbor/src/pkg/project/models"
+	accessorytesting "github.com/goharbor/harbor/src/testing/pkg/accessory"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -45,6 +49,9 @@ type MiddlewareTestSuite struct {
 	artifact *artifact.Artifact
 	project  *proModels.Project
 
+	originalAccessMgr accessory.Manager
+	accessMgr         *accessorytesting.Manager
+
 	isArtifactSigned func(req *http.Request, art lib.ArtifactInfo) (bool, error)
 	next             http.Handler
 }
@@ -57,6 +64,10 @@ func (suite *MiddlewareTestSuite) SetupTest() {
 	suite.originalProjectController = project.Ctl
 	suite.projectController = &projecttesting.Controller{}
 	project.Ctl = suite.projectController
+
+	suite.originalAccessMgr = accessory.Mgr
+	suite.accessMgr = &accessorytesting.Manager{}
+	accessory.Mgr = suite.accessMgr
 
 	suite.isArtifactSigned = isArtifactSigned
 	suite.artifact = &artifact.Artifact{}
@@ -85,6 +96,7 @@ func (suite *MiddlewareTestSuite) SetupTest() {
 func (suite *MiddlewareTestSuite) TearDownTest() {
 	artifact.Ctl = suite.originalArtifactController
 	project.Ctl = suite.originalProjectController
+	accessory.Mgr = suite.originalAccessMgr
 }
 
 func (suite *MiddlewareTestSuite) makeRequest() *http.Request {
@@ -143,6 +155,7 @@ func (suite *MiddlewareTestSuite) TestNoneArtifact() {
 func (suite *MiddlewareTestSuite) TestAuthenticatedUserPulling() {
 	mock.OnAnything(suite.artifactController, "GetByReference").Return(suite.artifact, nil)
 	mock.OnAnything(suite.projectController, "GetByName").Return(suite.project, nil)
+	mock.OnAnything(suite.accessMgr, "List").Return([]accessorymodel.Accessory{}, nil)
 	securityCtx := &securitytesting.Context{}
 	mock.OnAnything(securityCtx, "Name").Return("local")
 	mock.OnAnything(securityCtx, "Can").Return(true, nil)
@@ -159,6 +172,7 @@ func (suite *MiddlewareTestSuite) TestAuthenticatedUserPulling() {
 func (suite *MiddlewareTestSuite) TestScannerPulling() {
 	mock.OnAnything(suite.artifactController, "GetByReference").Return(suite.artifact, nil)
 	mock.OnAnything(suite.projectController, "GetByName").Return(suite.project, nil)
+	mock.OnAnything(suite.accessMgr, "List").Return([]accessorymodel.Accessory{}, nil)
 	securityCtx := &securitytesting.Context{}
 	mock.OnAnything(securityCtx, "Name").Return("v2token")
 	mock.OnAnything(securityCtx, "Can").Return(true, nil)
@@ -176,6 +190,7 @@ func (suite *MiddlewareTestSuite) TestScannerPulling() {
 func (suite *MiddlewareTestSuite) TestUnAuthenticatedUserPulling() {
 	mock.OnAnything(suite.artifactController, "GetByReference").Return(suite.artifact, nil)
 	mock.OnAnything(suite.projectController, "GetByName").Return(suite.project, nil)
+	mock.OnAnything(suite.accessMgr, "List").Return([]accessorymodel.Accessory{}, nil)
 	securityCtx := &securitytesting.Context{}
 	mock.OnAnything(securityCtx, "Name").Return("local")
 	mock.OnAnything(securityCtx, "Can").Return(true, nil)
@@ -186,6 +201,29 @@ func (suite *MiddlewareTestSuite) TestUnAuthenticatedUserPulling() {
 
 	Notary()(suite.next).ServeHTTP(rr, req)
 	suite.Equal(rr.Code, http.StatusPreconditionFailed)
+}
+
+// pull cosign signature when policy checker is enabled.
+func (suite *MiddlewareTestSuite) TestSignaturePulling() {
+	mock.OnAnything(suite.artifactController, "GetByReference").Return(suite.artifact, nil)
+	mock.OnAnything(suite.projectController, "GetByName").Return(suite.project, nil)
+	acc := &basemodel.Default{
+		Data: accessorymodel.AccessoryData{
+			ID:            1,
+			ArtifactID:    2,
+			SubArtifactID: 1,
+			Type:          accessorymodel.TypeCosignSignature,
+		},
+	}
+	mock.OnAnything(suite.accessMgr, "List").Return([]accessorymodel.Accessory{
+		acc,
+	}, nil)
+
+	req := suite.makeRequest()
+	rr := httptest.NewRecorder()
+
+	Notary()(suite.next).ServeHTTP(rr, req)
+	suite.Equal(rr.Code, http.StatusOK)
 }
 
 func TestMiddlewareTestSuite(t *testing.T) {

--- a/src/server/middleware/util/util.go
+++ b/src/server/middleware/util/util.go
@@ -17,6 +17,9 @@ package util
 import (
 	"fmt"
 	"github.com/goharbor/harbor/src/common/rbac/project"
+	"github.com/goharbor/harbor/src/lib/q"
+	"github.com/goharbor/harbor/src/pkg/accessory"
+	"github.com/goharbor/harbor/src/pkg/accessory/model"
 	"net/http"
 	"path"
 	"strings"
@@ -56,18 +59,27 @@ func ParseProjectName(r *http.Request) string {
 }
 
 // SkipPolicyChecking ...
-func SkipPolicyChecking(r *http.Request, projectID int64) bool {
+func SkipPolicyChecking(r *http.Request, projectID, artID int64) (bool, error) {
 	secCtx, ok := security.FromContext(r.Context())
 
 	// 1, scanner pull access can bypass.
 	// 2, cosign pull can bypass, it needs to pull the manifest before pushing the signature.
+	// 3, pull cosign signature can bypass.
 	if ok && secCtx.Name() == "v2token" {
 		if secCtx.Can(r.Context(), rbac.ActionScannerPull, project.NewNamespace(projectID).Resource(rbac.ResourceRepository)) ||
 			(secCtx.Can(r.Context(), rbac.ActionPush, project.NewNamespace(projectID).Resource(rbac.ResourceRepository)) &&
 				strings.Contains(r.UserAgent(), "cosign")) {
-			return true
+			return true, nil
 		}
 	}
 
-	return false
+	accs, err := accessory.Mgr.List(r.Context(), q.New(q.KeyWords{"ArtifactID": artID}))
+	if err != nil {
+		return false, err
+	}
+	if len(accs) > 0 && accs[0].GetData().Type == model.TypeCosignSignature {
+		return true, nil
+	}
+
+	return false, nil
 }

--- a/src/server/middleware/vulnerable/vulnerable_test.go
+++ b/src/server/middleware/vulnerable/vulnerable_test.go
@@ -16,7 +16,11 @@ package vulnerable
 
 import (
 	"fmt"
+	"github.com/goharbor/harbor/src/pkg/accessory"
+	accessorymodel "github.com/goharbor/harbor/src/pkg/accessory/model"
+	basemodel "github.com/goharbor/harbor/src/pkg/accessory/model/base"
 	proModels "github.com/goharbor/harbor/src/pkg/project/models"
+	accessorytesting "github.com/goharbor/harbor/src/testing/pkg/accessory"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -50,6 +54,9 @@ type MiddlewareTestSuite struct {
 	originalScanController scan.Controller
 	scanController         *scantesting.Controller
 
+	originalAccessMgr accessory.Manager
+	accessMgr         *accessorytesting.Manager
+
 	checker     *scantesting.Checker
 	scanChecker func() scan.Checker
 
@@ -67,6 +74,10 @@ func (suite *MiddlewareTestSuite) SetupTest() {
 	suite.originalProjectController = projectController
 	suite.projectController = &projecttesting.Controller{}
 	projectController = suite.projectController
+
+	suite.originalAccessMgr = accessory.Mgr
+	suite.accessMgr = &accessorytesting.Manager{}
+	accessory.Mgr = suite.accessMgr
 
 	suite.originalScanController = scanController
 	suite.scanController = &scantesting.Controller{}
@@ -103,7 +114,7 @@ func (suite *MiddlewareTestSuite) TearDownTest() {
 	artifactController = suite.originalArtifactController
 	projectController = suite.originalProjectController
 	scanController = suite.originalScanController
-
+	accessory.Mgr = suite.originalAccessMgr
 	scanChecker = suite.scanChecker
 }
 
@@ -167,6 +178,7 @@ func (suite *MiddlewareTestSuite) TestPreventionDisabled() {
 func (suite *MiddlewareTestSuite) TestNonScannerPulling() {
 	mock.OnAnything(suite.artifactController, "GetByReference").Return(suite.artifact, nil)
 	mock.OnAnything(suite.projectController, "Get").Return(suite.project, nil)
+	mock.OnAnything(suite.accessMgr, "List").Return([]accessorymodel.Accessory{}, nil)
 	securityCtx := &securitytesting.Context{}
 	mock.OnAnything(securityCtx, "Name").Return("local")
 	mock.OnAnything(securityCtx, "Can").Return(true, nil)
@@ -183,6 +195,7 @@ func (suite *MiddlewareTestSuite) TestNonScannerPulling() {
 func (suite *MiddlewareTestSuite) TestScannerPulling() {
 	mock.OnAnything(suite.artifactController, "GetByReference").Return(suite.artifact, nil)
 	mock.OnAnything(suite.projectController, "Get").Return(suite.project, nil)
+	mock.OnAnything(suite.accessMgr, "List").Return([]accessorymodel.Accessory{}, nil)
 	securityCtx := &securitytesting.Context{}
 	mock.OnAnything(securityCtx, "Name").Return("v2token")
 	mock.OnAnything(securityCtx, "Can").Return(true, nil)
@@ -199,6 +212,7 @@ func (suite *MiddlewareTestSuite) TestCheckIsScannableFailed() {
 	mock.OnAnything(suite.artifactController, "GetByReference").Return(suite.artifact, nil)
 	mock.OnAnything(suite.projectController, "Get").Return(suite.project, nil)
 	mock.OnAnything(suite.checker, "IsScannable").Return(false, fmt.Errorf("error"))
+	mock.OnAnything(suite.accessMgr, "List").Return([]accessorymodel.Accessory{}, nil)
 
 	req := suite.makeRequest()
 	rr := httptest.NewRecorder()
@@ -211,6 +225,7 @@ func (suite *MiddlewareTestSuite) TestArtifactIsNotScannable() {
 	mock.OnAnything(suite.artifactController, "GetByReference").Return(suite.artifact, nil)
 	mock.OnAnything(suite.projectController, "Get").Return(suite.project, nil)
 	mock.OnAnything(suite.checker, "IsScannable").Return(false, nil)
+	mock.OnAnything(suite.accessMgr, "List").Return([]accessorymodel.Accessory{}, nil)
 
 	req := suite.makeRequest()
 	rr := httptest.NewRecorder()
@@ -224,6 +239,7 @@ func (suite *MiddlewareTestSuite) TestArtifactNotScanned() {
 	mock.OnAnything(suite.projectController, "Get").Return(suite.project, nil)
 	mock.OnAnything(suite.checker, "IsScannable").Return(true, nil)
 	mock.OnAnything(suite.scanController, "GetVulnerable").Return(nil, errors.NotFoundError(nil))
+	mock.OnAnything(suite.accessMgr, "List").Return([]accessorymodel.Accessory{}, nil)
 
 	req := suite.makeRequest()
 	rr := httptest.NewRecorder()
@@ -237,6 +253,7 @@ func (suite *MiddlewareTestSuite) TestArtifactScanFailed() {
 	mock.OnAnything(suite.projectController, "Get").Return(suite.project, nil)
 	mock.OnAnything(suite.checker, "IsScannable").Return(true, nil)
 	mock.OnAnything(suite.scanController, "GetVulnerable").Return(&scan.Vulnerable{ScanStatus: "Error"}, nil)
+	mock.OnAnything(suite.accessMgr, "List").Return([]accessorymodel.Accessory{}, nil)
 
 	req := suite.makeRequest()
 	rr := httptest.NewRecorder()
@@ -250,6 +267,7 @@ func (suite *MiddlewareTestSuite) TestGetVulnerableFailed() {
 	mock.OnAnything(suite.projectController, "Get").Return(suite.project, nil)
 	mock.OnAnything(suite.checker, "IsScannable").Return(true, nil)
 	mock.OnAnything(suite.scanController, "GetVulnerable").Return(nil, fmt.Errorf("error"))
+	mock.OnAnything(suite.accessMgr, "List").Return([]accessorymodel.Accessory{}, nil)
 
 	req := suite.makeRequest()
 	rr := httptest.NewRecorder()
@@ -262,6 +280,7 @@ func (suite *MiddlewareTestSuite) TestNoVulnerabilities() {
 	mock.OnAnything(suite.artifactController, "GetByReference").Return(suite.artifact, nil)
 	mock.OnAnything(suite.projectController, "Get").Return(suite.project, nil)
 	mock.OnAnything(suite.checker, "IsScannable").Return(true, nil)
+	mock.OnAnything(suite.accessMgr, "List").Return([]accessorymodel.Accessory{}, nil)
 	mock.OnAnything(suite.scanController, "GetVulnerable").Return(&scan.Vulnerable{
 		ScanStatus:  "Success",
 		CVEBypassed: []string{"cve-2020"},
@@ -279,6 +298,7 @@ func (suite *MiddlewareTestSuite) TestAllowed() {
 	mock.OnAnything(suite.artifactController, "GetByReference").Return(suite.artifact, nil)
 	mock.OnAnything(suite.projectController, "Get").Return(suite.project, nil)
 	mock.OnAnything(suite.checker, "IsScannable").Return(true, nil)
+	mock.OnAnything(suite.accessMgr, "List").Return([]accessorymodel.Accessory{}, nil)
 	mock.OnAnything(suite.scanController, "GetVulnerable").Return(&scan.Vulnerable{
 		ScanStatus:           "Success",
 		Severity:             &low,
@@ -297,6 +317,7 @@ func (suite *MiddlewareTestSuite) TestPrevented() {
 	mock.OnAnything(suite.artifactController, "GetByReference").Return(suite.artifact, nil)
 	mock.OnAnything(suite.projectController, "Get").Return(suite.project, nil)
 	mock.OnAnything(suite.checker, "IsScannable").Return(true, nil)
+	mock.OnAnything(suite.accessMgr, "List").Return([]accessorymodel.Accessory{}, nil)
 
 	critical := vuln.Critical
 
@@ -342,9 +363,33 @@ func (suite *MiddlewareTestSuite) TestArtifactIsImageIndex() {
 	mock.OnAnything(suite.artifactController, "GetByReference").Return(suite.artifact, nil)
 	mock.OnAnything(suite.projectController, "Get").Return(suite.project, nil)
 	mock.OnAnything(suite.checker, "IsScannable").Return(true, nil)
+	mock.OnAnything(suite.accessMgr, "List").Return([]accessorymodel.Accessory{}, nil)
 	mock.OnAnything(suite.scanController, "GetVulnerable").Return(&scan.Vulnerable{
 		ScanStatus: "Success",
 		Severity:   &critical,
+	}, nil)
+
+	req := suite.makeRequest()
+	rr := httptest.NewRecorder()
+
+	Middleware()(suite.next).ServeHTTP(rr, req)
+	suite.Equal(rr.Code, http.StatusOK)
+}
+
+// pull cosign signature when policy checker is enabled.
+func (suite *MiddlewareTestSuite) TestSignaturePulling() {
+	mock.OnAnything(suite.artifactController, "GetByReference").Return(suite.artifact, nil)
+	mock.OnAnything(suite.projectController, "Get").Return(suite.project, nil)
+	acc := &basemodel.Default{
+		Data: accessorymodel.AccessoryData{
+			ID:            1,
+			ArtifactID:    2,
+			SubArtifactID: 1,
+			Type:          accessorymodel.TypeCosignSignature,
+		},
+	}
+	mock.OnAnything(suite.accessMgr, "List").Return([]accessorymodel.Accessory{
+		acc,
 	}, nil)
 
 	req := suite.makeRequest()


### PR DESCRIPTION
When user enables the cosign policy and triggers the replication, the harbor adapter will try to  pull the cosign siguature if it has to do the further push.
In this case, it has to skip policy check.

Signed-off-by: wang yan <wangyan@vmware.com>