### PR TITLE
Add dotted line between the artifacts and their accessories

### DIFF
--- a/src/portal/src/app/base/project/repository/artifact/artifact-list-page/artifact-list/artifact-list-tab/sub-accessories/sub-accessories.component.html
+++ b/src/portal/src/app/base/project/repository/artifact/artifact-list-page/artifact-list/artifact-list-tab/sub-accessories/sub-accessories.component.html
@@ -1,15 +1,16 @@
-<clr-datagrid (clrDgRefresh)="clrLoad()" [clrDgLoading]="loading">
+<clr-datagrid class="ml-8" (clrDgRefresh)="clrLoad()" [clrDgLoading]="loading">
     <clr-dg-column>{{'ACCESSORY.ACCESSORY' | translate}}</clr-dg-column>
     <clr-dg-column>{{'PROJECT.TYPE' | translate}}</clr-dg-column>
     <clr-dg-column>{{'REPOSITORY.SIZE' | translate}}</clr-dg-column>
     <clr-dg-column>{{'ROBOT_ACCOUNT.CREATETION' | translate}}</clr-dg-column>
-    <clr-dg-row *ngFor="let a of displayedAccessories" [clrDgItem]="a">
+    <clr-dg-row *ngFor="let a of displayedAccessories;let i = index;" [clrDgItem]="a">
         <clr-dg-action-overflow>
             <button class="action-item" (click)="delete(a)">{{'REPOSITORY.DELETE' | translate}}</button>
         </clr-dg-action-overflow>
-        <clr-dg-cell>
+        <clr-dg-cell class="relative">
+            <hr class="y-dash-line" *ngIf="i===displayedAccessories?.length-1" [style.height.px]="dashLineHeight"><hr class="x-dash-line">
             <div class="cell">
-                <div title="{{a?.digest}}" class="artifact-icon clr-display-inline-block">
+                <div title="{{a?.digest}}" class="artifact-icon-div clr-display-inline-block">
                     <img *ngIf="getIcon(a.icon)" class="artifact-icon" [title]="a.type"
                          [src]="getIcon(a.icon)" (error)="showDefaultIcon($event)" />
                 </div>

--- a/src/portal/src/app/base/project/repository/artifact/artifact-list-page/artifact-list/artifact-list-tab/sub-accessories/sub-accessories.component.scss
+++ b/src/portal/src/app/base/project/repository/artifact/artifact-list-page/artifact-list/artifact-list-tab/sub-accessories/sub-accessories.component.scss
@@ -1,5 +1,9 @@
-.artifact-icon {
+.artifact-icon-div {
+  text-align: center;
   width: 2.5rem;
+  height: 0.8rem;
+}
+.artifact-icon {
   height: 0.8rem;
 }
 .cell {
@@ -10,4 +14,21 @@
 }
 .margin-left-5 {
   margin-left: 5px;
+}
+.ml-8 {
+  margin-left: 8rem;
+}
+.x-dash-line {
+  position: absolute;
+  width: 80px;
+  left: -80px;
+  border: 0;
+  border-top: 2px dotted #a2a9b6;
+}
+.y-dash-line {
+  position: absolute;
+  border: 0;
+  border-left: 2px dotted #a2a9b6;
+  left: -4.2rem;
+  bottom: 0
 }

--- a/src/portal/src/app/base/project/repository/artifact/artifact-list-page/artifact-list/artifact-list-tab/sub-accessories/sub-accessories.component.ts
+++ b/src/portal/src/app/base/project/repository/artifact/artifact-list-page/artifact-list/artifact-list-tab/sub-accessories/sub-accessories.component.ts
@@ -113,4 +113,9 @@ export class SubAccessoriesComponent implements OnInit {
             this.artifactService.getIconsFromBackEnd(this.displayedAccessories);
         }
     }
+
+    get dashLineHeight() {
+        // fixed height 27 plus each row height 40
+        return 27 + this.displayedAccessories?.length * 40;
+    }
 }


### PR DESCRIPTION
Fixes #16655 
1. Add dotted lines between the artifacts and their accessories to make it easier for users to see the relationship between them
<img width="1673" alt="image" src="https://user-images.githubusercontent.com/30999793/163348925-d3c76357-a275-4c34-bce2-3a52c78691dd.png">

Signed-off-by: AllForNothing <sshijun@vmware.com>

