### PR TITLE
Add open image scanners documentation page test case

### DIFF
--- a/tests/resources/Harbor-Pages/Vulnerability.robot
+++ b/tests/resources/Harbor-Pages/Vulnerability.robot
@@ -119,3 +119,8 @@ Check Scan All Artifact Job Status Is Stopped
     Wait Until Element Is Visible  ${stopped_icon}
     ${stopped_total}=  Get Text  ${stopped_icon}
     Should Be True  ${stopped_total} > 0
+
+Open Image Scanners Documentation
+    Switch To Scanners Page
+    Retry Element Click  //clr-signpost//cds-icon
+    Retry Link Click  //clr-signpost-content//a[contains(.,'view documentation')]

--- a/tests/robot-cases/Group1-Nightly/Routing.robot
+++ b/tests/robot-cases/Group1-Nightly/Routing.robot
@@ -107,3 +107,13 @@ Test Case - Open CVE Details Page
     Switch Window  locator=NEW
     Retry Wait Element  //h1[contains(.,'${cve}')]
     Close Browser
+
+Test Case - Open Image Scanners Documentation Page
+    [Tags]  image_scanners_documentation_page
+    Init Chrome Driver
+    Sign In Harbor  ${HARBOR_URL}  ${HARBOR_ADMIN}  ${HARBOR_PASSWORD}
+    Open Image Scanners Documentation
+    Sleep  3
+    Switch Window  locator=NEW
+    Retry Wait Until Page Contains  Vulnerability Scanning with Pluggable Scanners
+    Close Browser


### PR DESCRIPTION
Add a test case for opening the Image Scanners Documentation Page to ensure this function is correct

Signed-off-by: Yang Jiao <jiaoya@vmware.com>

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #15967

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
