### PR TITLE
pkg/scan: fix dropped error

### DIFF
--- a/src/pkg/scan/job.go
+++ b/src/pkg/scan/job.go
@@ -182,9 +182,11 @@ func (j *Job) Run(ctx job.Context, params job.Parameters) error {
 	robotAccount, _ := extractRobotAccount(params)
 
 	var authorization string
+	var tokenURL string
+
 	authType, _ := extractAuthType(params)
 	if authType == authorizationBearer {
-		tokenURL, err := getInternalTokenServiceEndpoint(ctx)
+		tokenURL, err = getInternalTokenServiceEndpoint(ctx)
 		if err != nil {
 			return errors.Wrap(err, "scan job: get token service endpoint")
 		}


### PR DESCRIPTION
This fixes an `err` variable that was being redeclared inside an if-block with `:=` and lost.