### PR TITLE
Store default page size to local storage

### DIFF
--- a/src/portal/src/app/base/left-side-nav/distribution/distribution-instances/distribution-instances.component.ts
+++ b/src/portal/src/app/base/left-side-nav/distribution/distribution-instances/distribution-instances.component.ts
@@ -15,7 +15,7 @@ import {
 } from '../../../../shared/components/operation/operate';
 import { TranslateService } from '@ngx-translate/core';
 import { map, catchError, finalize } from 'rxjs/operators';
-import { clone, DEFAULT_PAGE_SIZE } from '../../../../shared/units/utils';
+import { clone, getPageSizeFromLocalStorage, PageSizeMapKeys, setPageSizeToLocalStorage } from '../../../../shared/units/utils';
 import { Instance } from "../../../../../../ng-swagger-gen/models/instance";
 import { PreheatService } from "../../../../../../ng-swagger-gen/services/preheat.service";
 import { Metadata } from '../../../../../../ng-swagger-gen/models/metadata';
@@ -47,7 +47,7 @@ export class DistributionInstancesComponent implements OnInit, OnDestroy {
   instances: FrontInstance[] = [];
   selectedRow: FrontInstance[] = [];
 
-  pageSize: number = DEFAULT_PAGE_SIZE;
+  pageSize: number = getPageSizeFromLocalStorage(PageSizeMapKeys.DISTRIBUTION_INSTANCE_COMPONENT);
   currentPage: number = 1;
   totalCount: number = 0;
   queryString: string;
@@ -116,6 +116,7 @@ export class DistributionInstancesComponent implements OnInit, OnDestroy {
   loadData(state?: ClrDatagridStateInterface) {
     if (state && state.page) {
       this.pageSize = state.page.size;
+      setPageSizeToLocalStorage(PageSizeMapKeys.DISTRIBUTION_INSTANCE_COMPONENT, this.pageSize);
     }
     this.selectedRow = [];
     const queryParam: PreheatService.ListInstancesParams = {

--- a/src/portal/src/app/base/left-side-nav/gc-page/gc/gc-history/gc-history.component.ts
+++ b/src/portal/src/app/base/left-side-nav/gc-page/gc/gc-history/gc-history.component.ts
@@ -3,7 +3,12 @@ import { ErrorHandler } from "../../../../../shared/units/error-handler";
 import { Subscription, timer } from "rxjs";
 import { REFRESH_TIME_DIFFERENCE } from '../../../../../shared/entities/shared.const';
 import { GcService } from "../../../../../../../ng-swagger-gen/services/gc.service";
-import { CURRENT_BASE_HREF, DEFAULT_PAGE_SIZE, getSortingString } from "../../../../../shared/units/utils";
+import {
+  CURRENT_BASE_HREF,
+  getPageSizeFromLocalStorage,
+  getSortingString,
+  PageSizeMapKeys, setPageSizeToLocalStorage
+} from "../../../../../shared/units/utils";
 import { ClrDatagridStateInterface } from "@clr/angular";
 import { finalize } from "rxjs/operators";
 import { GCHistory } from "../../../../../../../ng-swagger-gen/models/gchistory";
@@ -24,7 +29,7 @@ export class GcHistoryComponent implements OnInit, OnDestroy {
   jobs: Array<GCHistory> = [];
   loading: boolean = true;
   timerDelay: Subscription;
-  pageSize: number = DEFAULT_PAGE_SIZE;
+  pageSize: number = getPageSizeFromLocalStorage(PageSizeMapKeys.GC_HISTORY_COMPONENT);
   page: number = 1;
   total: number = 0;
   state: ClrDatagridStateInterface;
@@ -49,6 +54,7 @@ export class GcHistoryComponent implements OnInit, OnDestroy {
     }
     if (state && state.page) {
       this.pageSize = state.page.size;
+      setPageSizeToLocalStorage(PageSizeMapKeys.GC_HISTORY_COMPONENT, this.pageSize);
     }
     let q: string;
     if (state && state.filters && state.filters.length) {

--- a/src/portal/src/app/base/left-side-nav/group/group.component.ts
+++ b/src/portal/src/app/base/left-side-nav/group/group.component.ts
@@ -19,7 +19,7 @@ import { ConfirmationDialogService } from "../../global-confirmation-dialog/conf
 import { errorHandler } from "../../../shared/units/shared.utils";
 import { ConfirmationMessage } from "../../global-confirmation-dialog/confirmation-message";
 import { ClrDatagridStateInterface } from "@clr/angular";
-import { DEFAULT_PAGE_SIZE } from "../../../shared/units/utils";
+import { getPageSizeFromLocalStorage, PageSizeMapKeys, setPageSizeToLocalStorage } from "../../../shared/units/utils";
 import { UsergroupService } from "../../../../../ng-swagger-gen/services/usergroup.service";
 import { UserGroup } from "../../../../../ng-swagger-gen/models/user-group";
 import { FilterComponent } from "../../../shared/components/filter/filter.component";
@@ -34,7 +34,7 @@ export class GroupComponent implements OnInit, OnDestroy {
   groups: UserGroup[] = [];
   currentPage: number = 1;
   totalCount: number = 0;
-  pageSize: number = DEFAULT_PAGE_SIZE;
+  pageSize: number = getPageSizeFromLocalStorage(PageSizeMapKeys.SYSTEM_GROUP_COMPONENT);
   selectedGroups: UserGroup[] = [];
   currentTerm = "";
   delSub: Subscription;
@@ -118,6 +118,7 @@ export class GroupComponent implements OnInit, OnDestroy {
   loadData(state?: ClrDatagridStateInterface): void {
     if (state && state.page) {
       this.pageSize = state.page.size;
+      setPageSizeToLocalStorage(PageSizeMapKeys.SYSTEM_GROUP_COMPONENT, this.pageSize);
     }
     this.loading = true;
     if (this.currentTerm) {

--- a/src/portal/src/app/base/left-side-nav/interrogation-services/scanner/config-scanner.component.ts
+++ b/src/portal/src/app/base/left-side-nav/interrogation-services/scanner/config-scanner.component.ts
@@ -4,7 +4,13 @@ import { NewScannerModalComponent } from "./new-scanner-modal/new-scanner-modal.
 import { finalize } from "rxjs/operators";
 import { MessageHandlerService } from "../../../../shared/services/message-handler.service";
 import { ErrorHandler } from "../../../../shared/units/error-handler";
-import { clone, DEFAULT_PAGE_SIZE, getSortingString } from "../../../../shared/units/utils";
+import {
+    clone,
+    getPageSizeFromLocalStorage,
+    getSortingString,
+    PageSizeMapKeys,
+    setPageSizeToLocalStorage
+} from "../../../../shared/units/utils";
 import { ConfirmationDialogService } from "../../../global-confirmation-dialog/confirmation-dialog.service";
 import { ConfirmationButtons, ConfirmationState, ConfirmationTargets } from "../../../../shared/entities/shared.const";
 import { ConfirmationMessage } from "../../../global-confirmation-dialog/confirmation-message";
@@ -26,7 +32,7 @@ export class ConfigurationScannerComponent implements OnInit, OnDestroy {
     deletionSubscription: any;
     scannerDocUrl: string = SCANNERS_DOC;
     page: number = 1;
-    pageSize: number = DEFAULT_PAGE_SIZE;
+    pageSize: number = getPageSizeFromLocalStorage(PageSizeMapKeys.SYSTEM_SCANNER_COMPONENT);
     total: number = 0;
     state: ClrDatagridStateInterface;
     constructor(
@@ -70,6 +76,7 @@ export class ConfigurationScannerComponent implements OnInit, OnDestroy {
         this.state = state;
         if (state && state.page) {
             this.pageSize = state.page.size;
+            setPageSizeToLocalStorage(PageSizeMapKeys.SYSTEM_SCANNER_COMPONENT, this.pageSize);
         }
         let q: string;
         if (state && state.filters && state.filters.length) {

--- a/src/portal/src/app/base/left-side-nav/log/recent-log.component.ts
+++ b/src/portal/src/app/base/left-side-nav/log/recent-log.component.ts
@@ -18,6 +18,7 @@ import { AuditlogService } from "../../../../../ng-swagger-gen/services/auditlog
 import { AuditLog } from "../../../../../ng-swagger-gen/models/audit-log";
 import ListAuditLogsParams = AuditlogService.ListAuditLogsParams;
 import { ClrDatagridStateInterface } from '@clr/angular';
+import { getPageSizeFromLocalStorage, PageSizeMapKeys, setPageSizeToLocalStorage } from '../../../shared/units/utils';
 
 @Component({
     selector: 'hbr-log',
@@ -31,7 +32,7 @@ export class RecentLogComponent implements OnInit {
     currentTerm: string;
     defaultFilter = "username";
     isOpenFilterTag: boolean;
-    pageSize: number = 15;
+    pageSize: number = getPageSizeFromLocalStorage(PageSizeMapKeys.SYSTEM_RECENT_LOG_COMPONENT);
     currentPage: number = 1; // Double bound to pagination component
     totalCount: number = 0;
     constructor(
@@ -72,6 +73,7 @@ export class RecentLogComponent implements OnInit {
     load(state?: ClrDatagridStateInterface) {
         if (state && state.page) {
            this.pageSize = state.page.size;
+           setPageSizeToLocalStorage(PageSizeMapKeys.SYSTEM_RECENT_LOG_COMPONENT, this.pageSize);
         }
         // Keep it for future filter
         // this.currentState = state;

--- a/src/portal/src/app/base/left-side-nav/project-quotas/project-quotas/project-quotas.component.ts
+++ b/src/portal/src/app/base/left-side-nav/project-quotas/project-quotas/project-quotas.component.ts
@@ -5,7 +5,7 @@ import {
 } from '../../../../shared/services';
 import {
   clone, isEmpty, getChanges, getSuitableUnit, calculatePage
-  , getByte, GetIntegerAndUnit
+  , getByte, GetIntegerAndUnit, getPageSizeFromLocalStorage, PageSizeMapKeys, setPageSizeToLocalStorage
 } from '../../../../shared/units/utils';
 import { ErrorHandler } from '../../../../shared/units/error-handler';
 import { QuotaUnits, QuotaUnlimited, QUOTA_DANGER_COEFFICIENT, QUOTA_WARNING_COEFFICIENT } from '../../../../shared/entities/shared.const';
@@ -44,7 +44,7 @@ export class ProjectQuotasComponent implements OnChanges {
   originalConfig: Configuration;
   currentPage = 1;
   totalCount = 0;
-  pageSize = 15;
+  pageSize = getPageSizeFromLocalStorage(PageSizeMapKeys.PROJECT_QUOTA_COMPONENT);
   quotaDangerCoefficient: number = QUOTA_DANGER_COEFFICIENT;
   quotaWarningCoefficient: number = QUOTA_WARNING_COEFFICIENT;
   @Input()
@@ -176,6 +176,7 @@ export class ProjectQuotasComponent implements OnChanges {
       return;
     }
     this.pageSize = state.page.size;
+    setPageSizeToLocalStorage(PageSizeMapKeys.PROJECT_QUOTA_COMPONENT, this.pageSize);
     // Keep state for future filtering and sorting
     this.currentState = state;
 

--- a/src/portal/src/app/base/left-side-nav/projects/list-project/list-project.component.ts
+++ b/src/portal/src/app/base/left-side-nav/projects/list-project/list-project.component.ts
@@ -28,8 +28,8 @@ import { AppConfigService } from "../../../../services/app-config.service";
 import { Project } from "../../../project/project";
 import { map, catchError, finalize } from "rxjs/operators";
 import {
-    calculatePage,
-    getSortingString
+    calculatePage, getPageSizeFromLocalStorage,
+    getSortingString, PageSizeMapKeys, setPageSizeToLocalStorage
 } from "../../../../shared/units/utils";
 import { OperationService } from "../../../../shared/components/operation/operation.service";
 import { operateChanges, OperateInfo, OperationState } from "../../../../shared/components/operation/operate";
@@ -44,7 +44,6 @@ import {
 import { ConfirmationDialogService } from "../../../global-confirmation-dialog/confirmation-dialog.service";
 import { errorHandler } from "../../../../shared/units/shared.utils";
 import { ConfirmationMessage } from "../../../global-confirmation-dialog/confirmation-message";
-
 @Component({
     selector: "list-project",
     templateUrl: "list-project.component.html"
@@ -61,7 +60,7 @@ export class ListProjectComponent implements OnDestroy {
     roleInfo = RoleInfo;
     currentPage = 1;
     totalCount = 0;
-    pageSize = 15;
+    pageSize = getPageSizeFromLocalStorage(PageSizeMapKeys.LIST_PROJECT_COMPONENT);
     currentState: State;
     subscription: Subscription;
     projectTypeMap: any = {
@@ -143,6 +142,7 @@ export class ListProjectComponent implements OnDestroy {
         }
         this.state = state;
         this.pageSize = state.page.size;
+        setPageSizeToLocalStorage(PageSizeMapKeys.LIST_PROJECT_COMPONENT, this.pageSize);
         this.selectedRow = [];
 
         // Keep state for future filtering and sorting

--- a/src/portal/src/app/base/left-side-nav/registries/endpoint.component.ts
+++ b/src/portal/src/app/base/left-side-nav/registries/endpoint.component.ts
@@ -29,7 +29,12 @@ import {
     ConfirmationButtons
 } from "../../../shared/entities/shared.const";
 import { CreateEditEndpointComponent } from "./create-edit-endpoint/create-edit-endpoint.component";
-import { CustomComparator, DEFAULT_PAGE_SIZE, getSortingString } from "../../../shared/units/utils";
+import {
+    CustomComparator,
+    getPageSizeFromLocalStorage,
+    getSortingString, PageSizeMapKeys,
+    setPageSizeToLocalStorage
+} from "../../../shared/units/utils";
 import { operateChanges, OperateInfo, OperationState } from "../../../shared/components/operation/operate";
 import { OperationService } from "../../../shared/components/operation/operation.service";
 import { errorHandler } from "../../../shared/units/shared.utils";
@@ -39,7 +44,6 @@ import { EndpointService, HELM_HUB } from "../../../shared/services/endpoint.ser
 import { RegistryService } from "../../../../../ng-swagger-gen/services/registry.service";
 import { ClrDatagridStateInterface } from "@clr/angular";
 import { Registry } from "../../../../../ng-swagger-gen/models/registry";
-
 
 @Component({
     selector: "hbr-endpoint",
@@ -84,7 +88,7 @@ export class EndpointComponent implements OnInit, OnDestroy {
         };
     }
 
-    pageSize: number = DEFAULT_PAGE_SIZE;
+    pageSize: number = getPageSizeFromLocalStorage(PageSizeMapKeys.SYSTEM_ENDPOINT_COMPONENT);
     page: number = 1;
     total: number = 0;
     constructor(private endpointService: RegistryService,
@@ -114,6 +118,7 @@ export class EndpointComponent implements OnInit, OnDestroy {
         }
         if (state && state.page) {
             this.pageSize = state.page.size;
+            setPageSizeToLocalStorage(PageSizeMapKeys.SYSTEM_ENDPOINT_COMPONENT, this.pageSize);
         }
         let sort: string;
         if (state && state.sort && state.sort.by) {

--- a/src/portal/src/app/base/left-side-nav/replication/replication/list-replication-rule/list-replication-rule.component.ts
+++ b/src/portal/src/app/base/left-side-nav/replication/replication/list-replication-rule/list-replication-rule.component.ts
@@ -32,7 +32,7 @@ import {
     ConfirmationButtons
 } from "../../../../../shared/entities/shared.const";
 import { ErrorHandler } from "../../../../../shared/units/error-handler";
-import { clone } from "../../../../../shared/units/utils";
+import { clone, getPageSizeFromLocalStorage, PageSizeMapKeys, setPageSizeToLocalStorage } from "../../../../../shared/units/utils";
 import { operateChanges, OperateInfo, OperationState } from "../../../../../shared/components/operation/operate";
 import { OperationService } from "../../../../../shared/components/operation/operation.service";
 import { ClrDatagridStateInterface } from '@clr/angular';
@@ -69,7 +69,7 @@ export class ListReplicationRuleComponent  {
     @ViewChild("deletionConfirmDialog")
     deletionConfirmDialog: ConfirmationDialogComponent;
     page: number = 1;
-    pageSize: number = 5;
+    pageSize: number = getPageSizeFromLocalStorage(PageSizeMapKeys.LIST_REPLICATION_RULE_COMPONENT, 5);
     totalCount: number = 0;
     loading: boolean = true;
 
@@ -231,6 +231,7 @@ export class ListReplicationRuleComponent  {
     clrLoad(state?: ClrDatagridStateInterface) {
         if (state && state.page) {
             this.pageSize = state.page.size;
+            setPageSizeToLocalStorage(PageSizeMapKeys.LIST_REPLICATION_RULE_COMPONENT, this.pageSize);
         }
         this.loading = true;
         this.replicationService.getReplicationRulesResponse(

--- a/src/portal/src/app/base/left-side-nav/replication/replication/replication-tasks/replication-tasks.component.ts
+++ b/src/portal/src/app/base/left-side-nav/replication/replication/replication-tasks/replication-tasks.component.ts
@@ -8,10 +8,9 @@ import { ClrDatagridComparatorInterface, ReplicationJob, ReplicationTasks } from
 import {
   CURRENT_BASE_HREF,
   CustomComparator,
-  DEFAULT_PAGE_SIZE,
   doFiltering,
-  doSorting,
-  getSortingString
+  doSorting, getPageSizeFromLocalStorage,
+  getSortingString, PageSizeMapKeys, setPageSizeToLocalStorage
 } from "../../../../../shared/units/utils";
 import { REFRESH_TIME_DIFFERENCE } from '../../../../../shared/entities/shared.const';
 import { ClrDatagridStateInterface } from '@clr/angular';
@@ -34,7 +33,7 @@ export class ReplicationTasksComponent implements OnInit, OnDestroy {
   isOpenFilterTag: boolean;
   inProgress: boolean = false;
   currentPage: number = 1;
-  pageSize: number = DEFAULT_PAGE_SIZE;
+  pageSize: number = getPageSizeFromLocalStorage(PageSizeMapKeys.REPLICATION_TASKS_COMPONENT);
   totalCount: number;
   loading = true;
   searchTask: string;
@@ -164,6 +163,7 @@ export class ReplicationTasksComponent implements OnInit, OnDestroy {
       }
       if (state && state.page && state.page.size) {
         this.pageSize = state.page.size;
+        setPageSizeToLocalStorage(PageSizeMapKeys.REPLICATION_TASKS_COMPONENT, this.pageSize);
       }
       const param: ListReplicationTasksParams = {
         id: +this.executionId,

--- a/src/portal/src/app/base/left-side-nav/replication/replication/replication.component.ts
+++ b/src/portal/src/app/base/left-side-nav/replication/replication/replication.component.ts
@@ -36,10 +36,9 @@ import {
 
 import {
   CustomComparator,
-  DEFAULT_PAGE_SIZE,
   doFiltering,
   doSorting,
-  calculatePage
+  calculatePage, getPageSizeFromLocalStorage, PageSizeMapKeys, setPageSizeToLocalStorage
 } from "../../../../shared/units/utils";
 
 import {
@@ -79,7 +78,6 @@ export class SearchOption {
   trigger: string = "";
   status: string = "";
   page: number = 1;
-  pageSize: number = DEFAULT_PAGE_SIZE;
 }
 
 const STATUS_MAP = {
@@ -141,7 +139,7 @@ export class ReplicationComponent implements OnInit, OnDestroy {
   // Server driven pagination
   currentPage: number = 1;
   totalCount: number = 0;
-  pageSize: number = DEFAULT_PAGE_SIZE;
+  pageSize: number = getPageSizeFromLocalStorage(PageSizeMapKeys.LIST_REPLICATION_RULE_COMPONENT_EXECUTIONS);
   currentState: ClrDatagridStateInterface;
   jobsLoading: boolean = false;
   timerDelay: Subscription;
@@ -229,6 +227,7 @@ export class ReplicationComponent implements OnInit, OnDestroy {
       return;
     }
     this.pageSize = state.page.size;
+    setPageSizeToLocalStorage(PageSizeMapKeys.LIST_REPLICATION_RULE_COMPONENT_EXECUTIONS, this.pageSize);
     this.currentState = state;
 
     let pageNumber: number = calculatePage(state);

--- a/src/portal/src/app/base/left-side-nav/system-robot-accounts/system-robot-accounts.component.ts
+++ b/src/portal/src/app/base/left-side-nav/system-robot-accounts/system-robot-accounts.component.ts
@@ -3,7 +3,13 @@ import { NewRobotComponent } from './new-robot/new-robot.component';
 import { ViewTokenComponent } from '../../../shared/components/view-token/view-token.component';
 import { RobotService } from "../../../../../ng-swagger-gen/services/robot.service";
 import { Robot } from "../../../../../ng-swagger-gen/models/robot";
-import { clone, DEFAULT_PAGE_SIZE, getSortingString } from "../../../shared/units/utils";
+import {
+  clone,
+  getPageSizeFromLocalStorage,
+  getSortingString,
+  PageSizeMapKeys,
+  setPageSizeToLocalStorage
+} from "../../../shared/units/utils";
 import { ClrDatagridStateInterface, ClrLoadingState } from "@clr/angular";
 import { catchError, debounceTime, distinctUntilChanged, finalize, map, switchMap } from "rxjs/operators";
 import { MessageHandlerService } from "../../../shared/services/message-handler.service";
@@ -31,6 +37,7 @@ import { RobotPermission } from "../../../../../ng-swagger-gen/models/robot-perm
 import { SysteminfoService } from '../../../../../ng-swagger-gen/services/systeminfo.service';
 
 const FIRST_PROJECTS_PAGE_SIZE: number = 100;
+
 @Component({
   selector: 'system-robot-accounts',
   templateUrl: './system-robot-accounts.component.html',
@@ -38,7 +45,7 @@ const FIRST_PROJECTS_PAGE_SIZE: number = 100;
 })
 export class SystemRobotAccountsComponent implements OnInit, OnDestroy {
   i18nMap = ACTION_RESOURCE_I18N_MAP;
-  pageSize: number = DEFAULT_PAGE_SIZE;
+  pageSize: number = getPageSizeFromLocalStorage(PageSizeMapKeys.SYSTEM_ROBOT_COMPONENT);
   currentPage: number = 1;
   total: number = 0;
   robots: FrontRobot[] = [];
@@ -196,6 +203,7 @@ export class SystemRobotAccountsComponent implements OnInit, OnDestroy {
   clrLoad(state?: ClrDatagridStateInterface) {
     if (state && state.page && state.page.size) {
       this.pageSize = state.page.size;
+      setPageSizeToLocalStorage(PageSizeMapKeys.SYSTEM_ROBOT_COMPONENT, this.pageSize);
     }
     this.selectedRows = [];
     const queryParam: RobotService.ListRobotParams = {

--- a/src/portal/src/app/base/left-side-nav/user/user.component.ts
+++ b/src/portal/src/app/base/left-side-nav/user/user.component.ts
@@ -34,7 +34,7 @@ import {
 import { errorHandler } from "../../../shared/units/shared.utils";
 import { ConfirmationMessage } from "../../global-confirmation-dialog/confirmation-message";
 import { HttpErrorResponse } from "@angular/common/http";
-
+import { getPageSizeFromLocalStorage, PageSizeMapKeys, setPageSizeToLocalStorage } from '../../../shared/units/utils';
 
 /**
  * NOTES:
@@ -61,7 +61,7 @@ export class UserComponent implements OnInit, OnDestroy {
     currentTerm: string;
     totalCount: number = 0;
     currentPage: number = 1;
-    pageSize: number = 15;
+    pageSize: number = getPageSizeFromLocalStorage(PageSizeMapKeys.SYSTEM_USER_COMPONENT);
     timerHandler: any;
 
     private onGoing: boolean = true;
@@ -343,6 +343,7 @@ export class UserComponent implements OnInit, OnDestroy {
     load(state: any): void {
         if (state && state.page) {
            this.pageSize = state.page.size;
+           setPageSizeToLocalStorage(PageSizeMapKeys.SYSTEM_USER_COMPONENT, this.pageSize);
         }
         this.selectedRow = [];
         this.onGoing = true;

--- a/src/portal/src/app/base/project/helm-chart/helm-chart-detail/list-chart-versions/helm-chart-versions-detail/helm-chart-version.component.html
+++ b/src/portal/src/app/base/project/helm-chart/helm-chart-detail/list-chart-versions/helm-chart-versions-detail/helm-chart-version.component.html
@@ -35,7 +35,7 @@
     </div>
     <div class="row">
         <div *ngIf="!isCardView" class="col-lg-12 col-md-12 col-sm-12 col-xs-12">
-            <clr-datagrid (clrDgRefresh)="refresh()" [clrDgLoading]="loading" [(clrDgSelected)]="selectedRows">
+            <clr-datagrid (clrDgRefresh)="refresh($event)" [clrDgLoading]="loading" [(clrDgSelected)]="selectedRows">
                 <clr-dg-action-bar>
                     <button type="button" class="btn  btn-secondary"
                         [disabled]="!(selectedRows.length===1) || !hasDownloadHelmChartVersionPermission"

--- a/src/portal/src/app/base/project/helm-chart/helm-chart-detail/list-chart-versions/helm-chart-versions-detail/helm-chart-version.component.ts
+++ b/src/portal/src/app/base/project/helm-chart/helm-chart-detail/list-chart-versions/helm-chart-versions-detail/helm-chart-version.component.ts
@@ -12,7 +12,12 @@ import {
   UserPermissionService,
   USERSTATICPERMISSION
 } from "../../../../../../shared/services";
-import { DEFAULT_PAGE_SIZE, downloadFile } from "../../../../../../shared/units/utils";
+import {
+  downloadFile,
+  getPageSizeFromLocalStorage,
+  PageSizeMapKeys,
+  setPageSizeToLocalStorage
+} from "../../../../../../shared/units/utils";
 import { ErrorHandler } from "../../../../../../shared/units/error-handler";
 import { OperationService } from "../../../../../../shared/components/operation/operation.service";
 import { operateChanges, OperateInfo, OperationState } from "../../../../../../shared/components/operation/operate";
@@ -29,6 +34,7 @@ import { ConfirmationMessage } from "../../../../../global-confirmation-dialog/c
 import { ConfirmationAcknowledgement } from "../../../../../global-confirmation-dialog/confirmation-state-message";
 import { Label } from "../../../../../../../../ng-swagger-gen/models/label";
 import { LabelService } from "../../../../../../../../ng-swagger-gen/services/label.service";
+import { ClrDatagridStateInterface } from '@clr/angular';
 
 const PAGE_SIZE: number = 100;
 @Component({
@@ -60,7 +66,7 @@ export class ChartVersionComponent implements OnInit {
   cardHover = false;
   listHover = false;
 
-  pageSize: number = DEFAULT_PAGE_SIZE;
+  pageSize: number = getPageSizeFromLocalStorage(PageSizeMapKeys.CHART_VERSION_COMPONENT);
   currentPage = 1;
   totalCount = 0;
   currentState: State;
@@ -181,7 +187,10 @@ export class ChartVersionComponent implements OnInit {
     });
   }
 
-  refresh() {
+  refresh(state?: ClrDatagridStateInterface) {
+    if (state?.page?.size) {
+      setPageSizeToLocalStorage(PageSizeMapKeys.CHART_VERSION_COMPONENT, state.page.size);
+    }
     this.loading = true;
     this.helmChartService
       .getChartVersions(this.projectName, this.chartName)

--- a/src/portal/src/app/base/project/helm-chart/helm-chart-list/list-charts-detail/helm-chart.component.html
+++ b/src/portal/src/app/base/project/helm-chart/helm-chart-list/list-charts-detail/helm-chart.component.html
@@ -21,7 +21,7 @@
     </div>
     <div class="row">
         <div *ngIf="!isCardView" class="col-lg-12 col-md-12 col-sm-12 col-xs-12">
-            <clr-datagrid [clrDgLoading]="loading" [(clrDgSelected)]="selectedRows">
+            <clr-datagrid (clrDgRefresh)="clrLoad($event)" [clrDgLoading]="loading" [(clrDgSelected)]="selectedRows">
                 <clr-dg-action-bar>
                     <button type="button" id="helm-chart-upload" class="btn  btn-secondary"
                         [disabled]="!hasUploadHelmChartsPermission" (click)="onChartUpload()">

--- a/src/portal/src/app/base/project/helm-chart/helm-chart-list/list-charts-detail/helm-chart.component.ts
+++ b/src/portal/src/app/base/project/helm-chart/helm-chart-list/list-charts-detail/helm-chart.component.ts
@@ -6,7 +6,7 @@ import { catchError, finalize, map } from "rxjs/operators";
 import { HelmChartItem } from "../../helm-chart-detail/helm-chart.interface.service";
 import { HelmChartService } from "../../helm-chart-detail/helm-chart.service";
 import { State, SystemInfo, SystemInfoService, UserPermissionService, USERSTATICPERMISSION } from "../../../../../shared/services";
-import { DEFAULT_PAGE_SIZE, downloadFile } from "../../../../../shared/units/utils";
+import { downloadFile, getPageSizeFromLocalStorage, PageSizeMapKeys, setPageSizeToLocalStorage } from "../../../../../shared/units/utils";
 import { ErrorHandler } from "../../../../../shared/units/error-handler";
 import { OperationService } from "../../../../../shared/components/operation/operation.service";
 import { operateChanges, OperateInfo, OperationState } from "../../../../../shared/components/operation/operate";
@@ -21,7 +21,7 @@ import { errorHandler } from "../../../../../shared/units/shared.utils";
 import { ConfirmationDialogComponent } from "../../../../../shared/components/confirmation-dialog";
 import { ConfirmationMessage } from "../../../../global-confirmation-dialog/confirmation-message";
 import { ConfirmationAcknowledgement } from "../../../../global-confirmation-dialog/confirmation-state-message";
-
+import { ClrDatagridStateInterface } from '@clr/angular';
 
 @Component({
   selector: "hbr-helm-chart",
@@ -57,7 +57,7 @@ export class HelmChartComponent implements OnInit {
   cardHover = false;
   listHover = false;
 
-  pageSize: number = DEFAULT_PAGE_SIZE;
+  pageSize: number = getPageSizeFromLocalStorage(PageSizeMapKeys.HELM_CHART_COMPONENT);
   currentPage = 1;
   totalCount = 0;
   currentState: State;
@@ -311,6 +311,11 @@ export class HelmChartComponent implements OnInit {
       return "HELM_CHART.DEPRECATED";
     } else {
       return "HELM_CHART.ACTIVE";
+    }
+  }
+  clrLoad(state: ClrDatagridStateInterface) {
+    if (state?.page?.size) {
+      setPageSizeToLocalStorage(PageSizeMapKeys.HELM_CHART_COMPONENT, state.page.size);
     }
   }
 }

--- a/src/portal/src/app/base/project/member/member.component.ts
+++ b/src/portal/src/app/base/project/member/member.component.ts
@@ -29,7 +29,7 @@ import { ConfirmationButtons, ConfirmationState, ConfirmationTargets, RoleInfo }
 import { ConfirmationDialogService } from "../../global-confirmation-dialog/confirmation-dialog.service";
 import { errorHandler } from "../../../shared/units/shared.utils";
 import { ConfirmationMessage } from "../../global-confirmation-dialog/confirmation-message";
-import { DEFAULT_PAGE_SIZE } from "../../../shared/units/utils";
+import { getPageSizeFromLocalStorage, PageSizeMapKeys, setPageSizeToLocalStorage } from "../../../shared/units/utils";
 import { MemberService } from "../../../../../ng-swagger-gen/services/member.service";
 import { ClrDatagridStateInterface } from "@clr/angular";
 import { ProjectMemberEntity } from "../../../../../ng-swagger-gen/models/project-member-entity";
@@ -69,7 +69,7 @@ export class MemberComponent implements OnInit, OnDestroy {
   hasUpdateMemberPermission: boolean;
   hasDeleteMemberPermission: boolean;
   page: number = 1;
-  pageSize: number = DEFAULT_PAGE_SIZE;
+  pageSize: number = getPageSizeFromLocalStorage(PageSizeMapKeys.MEMBER_COMPONENT);
   total: number = 0;
   constructor(
     private route: ActivatedRoute,
@@ -135,6 +135,7 @@ export class MemberComponent implements OnInit, OnDestroy {
   retrieve(username: string, state?: ClrDatagridStateInterface) {
     if (state && state.page) {
       this.pageSize = state.page.size;
+      setPageSizeToLocalStorage(PageSizeMapKeys.MEMBER_COMPONENT, this.pageSize);
     }
     this.loading = true;
     this.selectedRow = [];

--- a/src/portal/src/app/base/project/p2p-provider/policy/policy.component.ts
+++ b/src/portal/src/app/base/project/p2p-provider/policy/policy.component.ts
@@ -17,7 +17,12 @@ import { Component, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import { ActivatedRoute, NavigationEnd, Router } from '@angular/router';
 import { MessageHandlerService } from '../../../../shared/services/message-handler.service';
 import { Project } from '../../project';
-import { clone, DEFAULT_PAGE_SIZE, getSortingString } from '../../../../shared/units/utils';
+import {
+  clone,
+  getPageSizeFromLocalStorage,
+  getSortingString, PageSizeMapKeys,
+  setPageSizeToLocalStorage
+} from '../../../../shared/units/utils';
 import { forkJoin, Observable, Subject, Subscription } from 'rxjs';
 import {
   UserPermissionService,
@@ -45,6 +50,7 @@ import { ConfirmationMessage } from "../../../global-confirmation-dialog/confirm
 import { EventService, HarborEvent } from "../../../../services/event-service/event.service";
 // The route path which will display this component
 const URL_TO_DISPLAY: RegExp = /\/harbor\/projects\/(\d+)\/p2p-provider\/policies/;
+
 @Component({
   templateUrl: './policy.component.html',
   styleUrls: ['./policy.component.scss']
@@ -72,7 +78,7 @@ export class PolicyComponent implements OnInit, OnDestroy {
   stopLoading: boolean = false;
   executionList: Execution[] = [];
   currentExecutionPage: number = 1;
-  pageSize: number = DEFAULT_PAGE_SIZE;
+  pageSize: number = getPageSizeFromLocalStorage(PageSizeMapKeys.P2P_POLICY_COMPONENT_EXECUTIONS);
   totalExecutionCount: number = 0;
   filterKey: string = 'id';
   searchString: string;
@@ -85,7 +91,7 @@ export class PolicyComponent implements OnInit, OnDestroy {
   routerSub: Subscription;
   scrollSub: Subscription;
   scrollTop: number;
-  policyPageSize: number = 10;
+  policyPageSize: number = getPageSizeFromLocalStorage(PageSizeMapKeys.P2P_POLICY_COMPONENT,  10);
   policyPage: number = 1;
   totalPolicy: number = 0;
   state: ClrDatagridStateInterface;
@@ -192,7 +198,8 @@ export class PolicyComponent implements OnInit, OnDestroy {
       this.state = state;
     }
     if (state && state.page) {
-      this.pageSize = state.page.size;
+      this.policyPageSize = state.page.size;
+      setPageSizeToLocalStorage(PageSizeMapKeys.P2P_POLICY_COMPONENT, this.policyPageSize);
     }
     let q: string;
     if (state && state.filters && state.filters.length) {
@@ -440,6 +447,7 @@ export class PolicyComponent implements OnInit, OnDestroy {
     if (this.selectedRow) {
       if (state && state.page) {
         this.pageSize = state.page.size;
+        setPageSizeToLocalStorage(PageSizeMapKeys.P2P_POLICY_COMPONENT_EXECUTIONS, this.pageSize);
       }
       if (withLoading) {
         // if datagrid is under control of *ngIf, should add timeout in case of ng changes checking error

--- a/src/portal/src/app/base/project/p2p-provider/task-list/task-list.component.ts
+++ b/src/portal/src/app/base/project/p2p-provider/task-list/task-list.component.ts
@@ -2,7 +2,7 @@ import { Component, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { TranslateService } from '@ngx-translate/core';
 import { debounceTime, finalize, switchMap } from 'rxjs/operators';
-import { clone, DEFAULT_PAGE_SIZE } from '../../../../shared/units/utils';
+import { clone, getPageSizeFromLocalStorage, PageSizeMapKeys, setPageSizeToLocalStorage } from '../../../../shared/units/utils';
 import { Task } from '../../../../../../ng-swagger-gen/models/task';
 import { MessageHandlerService } from '../../../../shared/services/message-handler.service';
 import { Project } from '../../project';
@@ -24,7 +24,7 @@ export class TaskListComponent implements OnInit, OnDestroy {
   isOpenFilterTag: boolean;
   inProgress: boolean = false;
   currentPage: number = 1;
-  pageSize: number = DEFAULT_PAGE_SIZE;
+  pageSize: number = getPageSizeFromLocalStorage(PageSizeMapKeys.P2P_TASKS_COMPONENT);
   totalCount: number;
   loading = true;
   tasks: Task[];
@@ -226,6 +226,7 @@ export class TaskListComponent implements OnInit, OnDestroy {
     }
     if (state && state.page) {
       this.pageSize = state.page.size;
+      setPageSizeToLocalStorage(PageSizeMapKeys.P2P_TASKS_COMPONENT, this.pageSize);
     }
     let params: string;
     if (this.searchString) {

--- a/src/portal/src/app/base/project/project-log/audit-log.component.ts
+++ b/src/portal/src/app/base/project/project-log/audit-log.component.ts
@@ -19,7 +19,7 @@ import { ProjectService } from "../../../../../ng-swagger-gen/services/project.s
 import { AuditLog } from "../../../../../ng-swagger-gen/models/audit-log";
 import { Project } from "../project";
 import { finalize } from "rxjs/operators";
-import { DEFAULT_PAGE_SIZE } from "../../../shared/units/utils";
+import { getPageSizeFromLocalStorage, PageSizeMapKeys, setPageSizeToLocalStorage } from "../../../shared/units/utils";
 import { ClrDatagridStateInterface } from "@clr/angular";
 
 const optionalSearch: {} = { 0: 'AUDIT_LOG.ADVANCED', 1: 'AUDIT_LOG.SIMPLE' };
@@ -73,7 +73,7 @@ export class AuditLogComponent implements OnInit {
   ];
 
   pageOffset = 1;
-  pageSize = DEFAULT_PAGE_SIZE;
+  pageSize = getPageSizeFromLocalStorage(PageSizeMapKeys.PROJECT_AUDIT_LOG_COMPONENT);
   totalRecordCount = 0;
   currentPage = 1;
   totalPage = 0;
@@ -102,6 +102,7 @@ export class AuditLogComponent implements OnInit {
   retrieve(state?: ClrDatagridStateInterface) {
     if (state && state.page) {
       this.pageSize = state.page.size;
+      setPageSizeToLocalStorage(PageSizeMapKeys.PROJECT_AUDIT_LOG_COMPONENT, this.pageSize);
     }
     const arr: string[] = [];
     if (this.queryUsername) {
@@ -139,7 +140,7 @@ export class AuditLogComponent implements OnInit {
           if (response.headers) {
             let xHeader: string = response.headers.get("x-total-count");
             if (xHeader) {
-              this.totalRecordCount = Number.parseInt(xHeader);
+              this.totalRecordCount = Number.parseInt(xHeader, 10);
             }
           }
           this.auditLogs = response.body;

--- a/src/portal/src/app/base/project/repository/artifact/artifact-additions/artifact-vulnerabilities/artifact-vulnerabilities.component.html
+++ b/src/portal/src/app/base/project/repository/artifact/artifact-additions/artifact-vulnerabilities/artifact-vulnerabilities.component.html
@@ -7,7 +7,7 @@
         </div>
     </div>
     <div class="col-lg-12 col-md-12 col-sm-12 col-xs-12">
-        <clr-datagrid [clrDgLoading]="loading">
+        <clr-datagrid [clrDgLoading]="loading" (clrDgRefresh)="load($event)">
             <clr-dg-action-bar>
                 <div class="clr-row center">
                     <div class="ml-05">
@@ -90,7 +90,7 @@
                 <div class="report">
                     <i *ngIf="scanner">{{'VULNERABILITY.REPORTED_BY' | translate: {scanner: getScannerInfo(scanner)} }}</i>
                 </div>
-                <clr-dg-pagination #pagination [clrDgPageSize]="25" [clrDgTotalItems]="scanningResults?.length">
+                <clr-dg-pagination #pagination [clrDgPageSize]="pageSize" [clrDgTotalItems]="scanningResults?.length">
                     <clr-dg-page-size [clrPageSizeOptions]="[15,25,50]">{{"PAGINATION.PAGE_SIZE" | translate}}</clr-dg-page-size>
                     <span *ngIf="scanningResults?.length">{{pagination.firstItem + 1}} - {{pagination.lastItem + 1}} {{'VULNERABILITY.GRID.FOOT_OF' | translate}}</span> {{scanningResults?.length}} {{'VULNERABILITY.GRID.FOOT_ITEMS' | translate}}
                 </clr-dg-pagination>

--- a/src/portal/src/app/base/project/repository/artifact/artifact-additions/artifact-vulnerabilities/artifact-vulnerabilities.component.ts
+++ b/src/portal/src/app/base/project/repository/artifact/artifact-additions/artifact-vulnerabilities/artifact-vulnerabilities.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import { AdditionsService } from "../additions.service";
-import { ClrDatagridComparatorInterface, ClrLoadingState } from "@clr/angular";
+import { ClrDatagridComparatorInterface, ClrDatagridStateInterface, ClrLoadingState } from "@clr/angular";
 import { finalize } from "rxjs/operators";
 import { AdditionLink } from "../../../../../../../../ng-swagger-gen/models/addition-link";
 import {
@@ -13,7 +13,12 @@ import {
   VulnerabilityItem
 } from "../../../../../../shared/services";
 import { ErrorHandler } from "../../../../../../shared/units/error-handler";
-import { SEVERITY_LEVEL_MAP, VULNERABILITY_SEVERITY } from "../../../../../../shared/units/utils";
+import {
+  getPageSizeFromLocalStorage,
+  PageSizeMapKeys, setPageSizeToLocalStorage,
+  SEVERITY_LEVEL_MAP,
+  VULNERABILITY_SEVERITY
+} from "../../../../../../shared/units/utils";
 import { ResultBarChartComponent } from "../../vulnerability-scanning/result-bar-chart.component";
 import { Subscription } from "rxjs";
 import { Artifact } from "../../../../../../../../ng-swagger-gen/models/artifact";
@@ -56,7 +61,7 @@ export class ArtifactVulnerabilitiesComponent implements OnInit, OnDestroy {
   sub: Subscription;
   hasViewInitWithDelay: boolean = false;
   currentCVEList: Array<{ "cve_id": string; }> = [];
-
+  pageSize: number = getPageSizeFromLocalStorage(PageSizeMapKeys.ARTIFACT_VUL_COMPONENT, 25);
   constructor(
       private errorHandler: ErrorHandler,
       private additionsService: AdditionsService,
@@ -301,5 +306,10 @@ export class ArtifactVulnerabilitiesComponent implements OnInit, OnDestroy {
   }
   canScan(): boolean {
     return this.hasEnabledScanner && this.hasScanningPermission && !this.onSendingScanCommand;
+  }
+  load(state: ClrDatagridStateInterface) {
+    if (state?.page?.size) {
+      setPageSizeToLocalStorage(PageSizeMapKeys.ARTIFACT_VUL_COMPONENT, state.page.size);
+    }
   }
 }

--- a/src/portal/src/app/base/project/repository/artifact/artifact-list-page/artifact-list/artifact-list-tab/artifact-list-tab.component.ts
+++ b/src/portal/src/app/base/project/repository/artifact/artifact-list-page/artifact-list/artifact-list-tab/artifact-list-tab.component.ts
@@ -23,11 +23,10 @@ import {
     clone,
     CustomComparator,
     dbEncodeURIComponent,
-    DEFAULT_PAGE_SIZE,
     DEFAULT_SUPPORTED_MIME_TYPES,
     doSorting,
-    formatSize,
-    getSortingString,
+    formatSize, getPageSizeFromLocalStorage,
+    getSortingString, PageSizeMapKeys, setPageSizeToLocalStorage,
     VULNERABILITY_SCAN_STATUS
 } from "../../../../../../../shared/units/utils";
 import { ImageNameInputComponent } from "../../../../../../../shared/components/image-name-input/image-name-input.component";
@@ -129,7 +128,7 @@ export class ArtifactListTabComponent implements OnInit, OnDestroy {
     imageNameInput: ImageNameInputComponent;
 
     @ViewChild("digestTarget") textInput: ElementRef;
-    pageSize: number = DEFAULT_PAGE_SIZE;
+    pageSize: number = getPageSizeFromLocalStorage(PageSizeMapKeys.ARTIFACT_LIST_TAB_COMPONENT);
     currentPage = 1;
     totalCount = 0;
     currentState: ClrDatagridStateInterface;
@@ -332,6 +331,7 @@ export class ArtifactListTabComponent implements OnInit, OnDestroy {
             return;
         }
         this.pageSize = state.page.size;
+        setPageSizeToLocalStorage(PageSizeMapKeys.ARTIFACT_LIST_TAB_COMPONENT, this.pageSize);
         this.selectedRow = [];
         // Keep it for future filtering and sorting
 

--- a/src/portal/src/app/base/project/repository/artifact/artifact-tag/artifact-tag.component.scss
+++ b/src/portal/src/app/base/project/repository/artifact/artifact-tag/artifact-tag.component.scss
@@ -12,7 +12,8 @@
   line-height: 1;
 }
 .immutable {
-  padding-right: 94px;
+  display: flex;
+  align-items: center;
   position: relative;
   .label {
     position: absolute;

--- a/src/portal/src/app/base/project/repository/artifact/artifact-tag/artifact-tag.component.ts
+++ b/src/portal/src/app/base/project/repository/artifact/artifact-tag/artifact-tag.component.ts
@@ -16,10 +16,9 @@ import { ClrDatagridStateInterface } from '@clr/angular';
 import {
   calculatePage,
   dbEncodeURIComponent,
-  DEFAULT_PAGE_SIZE,
   doFiltering,
-  doSorting,
-  getSortingString
+  doSorting, getPageSizeFromLocalStorage,
+  getSortingString, PageSizeMapKeys, setPageSizeToLocalStorage
 } from '../../../../../shared/units/utils';
 import { AppConfigService } from "../../../../../services/app-config.service";
 import { errorHandler } from "../../../../../shared/units/shared.utils";
@@ -61,7 +60,7 @@ export class ArtifactTagComponent implements OnInit, OnDestroy {
   totalCount: number = 0;
   allTags: Tag[] = [];
   currentTags: Tag[] = [];
-  pageSize: number = DEFAULT_PAGE_SIZE;
+  pageSize: number = getPageSizeFromLocalStorage(PageSizeMapKeys.ARTIFACT_TAGS_COMPONENT);
   currentPage = 1;
   tagNameChecker: Subject<string> = new Subject<string>();
   tagNameCheckSub: Subscription;
@@ -124,6 +123,7 @@ export class ArtifactTagComponent implements OnInit, OnDestroy {
       return ;
     }
     this.pageSize = state.page.size;
+    setPageSizeToLocalStorage(PageSizeMapKeys.ARTIFACT_TAGS_COMPONENT, this.pageSize);
     let pageNumber: number = calculatePage(state);
       if (pageNumber <= 0) { pageNumber = 1; }
     let params: ArtifactService.ListTagsParams = {

--- a/src/portal/src/app/base/project/repository/repository-gridview.component.ts
+++ b/src/portal/src/app/base/project/repository/repository-gridview.component.ts
@@ -22,9 +22,8 @@ import {
   clone,
   CURRENT_BASE_HREF,
   dbEncodeURIComponent,
-  DEFAULT_PAGE_SIZE,
-  doFiltering,
-  getSortingString
+  doFiltering, getPageSizeFromLocalStorage,
+  getSortingString, PageSizeMapKeys, setPageSizeToLocalStorage
 } from "../../../shared/units/utils";
 import { ErrorHandler } from "../../../shared/units/error-handler";
 import {
@@ -79,7 +78,7 @@ export class RepositoryGridviewComponent implements OnChanges, OnInit, OnDestroy
   cardHover = false;
   listHover = false;
 
-  pageSize: number = DEFAULT_PAGE_SIZE;
+  pageSize: number = getPageSizeFromLocalStorage(PageSizeMapKeys.REPOSITORY_GRIDVIEW_COMPONENT);
   currentPage = 1;
   totalCount = 0;
   currentState: ClrDatagridStateInterface;
@@ -359,6 +358,7 @@ export class RepositoryGridviewComponent implements OnChanges, OnInit, OnDestroy
       return;
     }
     this.pageSize = state.page.size;
+    setPageSizeToLocalStorage(PageSizeMapKeys.REPOSITORY_GRIDVIEW_COMPONENT, this.pageSize);
     this.selectedRow = [];
     // Keep it for future filtering and sorting
     this.currentState = state;

--- a/src/portal/src/app/base/project/robot-account/robot-account.component.ts
+++ b/src/portal/src/app/base/project/robot-account/robot-account.component.ts
@@ -7,7 +7,13 @@ import {
   ACTION_RESOURCE_I18N_MAP,
   PermissionsKinds
 } from "../../left-side-nav/system-robot-accounts/system-robot-util";
-import { clone, DEFAULT_PAGE_SIZE, getSortingString } from "../../../shared/units/utils";
+import {
+  clone,
+  getPageSizeFromLocalStorage,
+  getSortingString,
+  PageSizeMapKeys,
+  setPageSizeToLocalStorage
+} from "../../../shared/units/utils";
 import { ViewTokenComponent } from "../../../shared/components/view-token/view-token.component";
 import { FilterComponent } from "../../../shared/components/filter/filter.component";
 import { MessageHandlerService } from "../../../shared/services/message-handler.service";
@@ -34,7 +40,7 @@ import { SysteminfoService } from '../../../../../ng-swagger-gen/services/system
 })
 export class RobotAccountComponent implements OnInit, OnDestroy {
   i18nMap = ACTION_RESOURCE_I18N_MAP;
-  pageSize: number = DEFAULT_PAGE_SIZE;
+  pageSize: number = getPageSizeFromLocalStorage(PageSizeMapKeys.PROJECT_ROBOT_COMPONENT);
   currentPage: number = 1;
   total: number = 0;
   robots: Robot[] = [];
@@ -165,6 +171,7 @@ export class RobotAccountComponent implements OnInit, OnDestroy {
   clrLoad(state?: ClrDatagridStateInterface) {
     if (state && state.page && state.page.size) {
       this.pageSize = state.page.size;
+      setPageSizeToLocalStorage(PageSizeMapKeys.PROJECT_ROBOT_COMPONENT, this.pageSize);
     }
     this.selectedRows = [];
     const queryParam: RobotService.ListRobotParams = {

--- a/src/portal/src/app/base/project/tag-feature-integration/tag-retention/tag-retention.component.ts
+++ b/src/portal/src/app/base/project/tag-feature-integration/tag-retention/tag-retention.component.ts
@@ -21,7 +21,7 @@ import { finalize } from "rxjs/operators";
 import { CronScheduleComponent } from "../../../../shared/components/cron-schedule";
 import { ErrorHandler } from "../../../../shared/units/error-handler";
 import { OriginCron } from "../../../../shared/services";
-import { clone, DEFAULT_PAGE_SIZE} from "../../../../shared/units/utils";
+import { clone, getPageSizeFromLocalStorage, PageSizeMapKeys, setPageSizeToLocalStorage } from "../../../../shared/units/utils";
 
 const MIN = 60000;
 const SEC = 1000;
@@ -38,6 +38,7 @@ const DECORATION = {
     MATCHES: "matches",
     EXCLUDES: "excludes",
 };
+
 @Component({
     selector: 'tag-retention',
     templateUrl: './tag-retention.component.html',
@@ -76,7 +77,7 @@ export class TagRetentionComponent implements OnInit, OnDestroy {
     label: string = 'TAG_RETENTION.TRIGGER';
     loadingRule: boolean = false;
     currentPage: number = 1;
-    pageSize: number = DEFAULT_PAGE_SIZE;
+    pageSize: number = getPageSizeFromLocalStorage(PageSizeMapKeys.TAG_RETENTION_COMPONENT);
     totalCount: number = 0;
     @ViewChild('cronScheduleComponent')
     cronScheduleComponent: CronScheduleComponent;
@@ -309,6 +310,7 @@ export class TagRetentionComponent implements OnInit, OnDestroy {
         if (this.retentionId) {
             if (state && state.page) {
                 this.pageSize = state.page.size;
+                setPageSizeToLocalStorage(PageSizeMapKeys.TAG_RETENTION_COMPONENT, this.pageSize);
             }
             this.loadingExecutions = true;
             this.tagRetentionService.getRunNowList(this.retentionId, this.currentPage, this.pageSize)

--- a/src/portal/src/app/base/project/webhook/webhook.component.ts
+++ b/src/portal/src/app/base/project/webhook/webhook.component.ts
@@ -19,7 +19,13 @@ import { AddWebhookFormComponent } from './add-webhook-form/add-webhook-form.com
 import { ActivatedRoute } from '@angular/router';
 import { MessageHandlerService } from '../../../shared/services/message-handler.service';
 import { Project } from '../project';
-import { clone, DEFAULT_PAGE_SIZE, getSortingString } from '../../../shared/units/utils';
+import {
+  clone,
+  getPageSizeFromLocalStorage,
+  getSortingString,
+  PageSizeMapKeys,
+  setPageSizeToLocalStorage
+} from '../../../shared/units/utils';
 import { forkJoin, Observable } from 'rxjs';
 import { UserPermissionService, USERSTATICPERMISSION } from '../../../shared/services';
 import { ClrDatagridStateInterface } from '@clr/angular';
@@ -54,7 +60,7 @@ export class WebhookComponent implements OnInit {
   hasCreatPermission: boolean = false;
   hasUpdatePermission: boolean = false;
   page: number = 1;
-  pageSize: number = DEFAULT_PAGE_SIZE;
+  pageSize: number = getPageSizeFromLocalStorage(PageSizeMapKeys.WEBHOOK_COMPONENT);
   total: number = 0;
   state: ClrDatagridStateInterface;
   constructor(
@@ -147,6 +153,7 @@ export class WebhookComponent implements OnInit {
     }
     if (state && state.page) {
       this.pageSize = state.page.size;
+      setPageSizeToLocalStorage(PageSizeMapKeys.WEBHOOK_COMPONENT, this.pageSize);
     }
     let q: string;
     if (state && state.filters && state.filters.length) {

--- a/src/portal/src/app/shared/components/label/label.component.ts
+++ b/src/portal/src/app/shared/components/label/label.component.ts
@@ -35,8 +35,9 @@ import { ConfirmationMessage } from "../../../base/global-confirmation-dialog/co
 import { ConfirmationAcknowledgement } from "../../../base/global-confirmation-dialog/confirmation-state-message";
 import { LabelService } from "../../../../../ng-swagger-gen/services/label.service";
 import { Label } from "../../../../../ng-swagger-gen/models/label";
-import { DEFAULT_PAGE_SIZE, getSortingString } from "../../units/utils";
+import { getPageSizeFromLocalStorage, getSortingString, PageSizeMapKeys, setPageSizeToLocalStorage } from "../../units/utils";
 import { ClrDatagridStateInterface } from "@clr/angular";
+
 @Component({
     selector: "hbr-label",
     templateUrl: "./label.component.html",
@@ -61,7 +62,7 @@ export class LabelComponent implements OnInit {
     confirmationDialogComponent: ConfirmationDialogComponent;
 
     page: number = 1;
-    pageSize: number = DEFAULT_PAGE_SIZE;
+    pageSize: number = getPageSizeFromLocalStorage(PageSizeMapKeys.LABEL_COMPONENT);
     total: number = 0;
     constructor(private labelService: LabelService,
         private errorHandlerEntity: ErrorHandler,
@@ -77,6 +78,7 @@ export class LabelComponent implements OnInit {
         // this.targetName = "";
         if (state && state.page) {
             this.pageSize = state.page.size;
+            setPageSizeToLocalStorage(PageSizeMapKeys.LABEL_COMPONENT, this.pageSize);
         }
         let sort: string;
         if (state && state.sort && state.sort.by) {

--- a/src/portal/src/app/shared/units/utils.spec.ts
+++ b/src/portal/src/app/shared/units/utils.spec.ts
@@ -1,4 +1,15 @@
-import { delUrlParam, getQueryString, getSizeNumber, getSizeUnit, getSortingString, isSameArrayValue, isSameObject } from "./utils";
+import {
+  DEFAULT_PAGE_SIZE,
+  delUrlParam,
+  getPageSizeFromLocalStorage,
+  getQueryString,
+  getSizeNumber,
+  getSizeUnit,
+  getSortingString,
+  isSameArrayValue,
+  isSameObject,
+  setPageSizeToLocalStorage,
+} from "./utils";
 import { ClrDatagridStateInterface } from "@clr/angular";
 import {QuotaUnit} from "../entities/shared.const";
 
@@ -71,5 +82,25 @@ describe('functions in utils.ts should work', () => {
     expect(getSizeUnit(4564000)).toEqual(QuotaUnit.MB);
     expect(getSizeUnit(4564000000)).toEqual(QuotaUnit.GB);
     expect(getSizeUnit(4564000000000)).toEqual(QuotaUnit.TB);
+  });
+
+  it('functions getPageSizeFromLocalStorage() and setPageSizeToLocalStorage() should work', () => {
+    let store = {};
+    spyOn(localStorage, 'getItem').and.callFake( key => {
+      return store[key];
+    });
+    spyOn(localStorage, 'setItem').and.callFake((key, value) => {
+      return store[key] = value + '';
+    });
+    spyOn(localStorage, 'clear').and.callFake( () => {
+      store = {};
+    });
+    expect(getPageSizeFromLocalStorage(null)).toEqual(DEFAULT_PAGE_SIZE);
+    expect(getPageSizeFromLocalStorage('test', 99)).toEqual(99);
+    expect(getPageSizeFromLocalStorage('test1')).toEqual(DEFAULT_PAGE_SIZE);
+    setPageSizeToLocalStorage('test1', null);
+    expect(getPageSizeFromLocalStorage('test1')).toEqual(DEFAULT_PAGE_SIZE);
+    setPageSizeToLocalStorage('test1', 10);
+    expect(getPageSizeFromLocalStorage('test1')).toEqual(10);
   });
 });

--- a/src/portal/src/app/shared/units/utils.ts
+++ b/src/portal/src/app/shared/units/utils.ts
@@ -7,6 +7,7 @@ import {QuotaUnit, QuotaUnits, StorageMultipleConstant} from '../entities/shared
 import { AbstractControl } from "@angular/forms";
 import { isValidCron } from 'cron-validator';
 import { ClrDatagridStateInterface } from "@clr/angular";
+
 /**
  * Api levels
  */
@@ -816,4 +817,73 @@ export function delUrlParam(url: string, key: string): string {
         }
     }
     return url;
+}
+
+const PAGE_SIZE_MAP_KEY: string = 'pageSizeMap';
+
+/**
+ * Get the page size from the browser's localStorage
+ * @param key
+ * @param initialSize
+ */
+export function getPageSizeFromLocalStorage(key: string, initialSize?: number): number {
+    if (!initialSize) {
+        initialSize = DEFAULT_PAGE_SIZE;
+    }
+    if (localStorage && key && localStorage.getItem(PAGE_SIZE_MAP_KEY)) {
+        const pageSizeMap: {
+            [k: string]: number
+        } = JSON.parse(localStorage.getItem(PAGE_SIZE_MAP_KEY));
+        return pageSizeMap[key] ? pageSizeMap[key] : initialSize;
+    }
+    return initialSize;
+}
+
+/**
+ * Set the page size to the browser's localStorage
+ * @param key
+ * @param pageSize
+ */
+export function setPageSizeToLocalStorage(key: string, pageSize: number) {
+    if (localStorage && key && pageSize) {
+        if (!localStorage.getItem(PAGE_SIZE_MAP_KEY)) { // if first set
+            localStorage.setItem(PAGE_SIZE_MAP_KEY, '{}');
+        }
+        const pageSizeMap: {
+            [k: string]: number
+        } = JSON.parse(localStorage.getItem(PAGE_SIZE_MAP_KEY));
+        pageSizeMap[key] = pageSize;
+        localStorage.setItem(PAGE_SIZE_MAP_KEY, JSON.stringify(pageSizeMap));
+    }
+}
+
+export enum PageSizeMapKeys {
+    LIST_PROJECT_COMPONENT = 'ListProjectComponent',
+    REPOSITORY_GRIDVIEW_COMPONENT = 'RepositoryGridviewComponent',
+    ARTIFACT_LIST_TAB_COMPONENT = 'ArtifactListTabComponent',
+    ARTIFACT_TAGS_COMPONENT = 'ArtifactTagComponent',
+    ARTIFACT_VUL_COMPONENT = 'ArtifactVulnerabilitiesComponent',
+    HELM_CHART_COMPONENT = 'HelmChartComponent',
+    CHART_VERSION_COMPONENT = 'ChartVersionComponent',
+    MEMBER_COMPONENT = 'MemberComponent',
+    LABEL_COMPONENT = 'LabelComponent',
+    P2P_POLICY_COMPONENT = 'P2pPolicyComponent',
+    P2P_POLICY_COMPONENT_EXECUTIONS = 'P2pPolicyComponentExecutions',
+    P2P_TASKS_COMPONENT = 'P2pTaskListComponent',
+    TAG_RETENTION_COMPONENT = 'TagRetentionComponent',
+    PROJECT_ROBOT_COMPONENT = 'ProjectRobotAccountComponent',
+    WEBHOOK_COMPONENT = 'WebhookComponent',
+    PROJECT_AUDIT_LOG_COMPONENT = 'ProjectAuditLogComponent',
+    SYSTEM_RECENT_LOG_COMPONENT = 'SystemRecentLogComponent',
+    SYSTEM_USER_COMPONENT = 'SystemUserComponent',
+    SYSTEM_ROBOT_COMPONENT = 'SystemRobotAccountsComponent',
+    SYSTEM_ENDPOINT_COMPONENT = 'SystemEndpointComponent',
+    LIST_REPLICATION_RULE_COMPONENT = 'ListReplicationRuleComponent',
+    LIST_REPLICATION_RULE_COMPONENT_EXECUTIONS = 'ListReplicationRuleComponentExecutions',
+    REPLICATION_TASKS_COMPONENT = 'ReplicationTasksComponent',
+    DISTRIBUTION_INSTANCE_COMPONENT = 'DistributionInstancesComponent',
+    PROJECT_QUOTA_COMPONENT = 'ProjectQuotasComponent',
+    SYSTEM_SCANNER_COMPONENT = 'ConfigurationScannerComponent',
+    GC_HISTORY_COMPONENT = 'GcHistoryComponent',
+    SYSTEM_GROUP_COMPONENT = 'SystemGroupComponent'
 }


### PR DESCRIPTION
Fixes #16030
1. Store default page size to local storage for every datagrid, so user's choice can be remembered
Signed-off-by: AllForNothing <sshijun@vmware.com>

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
