### PR TITLE
replace install httpd by installing htpasswd binary only

### DIFF
--- a/make/photon/prepare/Dockerfile.base
+++ b/make/photon/prepare/Dockerfile.base
@@ -1,4 +1,11 @@
 FROM photon:4.0
 
-RUN tdnf install -y python3 python3-pip httpd python3-PyYAML python3-jinja2 && tdnf clean all
+RUN tdnf install -y python3 python3-pip python3-PyYAML python3-jinja2 && tdnf clean all
 RUN pip3 install pipenv==2020.11.15
+
+#To install only htpasswd binary from photon package httpd
+RUN tdnf install -y rpm
+RUN tdnf -y --downloadonly --downloaddir=/tmp install httpd
+RUN tdnf install -y apr-util
+RUN rpm2cpio /tmp/httpd-*.rpm | cpio -iuvdm /usr/bin/htpasswd
+RUN rm -f /tmp/*


### PR DESCRIPTION
Signed-off-by: yminer <yminer@vmmware.com>
To get reduce of CVE from photon package httpd, replace installing `httpd` by installing htpasswd binary only from photon package


Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [ ] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [ ] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
