### PR TITLE
Simplify HarborDatetimePipe

### DIFF
--- a/src/portal/src/app/shared/pipes/harbor-datetime.pipe.ts
+++ b/src/portal/src/app/shared/pipes/harbor-datetime.pipe.ts
@@ -11,13 +11,11 @@ const baseTimeLine: Date = new Date('1970-1-1');
 export class HarborDatetimePipe implements PipeTransform {
 
     transform(value: any, format?: string): string {
-        let lang: string = DeFaultLang;
-        if (localStorage && localStorage.getItem(DEFAULT_LANG_LOCALSTORAGE_KEY)) {
-            lang = localStorage.getItem(DEFAULT_LANG_LOCALSTORAGE_KEY);
-        }
         if (value && value <= baseTimeLine) {// invalid date
             return '-';
         }
+        const langFromLocalStorage = localStorage && localStorage.getItem(DEFAULT_LANG_LOCALSTORAGE_KEY);
+        const lang = langFromLocalStorage || DeFaultLang;
         // default format medium
         return new DatePipe(lang).transform(value, format ? format : 'medium');
     }


### PR DESCRIPTION
Why this change is correct/good:

  * No need to read from localStorage etc if we're just going to return `'-'` based on `value` anyway (hence the reordering).

  * No need to read from localStorage twice.

  * Unlike `let`, `const` communicates to the reader and the type checker that the variable will not be reassigned.

  * This is true both before and after this change:

    > If `localStorage && localStorage.getItem(…)` is truthy, then `lang` gets the value of `localStorage.getItem(…)`; otherwise, `lang` gets the value of `DeFaultLang`.
