### PR TITLE
Fix lint errors in portal

### DIFF
--- a/src/portal/src/app/base/left-side-nav/labels/labels.module.ts
+++ b/src/portal/src/app/base/left-side-nav/labels/labels.module.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import { NgModule } from "@angular/core";
-import { SharedModule } from "../../../shared/shared.module";;
+import { SharedModule } from "../../../shared/shared.module";
 import { RouterModule, Routes } from "@angular/router";
 import { LabelsComponent } from "./labels.component";
 

--- a/src/portal/src/app/base/password-setting/password-setting.component.ts
+++ b/src/portal/src/app/base/password-setting/password-setting.component.ts
@@ -27,7 +27,7 @@ import { InlineAlertComponent } from "../../shared/components/inline-alert/inlin
 export class PasswordSettingComponent implements AfterViewChecked {
     showOldPwd: boolean = false;
     showNewPwd: boolean = false;
-    showReNewPwd: boolean =false;
+    showReNewPwd: boolean = false;
     opened: boolean = false;
     oldPwd: string = "";
     newPwd: string = "";

--- a/src/portal/src/app/base/project/helm-chart/helm-chart-detail/chart-detail/chart-detail-value.component.spec.ts
+++ b/src/portal/src/app/base/project/helm-chart/helm-chart-detail/chart-detail/chart-detail-value.component.spec.ts
@@ -11,7 +11,7 @@ describe('ChartDetailValueComponent', () => {
     let component: ChartDetailValueComponent;
     let fixture: ComponentFixture<ChartDetailValueComponent>;
 
-    beforeEach(async ()=> {
+    beforeEach(async () => {
         await TestBed.configureTestingModule({
             imports: [
                 TranslateModule.forRoot(),

--- a/src/portal/src/app/base/project/helm-chart/helm-chart-detail/helm-chart.service.ts
+++ b/src/portal/src/app/base/project/helm-chart/helm-chart-detail/helm-chart.service.ts
@@ -177,9 +177,9 @@ export class HelmChartDefaultService extends HelmChartService {
       responseType: 'blob',
     })
     .pipe(map(response => {
-      let parts = filename.split('/')
+      let parts = filename.split('/');
       return {
-        filename: parts[parts.length-1],
+        filename: parts[parts.length - 1],
         data: response
       };
     }))

--- a/src/portal/src/app/base/project/helm-chart/helm-chart-list/list-charts.component.spec.ts
+++ b/src/portal/src/app/base/project/helm-chart/helm-chart-list/list-charts.component.spec.ts
@@ -14,7 +14,7 @@ describe('ListChartsComponent', () => {
     }
   };
 
-  beforeEach(()=> {
+  beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [ListChartsComponent],
       imports: [

--- a/src/portal/src/app/base/project/project-config/project-policy-config/project-policy-config.component.spec.ts
+++ b/src/portal/src/app/base/project/project-config/project-policy-config/project-policy-config.component.spec.ts
@@ -150,5 +150,5 @@ describe('ProjectPolicyConfigComponent', () => {
 })
 class TestHostComponent {
   @ViewChild(ProjectPolicyConfigComponent)
-  projectPolicyConfigComponent: ProjectPolicyConfigComponent
+  projectPolicyConfigComponent: ProjectPolicyConfigComponent;
 }

--- a/src/portal/src/app/shared/components/push-image/push-image.component.spec.ts
+++ b/src/portal/src/app/shared/components/push-image/push-image.component.spec.ts
@@ -15,7 +15,7 @@ describe('PushImageButtonComponent (inline template)', () => {
       imports: [
         SharedTestingModule
       ],
-      declarations: [InlineAlertComponent, CopyInputComponent, PushImageButtonComponent,TestHostComponent],
+      declarations: [InlineAlertComponent, CopyInputComponent, PushImageButtonComponent, TestHostComponent],
       providers: [
         ErrorHandler
       ]

--- a/src/portal/src/app/shared/directives/port.directive.ts
+++ b/src/portal/src/app/shared/directives/port.directive.ts
@@ -27,7 +27,7 @@ export function portValidator(): ValidatorFn {
         if (!regExp.test(value)) {
             return { 'port': 65535 };
         } else {
-            const portV = Number.parseInt(value);
+            const portV = Number.parseInt(value, 10);
             if (portV <= 0 || portV > 65535) {
                 return { 'port': 65535 };
             }


### PR DESCRIPTION
This PR fixes all lint errors reported by TSLint (`npm run lint` in `src/portal/`).

TSLint also reports multiple warnings (see #16798), but this PR doesn't fix any of them.

Signed-off-by: Simon Alling <alling.simon@gmail.com>