### PR TITLE
[cherry-pick]Add release.yml to automate release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,36 @@
+# .github/release.yml
+
+changelog:
+  exclude:
+    labels:
+      - release-note/ignore-for-release
+    authors:
+      - octocat
+  categories:
+    - title: Exciting New Features 🎉
+      labels:
+        - release-note/new-feature
+    - title: Enhancement 🚀
+      labels:
+        - release-note/enhancement
+    - title: Component updates ⬆️
+      labels:
+        - release-note/update
+    - title: Docs update 🗄️
+      labels:
+        - release-note/docs
+    - title: Community update 🧑🏻‍🤝‍🧑🏾
+      labels:
+        - release-note/community
+
+    - title: Breaking Changes 🛠
+      labels:
+        - release-note/breaking-change
+
+    - title: Deprecations ❌
+      labels:
+        - release-note/deprecation
+
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/label_check.yaml
+++ b/.github/workflows/label_check.yaml
@@ -1,0 +1,23 @@
+name: Release Note Label Check
+
+# Trigger the workflow on pull requests only
+on: 
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize]
+
+env:
+  GOPROXY: https://proxy.golang.org/
+  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+jobs:
+  # Ensures correct release-note labels are set:
+  # - At least one label
+  # - At most one two the main category labels
+  check-label:
+    name: Check release-note label set
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mheap/github-action-required-labels@v1
+        with:
+          mode: minimum
+          count: 1
+          labels: "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"


### PR DESCRIPTION
Use github autogeneration release notes and add action to check if the PR has labels

Complete and more readable relase notes
https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
Signed-off-by: OrlinVasilev <ovasilev@vmware.com>

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
