### PR TITLE
[cherry-pick]fix close response missing

### DIFF
--- a/src/pkg/reg/adapter/dockerhub/adapter.go
+++ b/src/pkg/reg/adapter/dockerhub/adapter.go
@@ -379,6 +379,7 @@ func (a *adapter) DeleteManifest(repository, reference string) error {
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {


### PR DESCRIPTION
It has to close the http response on deleting manifest

Signed-off-by: Wang Yan <wangyan@vmware.com>

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
