### PR TITLE
Change `golint` rule in the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -543,7 +543,7 @@ misspell:
 
 golint:
 	@echo checking golint...
-	@go list ./... | grep -v -E 'vendor|test' | xargs fgt golint
+	@cd src;go list ./... | grep -v -E 'vendor|test' | xargs golint
 
 govet:
 	@echo checking govet...


### PR DESCRIPTION
The `govet` rule immediately below performs `cd ./src` first,
this changes the golint rule to do the same.

# Issue being fixed
Fixes #16765

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
