### PR TITLE
[cherry-pick] fix: gc history update_time

### DIFF
--- a/src/controller/gc/controller.go
+++ b/src/controller/gc/controller.go
@@ -218,7 +218,7 @@ func convertExecution(exec *task.Execution) *Execution {
 		Trigger:       exec.Trigger,
 		ExtraAttrs:    exec.ExtraAttrs,
 		StartTime:     exec.StartTime,
-		EndTime:       exec.EndTime,
+		UpdateTime:    exec.UpdateTime,
 	}
 }
 

--- a/src/controller/gc/model.go
+++ b/src/controller/gc/model.go
@@ -26,7 +26,7 @@ type TriggerSettings struct {
 	Cron string `json:"cron"`
 }
 
-// Execution model for replication
+// Execution model for gc
 type Execution struct {
 	ID            int64
 	Status        string
@@ -34,10 +34,10 @@ type Execution struct {
 	Trigger       string
 	ExtraAttrs    map[string]interface{}
 	StartTime     time.Time
-	EndTime       time.Time
+	UpdateTime    time.Time
 }
 
-// Task model for replication
+// Task model for gc
 type Task struct {
 	ID             int64
 	ExecutionID    int64

--- a/src/server/v2.0/handler/gc.go
+++ b/src/server/v2.0/handler/gc.go
@@ -168,7 +168,7 @@ func (g *gcAPI) GetGCHistory(ctx context.Context, params operation.GetGCHistoryP
 			},
 			Status:       exec.Status,
 			CreationTime: exec.StartTime,
-			UpdateTime:   exec.EndTime,
+			UpdateTime:   exec.UpdateTime,
 		})
 	}
 
@@ -207,7 +207,7 @@ func (g *gcAPI) GetGC(ctx context.Context, params operation.GetGCParams) middlew
 			Type: exec.Trigger,
 		},
 		CreationTime: exec.StartTime,
-		UpdateTime:   exec.EndTime,
+		UpdateTime:   exec.UpdateTime,
 	}
 
 	return operation.NewGetGCOK().WithPayload(res.ToSwagger())


### PR DESCRIPTION
Signed-off-by: Shengwen Yu <yshengwen@vmware.com>

Thank you for contributing to Harbor!

# Comprehensive Summary of your change
The `Update Time` in gc history records was incorrect.

# Issue being fixed
Fixes #16355

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
