### PR TITLE
fix golangci-lint deadcode && staticcheck

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -533,6 +533,7 @@ misspell:
 	@find . -type d \( -path ./src/vendor -o -path ./tests \) -prune -o -name '*.go' -print | xargs misspell -error
 
 # go get -u github.com/golangci/golangci-lint/cmd/golangci-lint@v1.45.2
+# go mod tidy
 GOLANGCI_LINT := $(shell go env GOPATH)/bin/golangci-lint
 lint:
 	@echo checking lint

--- a/src/.golangci.yaml
+++ b/src/.golangci.yaml
@@ -27,12 +27,12 @@ linters:
     # - nolintlint
     # - revive
     # - whitespace
-    # - bodyclose
-    # - deadcode
+    - bodyclose
+    - deadcode
     # - errcheck
     # - gosec
     # - gosimple
-    # - govet
+    - govet
     # - noctx
     # - rowserrcheck
     # - staticcheck
@@ -44,13 +44,20 @@ linters:
     # - varcheck
  
 run:
+  tests: false 
   skip-files:
     - ".*_test.go"
     - ".*test.go"
-  skip-dir:
-    - "./testing/"
+  skip-dirs:
+    - src/testing/
   timeout: 5m
 
 issue:
   max-same-issues: 0
   max-per-linter: 0
+
+issues:
+  exclude-rules:
+    - path: ./...
+      linters:
+        - typecheck

--- a/src/.golangci.yaml
+++ b/src/.golangci.yaml
@@ -35,7 +35,7 @@ linters:
     - govet
     # - noctx
     # - rowserrcheck
-    # - staticcheck
+    - staticcheck
     # - structcheck
     # - stylecheck
     # - unconvert

--- a/src/controller/replication/flow/mock.go
+++ b/src/controller/replication/flow/mock.go
@@ -19,6 +19,7 @@ import (
 )
 
 // define a new interface to combine the two interfaces of adapter for mockery to generate the mocks
+//nolint:deadcode
 type registryAdapter interface {
 	adapter.Adapter
 	adapter.ArtifactRegistry

--- a/src/controller/replication/flow/mock.go
+++ b/src/controller/replication/flow/mock.go
@@ -19,7 +19,7 @@ import (
 )
 
 // define a new interface to combine the two interfaces of adapter for mockery to generate the mocks
-//nolint:deadcode
+// nolint:deadcode
 type registryAdapter interface {
 	adapter.Adapter
 	adapter.ArtifactRegistry

--- a/src/pkg/allowlist/validator.go
+++ b/src/pkg/allowlist/validator.go
@@ -41,7 +41,7 @@ func IsInvalidErr(err error) bool {
 	return ok
 }
 
-const cveIDPattern = `^CVE-\d{4}-\d+$` //nolint:deadcode
+const cveIDPattern = `^CVE-\d{4}-\d+$` // nolint:deadcode
 
 // Validate help validates the CVE allowlist, to ensure the CVE ID is valid and there's no duplication
 func Validate(wl models2.CVEAllowlist) error {

--- a/src/pkg/allowlist/validator.go
+++ b/src/pkg/allowlist/validator.go
@@ -41,7 +41,7 @@ func IsInvalidErr(err error) bool {
 	return ok
 }
 
-const cveIDPattern = `^CVE-\d{4}-\d+$`
+const cveIDPattern = `^CVE-\d{4}-\d+$` //nolint:deadcode
 
 // Validate help validates the CVE allowlist, to ensure the CVE ID is valid and there's no duplication
 func Validate(wl models2.CVEAllowlist) error {

--- a/src/pkg/reg/adapter/artifacthub/consts.go
+++ b/src/pkg/reg/adapter/artifacthub/consts.go
@@ -24,6 +24,7 @@ const (
 // ErrHTTPNotFound defines the return error when receiving 404 response code
 var ErrHTTPNotFound = errors.New("not found")
 
+//nolint:deadcode
 func searchPackages(kind, offset, limit int, queryString string) string {
 	if len(queryString) == 0 {
 		return fmt.Sprintf("/api/v1/packages/search?kind=%d&limit=%d&offset=%d",
@@ -33,6 +34,7 @@ func searchPackages(kind, offset, limit int, queryString string) string {
 		kind, limit, offset, queryString)
 }
 
+//nolint:deadcode
 func getHelmPackageDetail(fullName string) string {
 	return fmt.Sprintf("/api/v1/packages/helm/%s", fullName)
 }

--- a/src/pkg/reg/adapter/artifacthub/consts.go
+++ b/src/pkg/reg/adapter/artifacthub/consts.go
@@ -24,7 +24,7 @@ const (
 // ErrHTTPNotFound defines the return error when receiving 404 response code
 var ErrHTTPNotFound = errors.New("not found")
 
-//nolint:deadcode
+// nolint:deadcode
 func searchPackages(kind, offset, limit int, queryString string) string {
 	if len(queryString) == 0 {
 		return fmt.Sprintf("/api/v1/packages/search?kind=%d&limit=%d&offset=%d",
@@ -34,7 +34,7 @@ func searchPackages(kind, offset, limit int, queryString string) string {
 		kind, limit, offset, queryString)
 }
 
-//nolint:deadcode
+// nolint:deadcode
 func getHelmPackageDetail(fullName string) string {
 	return fmt.Sprintf("/api/v1/packages/helm/%s", fullName)
 }

--- a/src/pkg/reg/adapter/gitlab/client.go
+++ b/src/pkg/reg/adapter/gitlab/client.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	scheme = "bearer" //nolint:deadcode
+	scheme = "bearer" // nolint:deadcode
 )
 
 // Client is a client to interact with GitLab
@@ -55,7 +55,7 @@ func NewClient(registry *model.Registry) (*Client, error) {
 	return client, nil
 }
 
-//nolint:deadcode
+// nolint:deadcode
 func buildPingURL(endpoint string) string {
 	return fmt.Sprintf("%s/v2/", endpoint)
 }

--- a/src/pkg/reg/adapter/gitlab/client.go
+++ b/src/pkg/reg/adapter/gitlab/client.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	scheme = "bearer"
+	scheme = "bearer" //nolint:deadcode
 )
 
 // Client is a client to interact with GitLab
@@ -55,6 +55,7 @@ func NewClient(registry *model.Registry) (*Client, error) {
 	return client, nil
 }
 
+//nolint:deadcode
 func buildPingURL(endpoint string) string {
 	return fmt.Sprintf("%s/v2/", endpoint)
 }

--- a/src/pkg/scan/postprocessors/report_converters.go
+++ b/src/pkg/scan/postprocessors/report_converters.go
@@ -300,6 +300,7 @@ func toVulnerabilityItem(record *scan.VulnerabilityRecord, artifactDigest string
 	return item
 }
 
+//nolint:deadcode
 func convertingKey(reportUUID string) string {
 	return fmt.Sprintf("converting:%s", reportUUID)
 }

--- a/src/pkg/scan/postprocessors/report_converters.go
+++ b/src/pkg/scan/postprocessors/report_converters.go
@@ -300,7 +300,7 @@ func toVulnerabilityItem(record *scan.VulnerabilityRecord, artifactDigest string
 	return item
 }
 
-//nolint:deadcode
+// nolint:deadcode
 func convertingKey(reportUUID string) string {
 	return fmt.Sprintf("converting:%s", reportUUID)
 }

--- a/src/pkg/scan/report/manager.go
+++ b/src/pkg/scan/report/manager.go
@@ -104,7 +104,7 @@ type Manager interface {
 }
 
 const (
-	reportTimeout = 1 * time.Hour
+	reportTimeout = 1 * time.Hour //nolint:deadcode
 )
 
 // basicManager is a default implementation of report manager.

--- a/src/pkg/scan/report/manager.go
+++ b/src/pkg/scan/report/manager.go
@@ -104,7 +104,7 @@ type Manager interface {
 }
 
 const (
-	reportTimeout = 1 * time.Hour //nolint:deadcode
+	reportTimeout = 1 * time.Hour // nolint:deadcode
 )
 
 // basicManager is a default implementation of report manager.

--- a/src/vendor/github.com/vmihailenco/msgpack/v5/unsafe.go
+++ b/src/vendor/github.com/vmihailenco/msgpack/v5/unsafe.go
@@ -1,3 +1,4 @@
+//go:build !appengine
 // +build !appengine
 
 package msgpack


### PR DESCRIPTION
Signed-off-by: yminer <yminer@vmmware.com>

Enable several linters due to prior merged PR and fix several deadcode linters, staticcheck linters
enable: 
`bodyclose` (https://github.com/goharbor/harbor/pull/16820/files)
`govet` (no error)
`deadcode` (this pr)
`staticcheck`(https://github.com/goharbor/harbor/pull/16828 && this pr)

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [ ] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [ ] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
