### PR TITLE
fix replcation issue on accessory

### DIFF
--- a/src/pkg/reg/model/resource.go
+++ b/src/pkg/reg/model/resource.go
@@ -58,10 +58,12 @@ type Repository struct {
 
 // Artifact is the individual unit that can be replicated
 type Artifact struct {
-	Type   string   `json:"type"`
-	Digest string   `json:"digest"`
-	Labels []string `json:"labels"`
-	Tags   []string `json:"tags"`
+	Type       string   `json:"type"`
+	Digest     string   `json:"digest"`
+	Labels     []string `json:"labels"`
+	Tags       []string `json:"tags"`
+	IsAcc      bool     `json:"-"` // indicate whether it is an accessory artifact
+	ParentTags []string `json:"-"` // the tags belong to the artifact which the accessory is attached.
 }
 
 func (r *ResourceMetadata) String() string {


### PR DESCRIPTION
The tag/lable filter only works on the subject manifest, and if the subject manifest is mathed, all the accessories are marked as matched.

Signed-off-by: Wang Yan <wangyan@vmware.com>

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
