### PR TITLE
fix(swagger): append scan report version 1.1 to swagger docs

### DIFF
--- a/api/v2.0/swagger.yaml
+++ b/api/v2.0/swagger.yaml
@@ -5610,7 +5610,7 @@ parameters:
     name: X-Accept-Vulnerabilities
     in: header
     type: string
-    default: 'application/vnd.scanner.adapter.vuln.report.harbor+json; version=1.0'
+    default: 'application/vnd.security.vulnerability.report; version=1.1, application/vnd.scanner.adapter.vuln.report.harbor+json; version=1.0'
     description: |-
       A comma-separated lists of MIME types for the scan report or scan summary. The first mime type will be used when the report found for it.
       Currently the mime type supports 'application/vnd.scanner.adapter.vuln.report.harbor+json; version=1.0' and 'application/vnd.security.vulnerability.report; version=1.1'

--- a/src/server/v2.0/handler/artifact_test.go
+++ b/src/server/v2.0/handler/artifact_test.go
@@ -116,7 +116,7 @@ func (suite *ArtifactTestSuite) TestGetVulnerabilitiesAddition() {
 		suite.onGetReport(v1.MimeTypeNativeReport)
 
 		var body map[string]interface{}
-		res, err := suite.GetJSON(url, &body)
+		res, err := suite.GetJSON(url, &body, map[string]string{"X-Accept-Vulnerabilities": v1.MimeTypeNativeReport})
 		suite.NoError(err)
 		suite.Equal(200, res.StatusCode)
 		suite.Empty(body)
@@ -127,7 +127,7 @@ func (suite *ArtifactTestSuite) TestGetVulnerabilitiesAddition() {
 		suite.onGetReport(v1.MimeTypeNativeReport, suite.report1)
 
 		var body map[string]interface{}
-		res, err := suite.GetJSON(url, &body)
+		res, err := suite.GetJSON(url, &body, map[string]string{"X-Accept-Vulnerabilities": v1.MimeTypeNativeReport})
 		suite.NoError(err)
 		suite.Equal(200, res.StatusCode)
 		suite.NotEmpty(body)


### PR DESCRIPTION
The default value of swagger header X-Accept-Vulnerabilities should contains
scan report version 1.0 and 1.1.

Signed-off-by: chlins <chenyuzh@vmware.com>

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
