### PR TITLE
fix: update the jobservice hook retry concurrency

### DIFF
--- a/src/jobservice/hook/hook_agent.go
+++ b/src/jobservice/hook/hook_agent.go
@@ -33,8 +33,6 @@ import (
 const (
 	// Backoff duration of direct retrying.
 	errRetryBackoff = 5 * time.Minute
-	// Max concurrency of retrying goroutines.
-	maxConcurrency = 512
 )
 
 // Agent is designed to handle the hook events with reasonable numbers of concurrent threads.
@@ -75,13 +73,13 @@ type basicAgent struct {
 }
 
 // NewAgent is constructor of basic agent
-func NewAgent(ctx *env.Context, ns string, redisPool *redis.Pool) Agent {
+func NewAgent(ctx *env.Context, ns string, redisPool *redis.Pool, retryConcurrency uint) Agent {
 	return &basicAgent{
 		context:   ctx.SystemContext,
 		namespace: ns,
 		client:    NewClient(ctx.SystemContext),
 		redisPool: redisPool,
-		tokens:    make(chan struct{}, maxConcurrency),
+		tokens:    make(chan struct{}, retryConcurrency),
 	}
 }
 

--- a/src/jobservice/hook/hook_client.go
+++ b/src/jobservice/hook/hook_client.go
@@ -65,7 +65,7 @@ func NewClient(ctx context.Context) Client {
 	}
 
 	client := &http.Client{
-		Timeout:   15 * time.Second,
+		Timeout:   30 * time.Second,
 		Transport: transport,
 	}
 

--- a/src/jobservice/runtime/bootstrap.go
+++ b/src/jobservice/runtime/bootstrap.go
@@ -134,7 +134,8 @@ func (bs *Bootstrap) LoadAndRun(ctx context.Context, cancel context.CancelFunc) 
 		// Create stats manager
 		manager = mgt.NewManager(ctx, namespace, redisPool)
 		// Create hook agent, it's a singleton object
-		hookAgent := hook.NewAgent(rootContext, namespace, redisPool)
+		// the retryConcurrency keep same with worker num
+		hookAgent := hook.NewAgent(rootContext, namespace, redisPool, workerNum)
 		hookCallback := func(URL string, change *job.StatusChange) error {
 			msg := fmt.Sprintf(
 				"status change: job=%s, status=%s, revision=%d",


### PR DESCRIPTION
Change the jobservice hook max retry concurrency from 512 to same with
the js worker numbers.

Signed-off-by: chlins <chenyuzh@vmware.com>

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
