### PR TITLE
Update harbor-e2e-engine image

### DIFF
--- a/tests/test-engine-image/Dockerfile.common
+++ b/tests/test-engine-image/Dockerfile.common
@@ -54,7 +54,7 @@ RUN pwd && mkdir /tool/binary && \
     # Install CNAB
     CNAB_PATH=$(go env GOPATH)/src/github.com/cnabio && \
     mkdir -p $CNAB_PATH && cd $CNAB_PATH && git clone https://github.com/cnabio/cnab-to-oci.git && \
-    cd cnab-to-oci && git checkout v0.3.1-beta1 && \
+    cd cnab-to-oci && git checkout v0.3.3 && \
     go list && \
     make build && \
     mv bin/cnab-to-oci /tool/binary/ && \
@@ -62,14 +62,14 @@ RUN pwd && mkdir /tool/binary && \
     DIND_COMMIT=3b5fac462d21ca164b3778647420016315289034 && \
     wget "https://raw.githubusercontent.com/docker/docker/${DIND_COMMIT}/hack/dind" -O /tool/binary/dind \
     && chmod +x /tool/binary/dind && \
-    # Install  wasm-to-oci
+    # Install wasm-to-oci
     WASM_TO_OCI_VERSION=0.1.2 && wget https://github.com/engineerd/wasm-to-oci/releases/download/v${WASM_TO_OCI_VERSION}/linux-amd64-wasm-to-oci && \
     chmod +x linux-amd64-wasm-to-oci && mv linux-amd64-wasm-to-oci /tool/binary/wasm-to-oci && \
     # Install imgpkg
-    IMGPKG_VERSION=0.22.0 && wget https://github.com/vmware-tanzu/carvel-imgpkg/releases/download/v$IMGPKG_VERSION/imgpkg-linux-amd64 && \
+    IMGPKG_VERSION=0.29.0 && wget https://github.com/vmware-tanzu/carvel-imgpkg/releases/download/v$IMGPKG_VERSION/imgpkg-linux-amd64 && \
     mv imgpkg-linux-amd64 /tool/binary/imgpkg && chmod +x /tool/binary/imgpkg && \
     # Install cosign
-    COSIGN_VERSION=1.8.0 && wget https://github.com/sigstore/cosign/releases/download/v$COSIGN_VERSION/cosign-linux-amd64 && \
+    COSIGN_VERSION=1.9.0 && wget https://github.com/sigstore/cosign/releases/download/v$COSIGN_VERSION/cosign-linux-amd64 && \
     mv cosign-linux-amd64 /tool/binary/cosign && chmod +x /tool/binary/cosign && \
     pwd
 
@@ -87,7 +87,3 @@ RUN pwd && \
 
 RUN cd /tool/binary/ && tar czvf tools.tar.gz * && cp tools.tar.gz /tool
 # --- End of base file ---
-
-
-
-

--- a/tests/test-engine-image/Dockerfile.ui_test
+++ b/tests/test-engine-image/Dockerfile.ui_test
@@ -36,8 +36,8 @@ RUN pip3 install --upgrade pip pyasn1 google-apitools==0.5.31 gsutil \
     requests dbbot robotframework-seleniumlibrary==4.3.0 robotframework-pabot \
     robotframework-JSONLibrary hurry.filesize --upgrade && \
     apt-get clean all
-# Upgrade chromedriver version to 101.0.4951.41
-RUN wget -N https://chromedriver.storage.googleapis.com/101.0.4951.41/chromedriver_linux64.zip && \
+# Upgrade chromedriver version to 102.0.5005.61
+RUN wget -N https://chromedriver.storage.googleapis.com/102.0.5005.61/chromedriver_linux64.zip && \
     unzip chromedriver_linux64.zip && \
     chmod +x chromedriver && \
     mv -f chromedriver /usr/local/share/chromedriver && \


### PR DESCRIPTION
1 Bump up cnab-to-oci version to v0.3.3
2 Bump up carvel-imgpkg version to v0.29.0
3 Bump up cosign version to v1.9.0
4 Bump up chromedriver version to 102.0.5005.61

Signed-off-by: Yang Jiao <jiaoya@vmware.com>

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
