### PR TITLE
fix: enable structcheck/typecheck/unused for golangci-lint

### DIFF
--- a/src/.golangci.yaml
+++ b/src/.golangci.yaml
@@ -12,7 +12,7 @@ linters:
     - gofmt
     - goheader
     - misspell
-    # - typecheck
+    - typecheck
     # - dogsled
     # - dupl
     # - depguard
@@ -36,11 +36,11 @@ linters:
     # - noctx
     # - rowserrcheck
     # - staticcheck
-    # - structcheck
+    - structcheck
     # - stylecheck
     # - unconvert
     # - unparam
-    # - unused
+    - unused
     - varcheck
  
 run:


### PR DESCRIPTION
Signed-off-by: Shengwen Yu <yshengwen@vmware.com>

Thank you for contributing to Harbor!

# Comprehensive Summary of your change
This PR is to enable structcheck/typecheck/unused for golangci-lint
# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
