### PR TITLE
Revert "Skip to refresh execution status when unchanged(#17034)"

### DIFF
--- a/src/pkg/task/dao/execution.go
+++ b/src/pkg/task/dao/execution.go
@@ -1,16 +1,16 @@
-//  Copyright Project Harbor Authors
+// Copyright Project Harbor Authors
 //
-//  Licensed under the Apache License, Version 2.0 (the "License");
-//  you may not use this file except in compliance with the License.
-//  You may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//    http://www.apache.org/licenses/LICENSE-2.0
 //
-//  Unless required by applicable law or agreed to in writing, software
-//  distributed under the License is distributed on an "AS IS" BASIS,
-//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-//  See the License for the specific language governing permissions and
-//  limitations under the License.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package dao
 
@@ -205,6 +205,10 @@ func (e *executionDAO) RefreshStatus(ctx context.Context, id int64) (bool, strin
 // 3. bool: whether a retry is needed
 // 4. error: the error
 func (e *executionDAO) refreshStatus(ctx context.Context, id int64) (bool, string, bool, error) {
+	execution, err := e.Get(ctx, id)
+	if err != nil {
+		return false, "", false, err
+	}
 	metrics, err := e.GetMetrics(ctx, id)
 	if err != nil {
 		return false, "", false, err
@@ -223,14 +227,6 @@ func (e *executionDAO) refreshStatus(ctx context.Context, id int64) (bool, strin
 		status = job.StoppedStatus.String()
 	} else if metrics.SuccessTaskCount > 0 {
 		status = job.SuccessStatus.String()
-	}
-
-	execution, err := e.Get(ctx, id)
-	if err != nil {
-		return false, "", false, err
-	}
-	if status == execution.Status {
-		return false, status, false, nil // status not changed
 	}
 
 	ormer, err := orm.FromContext(ctx)


### PR DESCRIPTION
It causes the execution status to be unchanged in a high concurrency situation.

This reverts commit b6e4ef5b5485677b3a676adaa510a69c7390f7c4.

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
