### PR TITLE
fix updating robots with wildcard project access

### DIFF
--- a/src/server/v2.0/handler/robot.go
+++ b/src/server/v2.0/handler/robot.go
@@ -298,18 +298,17 @@ func (rAPI *robotAPI) updateV2Robot(ctx context.Context, params operation.Update
 	if err := rAPI.validate(params.Robot.Duration, params.Robot.Level, params.Robot.Permissions); err != nil {
 		return err
 	}
-	projectID, err := getProjectID(ctx, params.Robot.Permissions[0].Namespace)
-	if err != nil {
-		return err
-	}
-	if r.Level != robot.LEVELSYSTEM && r.ProjectID != projectID {
-		return errors.BadRequestError(nil).WithMessage("cannot update the project id of robot")
-	}
-	if err := rAPI.requireAccess(ctx, params.Robot.Level, projectID, rbac.ActionUpdate); err != nil {
-		return err
-	}
-	if params.Robot.Level != r.Level || params.Robot.Name != r.Name {
-		return errors.BadRequestError(nil).WithMessage("cannot update the level or name of robot")
+	if r.Level == robot.LEVELPROJECT {
+		projectID, err := getProjectID(ctx, params.Robot.Permissions[0].Namespace)
+		if err != nil {
+			return err
+		}
+		if r.ProjectID != projectID {
+			return errors.BadRequestError(nil).WithMessage("cannot update the project id of robot")
+		}
+		if err := rAPI.requireAccess(ctx, params.Robot.Level, projectID, rbac.ActionUpdate); err != nil {
+			return err
+		}
 	}
 
 	if r.Duration != params.Robot.Duration {


### PR DESCRIPTION
Updating an existing robot account that has system-level access on all projects will fail in any case.
This was introduced in https://github.com/goharbor/harbor/pull/17012/files#diff-431ad1ebfab4b93f5a2e26dcc7462cb6805e4eb38726c30791f8e36891a276beR302-R306
Checking access to a project is only considerable when one or more projects are selected. If all projects are selected by wildcard, the check will fail as it takes the wildcard `*` as input for the project name.