### PR TITLE
2.5 migration jinja correction for upload_purging

### DIFF
--- a/make/photon/prepare/migrations/version_2_5_0/harbor.yml.jinja
+++ b/make/photon/prepare/migrations/version_2_5_0/harbor.yml.jinja
@@ -536,10 +536,10 @@ trace:
 # enable purge _upload directories
 {% if upload_purging is defined %}
 upload_purging:
-  enabled: {{ trace.enabled | lower}}
-  age: {{ trace.age }}
-  interval: {{ trace.interval }}
-  dryrun: {{ trace.dryrun | lower}}
+  enabled: {{ upload_purging.enabled | lower}}
+  age: {{ upload_purging.age }}
+  interval: {{ upload_purging.interval }}
+  dryrun: {{ upload_purging.dryrun | lower}}
 {% else %}
 upload_purging:
   enabled: true


### PR DESCRIPTION
Signed-off-by: yminer <yminer@vmware.com>

Thank you for contributing to Harbor!

# Comprehensive Summary of your change
## case 1 ##
Generally, we don't need to migrate the harbor.yml between patch release, for example(v2.5.0 to v2.5.2)
so if we running the prepare migrate command, if would return `no need to upgrade` msg. So this would not impact the user upgrade Harbor from v2.5.0 to follwing patch release.
```
$ docker run -it --rm -v /:/hostfs goharbor/prepare:[tag] migrate -i ${path to harbor.yml}
=> Version of input harbor.yml is identical to target 2.5.0, no need to upgrade
```

## case 2 ##
Since the uploading_purging is a new config/feature in release-2.5.0, when user migrate from v2.4.x to v2.5.0,(or v2.5.1, or v2.5.2), NO uploading_purging configurations in the previous harbor.yml file, so it would generate using the default one

So, it wouldn't impact the migration process in anyway, I just raise this pr for correction .

---
Please indicate you've done the following:
- [ ] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [ ] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
