### PR TITLE
fix: repair execution status when it inconsistent

### DIFF
--- a/make/migrations/postgresql/0082_2.5.3_schema.up.sql
+++ b/make/migrations/postgresql/0082_2.5.3_schema.up.sql
@@ -1,0 +1,28 @@
+/* repair execution status */
+DO $$
+DECLARE
+    exec RECORD;
+    status_group RECORD;
+    status_count int;
+    final_status varchar(32);
+BEGIN
+    /* iterate all executions */
+    FOR exec IN SELECT * FROM execution WHERE status='Running'
+    LOOP
+        /* identify incorrect execution status, group tasks belong it by status */
+        status_count = 0;
+        final_status = '';
+        FOR status_group IN SELECT status FROM task WHERE execution_id=exec.id GROUP BY status
+        /* loop here to ensure all the tasks belong to the execution are success */
+        LOOP
+            status_count = status_count + 1;
+            final_status = status_group.status;
+        END LOOP;
+        /* update status and end_time when the tasks are all
+        success but itself status is not success */
+        IF status_count=1 AND final_status='Success' THEN
+            UPDATE execution SET status='Success', revision=revision+1 WHERE id=exec.id;
+            UPDATE execution SET end_time=(SELECT MAX(end_time) FROM task WHERE execution_id=exec.id) WHERE id=exec.id;
+        END IF;
+    END LOOP;
+END $$;

--- a/make/migrations/postgresql/0090_2.6.0_schema.up.sql
+++ b/make/migrations/postgresql/0090_2.6.0_schema.up.sql
@@ -22,3 +22,32 @@ CREATE INDEX IF NOT EXISTS idx_artifact_repository_name ON artifact (repository_
 CREATE INDEX IF NOT EXISTS idx_execution_vendor_type_vendor_id ON execution (vendor_type, vendor_id);
 CREATE INDEX IF NOT EXISTS idx_execution_start_time ON execution(start_time);
 CREATE INDEX IF NOT EXISTS idx_audit_log_project_id_optime ON audit_log (project_id, op_time);
+
+/* repair execution status */
+DO $$
+DECLARE
+    exec RECORD;
+    status_group RECORD;
+    status_count int;
+    final_status varchar(32);
+BEGIN
+    /* iterate all executions */
+    FOR exec IN SELECT * FROM execution WHERE status='Running'
+    LOOP
+        /* identify incorrect execution status, group tasks belong it by status */
+        status_count = 0;
+        final_status = '';
+        FOR status_group IN SELECT status FROM task WHERE execution_id=exec.id GROUP BY status
+        /* loop here to ensure all the tasks belong to the execution are success */
+        LOOP
+            status_count = status_count + 1;
+            final_status = status_group.status;
+        END LOOP;
+        /* update status and end_time when the tasks are all
+        success but itself status is not success */
+        IF status_count=1 AND final_status='Success' THEN
+            UPDATE execution SET status='Success', revision=revision+1 WHERE id=exec.id;
+            UPDATE execution SET end_time=(SELECT MAX(end_time) FROM task WHERE execution_id=exec.id) WHERE id=exec.id;
+        END IF;
+    END LOOP;
+END $$;


### PR DESCRIPTION
Add migrations sql to repair the execution status when it does not
consistent with task status.

Closes: #17114

Signed-off-by: chlins <chenyuzh@vmware.com>

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #([17114](https://github.com/goharbor/harbor/issues/17114))

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
