### PR TITLE
resolve robot authgen password format issue

### DIFF
--- a/src/controller/robot/controller_test.go
+++ b/src/controller/robot/controller_test.go
@@ -292,6 +292,20 @@ func (suite *ControllerTestSuite) TestToScope() {
 
 }
 
+func (suite *ControllerTestSuite) TestIsValidSec() {
+	sec := "1234abcdABCD"
+	suite.True(IsValidSec(sec))
+	sec = "1234abcd"
+	suite.False(IsValidSec(sec))
+	sec = "123abc"
+	suite.False(IsValidSec(sec))
+}
+
+func (suite *ControllerTestSuite) TestCreateSec() {
+	_, pwd, _, err := CreateSec()
+	suite.Nil(err)
+	suite.True(IsValidSec(pwd))
+}
 func TestControllerTestSuite(t *testing.T) {
 	suite.Run(t, &ControllerTestSuite{})
 }


### PR DESCRIPTION
In some cases, the robot automatically generates passwords that do not meet confidentiality requirements.
The fix adds retry for auto generating passwords, and the timeout is 1 minute.

The requirement: the secret must longer than 8 chars with at least 1 uppercase letter, 1 lowercase letter and 1 number

Signed-off-by: Wang Yan <wangyan@vmware.com>

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(16137)

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
