### PR TITLE
delete duplicate import and use ST1019 in golangci-lint

### DIFF
--- a/src/.golangci.yaml
+++ b/src/.golangci.yaml
@@ -7,6 +7,10 @@ linters-settings:
     locale: US,UK
   goimports:
     local-prefixes: github.com/goharbor/harbor
+  stylecheck:
+    checks: [
+      "ST1019",  # Importing the same package multiple times.
+    ]
 
 linters:
   disable-all: true
@@ -40,7 +44,7 @@ linters:
     # - rowserrcheck
     # - staticcheck
     - structcheck
-    # - stylecheck
+    - stylecheck
     # - unconvert
     # - unparam
     - unused

--- a/src/controller/event/handler/webhook/artifact/artifact.go
+++ b/src/controller/event/handler/webhook/artifact/artifact.go
@@ -27,7 +27,6 @@ import (
 	"github.com/goharbor/harbor/src/lib/orm"
 	"github.com/goharbor/harbor/src/pkg"
 	"github.com/goharbor/harbor/src/pkg/notification"
-	"github.com/goharbor/harbor/src/pkg/notifier/model"
 	notifyModel "github.com/goharbor/harbor/src/pkg/notifier/model"
 	proModels "github.com/goharbor/harbor/src/pkg/project/models"
 )
@@ -91,7 +90,7 @@ func (a *Handler) handle(ctx context.Context, event *event.ArtifactEvent) error 
 	return nil
 }
 
-func (a *Handler) constructArtifactPayload(event *event.ArtifactEvent, project *proModels.Project) (*model.Payload, error) {
+func (a *Handler) constructArtifactPayload(event *event.ArtifactEvent, project *proModels.Project) (*notifyModel.Payload, error) {
 	repoName := event.Repository
 	if repoName == "" {
 		return nil, fmt.Errorf("invalid %s event with empty repo name", event.EventType)

--- a/src/controller/event/handler/webhook/quota/quota.go
+++ b/src/controller/event/handler/webhook/quota/quota.go
@@ -25,7 +25,6 @@ import (
 	"github.com/goharbor/harbor/src/lib/log"
 	"github.com/goharbor/harbor/src/lib/orm"
 	"github.com/goharbor/harbor/src/pkg/notification"
-	"github.com/goharbor/harbor/src/pkg/notifier/model"
 	notifyModel "github.com/goharbor/harbor/src/pkg/notifier/model"
 	proModels "github.com/goharbor/harbor/src/pkg/project/models"
 )
@@ -82,7 +81,7 @@ func (qp *Handler) IsStateful() bool {
 	return false
 }
 
-func constructQuotaPayload(event *event.QuotaEvent) (*model.Payload, error) {
+func constructQuotaPayload(event *event.QuotaEvent) (*notifyModel.Payload, error) {
 	repoName := event.RepoName
 	if repoName == "" {
 		return nil, fmt.Errorf("invalid %s event with empty repo name", event.EventType)


### PR DESCRIPTION
Signed-off-by: Abirdcfly <fp544037857@gmail.com>

Thank you for contributing to Harbor!

# Comprehensive Summary of your change
Just notice https://github.com/goharbor/harbor/pull/17131 in my timeline.
Use [ST1019](https://staticcheck.io/docs/checks#ST1019) will make golangci-lint auto report "importing the same package multiple times" problems, like below:
```bash
controller/event/handler/webhook/artifact/artifact.go:30:2: ST1019: package "github.com/goharbor/harbor/src/pkg/notifier/model" is being imported more than once (stylecheck)
        "github.com/goharbor/harbor/src/pkg/notifier/model"
        ^
controller/event/handler/webhook/artifact/artifact.go:31:2: ST1019(related information): other import of "github.com/goharbor/harbor/src/pkg/notifier/model" (stylecheck)
        notifyModel "github.com/goharbor/harbor/src/pkg/notifier/model"
        ^

```
# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).

release-note/ignore-for-release