### PR TITLE
Add option to Disable Database Healthcheck 

### DIFF
--- a/make/harbor.yml.tmpl
+++ b/make/harbor.yml.tmpl
@@ -151,7 +151,7 @@ _version: 2.6.0
 #     max_idle_conns: 2
 #     max_open_conns: 0
 #     # Option to disable DB healthchecking for external database
-#     disable_healtcheck = false
+#     disable_healthcheck = false
 #   notary_signer:
 #     host: notary_signer_db_host
 #     port: notary_signer_db_port

--- a/make/harbor.yml.tmpl
+++ b/make/harbor.yml.tmpl
@@ -150,6 +150,8 @@ _version: 2.6.0
 #     ssl_mode: disable
 #     max_idle_conns: 2
 #     max_open_conns: 0
+#     # Option to disable DB healthchecking for external database
+#     disable_healtcheck = false
 #   notary_signer:
 #     host: notary_signer_db_host
 #     port: notary_signer_db_port

--- a/make/photon/prepare/templates/core/env.jinja
+++ b/make/photon/prepare/templates/core/env.jinja
@@ -89,3 +89,7 @@ TRACE_OTEL_INSECURE={{ trace.otel.insecure }}
 CACHE_ENABLED=true
 CACHE_EXPIRE_HOURS={{ cache.expire_hours }}
 {% endif %}
+
+{% if external_database %}
+DATABASE_DISABLE_HEALTHCHECK={{harbor_db_disable_healthcheck if harbor_db_disable_healthcheck else 'false'}}
+{% endif %}

--- a/make/photon/prepare/utils/configs.py
+++ b/make/photon/prepare/utils/configs.py
@@ -287,6 +287,7 @@ def parse_yaml_config(config_file_path, with_notary, with_trivy, with_chartmuseu
         config_dict['harbor_db_sslmode'] = external_db_configs['harbor']['ssl_mode']
         config_dict['harbor_db_max_idle_conns'] = external_db_configs['harbor'].get("max_idle_conns") or default_db_max_idle_conns
         config_dict['harbor_db_max_open_conns'] = external_db_configs['harbor'].get("max_open_conns") or default_db_max_open_conns
+        config_dict['harbor_db_disable_healthcheck'] = external_db_configs['harbor'].get("disable_healthcheck", False)
 
         if with_notary:
             # notary signer

--- a/src/common/const.go
+++ b/src/common/const.go
@@ -215,4 +215,7 @@ const (
 	AuditLogForwardEndpoint = "audit_log_forward_endpoint"
 	// SkipAuditLogDatabase skip to log audit log in database
 	SkipAuditLogDatabase = "skip_audit_log_database"
+
+	// DatabaseHealthCheckerDisabled option to disable database health checks
+	DatabaseHealthCheckerDisabled = "database_health_checker_disabled"
 )

--- a/src/controller/health/checker.go
+++ b/src/controller/health/checker.go
@@ -200,7 +200,9 @@ func RegisterHealthCheckers() {
 	registry["jobservice"] = jobserviceHealthChecker()
 	registry["registry"] = registryHealthChecker()
 	registry["registryctl"] = registryCtlHealthChecker()
-	registry["database"] = databaseHealthChecker()
+	if !config.DatabaseHealthCheckerDisabled() {
+		registry["database"] = databaseHealthChecker()
+	}
 	registry["redis"] = redisHealthChecker()
 	if config.WithChartMuseum() {
 		registry["chartmuseum"] = chartmuseumHealthChecker()

--- a/src/lib/config/metadata/metadatalist.go
+++ b/src/lib/config/metadata/metadatalist.go
@@ -192,5 +192,7 @@ var (
 
 		{Name: common.AuditLogForwardEndpoint, Scope: UserScope, Group: BasicGroup, EnvKey: "AUDIT_LOG_FORWARD_ENDPOINT", DefaultValue: "", ItemType: &StringType{}, Editable: false, Description: `The endpoint to forward the audit log.`},
 		{Name: common.SkipAuditLogDatabase, Scope: UserScope, Group: BasicGroup, EnvKey: "SKIP_LOG_AUDIT_DATABASE", DefaultValue: "false", ItemType: &BoolType{}, Editable: false, Description: `The option to skip audit log in database`},
+
+		{Name: common.DatabaseHealthCheckerDisabled, Scope: SystemScope, Group: DatabaseGroup, EnvKey: "DATABASE_DISABLE_HEALTHCHECK", DefaultValue: "false", ItemType: &BoolType{}, Editable: false, Description: `Option to disable database health checks`},
 	}
 )

--- a/src/lib/config/systemconfig.go
+++ b/src/lib/config/systemconfig.go
@@ -287,3 +287,11 @@ func Database() (*models.Database, error) {
 
 	return database, nil
 }
+
+func DatabaseHealthCheckerDisabled() bool {
+	if DefaultMgr() != nil {
+		return DefaultMgr().Get(backgroundCtx, common.DatabaseHealthCheckerDisabled).GetBool()
+	}
+	// backoff read from env.
+	return os.Getenv("HARBOR_DATABASE_DISABLE_HEALTHCHECK") == "true"
+}


### PR DESCRIPTION
# Comprehensive Summary
This commit adds functionality to disable healthchecks for external
databases in harbor.yml.

When for instance AWS RDS is used as an external DB, the periodic
healthcheck keeps the database 'hot', which introduces unnecessary
costs, as the database never reaches its cooldown state.

Fixes #17223 

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
