### PR TITLE
Filter out accessory from list artifact results

### DIFF
--- a/src/controller/artifact/controller.go
+++ b/src/controller/artifact/controller.go
@@ -240,17 +240,7 @@ func (c *controller) ensureArtifact(ctx context.Context, repository, digest stri
 }
 
 func (c *controller) Count(ctx context.Context, query *q.Query) (int64, error) {
-	if query != nil {
-		// ignore the page number and size
-		query = &q.Query{
-			Keywords: query.Keywords,
-		}
-	}
-	arts, err := c.List(ctx, query, nil)
-	if err != nil {
-		return int64(0), err
-	}
-	return int64(len(arts)), nil
+	return c.artMgr.Count(ctx, query)
 }
 
 func (c *controller) List(ctx context.Context, query *q.Query, option *Option) ([]*Artifact, error) {
@@ -260,15 +250,8 @@ func (c *controller) List(ctx context.Context, query *q.Query, option *Option) (
 	}
 
 	var res []*Artifact
-	// Only the displayed accessory will in the artifact list
 	for _, art := range arts {
-		accs, err := c.accessoryMgr.List(ctx, q.New(q.KeyWords{"ArtifactID": art.ID, "digest": art.Digest}))
-		if err != nil {
-			return nil, err
-		}
-		if len(accs) == 0 || (len(accs) > 0 && accs[0].Display()) {
-			res = append(res, c.assembleArtifact(ctx, art, option))
-		}
+		res = append(res, c.assembleArtifact(ctx, art, option))
 	}
 	return res, nil
 }

--- a/src/controller/artifact/controller_test.go
+++ b/src/controller/artifact/controller_test.go
@@ -40,8 +40,8 @@ import (
 	model_tag "github.com/goharbor/harbor/src/pkg/tag/model/tag"
 	tagtesting "github.com/goharbor/harbor/src/testing/controller/tag"
 	ormtesting "github.com/goharbor/harbor/src/testing/lib/orm"
-	accessorytesting "github.com/goharbor/harbor/src/testing/pkg/accessory"
 	"github.com/goharbor/harbor/src/testing/pkg/accessory"
+	accessorytesting "github.com/goharbor/harbor/src/testing/pkg/accessory"
 	arttesting "github.com/goharbor/harbor/src/testing/pkg/artifact"
 	artrashtesting "github.com/goharbor/harbor/src/testing/pkg/artifactrash"
 	"github.com/goharbor/harbor/src/testing/pkg/blob"
@@ -264,26 +264,10 @@ func (c *controllerTestSuite) TestEnsure() {
 }
 
 func (c *controllerTestSuite) TestCount() {
-	c.artMgr.On("List", mock.Anything, mock.Anything).Return([]*artifact.Artifact{
-		{
-			ID:           1,
-			RepositoryID: 1,
-		},
-	}, nil)
-	acc := &basemodel.Default{
-		Data: accessorymodel.AccessoryData{
-			ID:            1,
-			ArtifactID:    2,
-			SubArtifactID: 1,
-			Type:          accessorymodel.TypeCosignSignature,
-		},
-	}
-	c.accMgr.On("List", mock.Anything, mock.Anything).Return([]accessorymodel.Accessory{
-		acc,
-	}, nil)
+	c.artMgr.On("Count", mock.Anything, mock.Anything).Return(int64(1), nil)
 	total, err := c.ctl.Count(nil, nil)
 	c.Require().Nil(err)
-	c.Equal(int64(0), total)
+	c.Equal(int64(1), total)
 }
 
 func (c *controllerTestSuite) TestList() {


### PR DESCRIPTION
Fixed #17145
1, Filter the accessory from the artifact list.
2, Disable the display func of the accessory interface, currently this will not impact any kind of accessory, like signature and nydus. If we'd like to introduce it, it needs to resolve the pagiation issue of artifact list.

Signed-off-by: Wang Yan <wangyan@vmware.com>

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
