### PR TITLE
Disable Nydus middleware for v2.6

### DIFF
--- a/src/core/main.go
+++ b/src/core/main.go
@@ -56,7 +56,6 @@ import (
 	"github.com/goharbor/harbor/src/migration"
 	_ "github.com/goharbor/harbor/src/pkg/accessory/model/base"
 	_ "github.com/goharbor/harbor/src/pkg/accessory/model/cosign"
-	_ "github.com/goharbor/harbor/src/pkg/accessory/model/nydus"
 	"github.com/goharbor/harbor/src/pkg/audit"
 	dbCfg "github.com/goharbor/harbor/src/pkg/config/db"
 	_ "github.com/goharbor/harbor/src/pkg/config/inmemory"

--- a/src/server/registry/route.go
+++ b/src/server/registry/route.go
@@ -22,7 +22,6 @@ import (
 	"github.com/goharbor/harbor/src/server/middleware/cosign"
 	"github.com/goharbor/harbor/src/server/middleware/immutable"
 	"github.com/goharbor/harbor/src/server/middleware/metric"
-	"github.com/goharbor/harbor/src/server/middleware/nydus"
 	"github.com/goharbor/harbor/src/server/middleware/quota"
 	"github.com/goharbor/harbor/src/server/middleware/repoproxy"
 	"github.com/goharbor/harbor/src/server/middleware/v2auth"
@@ -81,7 +80,6 @@ func RegisterRoutes() {
 		Middleware(immutable.Middleware()).
 		Middleware(quota.PutManifestMiddleware()).
 		Middleware(cosign.SignatureMiddleware()).
-		Middleware(nydus.AcceleratorMiddleware()).
 		Middleware(blob.PutManifestMiddleware()).
 		HandlerFunc(putManifest)
 	// blob head


### PR DESCRIPTION
Signed-off-by: yminer <yminer@vmware.com>

Thank you for contributing to Harbor!

# Comprehensive Summary of your change
Support of manifest list in Nydus service side is still remained to be discussed.
Harbor would hold this feature in this v2.6 release and enable it  until there's a clear plan for nydus/image-acceleration service to support manifest index / manifest list considered to a better user experience

# Issue being fixed
https://github.com/goharbor/harbor/issues/17212

Please indicate you've done the following:
- [ ] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [ ] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
