### PR TITLE
Fix aliyun acr connect and replicate

### DIFF
--- a/src/pkg/reg/adapter/aliacr/adapter_test.go
+++ b/src/pkg/reg/adapter/aliacr/adapter_test.go
@@ -92,8 +92,10 @@ func Test_getRegion(t *testing.T) {
 		{"registry hangzhou", "https://registry.cn-hangzhou.aliyuncs.com", "cn-hangzhou", false},
 		{"cr shanghai", "https://cr.cn-shanghai.aliyuncs.com", "cn-shanghai", false},
 		{"cr hangzhou", "https://cr.cn-hangzhou.aliyuncs.com", "cn-hangzhou", false},
-		{"invalid cr url", "https://acr.cn-hangzhou.aliyuncs.com", "", true},
 		{"invalid registry url", "https://registry.cn-hangzhou.ali.com", "", true},
+		{"abc registry url", "https://abc-registry.cn-hangzhou.aliyuncs.com", "cn-hangzhou", false},
+		{"abc registry cr url", "https://abc-registry.cn-hangzhou.cr.aliyuncs.com", "cn-hangzhou", false},
+		{"abc registry cr url", "https://abc-registry-vpc.cn-hangzhou.cr.aliyuncs.com", "cn-hangzhou", false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -144,8 +146,28 @@ func Test_aliyunAuthCredential_isCacheTokenValid(t *testing.T) {
 	}{
 		{"nil cacheTokenExpiredAt", fields{"test-region", "MockAccessKey", "MockSecretKey", nil, nilTime}, false},
 		{"nil cacheToken", fields{"test-region", "MockAccessKey", "MockSecretKey", nil, time.Time{}}, false},
-		{"expired", fields{"test-region", "MockAccessKey", "MockSecretKey", &registryTemporaryToken{}, time.Now().AddDate(0, 0, -1)}, false},
-		{"ok", fields{"test-region", "MockAccessKey", "MockSecretKey", &registryTemporaryToken{}, time.Now().AddDate(0, 0, 1)}, true},
+		{
+			"expired",
+			fields{
+				"test-region",
+				"MockAccessKey",
+				"MockSecretKey",
+				&registryTemporaryToken{},
+				time.Now().AddDate(0, 0, -1),
+			},
+			false,
+		},
+		{
+			"ok",
+			fields{
+				"test-region",
+				"MockAccessKey",
+				"MockSecretKey",
+				&registryTemporaryToken{},
+				time.Now().AddDate(0, 0, 1),
+			},
+			true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/src/pkg/reg/adapter/aliacr/types.go
+++ b/src/pkg/reg/adapter/aliacr/types.go
@@ -8,12 +8,9 @@ const (
 )
 
 type authorizationToken struct {
-	Data struct {
-		ExpireDate         timeUnix `json:"expireDate"`
-		AuthorizationToken string   `json:"authorizationToken"`
-		TempUserName       string   `json:"tempUserName"`
-	} `json:"data"`
-	RequestID string `json:"requestId"`
+	ExpireTime         timeUnix `json:"expireTime"`
+	AuthorizationToken string   `json:"authorizationToken"`
+	TempUserName       string   `json:"tempUserName"`
 }
 
 type timeUnix int64


### PR DESCRIPTION
Signed-off-by: bzd111 <zxc@bzd111.me>

Fix aliyun acr connect and replicate

# Comprehensive Summary of your change

# Issue being fixed
Fixes #13771 #15569

Aliyun ACR can't get authorization token use api version "2016-06-07", so I fix it use api version "2018-12-01". But api version "2018-12-01", need a param InstanceId that means acr instance id. you can find it in https://cr.console.aliyun.com/
And Only enterprise Enterprise Edition has instance id
aliyun api doc
I use makefile to build new harbor-core and harbor-jobservice, It works.
![image](https://user-images.githubusercontent.com/18071885/182062192-f629e629-6855-46e5-bbe5-d43b155ae48d.png)

