### PR TITLE
fix: reduce the high db cpu usage for tag retention

### DIFF
--- a/make/migrations/postgresql/0090_2.6.0_schema.up.sql
+++ b/make/migrations/postgresql/0090_2.6.0_schema.up.sql
@@ -51,3 +51,7 @@ BEGIN
         END IF;
     END LOOP;
 END $$;
+
+/* Add indexes to improve the performance of tag retention */
+CREATE INDEX IF NOT EXISTS idx_artifact_blob_digest_blob ON artifact_blob (digest_blob);
+CREATE INDEX IF NOT EXISTS idx_artifact_digest_project_id ON artifact (digest,project_id);

--- a/src/controller/quota/options.go
+++ b/src/controller/quota/options.go
@@ -14,6 +14,8 @@
 
 package quota
 
+import "github.com/goharbor/harbor/src/lib/retry"
+
 // Option option for `Refresh` method of `Controller`
 type Option func(*Options)
 
@@ -21,6 +23,8 @@ type Option func(*Options)
 type Options struct {
 	IgnoreLimitation    bool
 	WithReferenceObject bool
+	// RetryOptions is the sets of options but for retry function.
+	RetryOptions []retry.Option
 }
 
 // IgnoreLimitation set IgnoreLimitation for the Options
@@ -34,6 +38,13 @@ func IgnoreLimitation(ignoreLimitation bool) func(*Options) {
 func WithReferenceObject() func(*Options) {
 	return func(opts *Options) {
 		opts.WithReferenceObject = true
+	}
+}
+
+// WithRetryOptions set RetryOptions to Options
+func WithRetryOptions(retryOpts []retry.Option) func(*Options) {
+	return func(opts *Options) {
+		opts.RetryOptions = retryOpts
 	}
 }
 

--- a/src/pkg/clients/core/client.go
+++ b/src/pkg/clients/core/client.go
@@ -47,10 +47,10 @@ type ChartClient interface {
 }
 
 // New returns an instance of the client which is a default implement for Client
-func New(url string, httpclient *http.Client, authorizer modifier.Modifier) Client {
+func New(url string, httpclient *http.Client, modifiers ...modifier.Modifier) Client {
 	return &client{
 		url:        url,
-		httpclient: chttp.NewClient(httpclient, authorizer),
+		httpclient: chttp.NewClient(httpclient, modifiers...),
 	}
 }
 

--- a/src/pkg/retention/dep/client_test.go
+++ b/src/pkg/retention/dep/client_test.go
@@ -15,6 +15,7 @@
 package dep
 
 import (
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -141,6 +142,17 @@ func (c *clientTestSuite) TestDelete() {
 	candidate.Kind = "unsupported"
 	err = client.Delete(candidate)
 	require.NotNil(c.T(), err)
+}
+
+func (c *clientTestSuite) TestInjectVendorType() {
+	injector := &injectVendorType{}
+	req, err := http.NewRequest("GET", "http://localhost:8080/api", nil)
+	assert.NoError(c.T(), err)
+	assert.Equal(c.T(), "", req.Header.Get("VendorType"))
+	// after injecting should appear vendor type in header
+	err = injector.Modify(req)
+	assert.NoError(c.T(), err)
+	assert.Equal(c.T(), "RETENTION", req.Header.Get("VendorType"))
 }
 
 func TestClientTestSuite(t *testing.T) {

--- a/src/pkg/retention/job.go
+++ b/src/pkg/retention/job.go
@@ -16,6 +16,7 @@ package retention
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -23,9 +24,11 @@ import (
 
 	"github.com/olekukonko/tablewriter"
 
+	"github.com/goharbor/harbor/src/controller/quota"
 	"github.com/goharbor/harbor/src/jobservice/job"
 	"github.com/goharbor/harbor/src/jobservice/logger"
 	"github.com/goharbor/harbor/src/lib/errors"
+	"github.com/goharbor/harbor/src/lib/retry"
 	"github.com/goharbor/harbor/src/lib/selector"
 	"github.com/goharbor/harbor/src/pkg/retention/dep"
 	"github.com/goharbor/harbor/src/pkg/retention/policy"
@@ -114,6 +117,14 @@ func (pj *Job) Run(ctx job.Context, params job.Parameters) error {
 	results, err := processor.Process(ctx.SystemContext(), allCandidates)
 	if err != nil {
 		return logError(myLogger, err)
+	}
+
+	// refreshQuota after the deleting candidates
+	if !isDryRun {
+		if err = refreshQuota(ctx.SystemContext(), results); err != nil {
+			// just log error if refresh quota error
+			myLogger.Errorf("Refresh quota error after deleting candidates, error: %v", err)
+		}
 	}
 
 	// Log stage: results with table view
@@ -287,4 +298,30 @@ func getParamMeta(params job.Parameters) (*lwp.Metadata, error) {
 	}
 
 	return meta, nil
+}
+
+// refreshQuota refreshes quota by deleted results.
+func refreshQuota(ctx context.Context, results []*selector.Result) error {
+	projects := make(map[int64]struct{})
+	for _, res := range results {
+		if res != nil && res.Target != nil {
+			projects[res.Target.NamespaceID] = struct{}{}
+		}
+	}
+
+	// refresh quota by project
+	for pid := range projects {
+		// retry options, enable backoff to reduce the db CPU resource usage.
+		opts := []retry.Option{
+			retry.Backoff(true),
+			// the interval value was determined based on experimental results as a way to achieve a faster total time with less cpu.
+			retry.InitialInterval(5 * time.Second),
+			retry.MaxInterval(10 * time.Second),
+		}
+		if err := quota.Ctl.Refresh(ctx, quota.ProjectReference, fmt.Sprintf("%d", pid), quota.WithRetryOptions(opts)); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/src/server/middleware/security/utils.go
+++ b/src/server/middleware/security/utils.go
@@ -3,6 +3,10 @@ package security
 import (
 	"net/http"
 	"strings"
+
+	commonsecret "github.com/goharbor/harbor/src/common/secret"
+	"github.com/goharbor/harbor/src/common/security"
+	"github.com/goharbor/harbor/src/jobservice/job"
 )
 
 func bearerToken(req *http.Request) string {
@@ -15,4 +19,23 @@ func bearerToken(req *http.Request) string {
 		return ""
 	}
 	return strings.TrimSpace(token[1])
+}
+
+// FromJobservice detects whether this request is from jobservice.
+func FromJobservice(req *http.Request) bool {
+	sc, ok := security.FromContext(req.Context())
+	if !ok {
+		return false
+	}
+	// check whether the user is jobservice user
+	return sc.GetUsername() == commonsecret.JobserviceUser
+}
+
+// FromJobRetention detects whether this request is from tag retention job.
+func FromJobRetention(req *http.Request) bool {
+	if req != nil && req.Header != nil {
+		return req.Header.Get("VendorType") == job.Retention
+	}
+
+	return false
 }

--- a/src/server/middleware/security/utils_test.go
+++ b/src/server/middleware/security/utils_test.go
@@ -4,6 +4,11 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/goharbor/harbor/src/common/models"
+	"github.com/goharbor/harbor/src/common/security"
+	"github.com/goharbor/harbor/src/common/security/local"
+	securitysecret "github.com/goharbor/harbor/src/common/security/secret"
+	"github.com/goharbor/harbor/src/lib/config"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -37,4 +42,35 @@ func TestBearerToken(t *testing.T) {
 	for _, c := range cases {
 		assert.Equal(t, c.token, bearerToken(c.request))
 	}
+}
+
+func TestFromJobservice(t *testing.T) {
+	// no security ctx should return false
+	req1, _ := http.NewRequest(http.MethodHead, "/api", nil)
+	assert.False(t, FromJobservice(req1))
+	// other username should return false
+	req2, _ := http.NewRequest(http.MethodHead, "/api", nil)
+	secCtx1 := local.NewSecurityContext(&models.User{UserID: 1, Username: "test-user"})
+	req2 = req2.WithContext(security.NewContext(req2.Context(), secCtx1))
+	assert.False(t, FromJobservice(req2))
+	// secret ctx from jobservice should return true
+	req3, _ := http.NewRequest(http.MethodHead, "/api", nil)
+	config.Init()
+	secCtx2 := securitysecret.NewSecurityContext(config.JobserviceSecret(), config.SecretStore)
+	req3 = req3.WithContext(security.NewContext(req3.Context(), secCtx2))
+	assert.True(t, FromJobservice(req3))
+}
+
+func TestFromJobRetention(t *testing.T) {
+	// return false if req is nil
+	assert.False(t, FromJobRetention(nil))
+	// return false if req has no header
+	req1, err := http.NewRequest("GET", "http://localhost:8080/api", nil)
+	assert.NoError(t, err)
+	assert.False(t, FromJobRetention(req1))
+	// return true if header has retention vendor type
+	req2, err := http.NewRequest("GET", "http://localhost:8080/api", nil)
+	assert.NoError(t, err)
+	req2.Header.Set("VendorType", "RETENTION")
+	assert.True(t, FromJobRetention(req2))
 }


### PR DESCRIPTION
1. Add two indexes to database migrations.
2. Skip refresh quota in middleware for requests from jobservice.
3. Refresh quota by self in the end of tag retention job.

Closes: #14708

Signed-off-by: chlins <chenyuzh@vmware.com>

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes https://github.com/goharbor/harbor/issues/14708

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
