### PR TITLE
fix: distribution v2.8.0 tag does not match checksum

### DIFF
--- a/src/go.mod
+++ b/src/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.1.1
 	github.com/coreos/go-oidc/v3 v3.0.0
 	github.com/dghubble/sling v1.1.0
-	github.com/docker/distribution v2.8.0+incompatible
+	github.com/docker/distribution v2.8.1+incompatible
 	github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-asn1-ber/asn1-ber v1.5.1
@@ -234,7 +234,7 @@ require (
 
 replace (
 	github.com/Azure/go-autorest => github.com/Azure/go-autorest v14.2.0+incompatible
-	github.com/docker/distribution => github.com/distribution/distribution v2.8.0+incompatible
+	github.com/docker/distribution => github.com/distribution/distribution v2.8.1+incompatible
 	github.com/goharbor/harbor => ../
 	google.golang.org/api => google.golang.org/api v0.0.0-20160322025152-9bf6e6e569ff
 )

--- a/src/go.sum
+++ b/src/go.sum
@@ -418,8 +418,8 @@ github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cu
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/dhui/dktest v0.3.7 h1:jWjWgHAPDAdqgUr7lAsB3bqB2DKWC3OaA+isfekjRew=
 github.com/dhui/dktest v0.3.7/go.mod h1:nYMOkafiA07WchSwKnKFUSbGMb2hMm5DrCGiXYG6gwM=
-github.com/distribution/distribution v2.8.0+incompatible h1:YKTAHrTIHNQ1HnaTYCudkxWkW9LujmtudCTQh3/5AYk=
-github.com/distribution/distribution v2.8.0+incompatible/go.mod h1:EgLm2NgWtdKgzF9NpMzUKgzmR7AMmb0VQi2B+ZzDRjc=
+github.com/distribution/distribution v2.8.1+incompatible h1:8iXUoOqRPx30bhzIEPUmNIqlmBlWdrieW1bqr6LrX30=
+github.com/distribution/distribution v2.8.1+incompatible/go.mod h1:EgLm2NgWtdKgzF9NpMzUKgzmR7AMmb0VQi2B+ZzDRjc=
 github.com/distribution/distribution/v3 v3.0.0-20210804104954-38ab4c606ee3 h1:rEK0juuU5idazw//KzUcL3yYwUU3DIe2OnfJwjDBqno=
 github.com/distribution/distribution/v3 v3.0.0-20210804104954-38ab4c606ee3/go.mod h1:gt38b7cvVKazi5XkHvINNytZXgTEntyhtyM3HQz46Nk=
 github.com/dnaeon/go-vcr v1.0.1 h1:r8L/HqC0Hje5AXMu1ooW8oyQyOFv4GxqpL0nRP7SLLY=

--- a/src/vendor/github.com/docker/distribution/.mailmap
+++ b/src/vendor/github.com/docker/distribution/.mailmap
@@ -44,3 +44,6 @@ Thomas Berger <loki@lokis-chaos.de> Thomas Berger <tbe@users.noreply.github.com>
 Samuel Karp <skarp@amazon.com> Samuel Karp <samuelkarp@users.noreply.github.com>
 Justin Cormack <justin.cormack@docker.com>
 sayboras <sayboras@yahoo.com>
+CrazyMax <github@crazymax.dev>
+CrazyMax <github@crazymax.dev> <1951866+crazy-max@users.noreply.github.com>
+CrazyMax <github@crazymax.dev> <crazy-max@users.noreply.github.com>

--- a/src/vendor/github.com/docker/distribution/Dockerfile
+++ b/src/vendor/github.com/docker/distribution/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.3
 
-ARG GO_VERSION=1.16
+ARG GO_VERSION=1.16.15
 ARG GORELEASER_XX_VERSION=1.2.5
 
 FROM --platform=$BUILDPLATFORM crazymax/goreleaser-xx:${GORELEASER_XX_VERSION} AS goreleaser-xx
@@ -12,6 +12,10 @@ WORKDIR /go/src/github.com/docker/distribution
 FROM base AS build
 ENV GO111MODULE=auto
 ENV CGO_ENABLED=0
+# GIT_REF is used by goreleaser-xx to handle the proper git ref when available.
+# It will fallback to the working tree info if empty and use "git tag --points-at"
+# or "git describe" to define the version info.
+ARG GIT_REF
 ARG TARGETPLATFORM
 ARG PKG="github.com/distribution/distribution"
 ARG BUILDTAGS="include_oss include_gcs"
@@ -28,7 +32,7 @@ RUN --mount=type=bind,rw \
     --files="LICENSE" \
     --files="README.md"
 
-FROM scratch AS artifacts
+FROM scratch AS artifact
 COPY --from=build /out/*.tar.gz /
 COPY --from=build /out/*.zip /
 COPY --from=build /out/*.sha256 /

--- a/src/vendor/github.com/docker/distribution/README.md
+++ b/src/vendor/github.com/docker/distribution/README.md
@@ -2,7 +2,7 @@
 
 The Docker toolset to pack, ship, store, and deliver content.
 
-This repository's main product is the Docker Registry 2.0 implementation
+This repository provides the Docker Registry 2.0 implementation
 for storing and distributing Docker images. It supersedes the
 [docker/docker-registry](https://github.com/docker/docker-registry)
 project with a new API design, focused around security and performance.

--- a/src/vendor/github.com/docker/distribution/docker-bake.hcl
+++ b/src/vendor/github.com/docker/distribution/docker-bake.hcl
@@ -1,3 +1,15 @@
+// GITHUB_REF is the actual ref that triggers the workflow
+// https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
+variable "GITHUB_REF" {
+  default = ""
+}
+
+target "_common" {
+  args = {
+    GIT_REF = GITHUB_REF
+  }
+}
+
 group "default" {
   targets = ["image-local"]
 }
@@ -8,12 +20,14 @@ target "docker-metadata-action" {
 }
 
 target "binary" {
+  inherits = ["_common"]
   target = "binary"
   output = ["./bin"]
 }
 
 target "artifact" {
-  target = "artifacts"
+  inherits = ["_common"]
+  target = "artifact"
   output = ["./bin"]
 }
 
@@ -30,7 +44,7 @@ target "artifact-all" {
 }
 
 target "image" {
-  inherits = ["docker-metadata-action"]
+  inherits = ["_common", "docker-metadata-action"]
 }
 
 target "image-local" {

--- a/src/vendor/github.com/docker/distribution/version/version.go
+++ b/src/vendor/github.com/docker/distribution/version/version.go
@@ -8,7 +8,7 @@ var Package = "github.com/docker/distribution"
 // the latest release tag by hand, always suffixed by "+unknown". During
 // build, it will be replaced by the actual version. The value here will be
 // used if the registry is run after a go get based install.
-var Version = "v2.8.0-beta.1+unknown"
+var Version = "v2.8.1+unknown"
 
 // Revision is filled with the VCS (e.g. git) revision being used to build
 // the program at linking time.

--- a/src/vendor/modules.txt
+++ b/src/vendor/modules.txt
@@ -217,7 +217,7 @@ github.com/docker/cli/cli/config
 github.com/docker/cli/cli/config/configfile
 github.com/docker/cli/cli/config/credentials
 github.com/docker/cli/cli/config/types
-# github.com/docker/distribution v2.8.0+incompatible => github.com/distribution/distribution v2.8.0+incompatible
+# github.com/docker/distribution v2.8.1+incompatible => github.com/distribution/distribution v2.8.1+incompatible
 ## explicit
 github.com/docker/distribution
 github.com/docker/distribution/configuration
@@ -1296,6 +1296,6 @@ sigs.k8s.io/structured-merge-diff/v4/value
 ## explicit; go 1.12
 sigs.k8s.io/yaml
 # github.com/Azure/go-autorest => github.com/Azure/go-autorest v14.2.0+incompatible
-# github.com/docker/distribution => github.com/distribution/distribution v2.8.0+incompatible
+# github.com/docker/distribution => github.com/distribution/distribution v2.8.1+incompatible
 # github.com/goharbor/harbor => ../
 # google.golang.org/api => google.golang.org/api v0.0.0-20160322025152-9bf6e6e569ff


### PR DESCRIPTION
Signed-off-by: lengrongfu <1275177125@qq.com>

Thank you for contributing to Harbor!

# Comprehensive Summary of your change
Upgrade distribution version from v2.8.0 to v2.8.1, because v2.8.0 tag does not match checksum.

# Issue being fixed
issue: https://github.com/goharbor/harbor/issues/17295

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/update"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
