### PR TITLE
[cherry-pick] fix: replication webhook lost when src namespace different with dest

### DIFF
--- a/src/controller/event/handler/webhook/artifact/replication_test.go
+++ b/src/controller/event/handler/webhook/artifact/replication_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/goharbor/harbor/src/pkg/notification"
 	policy_model "github.com/goharbor/harbor/src/pkg/notification/policy/model"
 	proModels "github.com/goharbor/harbor/src/pkg/project/models"
+	rpModel "github.com/goharbor/harbor/src/pkg/reg/model"
 	projecttesting "github.com/goharbor/harbor/src/testing/controller/project"
 	replicationtesting "github.com/goharbor/harbor/src/testing/controller/replication"
 	"github.com/goharbor/harbor/src/testing/mock"
@@ -127,4 +128,21 @@ func TestReplicationHandler_IsStateful(t *testing.T) {
 func TestReplicationHandler_Name(t *testing.T) {
 	handler := &ReplicationHandler{}
 	assert.Equal(t, "ReplicationWebhook", handler.Name())
+}
+
+func TestIsLocalRegistry(t *testing.T) {
+	// local registry should return true
+	reg1 := &rpModel.Registry{
+		Type: "harbor",
+		Name: "Local",
+		URL:  config.InternalCoreURL(),
+	}
+	assert.True(t, isLocalRegistry(reg1))
+	// non-local registry should return false
+	reg2 := &rpModel.Registry{
+		Type: "docker-registry",
+		Name: "distribution",
+		URL:  "http://127.0.0.1:5000",
+	}
+	assert.False(t, isLocalRegistry(reg2))
 }


### PR DESCRIPTION
Fix the replication webhook notification lost when the rule is
pull-based and src namespace different with dest.

Closes: #17298

Signed-off-by: chlins <chenyuzh@vmware.com>

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes (#17298)

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
