### PR TITLE
Export CVE data Score column empty values

### DIFF
--- a/src/jobservice/job/impl/scandataexport/scan_data_export_test.go
+++ b/src/jobservice/job/impl/scandataexport/scan_data_export_test.go
@@ -637,10 +637,6 @@ func (suite *ScanDataExportJobTestSuite) createDataRecords(numRecs int, ownerId 
 			Version:        fmt.Sprintf("Version%d", i),
 			FixVersion:     fmt.Sprintf("FixVersion%d", i),
 			Severity:       fmt.Sprintf("Severity%d", i),
-			CVSSScoreV3:    fmt.Sprintf("3.0"),
-			CVSSScoreV2:    fmt.Sprintf("2.0"),
-			CVSSVectorV3:   fmt.Sprintf("TestCVSSVectorV3%d", i),
-			CVSSVectorV2:   fmt.Sprintf("TestCVSSVectorV2%d", i),
 			CWEIds:         "",
 		}
 		data = append(data, dataRec)

--- a/src/pkg/scan/export/export_data_selector.go
+++ b/src/pkg/scan/export/export_data_selector.go
@@ -36,10 +36,6 @@ func (vds *defaultVulnerabilitySelector) Select(vulnDataRecords []Data, decorati
 			value = vulnDataRecord.Package
 		case ScannerMatches:
 			value = vulnDataRecord.ScannerName
-		case CVE2VectorMatches:
-			value = vulnDataRecord.CVSSVectorV2
-		case CVE3VectorMatches:
-			value = vulnDataRecord.CVSSVectorV3
 		}
 		matched, err := vds.match(pattern, value)
 		if err != nil {

--- a/src/pkg/scan/export/export_data_selector_test.go
+++ b/src/pkg/scan/export/export_data_selector_test.go
@@ -64,38 +64,6 @@ func (suite *ExportDataSelectorTestSuite) TestScannerNameFilter() {
 	}
 }
 
-func (suite *ExportDataSelectorTestSuite) TestCVE2VectorMatches() {
-	{
-		dataRecords := suite.createDataRecords(10, 1)
-		filtered, err := suite.exportDataSelector.Select(dataRecords, CVE2VectorMatches, "TestCVSSVectorV21")
-		suite.NoError(err)
-		suite.Equal(1, len(filtered))
-		suite.Equal("TestCVSSVectorV21", filtered[0].CVSSVectorV2)
-	}
-	{
-		dataRecords := suite.createDataRecords(10, 1)
-		filtered, err := suite.exportDataSelector.Select(dataRecords, CVE2VectorMatches, "")
-		suite.NoError(err)
-		suite.Equal(10, len(filtered))
-	}
-}
-
-func (suite *ExportDataSelectorTestSuite) TestCVE3VectorMatches() {
-	{
-		dataRecords := suite.createDataRecords(10, 1)
-		filtered, err := suite.exportDataSelector.Select(dataRecords, CVE3VectorMatches, "TestCVSSVectorV31")
-		suite.NoError(err)
-		suite.Equal(1, len(filtered))
-		suite.Equal("TestCVSSVectorV31", filtered[0].CVSSVectorV3)
-	}
-	{
-		dataRecords := suite.createDataRecords(10, 1)
-		filtered, err := suite.exportDataSelector.Select(dataRecords, CVE3VectorMatches, "")
-		suite.NoError(err)
-		suite.Equal(10, len(filtered))
-	}
-}
-
 func TestExportDataSelectorTestSuite(t *testing.T) {
 	suite.Run(t, &ExportDataSelectorTestSuite{})
 }
@@ -113,10 +81,6 @@ func (suite *ExportDataSelectorTestSuite) createDataRecords(numRecs int, ownerId
 			Version:        fmt.Sprintf("Version%d", i),
 			FixVersion:     fmt.Sprintf("FixVersion%d", i),
 			Severity:       fmt.Sprintf("Severity%d", i),
-			CVSSScoreV3:    fmt.Sprintf("3.0"),
-			CVSSScoreV2:    fmt.Sprintf("2.0"),
-			CVSSVectorV3:   fmt.Sprintf("TestCVSSVectorV3%d", i),
-			CVSSVectorV2:   fmt.Sprintf("TestCVSSVectorV2%d", i),
 			CWEIds:         "",
 		}
 		data = append(data, dataRec)

--- a/src/pkg/scan/export/manager.go
+++ b/src/pkg/scan/export/manager.go
@@ -29,13 +29,10 @@ select
     vulnerability_record.cve_id,
     vulnerability_record.package,
     vulnerability_record.severity,
-    vulnerability_record.cvss_score_v3,
-    vulnerability_record.cvss_score_v2,
-    vulnerability_record.cvss_vector_v3,
-    vulnerability_record.cvss_vector_v2,
     vulnerability_record.cwe_ids,
     vulnerability_record.package_version,
     vulnerability_record.fixed_version,
+    to_jsonb(vulnerability_record.vendor_attributes)  as vendor_attributes,
     scanner_registration."name" as scanner_name
 from
     report_vulnerability_record
@@ -53,13 +50,10 @@ group by
     artifact.digest,
     artifact.repository_id,
     artifact.repository_name,
-    vulnerability_record.cvss_score_v3,
-    vulnerability_record.cvss_score_v2,
-    vulnerability_record.cvss_vector_v3,
-    vulnerability_record.cvss_vector_v2,
     vulnerability_record.cwe_ids,
     vulnerability_record.package_version,
     vulnerability_record.fixed_version,
+    to_jsonb(vulnerability_record.vendor_attributes),
     scanner_registration.id
 	`
 	JobModeExport = "export"

--- a/src/pkg/scan/export/manager_test.go
+++ b/src/pkg/scan/export/manager_test.go
@@ -1,6 +1,7 @@
 package export
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 	"time"
@@ -122,6 +123,9 @@ func (suite *ExportManagerSuite) TestExport() {
 		data, err := suite.exportManager.Fetch(suite.Context(), Params{ArtifactIDs: []int64{1}})
 		suite.NoError(err)
 		suite.Equal(10, len(data))
+		for _, datum := range data {
+			suite.Equal("{\"CVSS\": {\"nvd\": {\"V2Score\": \"4.3\"}}}", datum.AdditionalData)
+		}
 	}
 }
 
@@ -170,6 +174,10 @@ func (suite *ExportManagerSuite) generateVulnerabilityRecordsForReport(registrat
 		} else {
 			vulnV2.Severity = "Low"
 		}
+		var vendorAttributes = make(map[string]interface{})
+		vendorAttributes["CVSS"] = map[string]interface{}{"nvd": map[string]interface{}{"V2Score": "4.3"}}
+		data, _ := json.Marshal(vendorAttributes)
+		vulnV2.VendorAttributes = string(data)
 		vulns = append(vulns, vulnV2)
 	}
 

--- a/src/pkg/scan/export/model.go
+++ b/src/pkg/scan/export/model.go
@@ -18,11 +18,8 @@ type Data struct {
 	Version        string `orm:"column(package_version)" csv:"Current Version"`
 	FixVersion     string `orm:"column(fixed_version)" csv:"Fixed in version"`
 	Severity       string `orm:"column(severity)" csv:"Severity"`
-	CVSSScoreV3    string `orm:"column(cvss_score_v3)" csv:"CVSS V3 Score"`
-	CVSSScoreV2    string `orm:"column(cvss_score_v2)" csv:"CVSS V2 Score"`
-	CVSSVectorV3   string `orm:"column(cvss_vector_v3)" csv:"CVSS V3 Vector"`
-	CVSSVectorV2   string `orm:"column(cvss_vector_v2)" csv:"CVSS V2 Vector"`
 	CWEIds         string `orm:"column(cwe_ids)" csv:"CWE Ids"`
+	AdditionalData string `orm:"column(vendor_attributes)" csv:"Additional Data"`
 }
 
 // Request encapsulates the filters to be provided when exporting the data for a scan.


### PR DESCRIPTION
Closes: https://github.com/goharbor/harbor/issues/17189

Scope of change:
Fetched data column named `vendor_attributes` when exporting CSV data and dumping the data into the `Additional Data`  column.

Signed-off-by: prahaladdarkin <prahaladd@vmware.com>

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
