### PR TITLE
[cherry-pick] fix: validate export cve request params

### DIFF
--- a/src/jobservice/job/impl/scandataexport/scan_data_export.go
+++ b/src/jobservice/job/impl/scandataexport/scan_data_export.go
@@ -285,7 +285,20 @@ func (sde *ScanDataExport) extractCriteria(params job.Parameters) (*export.Reque
 	if err != nil {
 		return nil, err
 	}
-	return criteria, nil
+
+	// sterilize trim spaces for some fields.
+	sterilize := func(c *export.Request) *export.Request {
+		if c != nil {
+			space, empty := " ", ""
+			c.Repositories = strings.ReplaceAll(c.Repositories, space, empty)
+			c.Tags = strings.ReplaceAll(c.Tags, space, empty)
+			c.CVEIds = strings.ReplaceAll(c.CVEIds, space, empty)
+		}
+
+		return c
+	}
+
+	return sterilize(criteria), nil
 }
 
 func (sde *ScanDataExport) calculateFileHash(fileName string) (digest.Digest, error) {

--- a/src/jobservice/job/impl/scandataexport/scan_data_export_test.go
+++ b/src/jobservice/job/impl/scandataexport/scan_data_export_test.go
@@ -144,6 +144,25 @@ func (suite *ScanDataExportJobTestSuite) TestRunAttributeUpdateError() {
 
 }
 
+func (suite *ScanDataExportJobTestSuite) TestExtractCriteria() {
+	// empty request should return error
+	_, err := suite.job.extractCriteria(job.Parameters{})
+	suite.Error(err)
+	// invalid request should return error
+	_, err = suite.job.extractCriteria(job.Parameters{"Request": ""})
+	suite.Error(err)
+	// valid request should not return error and trim space
+	c, err := suite.job.extractCriteria(job.Parameters{"Request": map[string]interface{}{
+		"CVEIds":       "CVE-123, CVE-456 ",
+		"Repositories": " test-repo1 ",
+		"Tags":         "test-tag1, test-tag2",
+	}})
+	suite.NoError(err)
+	suite.Equal("CVE-123,CVE-456", c.CVEIds)
+	suite.Equal("test-repo1", c.Repositories)
+	suite.Equal("test-tag1,test-tag2", c.Tags)
+}
+
 func (suite *ScanDataExportJobTestSuite) TestRunWithCriteria() {
 	{
 		data := suite.createDataRecords(3, 1)


### PR DESCRIPTION
1. Validate export cve request params in the API handler
2. Trim space for request in the scan export job

Closes: #17326

Signed-off-by: chlins <chenyuzh@vmware.com>

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #17326

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
