### PR TITLE
feat: Optimize quota checking when pushing images

### DIFF
--- a/src/controller/quota/controller_test.go
+++ b/src/controller/quota/controller_test.go
@@ -143,6 +143,19 @@ func (suite *ControllerTestSuite) TestRequestFunctionFailed() {
 	suite.Error(suite.ctl.Request(ctx, suite.reference, referenceID, resources, func() error { return fmt.Errorf("error") }))
 }
 
+func (suite *ControllerTestSuite) TestRequestResourceIsZero() {
+	suite.PrepareForUpdate(suite.quota, nil)
+
+	ctx := orm.NewContext(context.TODO(), &ormtesting.FakeOrmer{})
+	referenceID := uuid.New().String()
+	f := func() error {
+		return nil
+	}
+	res := types.ResourceList{types.ResourceStorage: 0}
+	err := suite.ctl.Request(ctx, suite.reference, referenceID, res, f)
+	suite.Nil(err)
+}
+
 func TestControllerTestSuite(t *testing.T) {
 	suite.Run(t, &ControllerTestSuite{})
 }

--- a/src/pkg/quota/util.go
+++ b/src/pkg/quota/util.go
@@ -32,7 +32,7 @@ func IsSafe(hardLimits types.ResourceList, currentUsed types.ResourceList, newUs
 			continue
 		}
 
-		if hardLimit == types.UNLIMITED || value == currentUsed[resource] {
+		if hardLimit == types.UNLIMITED {
 			continue
 		}
 

--- a/src/server/middleware/quota/post_initiate_blob_upload.go
+++ b/src/server/middleware/quota/post_initiate_blob_upload.go
@@ -38,8 +38,8 @@ func postInitiateBlobUploadResources(r *http.Request, reference, referenceID str
 	query := r.URL.Query()
 	mount := query.Get("mount")
 	if mount == "" {
-		// it is not mount blob http request, skip to request the resources
-		return nil, nil
+		// it is not mount blob http request, create length is zero resource to check quota is full
+		return types.ResourceList{types.ResourceStorage: 0}, nil
 	}
 
 	ctx := r.Context()


### PR DESCRIPTION
Thank you for contributing to Harbor!

# Comprehensive Summary of your change
Create a zero-length resource when calling the `post /v2/library/ubuntu/blobs/uploads/` API to check if the quota is full.

# Issue being fixed
Fixes https://github.com/goharbor/harbor/issues/17390

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/new-feature,"
- [X] Accepted the DCO. Commits without the DCO will delay acceptance.
- [X] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
