### PR TITLE
add deprecation msg for chartmsuem and notary

### DIFF
--- a/make/install.sh
+++ b/make/install.sh
@@ -99,6 +99,20 @@ fi
 echo ""
 
 h2 "[Step $item]: starting Harbor ..."
+if [ $with_chartmuseum ]
+then
+    warn "
+    Chartmusuem will be deprecated as of Harbor v2.6.0 and start to be removed in v2.8.0 or later.
+    Please see discussion here for more details. https://github.com/goharbor/harbor/discussions/15057"
+fi
+if [ $with_notary ]
+then
+    warn "
+    Notary will be deprecated as of Harbor v2.6.0 and start to be removed in v2.8.0 or later.
+    You can use cosign for signature instead since Harbor v2.5.0.
+    Please see discussion here for more details. https://github.com/goharbor/harbor/discussions/16612"
+fi
+
 $DOCKER_COMPOSE up -d
 
 success $"----Harbor has been installed and started successfully.----"


### PR DESCRIPTION
Signed-off-by: yminer <yminer@vmware.com>

Thank you for contributing to Harbor!

# Comprehensive Summary of your change
when we are installing harbor using `sudo ./install.sh --with-notary --with-chartmuseum`, there would be a deprecation warning message for notary or chartmusuem.
# Issue being fixed

<img width="1033" alt="Screen Shot 2022-08-16 at 11 39 44 AM" src="https://user-images.githubusercontent.com/44956229/184793116-2208bfe2-fe63-41b6-b1d7-a9d94e56a28d.png">

Fixes #(issue)

Please indicate you've done the following:
- [ ] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [ ] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
