### PR TITLE
[cherry-pick] fix: correct description for export cve project parameter

### DIFF
--- a/api/v2.0/swagger.yaml
+++ b/api/v2.0/swagger.yaml
@@ -9176,7 +9176,7 @@ definitions:
         items:
           type: integer
           format: int64
-        description: A list of one or more projects for which to export the scan data, defaults to all if empty
+        description: A list of one or more projects for which to export the scan data, currently only one project is supported due to performance concerns, but define as array for extension in the future.
       labels:
         type: array
         items:


### PR DESCRIPTION
Correct the description for the project parameter of export CVE API in
the swagger.

Closes: #17429

Signed-off-by: chlins <chenyuzh@vmware.com>

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #17429

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
