### PR TITLE
[cherry-pick]Update portal-base and nginx-base Dockerfile.base

### DIFF
--- a/make/photon/nginx/Dockerfile.base
+++ b/make/photon/nginx/Dockerfile.base
@@ -2,6 +2,6 @@ FROM photon:4.0
 
 RUN tdnf install -y nginx shadow >> /dev/null \
     && tdnf clean all \
-    && groupadd -r -g 10000 nginx && useradd --no-log-init -r -g 10000 -u 10000 nginx \
+    && groupmod -g 10000 nginx && usermod -g 10000 -u 10000 -d /home/nginx -s /bin/bash nginx \
     && ln -sf /dev/stdout /var/log/nginx/access.log \
     && ln -sf /dev/stderr /var/log/nginx/error.log

--- a/make/photon/portal/Dockerfile.base
+++ b/make/photon/portal/Dockerfile.base
@@ -4,5 +4,5 @@ RUN tdnf install -y nginx shadow >> /dev/null \
     && tdnf clean all \
     && ln -sf /dev/stdout /var/log/nginx/access.log \
     && ln -sf /dev/stderr /var/log/nginx/error.log \
-    && groupadd -r -g 10000 nginx && useradd --no-log-init -r -g 10000 -u 10000 nginx \
+    && groupmod -g 10000 nginx && usermod -g 10000 -u 10000 -d /home/nginx -s /bin/bash nginx \
     && chown -R nginx:nginx /etc/nginx


### PR DESCRIPTION
Installing nginx 1.22 creates the nginx group and nginx user, so instead
of creating them again, modify them.

Signed-off-by: Yang Jiao <jiaoya@vmware.com>

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #17440

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
