### PR TITLE
Allow to set secrets using prepare scripts

### DIFF
--- a/make/harbor.yml.tmpl
+++ b/make/harbor.yml.tmpl
@@ -100,9 +100,21 @@ trivy:
   #
   # github_token: xxx
 
+# Core related config
+# core:
+#   # Secret is used when core server communicates with other components.
+#   # If a secret key is not specified, prepare script will generate one. Must be a string of 16 chars.
+#   secret: xxx
+#   #
+#   # The XSRF key. Will be generated automatically if it isn't specified
+#   xsrf_token: xxx
+
 jobservice:
   # Maximum number of job workers in job service
   max_job_workers: 10
+  # Secret is used when job service communicates with other components.
+  # If a secret key is not specified, prepare script will generate one. Must be a string of 16 chars.
+  # secret: xxx
 
 notification:
   # Maximum retry count for webhook job
@@ -172,7 +184,7 @@ _version: 2.6.0
 #   # host for redis+sentinel:
 #   #  <host_sentinel1>:<port_sentinel1>,<host_sentinel2>:<port_sentinel2>,<host_sentinel3>:<port_sentinel3>
 #   host: redis:6379
-#   password: 
+#   password:
 #   # sentinel_master_set must be set to support redis+sentinel
 #   #sentinel_master_set:
 #   # db_index 0 is for core, it's unchangeable

--- a/make/photon/prepare/utils/configs.py
+++ b/make/photon/prepare/utils/configs.py
@@ -240,10 +240,15 @@ def parse_yaml_config(config_file_path, with_notary, with_trivy, with_chartmuseu
     else:
         config_dict['chart_absolute_url'] = False
 
+    # core config
+    core_config = configs.get('core') or {}
+    config_dict['core_secret'] = core_config.get('secret') or generate_random_string(16)
+    config_dict['csrf_key'] = core_config.get('xsrf_key') or generate_random_string(32)
+
     # jobservice config
     js_config = configs.get('jobservice') or {}
     config_dict['max_job_workers'] = js_config["max_job_workers"]
-    config_dict['jobservice_secret'] = generate_random_string(16)
+    config_dict['jobservice_secret'] = js_config.get('secret') or generate_random_string(16)
 
     # notification config
     notification_config = configs.get('notification') or {}
@@ -308,9 +313,6 @@ def parse_yaml_config(config_file_path, with_notary, with_trivy, with_chartmuseu
 
     # update redis configs
     config_dict.update(get_redis_configs(configs.get("external_redis", None), with_trivy))
-
-    # auto generated secret string for core
-    config_dict['core_secret'] = generate_random_string(16)
 
     # UAA configs
     config_dict['uaa'] = configs.get('uaa') or {}

--- a/make/photon/prepare/utils/core.py
+++ b/make/photon/prepare/utils/core.py
@@ -31,7 +31,6 @@ def prepare_core(config_dict, with_notary, with_trivy, with_chartmuseum):
         with_notary=with_notary,
         with_trivy=with_trivy,
         with_chartmuseum=with_chartmuseum,
-        csrf_key=generate_random_string(32),
         **config_dict)
 
     render_jinja(


### PR DESCRIPTION
 - Add `core.secret` option
 - Add `core.xsrf_token` option
 - Add `jobservice.secret` option

Signed-off-by: Dmitry G <dmitry@vinted.com>

***

These configuration options are supported by Helm chart, but they were not available for docker-compose setup.

This change allows to share the same secrets between multiple instances of Harbor. To maintain high availability we would like to run several instances of Harbor that share the same external database, redis and storage. While these external components work fine for HA setup, the core and jobservice secrets and XSRF token being different between applications do not allow to properly run Harbor.

When using only one instance of Harbor, it requires about 30 seconds to restart docker-compose application and the whole registry becomes unreachable. We use Chef for automation of Harbor installation, configuration and updates (chef cookbook to be released soon), so when configuration is changed, that single instance of Harbor becomes unavailable during restart.

Currently prepare scripts can only generate random secrets for every install. Using shared secrets would allow to use a set of applications for high availability.

This change is not breaking. If the options are not specified, they will be automatically generated the same way as before. Also, configuration keys are named in the same manner as Helm chart values. 

***

Please indicate you've done the following:
- [ ] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [ ] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website). - goharbor/website/pull/359
