### PR TITLE
Fix cross account issue

### DIFF
--- a/src/pkg/reg/adapter/awsecr/adapter.go
+++ b/src/pkg/reg/adapter/awsecr/adapter.go
@@ -50,7 +50,7 @@ func newAdapter(registry *model.Registry) (*adapter, error) {
 		return nil, err
 	}
 	svc, err := getAwsSvc(
-		region, registry.Credential.AccessKey, registry.Credential.AccessSecret, registry.Insecure, nil)
+		region, registry.Credential.AccessKey, registry.Credential.AccessSecret, registry.Insecure, &registry.URL)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Thank you for contributing to Harbor!

# Comprehensive Summary of your change
Pass in the correct endpoint to AWS ECR client config, so at the time of fetching token, the token will be valid for the target endpoint.

# Issue being fixed
Fixes [#(issue)](https://github.com/goharbor/harbor/issues/15388)
Currently, when AWS ECR client is created, it defaults the endpoint to whatever AWS_ACCESS_KEY_ID belongs to and thus falls short in the cross account case. The proposed fix sets the endpoint explicitly so it works in all cases.

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
