### PR TITLE
test: add GetRedisURL to tests redis pkg and fix hardcoded redis url

### DIFF
--- a/src/jobservice/job/impl/gc/garbage_collection_test.go
+++ b/src/jobservice/job/impl/gc/garbage_collection_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/goharbor/harbor/src/controller/artifact"
 	"github.com/goharbor/harbor/src/controller/project"
 	"github.com/goharbor/harbor/src/jobservice/job"
+	"github.com/goharbor/harbor/src/jobservice/tests"
 	pkgart "github.com/goharbor/harbor/src/pkg/artifact"
 	"github.com/goharbor/harbor/src/pkg/artifactrash/model"
 	pkg_blob "github.com/goharbor/harbor/src/pkg/blob/models"
@@ -276,9 +277,8 @@ func (suite *gcTestSuite) TestRun() {
 	}
 	params := map[string]interface{}{
 		"delete_untagged": false,
-		// ToDo add a redis testing pkg, we do have a 'localhost' redis server in UT
-		"redis_url_reg": "redis://localhost:6379",
-		"time_window":   1,
+		"redis_url_reg":   tests.GetRedisURL(),
+		"time_window":     1,
 	}
 
 	suite.Nil(gc.Run(ctx, params))

--- a/src/jobservice/tests/utils.go
+++ b/src/jobservice/tests/utils.go
@@ -27,20 +27,22 @@ import (
 )
 
 const (
+	poolMaxIdle           = 6
+	PoolMaxActive         = 6
 	dialConnectionTimeout = 30 * time.Second
 	healthCheckPeriod     = time.Minute
 	dialReadTimeout       = healthCheckPeriod + 10*time.Second
 	dialWriteTimeout      = 10 * time.Second
-	testingRedisHost      = "REDIS_HOST"
+	testingRedisHostEnv   = "REDIS_HOST"
+	testingRedisPort      = 6379
 	testingNamespace      = "testing_job_service_v2"
 )
 
 // GiveMeRedisPool ...
 func GiveMeRedisPool() *redis.Pool {
-	redisHost := getRedisHost()
-	pool, _ := redislib.GetRedisPool("test", fmt.Sprintf("redis://%s:%d", redisHost, 6379), &redislib.PoolParam{
-		PoolMaxIdle:           6,
-		PoolMaxActive:         6,
+	pool, _ := redislib.GetRedisPool("test", GetRedisURL(), &redislib.PoolParam{
+		PoolMaxIdle:           poolMaxIdle,
+		PoolMaxActive:         PoolMaxActive,
 		DialConnectionTimeout: dialConnectionTimeout,
 		DialReadTimeout:       dialReadTimeout,
 		DialWriteTimeout:      dialWriteTimeout,
@@ -51,6 +53,16 @@ func GiveMeRedisPool() *redis.Pool {
 // GiveMeTestNamespace ...
 func GiveMeTestNamespace() string {
 	return testingNamespace
+}
+
+// GetRedisURL ...
+func GetRedisURL() string {
+	redisHost := os.Getenv(testingRedisHostEnv)
+	if redisHost == "" {
+		redisHost = "127.0.0.1" // for local test
+	}
+
+	return fmt.Sprintf("redis://%s:%d", redisHost, testingRedisPort)
 }
 
 // Clear ...
@@ -81,13 +93,4 @@ func ClearAll(namespace string, conn redis.Conn) error {
 	}
 
 	return conn.Flush()
-}
-
-func getRedisHost() string {
-	redisHost := os.Getenv(testingRedisHost)
-	if redisHost == "" {
-		redisHost = "127.0.0.1" // for local test
-	}
-
-	return redisHost
 }


### PR DESCRIPTION
Signed-off-by: Gaius <gaius.qi@gmail.com>

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

- Add `GetRedisURL` to `src/jobservice/tests` pkg.
- Fix hardcoded redis url in `src/jobservice/job/impl/gc/garbage_collection_test.go`.
# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
