### PR TITLE
Fix redirect url redirect_url  when OIDC auth mode is enabled

### DIFF
--- a/src/core/controllers/oidc.go
+++ b/src/core/controllers/oidc.go
@@ -35,6 +35,7 @@ import (
 const tokenKey = "oidc_token"
 const stateKey = "oidc_state"
 const userInfoKey = "oidc_user_info"
+const redirectUrlKey = "oidc_redirect_url"
 const oidcUserComment = "Onboarded via OIDC provider"
 
 // OIDCController handles requests for OIDC login, callback and user onboard
@@ -62,6 +63,7 @@ func (oc *OIDCController) RedirectLogin() {
 		oc.SendInternalServerError(err)
 		return
 	}
+	oc.SetSession(redirectUrlKey, oc.Ctx.Request.URL.Query().Get("redirect_url"))
 	oc.SetSession(stateKey, state)
 	log.Debugf("State dumped to session: %s", state)
 	// Force to use the func 'Redirect' of beego.Controller
@@ -85,7 +87,12 @@ func (oc *OIDCController) Callback() {
 		oc.SendBadRequestError(errors.Errorf("OIDC callback returned error: %s - %s", errorCode, errorDescription))
 		return
 	}
-
+	var redirectUrlStr string
+	redirectUrl := oc.GetSession(redirectUrlKey)
+	if redirectUrl != nil {
+		redirectUrlStr = redirectUrl.(string)
+		oc.DelSession(redirectUrlKey)
+	}
 	code := oc.Ctx.Request.URL.Query().Get("code")
 	ctx := oc.Ctx.Request.Context()
 	token, err := oidc.ExchangeToken(ctx, code)
@@ -144,7 +151,7 @@ func (oc *OIDCController) Callback() {
 			u = userRec
 		} else {
 			oc.SetSession(userInfoKey, string(ouDataStr))
-			oc.Controller.Redirect(fmt.Sprintf("/oidc-onboard?username=%s", username), http.StatusFound)
+			oc.Controller.Redirect(fmt.Sprintf("/oidc-onboard?username=%s&redirect_url=%s", username, redirectUrlStr), http.StatusFound)
 			// Once redirected, no further actions are done
 			return
 		}
@@ -170,7 +177,11 @@ func (oc *OIDCController) Callback() {
 		return
 	}
 	oc.PopulateUserSession(*u)
-	oc.Controller.Redirect("/", http.StatusFound)
+
+	if redirectUrlStr == "" {
+		redirectUrlStr = "/"
+	}
+	oc.Controller.Redirect(redirectUrlStr, http.StatusFound)
 }
 
 func userOnboard(ctx context.Context, oc *OIDCController, info *oidc.UserInfo, username string, tokenBytes []byte) (*models.User, bool) {

--- a/src/core/controllers/oidc.go
+++ b/src/core/controllers/oidc.go
@@ -35,7 +35,7 @@ import (
 const tokenKey = "oidc_token"
 const stateKey = "oidc_state"
 const userInfoKey = "oidc_user_info"
-const redirectUrlKey = "oidc_redirect_url"
+const redirectURLKey = "oidc_redirect_url"
 const oidcUserComment = "Onboarded via OIDC provider"
 
 // OIDCController handles requests for OIDC login, callback and user onboard
@@ -63,7 +63,7 @@ func (oc *OIDCController) RedirectLogin() {
 		oc.SendInternalServerError(err)
 		return
 	}
-	oc.SetSession(redirectUrlKey, oc.Ctx.Request.URL.Query().Get("redirect_url"))
+	oc.SetSession(redirectURLKey, oc.Ctx.Request.URL.Query().Get("redirect_url"))
 	oc.SetSession(stateKey, state)
 	log.Debugf("State dumped to session: %s", state)
 	// Force to use the func 'Redirect' of beego.Controller
@@ -87,11 +87,11 @@ func (oc *OIDCController) Callback() {
 		oc.SendBadRequestError(errors.Errorf("OIDC callback returned error: %s - %s", errorCode, errorDescription))
 		return
 	}
-	var redirectUrlStr string
-	redirectUrl := oc.GetSession(redirectUrlKey)
-	if redirectUrl != nil {
-		redirectUrlStr = redirectUrl.(string)
-		oc.DelSession(redirectUrlKey)
+	var redirectURLStr string
+	redirectURL := oc.GetSession(redirectURLKey)
+	if redirectURL != nil {
+		redirectURLStr = redirectURL.(string)
+		oc.DelSession(redirectURLKey)
 	}
 	code := oc.Ctx.Request.URL.Query().Get("code")
 	ctx := oc.Ctx.Request.Context()
@@ -151,7 +151,7 @@ func (oc *OIDCController) Callback() {
 			u = userRec
 		} else {
 			oc.SetSession(userInfoKey, string(ouDataStr))
-			oc.Controller.Redirect(fmt.Sprintf("/oidc-onboard?username=%s&redirect_url=%s", username, redirectUrlStr), http.StatusFound)
+			oc.Controller.Redirect(fmt.Sprintf("/oidc-onboard?username=%s&redirect_url=%s", username, redirectURLStr), http.StatusFound)
 			// Once redirected, no further actions are done
 			return
 		}
@@ -178,10 +178,10 @@ func (oc *OIDCController) Callback() {
 	}
 	oc.PopulateUserSession(*u)
 
-	if redirectUrlStr == "" {
-		redirectUrlStr = "/"
+	if redirectURLStr == "" {
+		redirectURLStr = "/"
 	}
-	oc.Controller.Redirect(redirectUrlStr, http.StatusFound)
+	oc.Controller.Redirect(redirectURLStr, http.StatusFound)
 }
 
 func userOnboard(ctx context.Context, oc *OIDCController, info *oidc.UserInfo, username string, tokenBytes []byte) (*models.User, bool) {

--- a/src/portal/src/app/account/sign-in/sign-in.component.html
+++ b/src/portal/src/app/account/sign-in/sign-in.component.html
@@ -22,7 +22,7 @@
             </label>
             <div class="login-group">
                 <ng-container *ngIf="isOidcLoginMode && steps === 1">
-                    <a href="/c/oidc/login?redirect_url={{redirectUrl}}">
+                    <a href="/c/oidc/login?redirect_url={{ redirectUrl }}">
                         <button
                             type="button"
                             id="log_oidc"

--- a/src/portal/src/app/account/sign-in/sign-in.component.html
+++ b/src/portal/src/app/account/sign-in/sign-in.component.html
@@ -22,7 +22,7 @@
             </label>
             <div class="login-group">
                 <ng-container *ngIf="isOidcLoginMode && steps === 1">
-                    <a href="/c/oidc/login">
+                    <a href="/c/oidc/login?redirect_url={{redirectUrl}}">
                         <button
                             type="button"
                             id="log_oidc"

--- a/src/portal/src/app/oidc-onboard/oidc-onboard.component.ts
+++ b/src/portal/src/app/oidc-onboard/oidc-onboard.component.ts
@@ -34,10 +34,10 @@ export class OidcOnboardComponent implements OnInit {
             .subscribe(
                 res => {
                     if (this.redirectUrl === '') {
-                      // Routing to the default location
-                      this.router.navigateByUrl(CommonRoutes.HARBOR_DEFAULT);
+                        // Routing to the default location
+                        this.router.navigateByUrl(CommonRoutes.HARBOR_DEFAULT);
                     } else {
-                      this.router.navigateByUrl(this.redirectUrl);
+                        this.router.navigateByUrl(this.redirectUrl);
                     }
                 },
                 error => {

--- a/src/portal/src/app/oidc-onboard/oidc-onboard.component.ts
+++ b/src/portal/src/app/oidc-onboard/oidc-onboard.component.ts
@@ -12,6 +12,7 @@ import { errorHandler } from '../shared/units/shared.utils';
 })
 export class OidcOnboardComponent implements OnInit {
     url: string;
+    redirectUrl: string;
     errorMessage: string = '';
     oidcUsername = new UntypedFormControl('');
     errorOpen: boolean = false;
@@ -23,6 +24,7 @@ export class OidcOnboardComponent implements OnInit {
 
     ngOnInit() {
         this.route.queryParams.subscribe(params => {
+            this.redirectUrl = params['redirect_url'] || '';
             this.oidcUsername.setValue(params['username'] || '');
         });
     }
@@ -31,7 +33,12 @@ export class OidcOnboardComponent implements OnInit {
             .oidcSave({ username: this.oidcUsername.value })
             .subscribe(
                 res => {
-                    this.router.navigate([CommonRoutes.HARBOR_DEFAULT]);
+                    if (this.redirectUrl === '') {
+                      // Routing to the default location
+                      this.router.navigateByUrl(CommonRoutes.HARBOR_DEFAULT);
+                    } else {
+                      this.router.navigateByUrl(this.redirectUrl);
+                    }
                 },
                 error => {
                     this.errorMessage = errorHandler(error);


### PR DESCRIPTION
Fix redirect URL parameter `redirect_url` in case the user is redirected to sign-in screen in OIDC.

The fix is using server-side session storage to track the original URL being requested before login redirect.

# Issue being fixed
Fixes #17594

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. **release-note/enhancement**
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
