### PR TITLE
Add labeling for dependa bot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,15 +11,26 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    labels:
+      - "release-note/infra"
+      - "release-note/update"
+    assignees:
+      - "OrlinVasilev"
+    reviewers:
+      - "OrlinVasilev"
 
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
       interval: "weekly"
+    labels:
+      - "release-note/update"
 
   - package-ecosystem: "gomod"
     directory: "tests/"
     schedule:
       interval: "weekly"
+    labels:
+      - "release-note/update"
   
   # More will be needed


### PR DESCRIPTION
Add labels for github action as infra for release notes and add update for all other components

Signed-off-by: OrlinVasilev <ovasilev@vmware.com>

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [X] Well Written Title and Summary of the PR
- [X] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [X] Accepted the DCO. Commits without the DCO will delay acceptance.
- [X] Made sure tests are passing and test coverage is added if needed.
- [X] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
