### PR TITLE
test: use `T.Setenv` to set env vars in tests

### DIFF
--- a/src/controller/robot/controller_test.go
+++ b/src/controller/robot/controller_test.go
@@ -90,7 +90,7 @@ func (suite *ControllerTestSuite) TestCreate() {
 	_, err := test.GenerateKey(secretKeyPath)
 	suite.Nil(err)
 	defer os.Remove(secretKeyPath)
-	os.Setenv("KEY_PATH", secretKeyPath)
+	suite.T().Setenv("KEY_PATH", secretKeyPath)
 
 	conf := map[string]interface{}{
 		common.RobotTokenDuration: "30",

--- a/src/jobservice/api/handler_test.go
+++ b/src/jobservice/api/handler_test.go
@@ -55,7 +55,7 @@ type APIHandlerTestSuite struct {
 
 // SetupSuite prepares test suite
 func (suite *APIHandlerTestSuite) SetupSuite() {
-	_ = os.Setenv(secretKey, fakeSecret)
+	suite.T().Setenv(secretKey, fakeSecret)
 
 	suite.client = &http.Client{
 		Timeout: 10 * time.Second,
@@ -76,7 +76,6 @@ func (suite *APIHandlerTestSuite) SetupSuite() {
 
 // TearDownSuite clears test suite
 func (suite *APIHandlerTestSuite) TearDownSuite() {
-	_ = os.Unsetenv(secretKey)
 	_ = suite.server.Stop()
 	suite.cancel()
 }

--- a/src/jobservice/common/utils/utils_test.go
+++ b/src/jobservice/common/utils/utils_test.go
@@ -16,7 +16,6 @@
 package utils
 
 import (
-	"os"
 	"testing"
 
 	"github.com/gocraft/work"
@@ -51,10 +50,9 @@ func (suite *UtilsTestSuite) TestIsEmptyStr() {
 
 // TestReadEnv tests ReadEnv
 func (suite *UtilsTestSuite) TestReadEnv() {
-	os.Setenv("TEST_EXIST_ENV_VAR", "test")
+	suite.T().Setenv("TEST_EXIST_ENV_VAR", "test")
 	assert.Equal(suite.T(), "test", ReadEnv("TEST_EXIST_ENV_VAR"), "env var TEST_EXIST_ENV_VAR should return test value")
 	assert.Equal(suite.T(), "", ReadEnv("TEST_NOT_EXIST_ENV_VAR"), "env var TEST_NOT_EXIST_ENV_VAR should return empty value")
-	os.Unsetenv("TEST_EXIST_ENV_VAR")
 }
 
 // TestFileExists tests FileExists

--- a/src/jobservice/config/config_test.go
+++ b/src/jobservice/config/config_test.go
@@ -14,7 +14,6 @@
 package config
 
 import (
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -48,16 +47,10 @@ func (suite *ConfigurationTestSuite) TestConfigLoadingSucceed() {
 
 // TestConfigLoadingWithEnv ...
 func (suite *ConfigurationTestSuite) TestConfigLoadingWithEnv() {
-	err := setENV()
-	require.Nil(suite.T(), err, "set envs: expect nil error but got error '%s'", err)
-
-	defer func() {
-		err := unsetENV()
-		require.Nil(suite.T(), err, "unset envs: expect nil error but got error '%s'", err)
-	}()
+	setENV(suite.T())
 
 	cfg := &Configuration{}
-	err = cfg.Load("../config_test.yml", true)
+	err := cfg.Load("../config_test.yml", true)
 	require.Nil(suite.T(), err, "load config from yaml file, expect nil error but got error '%s'", err)
 
 	assert.Equal(suite.T(), "https", cfg.Protocol, "expect protocol 'https', but got '%s'", cfg.Protocol)
@@ -125,33 +118,16 @@ func (suite *ConfigurationTestSuite) TestDefaultConfig() {
 	)
 }
 
-func setENV() error {
-	err := os.Setenv("JOB_SERVICE_PROTOCOL", "https")
-	err = os.Setenv("JOB_SERVICE_PORT", "8989")
-	err = os.Setenv("JOB_SERVICE_HTTPS_CERT", "../server.crt")
-	err = os.Setenv("JOB_SERVICE_HTTPS_KEY", "../server.key")
-	err = os.Setenv("JOB_SERVICE_POOL_BACKEND", "redis")
-	err = os.Setenv("JOB_SERVICE_POOL_WORKERS", "8")
-	err = os.Setenv("JOB_SERVICE_POOL_REDIS_URL", "redis://:password@8.8.8.8:6379/2")
-	err = os.Setenv("JOB_SERVICE_POOL_REDIS_NAMESPACE", "ut_namespace")
-	err = os.Setenv("JOBSERVICE_SECRET", "js_secret")
-	err = os.Setenv("CORE_SECRET", "core_secret")
-	err = os.Setenv("CORE_URL", "core_url")
-
-	return err
-}
-
-func unsetENV() error {
-	err := os.Unsetenv("JOB_SERVICE_PROTOCOL")
-	err = os.Unsetenv("JOB_SERVICE_PORT")
-	err = os.Unsetenv("JOB_SERVICE_HTTPS_CERT")
-	err = os.Unsetenv("JOB_SERVICE_HTTPS_KEY")
-	err = os.Unsetenv("JOB_SERVICE_POOL_BACKEND")
-	err = os.Unsetenv("JOB_SERVICE_POOL_WORKERS")
-	err = os.Unsetenv("JOB_SERVICE_POOL_REDIS_URL")
-	err = os.Unsetenv("JOB_SERVICE_POOL_REDIS_NAMESPACE")
-	err = os.Unsetenv("JOBSERVICE_SECRET")
-	err = os.Unsetenv("CORE_SECRET")
-
-	return err
+func setENV(t *testing.T) {
+	t.Setenv("JOB_SERVICE_PROTOCOL", "https")
+	t.Setenv("JOB_SERVICE_PORT", "8989")
+	t.Setenv("JOB_SERVICE_HTTPS_CERT", "../server.crt")
+	t.Setenv("JOB_SERVICE_HTTPS_KEY", "../server.key")
+	t.Setenv("JOB_SERVICE_POOL_BACKEND", "redis")
+	t.Setenv("JOB_SERVICE_POOL_WORKERS", "8")
+	t.Setenv("JOB_SERVICE_POOL_REDIS_URL", "redis://:password@8.8.8.8:6379/2")
+	t.Setenv("JOB_SERVICE_POOL_REDIS_NAMESPACE", "ut_namespace")
+	t.Setenv("JOBSERVICE_SECRET", "js_secret")
+	t.Setenv("CORE_SECRET", "core_secret")
+	t.Setenv("CORE_URL", "core_url")
 }

--- a/src/jobservice/job/impl/gc/garbage_collection_test.go
+++ b/src/jobservice/job/impl/gc/garbage_collection_test.go
@@ -15,7 +15,6 @@
 package gc
 
 import (
-	"os"
 	"testing"
 
 	"github.com/docker/distribution/manifest/schema2"
@@ -380,6 +379,6 @@ func (suite *gcTestSuite) TestSweep() {
 }
 
 func TestGCTestSuite(t *testing.T) {
-	os.Setenv("UTTEST", "true")
+	t.Setenv("UTTEST", "true")
 	suite.Run(t, &gcTestSuite{})
 }

--- a/src/jobservice/job/impl/notification/slack_job_test.go
+++ b/src/jobservice/job/impl/notification/slack_job_test.go
@@ -4,7 +4,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -15,16 +14,19 @@ import (
 
 func TestSlackJobMaxFails(t *testing.T) {
 	rep := &SlackJob{}
-	// test default max fails
-	assert.Equal(t, uint(10), rep.MaxFails())
+	t.Run("default max fails", func(t *testing.T) {
+		assert.Equal(t, uint(10), rep.MaxFails())
+	})
 
-	// test user defined max fails
-	_ = os.Setenv(maxFails, "15")
-	assert.Equal(t, uint(15), rep.MaxFails())
+	t.Run("user defined max fails", func(t *testing.T) {
+		t.Setenv(maxFails, "15")
+		assert.Equal(t, uint(15), rep.MaxFails())
+	})
 
-	// test user defined wrong max fails
-	_ = os.Setenv(maxFails, "abc")
-	assert.Equal(t, uint(10), rep.MaxFails())
+	t.Run("user defined wrong max fails", func(t *testing.T) {
+		t.Setenv(maxFails, "abc")
+		assert.Equal(t, uint(10), rep.MaxFails())
+	})
 }
 
 func TestSlackJobShouldRetry(t *testing.T) {

--- a/src/jobservice/job/impl/notification/webhook_job_test.go
+++ b/src/jobservice/job/impl/notification/webhook_job_test.go
@@ -4,7 +4,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -14,16 +13,19 @@ import (
 
 func TestMaxFails(t *testing.T) {
 	rep := &WebhookJob{}
-	// test default max fails
-	assert.Equal(t, uint(10), rep.MaxFails())
+	t.Run("default max fails", func(t *testing.T) {
+		assert.Equal(t, uint(10), rep.MaxFails())
+	})
 
-	// test user defined max fails
-	_ = os.Setenv(maxFails, "15")
-	assert.Equal(t, uint(15), rep.MaxFails())
+	t.Run("user defined max fails", func(t *testing.T) {
+		t.Setenv(maxFails, "15")
+		assert.Equal(t, uint(15), rep.MaxFails())
+	})
 
-	// test user defined wrong max fails
-	_ = os.Setenv(maxFails, "abc")
-	assert.Equal(t, uint(10), rep.MaxFails())
+	t.Run("user defined wrong max fails", func(t *testing.T) {
+		t.Setenv(maxFails, "abc")
+		assert.Equal(t, uint(10), rep.MaxFails())
+	})
 }
 
 func TestShouldRetry(t *testing.T) {

--- a/src/lib/config/test/userconfig_test.go
+++ b/src/lib/config/test/userconfig_test.go
@@ -59,17 +59,10 @@ func TestConfig(t *testing.T) {
 	defer os.Remove(secretKeyPath)
 	assert := assert.New(t)
 
-	if err := os.Setenv("KEY_PATH", secretKeyPath); err != nil {
-		t.Fatalf("failed to set env %s: %v", "KEY_PATH", err)
-	}
-	oriKeyPath := os.Getenv("TOKEN_PRIVATE_KEY_PATH")
-	if err := os.Setenv("TOKEN_PRIVATE_KEY_PATH", ""); err != nil {
-		t.Fatalf("failed to set env %s: %v", "TOKEN_PRIVATE_KEY_PATH", err)
-	}
-	defer os.Setenv("TOKEN_PRIVATE_KEY_PATH", oriKeyPath)
-
-	os.Setenv("JOBSERVICE_URL", "http://myjob:8888")
-	os.Setenv("GC_TIME_WINDOW_HOURS", "0")
+	t.Setenv("KEY_PATH", secretKeyPath)
+	t.Setenv("TOKEN_PRIVATE_KEY_PATH", "")
+	t.Setenv("JOBSERVICE_URL", "http://myjob:8888")
+	t.Setenv("GC_TIME_WINDOW_HOURS", "0")
 
 	Init()
 	ctx := orm.Context()

--- a/src/pkg/immutable/manager_test.go
+++ b/src/pkg/immutable/manager_test.go
@@ -2,7 +2,6 @@ package immutable
 
 import (
 	"context"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -29,13 +28,7 @@ func (m *managerTestingSuite) SetupSuite() {
 	m.assert = assert.New(m.t)
 	m.require = require.New(m.t)
 
-	err := os.Setenv("RUN_MODE", "TEST")
-	m.require.Nil(err)
-}
-
-func (m *managerTestingSuite) TearDownSuite() {
-	err := os.Unsetenv("RUN_MODE")
-	m.require.Nil(err)
+	m.T().Setenv("RUN_MODE", "TEST")
 }
 
 func (m *managerTestingSuite) SetupTest() {

--- a/src/pkg/joblog/managet_test.go
+++ b/src/pkg/joblog/managet_test.go
@@ -2,7 +2,6 @@ package joblog
 
 import (
 	"context"
-	"os"
 	"testing"
 	"time"
 
@@ -28,13 +27,7 @@ func (m *managerTestingSuite) SetupSuite() {
 	m.assert = assert.New(m.t)
 	m.require = require.New(m.t)
 
-	err := os.Setenv("RUN_MODE", "TEST")
-	m.require.Nil(err)
-}
-
-func (m *managerTestingSuite) TearDownSuite() {
-	err := os.Unsetenv("RUN_MODE")
-	m.require.Nil(err)
+	m.T().Setenv("RUN_MODE", "TEST")
 }
 
 func (m *managerTestingSuite) SetupTest() {

--- a/src/registryctl/config/config_test.go
+++ b/src/registryctl/config/config_test.go
@@ -15,7 +15,6 @@
 package config
 
 import (
-	"os"
 	"testing"
 
 	_ "github.com/docker/distribution/registry/storage/driver/filesystem"
@@ -29,9 +28,9 @@ func TestConfigDoesNotExists(t *testing.T) {
 }
 
 func TestConfigLoadingWithEnv(t *testing.T) {
-	os.Setenv("REGISTRYCTL_PROTOCOL", "https")
-	os.Setenv("PORT", "1000")
-	os.Setenv("LOG_LEVEL", "DEBUG")
+	t.Setenv("REGISTRYCTL_PROTOCOL", "https")
+	t.Setenv("PORT", "1000")
+	t.Setenv("LOG_LEVEL", "DEBUG")
 
 	cfg := &Configuration{}
 	err := cfg.Load("../config_test.yml", true)
@@ -60,11 +59,11 @@ func TestGetLogLevel(t *testing.T) {
 }
 
 func TestGetJobAuthSecret(t *testing.T) {
-	os.Setenv("JOBSERVICE_SECRET", "test_job_secret")
+	t.Setenv("JOBSERVICE_SECRET", "test_job_secret")
 	assert.Equal(t, "test_job_secret", GetJobAuthSecret())
 }
 
 func TestGetUIAuthSecret(t *testing.T) {
-	os.Setenv("CORE_SECRET", "test_core_secret")
+	t.Setenv("CORE_SECRET", "test_core_secret")
 	assert.Equal(t, "test_core_secret", GetUIAuthSecret())
 }

--- a/src/server/registry/handler_test.go
+++ b/src/server/registry/handler_test.go
@@ -16,7 +16,6 @@ package registry
 
 import (
 	"net/http"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -28,12 +27,8 @@ func direct(req *http.Request) {
 
 func TestBasicAuthDirector(t *testing.T) {
 	req, _ := http.NewRequest(http.MethodGet, "127.0.0.1", nil)
-	os.Setenv("REGISTRY_CREDENTIAL_USERNAME", "testuser")
-	os.Setenv("REGISTRY_CREDENTIAL_PASSWORD", "testpassword")
-	defer func() {
-		os.Unsetenv("REGISTRY_CREDENTIAL_USERNAME")
-		os.Unsetenv("REGISTRY_CREDENTIAL_PASSWORD")
-	}()
+	t.Setenv("REGISTRY_CREDENTIAL_USERNAME", "testuser")
+	t.Setenv("REGISTRY_CREDENTIAL_PASSWORD", "testpassword")
 
 	d := basicAuthDirector(direct)
 	d(req)


### PR DESCRIPTION
# Comprehensive Summary of your change

A testing cleanup.

This PR replaces `os.Setenv` with `t.Setenv`. Starting from Go 1.17, we can use `t.Setenv` to set environment variable in test. The environment variable is automatically restored to its original value when the test and all its subtests complete. This ensures that each test does not start with leftover environment variables from previous completed tests.

```go
func TestFoo(t *testing.T) {
	// before
	key := "ENV"
	originalEnv := os.Getenv(key)
	
	if err := os.Setenv(key, "new value"); err != nil {
		t.Fatal(err)
	}
	defer func() {
		if err := os.Setenv(key, originalEnv); err != nil {
			t.Logf("failed to set env %s back to original value: %v", key, err)
		}
	}()
	
	// after
	t.Setenv(key, "new value")
}
```

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
