### PR TITLE
fix: panic recover when stream

### DIFF
--- a/src/server/middleware/repoproxy/proxy.go
+++ b/src/server/middleware/repoproxy/proxy.go
@@ -22,6 +22,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/beego/beego"
+
 	"github.com/goharbor/harbor/src/common/security"
 	"github.com/goharbor/harbor/src/common/security/proxycachesecret"
 	"github.com/goharbor/harbor/src/controller/project"
@@ -73,6 +75,12 @@ func handleBlob(w http.ResponseWriter, r *http.Request, next http.Handler) error
 	}
 
 	if !canProxy(r.Context(), p) || proxyCtl.UseLocalBlob(ctx, art) {
+		defer func() {
+			if err := recover(); err != nil {
+				log.Error(err)
+				panic(beego.ErrAbort)
+			}
+		}()
 		next.ServeHTTP(w, r)
 		return nil
 	}

--- a/src/server/middleware/repoproxy/proxy.go
+++ b/src/server/middleware/repoproxy/proxy.go
@@ -58,6 +58,12 @@ func BlobGetMiddleware() func(http.Handler) http.Handler {
 }
 
 func handleBlob(w http.ResponseWriter, r *http.Request, next http.Handler) error {
+	defer func() {
+		if err := recover(); err != nil {
+			log.Error(err)
+			panic(beego.ErrAbort)
+		}
+	}()
 	ctx := r.Context()
 	art, p, proxyCtl, err := preCheck(ctx)
 	if err != nil {
@@ -75,12 +81,6 @@ func handleBlob(w http.ResponseWriter, r *http.Request, next http.Handler) error
 	}
 
 	if !canProxy(r.Context(), p) || proxyCtl.UseLocalBlob(ctx, art) {
-		defer func() {
-			if err := recover(); err != nil {
-				log.Error(err)
-				panic(beego.ErrAbort)
-			}
-		}()
 		next.ServeHTTP(w, r)
 		return nil
 	}


### PR DESCRIPTION
Thank you for contributing to Harbor!

# Comprehensive Summary of your change

when download a layer and the http request between core and registry is aborted, the ReverseProxy handler will panic. [net/http/httputil: ReverseProxy should use ErrAbortHandler on read error while copying body · Issue ](https://github.com/golang/go/issues/23643)

but beego will recover this panic and show a error page. so the layer will like this 

![tar content](https://user-images.githubusercontent.com/11679819/198564561-85e00136-274e-453a-9dc7-d8d55554ee9f.png)

If this is a client which has auto-retry with broken-point continuingly-transferring, the content will be dirty.(include error html page), such as wget and containerd [link to code](https://github.com/containerd/containerd/blob/8167751f569c9374a6c3ef5b39a42629577a543a/remotes/docker/fetcher.go#L160)

![wget](https://user-images.githubusercontent.com/11679819/198813249-ad98e148-6edc-465a-9aa8-dd40fc093d9a.png)

after retry with breakpoint transmission, the content will be wrong.
![sha256sum](https://user-images.githubusercontent.com/11679819/198813270-796967e9-617d-4808-9bc3-908a51752764.png)

maybe related to https://github.com/containerd/containerd/issues/3974#issuecomment-989510035 , https://github.com/goharbor/harbor/issues/17643 , https://github.com/goharbor/harbor/issues/16556

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository]([GitHub - goharbor/website: Source for the main Harbor website](https://github.com/goharbor/website)).