### PR TITLE
fix: add human friendly message when export cve job failure

### DIFF
--- a/src/controller/scandataexport/execution.go
+++ b/src/controller/scandataexport/execution.go
@@ -185,6 +185,11 @@ func (c *controller) convertToExportExecStatus(ctx context.Context, exec *task.E
 	if userName, ok := exec.ExtraAttrs[export.UserNameAttribute]; ok {
 		execStatus.UserName = userName.(string)
 	}
+	// Do not define the 'status_message' as const because this is not the final solution,
+	// should refactor this part.
+	if statusMessage, ok := exec.ExtraAttrs["status_message"]; ok {
+		execStatus.StatusMessage = statusMessage.(string)
+	}
 	artifactExists := c.isCsvArtifactPresent(ctx, exec.ID, execStatus.ExportDataDigest)
 	execStatus.FilePresent = artifactExists
 	return execStatus

--- a/src/controller/scandataexport/execution_test.go
+++ b/src/controller/scandataexport/execution_test.go
@@ -97,6 +97,7 @@ func (suite *ScanDataExportExecutionTestSuite) TestGetExecution() {
 	attrs := make(map[string]interface{})
 	attrs[export.JobNameAttribute] = "test-job"
 	attrs[export.UserNameAttribute] = "test-user"
+	attrs["status_message"] = "test-message"
 	{
 		exec := task.Execution{
 			ID:            100,
@@ -119,6 +120,7 @@ func (suite *ScanDataExportExecutionTestSuite) TestGetExecution() {
 		suite.Equal(exec.ID, exportExec.ID)
 		suite.Equal("test-user", exportExec.UserName)
 		suite.Equal("test-job", exportExec.JobName)
+		suite.Equal("test-message", exportExec.StatusMessage)
 		suite.Equal(true, exportExec.FilePresent)
 	}
 

--- a/src/server/v2.0/handler/scanexport.go
+++ b/src/server/v2.0/handler/scanexport.go
@@ -132,6 +132,10 @@ func (se *scanDataExportAPI) GetScanDataExportExecution(ctx context.Context, par
 		UserName:    execution.UserName,
 		FilePresent: execution.FilePresent,
 	}
+	// add human friendly message when status is error
+	if sdeExec.Status == job.ErrorStatus.String() && sdeExec.StatusText == "" {
+		sdeExec.StatusText = "Please contact the system administrator to check the logs of jobservice."
+	}
 
 	return operation.NewGetScanDataExportExecutionOK().WithPayload(&sdeExec)
 }
@@ -226,7 +230,7 @@ func (se *scanDataExportAPI) GetScanDataExportExecutionList(ctx context.Context,
 			FilePresent: execution.FilePresent,
 		}
 		// add human friendly message when status is error
-		if sdeExec.Status == job.ErrorStatus.String() {
+		if sdeExec.Status == job.ErrorStatus.String() && sdeExec.StatusText == "" {
 			sdeExec.StatusText = "Please contact the system administrator to check the logs of jobservice."
 		}
 		// store project ids


### PR DESCRIPTION
Add human friendly when export CVE in the condition of empty CSV file, because this file will be stored as system artifact and pushed to distribution, but it will leads to error when push empty blob to S3 storage driver.

Signed-off-by: chlins <chenyuzh@vmware.com>

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
