### PR TITLE
Add OIDC group filter

### DIFF
--- a/api/v2.0/swagger.yaml
+++ b/api/v2.0/swagger.yaml
@@ -8515,6 +8515,9 @@ definitions:
       oidc_admin_group:
         $ref: '#/definitions/StringConfigItem'
         description: The OIDC group which has the harbor admin privileges
+      oidc_group_filter:
+        $ref: '#/definitions/StringConfigItem'
+        description: The OIDC group filter which filters out the group doesn't match the regular expression   
       oidc_scope:
         $ref: '#/definitions/StringConfigItem'
         description: The scope of the OIDC provider
@@ -8792,6 +8795,11 @@ definitions:
         description: The OIDC group which has the harbor admin privileges
         x-omitempty: true
         x-isnullable: true
+      oidc_group_filter:
+        type: string
+        description: The OIDC group filter which filters out the group name doesn't match the regular expression
+        x-omitempty: true
+        x-isnullable: true        
       oidc_scope:
         type: string
         description: The scope of the OIDC provider

--- a/src/common/const.go
+++ b/src/common/const.go
@@ -111,6 +111,7 @@ const (
 	OIDCVerifyCert                   = "oidc_verify_cert"
 	OIDCAdminGroup                   = "oidc_admin_group"
 	OIDCGroupsClaim                  = "oidc_groups_claim"
+	OIDCGroupFilter                  = "oidc_group_filter"
 	OIDCAutoOnboard                  = "oidc_auto_onboard"
 	OIDCExtraRedirectParms           = "oidc_extra_redirect_parms"
 	OIDCScope                        = "oidc_scope"

--- a/src/lib/config/metadata/metadatalist.go
+++ b/src/lib/config/metadata/metadatalist.go
@@ -144,6 +144,7 @@ var (
 		{Name: common.OIDCClientSecret, Scope: UserScope, Group: OIDCGroup, ItemType: &PasswordType{}, Description: `The OIDC provider secret`},
 		{Name: common.OIDCGroupsClaim, Scope: UserScope, Group: OIDCGroup, ItemType: &StringType{}, Description: `The attribute claims the group name`},
 		{Name: common.OIDCAdminGroup, Scope: UserScope, Group: OIDCGroup, ItemType: &StringType{}, Description: `The OIDC group which has the harbor admin privileges`},
+		{Name: common.OIDCGroupFilter, Scope: UserScope, Group: OIDCGroup, ItemType: &StringType{}, Description: `The OIDC group filter to filter which groups could be onboarded to Harbor`},
 		{Name: common.OIDCScope, Scope: UserScope, Group: OIDCGroup, ItemType: &StringType{}, Description: `The scope of the OIDC provider`},
 		{Name: common.OIDCUserClaim, Scope: UserScope, Group: OIDCGroup, ItemType: &StringType{}, Description: `The attribute claims the username`},
 		{Name: common.OIDCVerifyCert, Scope: UserScope, Group: OIDCGroup, DefaultValue: "true", ItemType: &BoolType{}, Description: `Verify the OIDC provider's certificate'`},

--- a/src/lib/config/models/model.go
+++ b/src/lib/config/models/model.go
@@ -51,6 +51,7 @@ type OIDCSetting struct {
 	ClientSecret       string            `json:"client_secret"`
 	GroupsClaim        string            `json:"groups_claim"`
 	AdminGroup         string            `json:"admin_group"`
+	GroupFilter        string            `json:"group_filter"`
 	RedirectURL        string            `json:"redirect_url"`
 	Scope              []string          `json:"scope"`
 	UserClaim          string            `json:"user_claim"`

--- a/src/lib/config/userconfig.go
+++ b/src/lib/config/userconfig.go
@@ -184,6 +184,7 @@ func OIDCSetting(ctx context.Context) (*cfgModels.OIDCSetting, error) {
 		ClientID:           mgr.Get(ctx, common.OIDCCLientID).GetString(),
 		ClientSecret:       mgr.Get(ctx, common.OIDCClientSecret).GetString(),
 		GroupsClaim:        mgr.Get(ctx, common.OIDCGroupsClaim).GetString(),
+		GroupFilter:        mgr.Get(ctx, common.OIDCGroupFilter).GetString(),
 		AdminGroup:         mgr.Get(ctx, common.OIDCAdminGroup).GetString(),
 		RedirectURL:        extEndpoint + common.OIDCCallbackPath,
 		Scope:              scope,

--- a/src/pkg/oidc/helper_test.go
+++ b/src/pkg/oidc/helper_test.go
@@ -537,3 +537,25 @@ func TestInjectGroupsToUser(t *testing.T) {
 		assert.Equal(t, *c.new, *u)
 	}
 }
+
+func Test_filterGroup(t *testing.T) {
+	type args struct {
+		groupNames []string
+		filter     string
+	}
+	tests := []struct {
+		name string
+		args args
+		want []string
+	}{
+		{"normal", args{[]string{"admin_user"}, "^admin.*"}, []string{"admin_user"}},
+		{"multiple ", args{[]string{"admin_user", "harbor_admin"}, "^admin.*"}, []string{"admin_user"}},
+		{"no match", args{[]string{"harbor_admin", "harbor_user", "sample_admin", "myadmin"}, "^admin.*"}, []string{}},
+		{"empty filter", args{[]string{"harbor_admin", "harbor_user", "sample_admin", "myadmin"}, ""}, []string{"harbor_admin", "harbor_user", "sample_admin", "myadmin"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, filterGroup(tt.args.groupNames, tt.args.filter), "filterGroup(%v, %v)", tt.args.groupNames, tt.args.filter)
+		})
+	}
+}


### PR DESCRIPTION
  Filter out the OIDC group which doesn't match the regular expression when user login
  It doesn't filter the group when administrator adds the group manually in project member or user_group.
  Fixes #17130

Signed-off-by: stonezdj <stonezdj@gmail.com>

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
