### PR TITLE
add cli randomly for empty update

### DIFF
--- a/src/server/v2.0/handler/user_test.go
+++ b/src/server/v2.0/handler/user_test.go
@@ -90,6 +90,14 @@ func (uts *UserTestSuite) TestUpdateUserPassword() {
 	}
 }
 
+func (uts *UserTestSuite) TestGetRandomSecret() {
+	for i := 1; i < 5; i++ {
+		rSec, err := getRandomSecret()
+		uts.NoError(err)
+		uts.NoError(requireValidSecret(rSec))
+	}
+}
+
 func TestUserTestSuite(t *testing.T) {
 	suite.Run(t, &UserTestSuite{})
 }


### PR DESCRIPTION
give an random cli secret when client gives empty update.

Signed-off-by: Wang Yan <wangyan@vmware.com>

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
