### PR TITLE
feat: support customize session timeout

### DIFF
--- a/api/v2.0/swagger.yaml
+++ b/api/v2.0/swagger.yaml
@@ -8649,6 +8649,9 @@ definitions:
                 type: integer
                 description: 'The offset in seconds of UTC 0 o''clock, only valid when the policy type is "daily"'
             description: 'The parameters of the policy, the values are dependent on the type of the policy.'
+      session_timeout:
+        $ref: '#/definitions/IntegerConfigItem'
+        description: The session timeout in minutes
   Configurations:
     type: object
     properties:
@@ -8936,7 +8939,12 @@ definitions:
         type: boolean
         description: Skip audit log database
         x-omitempty: true
-        x-isnullable: true          
+        x-isnullable: true
+      session_timeout:
+        type: integer
+        description: The session timeout for harbor, in minutes.
+        x-omitempty: true
+        x-isnullable: true
   StringConfigItem:
     type: object
     properties:

--- a/src/common/const.go
+++ b/src/common/const.go
@@ -217,4 +217,7 @@ const (
 	SkipAuditLogDatabase = "skip_audit_log_database"
 	// MaxAuditRetentionHour allowed in audit log purge
 	MaxAuditRetentionHour = 240000
+
+	// SessionTimeout defines the web session timeout
+	SessionTimeout = "session_timeout"
 )

--- a/src/core/session/session_test.go
+++ b/src/core/session/session_test.go
@@ -19,6 +19,10 @@ import (
 
 	"github.com/beego/beego/session"
 	"github.com/stretchr/testify/suite"
+
+	"github.com/goharbor/harbor/src/lib/config"
+	_ "github.com/goharbor/harbor/src/pkg/config/db"
+	_ "github.com/goharbor/harbor/src/pkg/config/inmemory"
 )
 
 type sessionTestSuite struct {
@@ -27,7 +31,9 @@ type sessionTestSuite struct {
 	provider session.Provider
 }
 
-func (s *sessionTestSuite) SetupTest() {
+func (s *sessionTestSuite) SetupSuite() {
+	config.Init()
+
 	var err error
 	s.provider, err = session.GetProvider("harbor")
 	s.NoError(err, "should get harbor provider")

--- a/src/lib/config/metadata/metadatalist.go
+++ b/src/lib/config/metadata/metadatalist.go
@@ -192,5 +192,7 @@ var (
 
 		{Name: common.AuditLogForwardEndpoint, Scope: UserScope, Group: BasicGroup, EnvKey: "AUDIT_LOG_FORWARD_ENDPOINT", DefaultValue: "", ItemType: &StringType{}, Editable: false, Description: `The endpoint to forward the audit log.`},
 		{Name: common.SkipAuditLogDatabase, Scope: UserScope, Group: BasicGroup, EnvKey: "SKIP_LOG_AUDIT_DATABASE", DefaultValue: "false", ItemType: &BoolType{}, Editable: false, Description: `The option to skip audit log in database`},
+
+		{Name: common.SessionTimeout, Scope: UserScope, Group: BasicGroup, EnvKey: "SESSION_TIMEOUT", DefaultValue: "60", ItemType: &Int64Type{}, Editable: true, Description: `The session timeout in minutes`},
 	}
 )

--- a/src/lib/config/userconfig.go
+++ b/src/lib/config/userconfig.go
@@ -84,6 +84,11 @@ func LDAPGroupConf(ctx context.Context) (*cfgModels.GroupConf, error) {
 	}, nil
 }
 
+// SessionTimeout returns the session timeout for web (in minute).
+func SessionTimeout(ctx context.Context) int64 {
+	return DefaultMgr().Get(ctx, common.SessionTimeout).GetInt64()
+}
+
 // TokenExpiration returns the token expiration time (in minute)
 func TokenExpiration(ctx context.Context) (int, error) {
 	return DefaultMgr().Get(ctx, common.TokenExpiration).GetInt(), nil


### PR DESCRIPTION
Add configuration session_timeout for API, then user can customize the timeout from system config page or API. The timeout is 60 minutes by default.

Signed-off-by: chlins <chenyuzh@vmware.com>

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes https://github.com/goharbor/harbor/issues/17474

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
