### PR TITLE
Fix permission issue for edit button of repo info

### DIFF
--- a/src/portal/src/app/base/project/repository/artifact/artifact-list-page/artifact-list/artifact-info/artifact-info.component.html
+++ b/src/portal/src/app/base/project/repository/artifact/artifact-list-page/artifact-list/artifact-info/artifact-info.component.html
@@ -3,7 +3,7 @@
         <div id="info-edit-button">
             <button
                 class="btn"
-                [disabled]="editing || !hasProjectAdminRole || onSaving"
+                [disabled]="editing || !hasEditPermission || onSaving"
                 (click)="editInfo()">
                 <clr-icon shape="pencil" size="16"></clr-icon>&nbsp;{{
                     'BUTTON.EDIT' | translate

--- a/src/portal/src/app/base/project/repository/artifact/artifact-list-page/artifact-list/artifact-info/artifact-info.component.spec.ts
+++ b/src/portal/src/app/base/project/repository/artifact/artifact-list-page/artifact-list/artifact-info/artifact-info.component.spec.ts
@@ -3,6 +3,7 @@ import { of } from 'rxjs';
 import { ArtifactInfoComponent } from './artifact-info.component';
 import { SharedTestingModule } from 'src/app/shared/shared.module';
 import { RepositoryService } from 'ng-swagger-gen/services/repository.service';
+import { UserPermissionService } from '../../../../../../../shared/services';
 
 describe('ArtifactInfoComponent', () => {
     let compRepo: ArtifactInfoComponent;
@@ -10,6 +11,11 @@ describe('ArtifactInfoComponent', () => {
     let FakedRepositoryService = {
         updateRepository: () => of(null),
         getRepository: () => of({ description: '' }),
+    };
+    const fakedUserPermissionService = {
+        getPermission() {
+            return of(true);
+        },
     };
     beforeEach(async () => {
         await TestBed.configureTestingModule({
@@ -19,6 +25,10 @@ describe('ArtifactInfoComponent', () => {
                 {
                     provide: RepositoryService,
                     useValue: FakedRepositoryService,
+                },
+                {
+                    provide: UserPermissionService,
+                    useValue: fakedUserPermissionService,
                 },
             ],
         }).compileComponents();
@@ -31,5 +41,10 @@ describe('ArtifactInfoComponent', () => {
     });
     it('should create', () => {
         expect(compRepo).toBeTruthy();
+    });
+
+    it('should check permission', async () => {
+        await fixture.whenStable();
+        expect(compRepo.hasEditPermission).toBeTruthy();
     });
 });


### PR DESCRIPTION
Fixes #14138
1. Fix the permission issue for the edit button of repo info to make it consistent with the doc


Signed-off-by: AllForNothing <sshijun@vmware.com>

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
