### PR TITLE
Replaced io/ioutil with "os / io" package.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,14 +20,7 @@ updates:
       - "OrlinVasilev"
 
   - package-ecosystem: "gomod"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    labels:
-      - "release-note/update"
-
-  - package-ecosystem: "gomod"
-    directory: "tests/"
+    directory: "/src"
     schedule:
       interval: "weekly"
     labels:

--- a/src/chartserver/client.go
+++ b/src/chartserver/client.go
@@ -3,7 +3,6 @@ package chartserver
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
@@ -69,7 +68,7 @@ func (cc *ChartClient) GetContent(addr string) ([]byte, error) {
 		return nil, err
 	}
 
-	content, err := ioutil.ReadAll(response.Body)
+	content, err := io.ReadAll(response.Body)
 	if err != nil {
 		err = errors.Wrap(err, "Read response body error")
 		return nil, err
@@ -97,7 +96,7 @@ func (cc *ChartClient) DeleteContent(addr string) error {
 		return err
 	}
 
-	content, err := ioutil.ReadAll(response.Body)
+	content, err := io.ReadAll(response.Body)
 	if err != nil {
 		return err
 	}

--- a/src/chartserver/handler_proxy_traffic_test.go
+++ b/src/chartserver/handler_proxy_traffic_test.go
@@ -3,7 +3,7 @@ package chartserver
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -92,7 +92,7 @@ func TestResponseRewrite(t *testing.T) {
 		t.Fatalf("Expect status code 500 but got %d", response.StatusCode)
 	}
 
-	bytes, err := ioutil.ReadAll(response.Body)
+	bytes, err := io.ReadAll(response.Body)
 	if err != nil {
 		t.Fatalf("Read bytes from http response failed with error: %s", err)
 	}

--- a/src/chartserver/reverse_proxy.go
+++ b/src/chartserver/reverse_proxy.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"net/http/httputil"
@@ -171,7 +171,7 @@ func modifyResponse(res *http.Response) error {
 		res.StatusCode = http.StatusInternalServerError
 	} else {
 		// Extract the error and wrap it into the error object
-		data, err := ioutil.ReadAll(res.Body)
+		data, err := io.ReadAll(res.Body)
 		if err != nil {
 			errorObj["error"] = fmt.Sprintf("%s: %s", res.Status, err.Error())
 		} else {
@@ -187,7 +187,7 @@ func modifyResponse(res *http.Response) error {
 	}
 
 	size := len(content)
-	body := ioutil.NopCloser(bytes.NewReader(content))
+	body := io.NopCloser(bytes.NewReader(content))
 	res.Body = body
 	res.ContentLength = int64(size)
 	res.Header.Set(contentLengthHeader, strconv.Itoa(size))

--- a/src/common/http/client.go
+++ b/src/common/http/client.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -160,7 +159,7 @@ func (c *Client) do(req *http.Request) ([]byte, error) {
 	}
 	defer resp.Body.Close()
 
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -202,7 +201,7 @@ func (c *Client) GetAndIteratePagination(endpoint string, v interface{}) error {
 		if err != nil {
 			return err
 		}
-		data, err := ioutil.ReadAll(resp.Body)
+		data, err := io.ReadAll(resp.Body)
 		resp.Body.Close()
 		if err != nil {
 			return err

--- a/src/common/job/client.go
+++ b/src/common/job/client.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -119,7 +119,7 @@ func (d *DefaultClient) SubmitJob(jd *models.JobData) (string, error) {
 		return "", err
 	}
 	defer resp.Body.Close()
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", err
 	}
@@ -148,7 +148,7 @@ func (d *DefaultClient) GetJobLog(uuid string) ([]byte, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -173,7 +173,7 @@ func (d *DefaultClient) GetExecutions(periodicJobID string) ([]job.Stats, error)
 		return nil, err
 	}
 	defer resp.Body.Close()
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -226,7 +226,7 @@ func (d *DefaultClient) GetJobServiceConfig() (*job.Config, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/src/common/job/test/server.go
+++ b/src/common/job/test/server.go
@@ -3,9 +3,10 @@ package test
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path"
 	"runtime"
 	"strings"
@@ -41,7 +42,7 @@ func NewJobServiceServer() *httptest.Server {
 			rw.Header().Add("Content-Type", "text/plain")
 			rw.WriteHeader(http.StatusOK)
 			f := path.Join(currPath(), "test.log")
-			b, _ := ioutil.ReadFile(f)
+			b, _ := os.ReadFile(f)
 			_, err := rw.Write(b)
 			if err != nil {
 				panic(err)
@@ -75,7 +76,7 @@ func NewJobServiceServer() *httptest.Server {
 				rw.WriteHeader(http.StatusMethodNotAllowed)
 				return
 			}
-			data, err := ioutil.ReadAll(req.Body)
+			data, err := io.ReadAll(req.Body)
 			if err != nil {
 				panic(err)
 			}
@@ -92,7 +93,7 @@ func NewJobServiceServer() *httptest.Server {
 	mux.HandleFunc(jobsPrefix,
 		func(rw http.ResponseWriter, req *http.Request) {
 			if req.Method == http.MethodPost {
-				data, err := ioutil.ReadAll(req.Body)
+				data, err := io.ReadAll(req.Body)
 				if err != nil {
 					panic(err)
 				}

--- a/src/common/utils/test/key.go
+++ b/src/common/utils/test/key.go
@@ -18,7 +18,7 @@ import (
 	"crypto/aes"
 	"crypto/rand"
 	"fmt"
-	"io/ioutil"
+	"os"
 )
 
 // GenerateKey generates aes key
@@ -32,7 +32,7 @@ func GenerateKey(path string) (string, error) {
 		return "", fmt.Errorf("the length of random bytes %d != %d", n, aes.BlockSize)
 	}
 
-	if err = ioutil.WriteFile(path, data, 0777); err != nil {
+	if err = os.WriteFile(path, data, 0777); err != nil {
 		return "", fmt.Errorf("failed write secret key to file %s: %v", path, err)
 	}
 

--- a/src/common/utils/uaa/client.go
+++ b/src/common/utils/uaa/client.go
@@ -20,7 +20,7 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"strings"
@@ -124,7 +124,7 @@ func (dc *defaultClient) GetUserInfo(token string) (*UserInfo, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -155,7 +155,7 @@ func (dc *defaultClient) SearchUser(username string) ([]*SearchUserEntry, error)
 	if err != nil {
 		return nil, err
 	}
-	bytes, err := ioutil.ReadAll(resp.Body)
+	bytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -186,7 +186,7 @@ func (dc *defaultClient) UpdateConfig(cfg *ClientConfig) error {
 	}
 	if !cfg.SkipTLSVerify && len(cfg.CARootPath) > 0 {
 		if _, err := os.Stat(cfg.CARootPath); !os.IsNotExist(err) {
-			content, err := ioutil.ReadFile(cfg.CARootPath)
+			content, err := os.ReadFile(cfg.CARootPath)
 			if err != nil {
 				return err
 			}

--- a/src/common/utils/uaa/client_test.go
+++ b/src/common/utils/uaa/client_test.go
@@ -2,7 +2,6 @@ package uaa
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http/httptest"
 	"os"
 	"path"
@@ -55,7 +54,7 @@ func TestUserInfo(t *testing.T) {
 	assert := assert.New(t)
 	client, err := NewDefaultClient(getCfg())
 	assert.Nil(err)
-	token, err := ioutil.ReadFile(path.Join(currPath(), "test", "./good-access-token.txt"))
+	token, err := os.ReadFile(path.Join(currPath(), "test", "./good-access-token.txt"))
 	if err != nil {
 		panic(err)
 	}

--- a/src/common/utils/uaa/test/server.go
+++ b/src/common/utils/uaa/test/server.go
@@ -17,9 +17,9 @@ package test
 import (
 	"fmt"
 	"html"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path"
 	"runtime"
 	"strings"
@@ -76,7 +76,7 @@ func serveToken(rw http.ResponseWriter) {
 }
 
 func serveJSONFile(rw http.ResponseWriter, filename string) {
-	data, err := ioutil.ReadFile(path.Join(currPath(), filename))
+	data, err := os.ReadFile(path.Join(currPath(), filename))
 	if err != nil {
 		panic(err)
 	}
@@ -143,7 +143,7 @@ func NewMockServer(cfg *MockServerConfig) *httptest.Server {
 		cfg.Username,
 		cfg.Password,
 	})
-	token, err := ioutil.ReadFile(path.Join(currPath(), "./good-access-token.txt"))
+	token, err := os.ReadFile(path.Join(currPath(), "./good-access-token.txt"))
 	if err != nil {
 		panic(err)
 	}

--- a/src/controller/artifact/annotation/v1alpha1.go
+++ b/src/controller/artifact/annotation/v1alpha1.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 
@@ -80,7 +79,7 @@ func parseV1alpha1Icon(artifact *artifact.Artifact, manifest *v1.Manifest, reg r
 		return err
 	}
 	// check the size of the size <= 1MB
-	data, err := ioutil.ReadAll(io.LimitReader(icon, 1<<20))
+	data, err := io.ReadAll(io.LimitReader(icon, 1<<20))
 	if err != nil {
 		if err == io.EOF {
 			return errors.New(nil).WithCode(errors.BadRequestCode).WithMessage("the maximum size of the icon is 1MB")

--- a/src/controller/artifact/annotation/v1alpha1_test.go
+++ b/src/controller/artifact/annotation/v1alpha1_test.go
@@ -17,7 +17,7 @@ package annotation
 import (
 	"encoding/base64"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"strings"
 	"testing"
 
@@ -191,12 +191,12 @@ func (p *v1alpha1TestSuite) TestParse() {
 	p.Require().Nil(err)
 
 	metadata := map[string]interface{}{}
-	configBlob := ioutil.NopCloser(strings.NewReader(ormbConfig))
+	configBlob := io.NopCloser(strings.NewReader(ormbConfig))
 	err = json.NewDecoder(configBlob).Decode(&metadata)
 	p.Require().Nil(err)
 	art := &artifact.Artifact{ManifestMediaType: manifestMediaType, ExtraAttrs: metadata}
 
-	blob := ioutil.NopCloser(base64.NewDecoder(base64.StdEncoding, strings.NewReader(ormbIcon)))
+	blob := io.NopCloser(base64.NewDecoder(base64.StdEncoding, strings.NewReader(ormbIcon)))
 	p.regCli.On("PullBlob", mock.Anything, mock.Anything).Return(int64(0), blob, nil)
 	err = p.v1alpha1Parser.Parse(nil, art, content)
 	p.Require().Nil(err)
@@ -214,12 +214,12 @@ func (p *v1alpha1TestSuite) TestParse() {
 	p.Require().Nil(err)
 
 	metadata = map[string]interface{}{}
-	configBlob = ioutil.NopCloser(strings.NewReader(ormbConfig))
+	configBlob = io.NopCloser(strings.NewReader(ormbConfig))
 	err = json.NewDecoder(configBlob).Decode(&metadata)
 	p.Require().Nil(err)
 	art = &artifact.Artifact{ManifestMediaType: manifestMediaType, ExtraAttrs: metadata}
 
-	blob = ioutil.NopCloser(base64.NewDecoder(base64.StdEncoding, strings.NewReader(ormbIcon)))
+	blob = io.NopCloser(base64.NewDecoder(base64.StdEncoding, strings.NewReader(ormbIcon)))
 	p.regCli.On("PullBlob", mock.Anything, mock.Anything).Return(int64(0), blob, nil)
 	err = p.v1alpha1Parser.Parse(nil, art, content)
 	p.Require().Nil(err)
@@ -237,7 +237,7 @@ func (p *v1alpha1TestSuite) TestParse() {
 	p.Require().Nil(err)
 
 	metadata = map[string]interface{}{}
-	configBlob = ioutil.NopCloser(strings.NewReader(ormbConfig))
+	configBlob = io.NopCloser(strings.NewReader(ormbConfig))
 	err = json.NewDecoder(configBlob).Decode(&metadata)
 	p.Require().Nil(err)
 	art = &artifact.Artifact{ManifestMediaType: manifestMediaType, ExtraAttrs: metadata}

--- a/src/controller/artifact/processor/base/manifest_test.go
+++ b/src/controller/artifact/processor/base/manifest_test.go
@@ -15,7 +15,7 @@
 package base
 
 import (
-	"io/ioutil"
+	"io"
 	"strings"
 	"testing"
 
@@ -140,7 +140,7 @@ func (m *manifestTestSuite) TestAbstractMetadata() {
 	// abstract all properties
 	art := &artifact.Artifact{}
 
-	m.regCli.On("PullBlob", mock.Anything, mock.Anything).Return(int64(0), ioutil.NopCloser(strings.NewReader(config)), nil)
+	m.regCli.On("PullBlob", mock.Anything, mock.Anything).Return(int64(0), io.NopCloser(strings.NewReader(config)), nil)
 	m.processor.AbstractMetadata(nil, art, []byte(manifest))
 	m.Len(art.ExtraAttrs, 9)
 
@@ -150,14 +150,14 @@ func (m *manifestTestSuite) TestAbstractMetadata() {
 	// abstract the specified properties
 	m.processor.properties = []string{"os"}
 	art = &artifact.Artifact{}
-	m.regCli.On("PullBlob", mock.Anything, mock.Anything).Return(int64(0), ioutil.NopCloser(strings.NewReader(config)), nil)
+	m.regCli.On("PullBlob", mock.Anything, mock.Anything).Return(int64(0), io.NopCloser(strings.NewReader(config)), nil)
 	m.processor.AbstractMetadata(nil, art, []byte(manifest))
 	m.Require().Len(art.ExtraAttrs, 1)
 	m.Equal("linux", art.ExtraAttrs["os"])
 }
 
 func (m *manifestTestSuite) TestUnmarshalConfig() {
-	m.regCli.On("PullBlob", mock.Anything, mock.Anything).Return(int64(0), ioutil.NopCloser(strings.NewReader(config)), nil)
+	m.regCli.On("PullBlob", mock.Anything, mock.Anything).Return(int64(0), io.NopCloser(strings.NewReader(config)), nil)
 	config := &v1.Image{}
 	err := m.processor.UnmarshalConfig(nil, "library/hello-world", []byte(manifest), config)
 	m.Require().Nil(err)

--- a/src/controller/artifact/processor/chart/chart.go
+++ b/src/controller/artifact/processor/chart/chart.go
@@ -17,7 +17,7 @@ package chart
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 
@@ -85,7 +85,7 @@ func (p *processor) AbstractAddition(ctx context.Context, artifact *artifact.Art
 			if err != nil {
 				return nil, err
 			}
-			content, err := ioutil.ReadAll(blob)
+			content, err := io.ReadAll(blob)
 			if err != nil {
 				return nil, err
 			}

--- a/src/controller/artifact/processor/chart/chart_test.go
+++ b/src/controller/artifact/processor/chart/chart_test.go
@@ -15,7 +15,7 @@
 package chart
 
 import (
-	"io/ioutil"
+	"io"
 	"strings"
 	"testing"
 
@@ -105,7 +105,7 @@ func (p *processorTestSuite) TestAbstractAddition() {
 	manifest, _, err := distribution.UnmarshalManifest(v1.MediaTypeImageManifest, []byte(chartManifest))
 	p.Require().Nil(err)
 	p.regCli.On("PullManifest", mock.Anything, mock.Anything).Return(manifest, "", nil)
-	p.regCli.On("PullBlob", mock.Anything, mock.Anything).Return(int64(0), ioutil.NopCloser(strings.NewReader(chartYaml)), nil)
+	p.regCli.On("PullBlob", mock.Anything, mock.Anything).Return(int64(0), io.NopCloser(strings.NewReader(chartYaml)), nil)
 	p.chartOptr.On("GetDetails").Return(chartDetails, nil)
 
 	// values.yaml

--- a/src/controller/artifact/processor/cnab/cnab_test.go
+++ b/src/controller/artifact/processor/cnab/cnab_test.go
@@ -15,7 +15,7 @@
 package cnab
 
 import (
-	"io/ioutil"
+	"io"
 	"strings"
 	"testing"
 
@@ -95,7 +95,7 @@ func (p *processorTestSuite) TestAbstractMetadata() {
 	mani, _, err := distribution.UnmarshalManifest(v1.MediaTypeImageManifest, []byte(manifest))
 	p.Require().Nil(err)
 	p.regCli.On("PullManifest", mock.Anything, mock.Anything).Return(mani, "", nil)
-	p.regCli.On("PullBlob", mock.Anything, mock.Anything).Return(int64(0), ioutil.NopCloser(strings.NewReader(config)), nil)
+	p.regCli.On("PullBlob", mock.Anything, mock.Anything).Return(int64(0), io.NopCloser(strings.NewReader(config)), nil)
 	err = p.processor.AbstractMetadata(nil, art, nil)
 	p.Require().Nil(err)
 	p.Len(art.ExtraAttrs, 7)

--- a/src/controller/artifact/processor/default_test.go
+++ b/src/controller/artifact/processor/default_test.go
@@ -16,7 +16,7 @@ package processor
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"strings"
 	"testing"
 
@@ -177,7 +177,7 @@ func (d *defaultProcessorTestSuite) TestAbstractMetadata() {
 	manifestMediaType, content, err := manifest.Payload()
 	d.Require().Nil(err)
 
-	configBlob := ioutil.NopCloser(strings.NewReader(ormbConfig))
+	configBlob := io.NopCloser(strings.NewReader(ormbConfig))
 	art := &artifact.Artifact{ManifestMediaType: manifestMediaType}
 	d.regCli.On("PullBlob", mock.Anything, mock.Anything).Return(int64(0), configBlob, nil)
 	d.parser.On("Parse", context.TODO(), mock.AnythingOfType("*artifact.Artifact"), mock.AnythingOfType("[]byte")).Return(nil)

--- a/src/controller/artifact/processor/image/manifest_v2_test.go
+++ b/src/controller/artifact/processor/image/manifest_v2_test.go
@@ -16,7 +16,7 @@ package image
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"strings"
 	"testing"
 
@@ -142,7 +142,7 @@ func (m *manifestV2ProcessorTestSuite) SetupTest() {
 
 func (m *manifestV2ProcessorTestSuite) TestAbstractMetadata() {
 	artifact := &artifact.Artifact{}
-	m.regCli.On("PullBlob", mock.Anything, mock.Anything).Return(int64(0), ioutil.NopCloser(bytes.NewReader([]byte(config))), nil)
+	m.regCli.On("PullBlob", mock.Anything, mock.Anything).Return(int64(0), io.NopCloser(bytes.NewReader([]byte(config))), nil)
 	err := m.processor.AbstractMetadata(nil, artifact, []byte(manifest))
 	m.Require().Nil(err)
 	m.NotNil(artifact.ExtraAttrs["created"])
@@ -163,7 +163,7 @@ func (m *manifestV2ProcessorTestSuite) TestAbstractAddition() {
 	manifest, _, err := distribution.UnmarshalManifest(schema2.MediaTypeManifest, []byte(manifest))
 	m.Require().Nil(err)
 	m.regCli.On("PullManifest", mock.Anything, mock.Anything).Return(manifest, "", nil)
-	m.regCli.On("PullBlob", mock.Anything, mock.Anything).Return(int64(0), ioutil.NopCloser(strings.NewReader(config)), nil)
+	m.regCli.On("PullBlob", mock.Anything, mock.Anything).Return(int64(0), io.NopCloser(strings.NewReader(config)), nil)
 	addition, err := m.processor.AbstractAddition(nil, artifact, AdditionTypeBuildHistory)
 	m.Require().Nil(err)
 	m.Equal("application/json; charset=utf-8", addition.ContentType)

--- a/src/controller/artifact/processor/wasm/wasm_test.go
+++ b/src/controller/artifact/processor/wasm/wasm_test.go
@@ -17,7 +17,7 @@ package wasm
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"strings"
 	"testing"
 
@@ -124,7 +124,7 @@ func (m *WASMProcessorTestSuite) SetupTest() {
 
 func (m *WASMProcessorTestSuite) TestAbstractMetadataForAnnotationFashion() {
 	artifact := &artifact.Artifact{}
-	m.regCli.On("PullBlob", mock.Anything, mock.Anything).Return(int64(0), ioutil.NopCloser(bytes.NewReader([]byte(annnotated_config))), nil)
+	m.regCli.On("PullBlob", mock.Anything, mock.Anything).Return(int64(0), io.NopCloser(bytes.NewReader([]byte(annnotated_config))), nil)
 	err := m.processor.AbstractMetadata(nil, artifact, []byte(annnotated_manifest))
 	m.Require().Nil(err)
 	m.NotNil(artifact.ExtraAttrs["created"])
@@ -158,7 +158,7 @@ func (m *WASMProcessorTestSuite) TestAbstractAdditionForAnnotationFashion() {
 	deserializedManifest, err := schema2.FromStruct(manifest)
 	m.Require().Nil(err)
 	m.regCli.On("PullManifest", mock.Anything, mock.Anything).Return(deserializedManifest, "", nil)
-	m.regCli.On("PullBlob", mock.Anything, mock.Anything).Return(int64(0), ioutil.NopCloser(strings.NewReader(annnotated_config)), nil)
+	m.regCli.On("PullBlob", mock.Anything, mock.Anything).Return(int64(0), io.NopCloser(strings.NewReader(annnotated_config)), nil)
 	addition, err := m.processor.AbstractAddition(nil, artifact, AdditionTypeBuildHistory)
 	m.Require().Nil(err)
 	m.Equal("application/json; charset=utf-8", addition.ContentType)

--- a/src/controller/health/checker.go
+++ b/src/controller/health/checker.go
@@ -17,7 +17,7 @@ package health
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"sync"
@@ -59,7 +59,7 @@ func HTTPStatusCodeHealthChecker(method string, url string, header http.Header,
 		}
 		defer resp.Body.Close()
 		if resp.StatusCode != statusCode {
-			data, err := ioutil.ReadAll(resp.Body)
+			data, err := io.ReadAll(resp.Body)
 			if err != nil {
 				log.Debugf("failed to read response body: %v", err)
 			}

--- a/src/controller/icon/controller_test.go
+++ b/src/controller/icon/controller_test.go
@@ -16,7 +16,7 @@ package icon
 
 import (
 	"encoding/base64"
-	"io/ioutil"
+	"io"
 	"strings"
 	"testing"
 
@@ -67,7 +67,7 @@ func (c *controllerTestSuite) TestGet() {
 			RepositoryName: "library/hello-world",
 		},
 	}, nil)
-	blob := ioutil.NopCloser(base64.NewDecoder(base64.StdEncoding, strings.NewReader(iconStr)))
+	blob := io.NopCloser(base64.NewDecoder(base64.StdEncoding, strings.NewReader(iconStr)))
 	c.regCli.On("PullBlob", mock.Anything, mock.Anything).Return(int64(0), blob, nil)
 	icon, err := c.controller.Get(nil, "sha256:364feec11702f7ee079ba81da723438373afb0921f3646e9e5015406ee150986")
 	c.Require().Nil(err)

--- a/src/controller/replication/transfer/chart/transfer_test.go
+++ b/src/controller/replication/transfer/chart/transfer_test.go
@@ -17,7 +17,6 @@ package chart
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -47,7 +46,7 @@ func (f *fakeRegistry) ChartExist(name, version string) (bool, error) {
 	return true, nil
 }
 func (f *fakeRegistry) DownloadChart(name, version, contentURL string) (io.ReadCloser, error) {
-	r := ioutil.NopCloser(bytes.NewReader([]byte{'a'}))
+	r := io.NopCloser(bytes.NewReader([]byte{'a'}))
 	return r, nil
 }
 func (f *fakeRegistry) UploadChart(name, version string, chart io.Reader) error {

--- a/src/controller/replication/transfer/image/transfer_test.go
+++ b/src/controller/replication/transfer/image/transfer_test.go
@@ -17,7 +17,6 @@ package image
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"testing"
 
 	"github.com/docker/distribution"
@@ -88,11 +87,11 @@ func (f *fakeRegistry) BlobExist(repository, digest string) (bool, error) {
 	return false, nil
 }
 func (f *fakeRegistry) PullBlob(repository, digest string) (size int64, blob io.ReadCloser, err error) {
-	r := ioutil.NopCloser(bytes.NewReader([]byte{'a'}))
+	r := io.NopCloser(bytes.NewReader([]byte{'a'}))
 	return 1, r, nil
 }
 func (f *fakeRegistry) PullBlobChunk(repository, digest string, blobSize, start, end int64) (size int64, blob io.ReadCloser, err error) {
-	r := ioutil.NopCloser(bytes.NewReader([]byte{'a'}))
+	r := io.NopCloser(bytes.NewReader([]byte{'a'}))
 	return 1, r, nil
 }
 func (f *fakeRegistry) PushBlob(repository, digest string, size int64, blob io.Reader) error {

--- a/src/core/api/api_test.go
+++ b/src/core/api/api_test.go
@@ -16,7 +16,7 @@ package api
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -147,7 +147,7 @@ func handleAndParse(r *testingRequest, v interface{}) error {
 		return err
 	}
 
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}

--- a/src/core/api/chart_repository.go
+++ b/src/core/api/chart_repository.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"mime/multipart"
 	"net/http"
 	"net/url"
@@ -587,7 +586,7 @@ func (cra *ChartRepositoryAPI) rewriteFileContent(files []formFile, request *htt
 
 	request.Header.Set(headerContentType, w.FormDataContentType())
 	request.ContentLength = -1
-	request.Body = ioutil.NopCloser(&body)
+	request.Body = io.NopCloser(&body)
 
 	return nil
 }

--- a/src/core/api/harborapi_test.go
+++ b/src/core/api/harborapi_test.go
@@ -16,7 +16,7 @@
 package api
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -135,7 +135,7 @@ func request0(_sling *sling.Sling, acceptHeader string, authInfo ...usrInfo) (in
 	w := httptest.NewRecorder()
 	handler.ServeHTTP(w, req)
 
-	body, err := ioutil.ReadAll(w.Body)
+	body, err := io.ReadAll(w.Body)
 	return w.Code, w.Header(), body, err
 }
 

--- a/src/core/auth/authproxy/auth.go
+++ b/src/core/auth/authproxy/auth.go
@@ -21,7 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"sync"
@@ -83,7 +83,7 @@ func (a *Auth) Authenticate(ctx context.Context, m models.AuthModel) (*models.Us
 	if err != nil {
 		return nil, err
 	}
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		log.Warningf("Failed to read response body, error: %v", err)
 		return nil, auth.ErrAuth{}
@@ -103,7 +103,7 @@ func (a *Auth) Authenticate(ctx context.Context, m models.AuthModel) (*models.Us
 	} else if resp.StatusCode == http.StatusUnauthorized {
 		return nil, auth.NewErrAuth(string(data))
 	} else {
-		data, err := ioutil.ReadAll(resp.Body)
+		data, err := io.ReadAll(resp.Body)
 		if err != nil {
 			log.Warningf("Failed to read response body, error: %v", err)
 		}

--- a/src/core/auth/authproxy/test/server.go
+++ b/src/core/auth/authproxy/test/server.go
@@ -18,7 +18,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"html"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -75,7 +75,7 @@ func (rth *reviewTokenHandler) ServeHTTP(rw http.ResponseWriter, req *http.Reque
 	if req.Method != http.MethodPost {
 		http.Error(rw, "", http.StatusMethodNotAllowed)
 	}
-	bodyBytes, err := ioutil.ReadAll(req.Body)
+	bodyBytes, err := io.ReadAll(req.Body)
 	if err != nil {
 		http.Error(rw, html.EscapeString(fmt.Sprintf("failed to read request body, error: %v", err)), http.StatusBadRequest)
 	}

--- a/src/core/service/token/token_test.go
+++ b/src/core/service/token/token_test.go
@@ -19,7 +19,6 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path"
@@ -110,7 +109,7 @@ func getKeyAndCertPath() (string, string) {
 }
 
 func getPublicKey(crtPath string) (*rsa.PublicKey, error) {
-	crt, err := ioutil.ReadFile(crtPath)
+	crt, err := os.ReadFile(crtPath)
 	if err != nil {
 		return nil, err
 	}

--- a/src/core/utils/response_handlers.go
+++ b/src/core/utils/response_handlers.go
@@ -17,7 +17,6 @@ package utils
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 
 	"github.com/goharbor/harbor/src/common/api"
@@ -38,7 +37,7 @@ type StatusRespHandler struct {
 func (s StatusRespHandler) Handle(resp *http.Response) error {
 	defer resp.Body.Close()
 	if resp.StatusCode != s.status {
-		b, err := ioutil.ReadAll(resp.Body)
+		b, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return err
 		}
@@ -73,7 +72,7 @@ func (h JobLogRespHandler) Handle(resp *http.Response) error {
 		return nil
 	}
 
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		log.Errorf("failed to read response body: %v", err)
 		return err

--- a/src/jobservice/api/handler.go
+++ b/src/jobservice/api/handler.go
@@ -17,7 +17,7 @@ package api
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"strconv"
@@ -81,7 +81,7 @@ func NewDefaultHandler(ctl core.Interface) *DefaultHandler {
 
 // HandleLaunchJobReq is implementation of method defined in interface 'Handler'
 func (dh *DefaultHandler) HandleLaunchJobReq(w http.ResponseWriter, req *http.Request) {
-	data, err := ioutil.ReadAll(req.Body)
+	data, err := io.ReadAll(req.Body)
 	if err != nil {
 		dh.handleError(w, req, http.StatusInternalServerError, errs.ReadRequestBodyError(err))
 		return
@@ -143,7 +143,7 @@ func (dh *DefaultHandler) HandleJobActionReq(w http.ResponseWriter, req *http.Re
 	vars := mux.Vars(req)
 	jobID := vars["job_id"]
 
-	data, err := ioutil.ReadAll(req.Body)
+	data, err := io.ReadAll(req.Body)
 	if err != nil {
 		dh.handleError(w, req, http.StatusInternalServerError, errs.ReadRequestBodyError(err))
 		return

--- a/src/jobservice/api/handler_test.go
+++ b/src/jobservice/api/handler_test.go
@@ -18,7 +18,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math/rand"
 	"net/http"
 	"os"
@@ -344,7 +344,7 @@ func (suite *APIHandlerTestSuite) postReq(url string, data []byte) ([]byte, int)
 		_ = res.Body.Close()
 	}()
 	if res.ContentLength > 0 {
-		resData, err = ioutil.ReadAll(res.Body)
+		resData, err = io.ReadAll(res.Body)
 		if err != nil {
 			return nil, 0
 		}
@@ -371,7 +371,7 @@ func (suite *APIHandlerTestSuite) getReq(url string) ([]byte, int) {
 		_ = res.Body.Close()
 	}()
 
-	data, err := ioutil.ReadAll(res.Body)
+	data, err := io.ReadAll(res.Body)
 	if err != nil {
 		return nil, 0
 	}

--- a/src/jobservice/config/config.go
+++ b/src/jobservice/config/config.go
@@ -18,8 +18,8 @@ package config
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
 
@@ -142,7 +142,7 @@ type LoggerConfig struct {
 func (c *Configuration) Load(yamlFilePath string, detectEnv bool) error {
 	if !utils.IsEmptyStr(yamlFilePath) {
 		// Try to load from file first
-		data, err := ioutil.ReadFile(yamlFilePath)
+		data, err := os.ReadFile(yamlFilePath)
 		if err != nil {
 			return err
 		}

--- a/src/jobservice/hook/hook_client.go
+++ b/src/jobservice/hook/hook_client.go
@@ -19,7 +19,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"strings"
@@ -111,7 +111,7 @@ func (bc *basicClient) SendEvent(evt *Event) error {
 	if res.StatusCode != http.StatusOK {
 		if res.ContentLength > 0 {
 			// read error content and return
-			dt, err := ioutil.ReadAll(res.Body)
+			dt, err := io.ReadAll(res.Body)
 			if err != nil {
 				return err
 			}

--- a/src/jobservice/hook/hook_client_test.go
+++ b/src/jobservice/hook/hook_client_test.go
@@ -17,7 +17,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -41,7 +41,7 @@ type HookClientTestSuite struct {
 func (suite *HookClientTestSuite) SetupSuite() {
 	suite.client = NewClient(context.Background())
 	suite.mockServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		bytes, err := ioutil.ReadAll(r.Body)
+		bytes, err := io.ReadAll(r.Body)
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 			return

--- a/src/jobservice/job/impl/notification/slack_job_test.go
+++ b/src/jobservice/job/impl/notification/slack_job_test.go
@@ -1,7 +1,7 @@
 package notification
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -56,7 +56,7 @@ func TestSlackJobRun(t *testing.T) {
 	// test slack request
 	ts := httptest.NewServer(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			body, _ := ioutil.ReadAll(r.Body)
+			body, _ := io.ReadAll(r.Body)
 
 			// test request method
 			assert.Equal(t, http.MethodPost, r.Method)

--- a/src/jobservice/job/impl/notification/webhook_job_test.go
+++ b/src/jobservice/job/impl/notification/webhook_job_test.go
@@ -1,7 +1,7 @@
 package notification
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -49,7 +49,7 @@ func TestRun(t *testing.T) {
 	// test webhook request
 	ts := httptest.NewServer(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			body, _ := ioutil.ReadAll(r.Body)
+			body, _ := io.ReadAll(r.Body)
 
 			// test request method
 			assert.Equal(t, http.MethodPost, r.Method)

--- a/src/jobservice/logger/base_test.go
+++ b/src/jobservice/logger/base_test.go
@@ -3,7 +3,6 @@ package logger
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -150,7 +149,7 @@ func TestGetGetter(t *testing.T) {
 	}
 
 	logFile := path.Join(os.TempDir(), fakeLogFile)
-	if err := ioutil.WriteFile(logFile, []byte("hello log getter"), 0644); err != nil {
+	if err := os.WriteFile(logFile, []byte("hello log getter"), 0644); err != nil {
 		t.Fatal(err)
 	}
 	defer func() {

--- a/src/jobservice/logger/getter/file_getter.go
+++ b/src/jobservice/logger/getter/file_getter.go
@@ -4,7 +4,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path"
 	"strings"
 
@@ -34,7 +34,7 @@ func (fg *FileGetter) Retrieve(logID string) ([]byte, error) {
 		return nil, errs.NoObjectFoundError(logID)
 	}
 
-	return ioutil.ReadFile(fPath)
+	return os.ReadFile(fPath)
 }
 
 func isValidLogID(id string) error {

--- a/src/jobservice/logger/getter/file_getter_test.go
+++ b/src/jobservice/logger/getter/file_getter_test.go
@@ -1,7 +1,6 @@
 package getter
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -18,7 +17,7 @@ const (
 // Test the log data getter
 func TestLogDataGetter(t *testing.T) {
 	fakeLog := path.Join(os.TempDir(), newLogFileName)
-	if err := ioutil.WriteFile(fakeLog, []byte("hello"), 0600); err != nil {
+	if err := os.WriteFile(fakeLog, []byte("hello"), 0600); err != nil {
 		t.Fatal(err)
 	}
 	defer func() {

--- a/src/jobservice/logger/sweeper/file_sweeper_test.go
+++ b/src/jobservice/logger/sweeper/file_sweeper_test.go
@@ -1,7 +1,6 @@
 package sweeper
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -21,7 +20,7 @@ func TestFileSweeper(t *testing.T) {
 	}()
 
 	logFile := path.Join(workDir, "TestFileSweeper.log")
-	if err := ioutil.WriteFile(logFile, []byte("hello"), os.ModePerm); err != nil {
+	if err := os.WriteFile(logFile, []byte("hello"), os.ModePerm); err != nil {
 		t.Fatal(err)
 	}
 	oldModTime := time.Unix(time.Now().Unix()-6*24*3600, 0)

--- a/src/lib/encrypt/encrypt_test.go
+++ b/src/lib/encrypt/encrypt_test.go
@@ -16,7 +16,6 @@ package encrypt
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -25,8 +24,8 @@ import (
 
 func TestMain(m *testing.M) {
 	secret := []byte("9TXCcHgNAAp1aSHh")
-	filename, err := ioutil.TempFile(os.TempDir(), "keyfile")
-	err = ioutil.WriteFile(filename.Name(), secret, 0644)
+	filename, err := os.CreateTemp(os.TempDir(), "keyfile")
+	err = os.WriteFile(filename.Name(), secret, 0644)
 	if err != nil {
 		fmt.Printf("failed to create temp key file\n")
 	}

--- a/src/lib/encrypt/keyprovider.go
+++ b/src/lib/encrypt/keyprovider.go
@@ -14,9 +14,7 @@
 
 package encrypt
 
-import (
-	"io/ioutil"
-)
+import "os"
 
 // KeyProvider provides the key used to encrypt and decrypt attrs
 type KeyProvider interface {
@@ -40,7 +38,7 @@ func NewFileKeyProvider(path string) KeyProvider {
 
 // Get returns the key read from file
 func (f *FileKeyProvider) Get(params map[string]interface{}) (string, error) {
-	b, err := ioutil.ReadFile(f.path)
+	b, err := os.ReadFile(f.path)
 	if err != nil {
 		return "", err
 	}

--- a/src/lib/encrypt/keyprovider_test.go
+++ b/src/lib/encrypt/keyprovider_test.go
@@ -15,7 +15,6 @@
 package encrypt
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 )
@@ -24,7 +23,7 @@ func TestGetOfFileKeyProvider(t *testing.T) {
 	path := "/tmp/key"
 	key := "key_content"
 
-	if err := ioutil.WriteFile(path, []byte(key), 0777); err != nil {
+	if err := os.WriteFile(path, []byte(key), 0777); err != nil {
 		t.Errorf("failed to write to file %s: %v", path, err)
 		return
 	}

--- a/src/lib/request_test.go
+++ b/src/lib/request_test.go
@@ -15,7 +15,7 @@
 package lib
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -30,22 +30,22 @@ type NopCloseRequestTestSuite struct {
 func (suite *NopCloseRequestTestSuite) TestReusableBody() {
 	r, _ := http.NewRequest(http.MethodPost, "/", strings.NewReader("body"))
 
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	suite.Nil(err)
 	suite.Equal([]byte("body"), body)
 
-	body, err = ioutil.ReadAll(r.Body)
+	body, err = io.ReadAll(r.Body)
 	suite.Nil(err)
 	suite.Equal([]byte(""), body)
 
 	r, _ = http.NewRequest(http.MethodPost, "/", strings.NewReader("body"))
 	r = NopCloseRequest(r)
 
-	body, err = ioutil.ReadAll(r.Body)
+	body, err = io.ReadAll(r.Body)
 	suite.Nil(err)
 	suite.Equal([]byte("body"), body)
 
-	body, err = ioutil.ReadAll(r.Body)
+	body, err = io.ReadAll(r.Body)
 	suite.Nil(err)
 	suite.Equal([]byte("body"), body)
 }

--- a/src/pkg/config/rest/rest_test.go
+++ b/src/pkg/config/rest/rest_test.go
@@ -17,7 +17,7 @@ package rest
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -58,7 +58,7 @@ var configMapForTest = map[string]interface{}{}
 
 func ConfigPutHandler(w http.ResponseWriter, r *http.Request) {
 	cfgs := map[string]interface{}{}
-	content, err := ioutil.ReadAll(r.Body)
+	content, err := io.ReadAll(r.Body)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/src/pkg/p2p/preheat/provider/client/http_client.go
+++ b/src/pkg/p2p/preheat/provider/client/http_client.go
@@ -4,7 +4,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -119,7 +119,7 @@ func (hc *HTTPClient) get(url string, cred *auth.Credential, parmas map[string]s
 
 	// If failed, read error message; if succeeded, read content.
 	defer res.Body.Close()
-	bytes, err := ioutil.ReadAll(res.Body)
+	bytes, err := io.ReadAll(res.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -185,7 +185,7 @@ func (hc *HTTPClient) post(url string, cred *auth.Credential, body interface{}, 
 	}
 
 	defer res.Body.Close()
-	bytes, err := ioutil.ReadAll(res.Body)
+	bytes, err := io.ReadAll(res.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/src/pkg/p2p/preheat/provider/mock.go
+++ b/src/pkg/p2p/preheat/provider/mock.go
@@ -16,7 +16,7 @@ package provider
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -45,7 +45,7 @@ func MockDragonflyProvider() *httptest.Server {
 				return
 			}
 
-			data, err := ioutil.ReadAll(r.Body)
+			data, err := io.ReadAll(r.Body)
 			if err != nil {
 				w.WriteHeader(http.StatusInternalServerError)
 				_, _ = w.Write([]byte(err.Error()))
@@ -118,7 +118,7 @@ func MockKrakenProvider() *httptest.Server {
 				return
 			}
 
-			data, err := ioutil.ReadAll(r.Body)
+			data, err := io.ReadAll(r.Body)
 			if err != nil {
 				w.WriteHeader(http.StatusInternalServerError)
 				_, _ = w.Write([]byte(err.Error()))

--- a/src/pkg/reg/adapter/aliacr/adapter_test.go
+++ b/src/pkg/reg/adapter/aliacr/adapter_test.go
@@ -3,7 +3,6 @@ package aliacr
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -43,7 +42,7 @@ func getMockAdapter(t *testing.T, hasCred, health bool) (*adapter, *httptest.Ser
 			Pattern: "/",
 			Handler: func(w http.ResponseWriter, r *http.Request) {
 				fmt.Println(r.Method, r.URL)
-				if buf, e := ioutil.ReadAll(&io.LimitedReader{R: r.Body, N: 80}); e == nil {
+				if buf, e := io.ReadAll(&io.LimitedReader{R: r.Body, N: 80}); e == nil {
 					fmt.Println("\t", string(buf))
 				}
 				w.WriteHeader(http.StatusOK)

--- a/src/pkg/reg/adapter/artifacthub/chart_registry.go
+++ b/src/pkg/reg/adapter/artifacthub/chart_registry.go
@@ -17,7 +17,6 @@ package artifacthub
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 
 	"github.com/goharbor/harbor/src/lib/errors"
@@ -140,7 +139,7 @@ func (a *adapter) download(contentURL string) (io.ReadCloser, error) {
 		return nil, err
 	}
 	if resp.StatusCode != http.StatusOK {
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return nil, err
 		}

--- a/src/pkg/reg/adapter/artifacthub/client.go
+++ b/src/pkg/reg/adapter/artifacthub/client.go
@@ -3,7 +3,7 @@ package artifacthub
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	common_http "github.com/goharbor/harbor/src/common/http"
@@ -38,7 +38,7 @@ func (c *Client) getHelmChartVersion(fullName, version string) (*ChartVersion, e
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -77,7 +77,7 @@ func (c *Client) getReplicationInfo() ([]*ChartInfo, error) {
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -112,7 +112,7 @@ func (c *Client) checkHealthy() error {
 	}
 	defer resp.Body.Close()
 
-	_, err = ioutil.ReadAll(resp.Body)
+	_, err = io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}

--- a/src/pkg/reg/adapter/awsecr/adapter_test.go
+++ b/src/pkg/reg/adapter/awsecr/adapter_test.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"regexp"
@@ -140,7 +139,7 @@ func getMockAdapter(t *testing.T, hasCred, health bool) (*adapter, *httptest.Ser
 			Pattern: "/",
 			Handler: func(w http.ResponseWriter, r *http.Request) {
 				fmt.Println(r.Method, r.URL)
-				if buf, e := ioutil.ReadAll(&io.LimitedReader{R: r.Body, N: 80}); e == nil {
+				if buf, e := io.ReadAll(&io.LimitedReader{R: r.Body, N: 80}); e == nil {
 					fmt.Println("\t", string(buf))
 				}
 				w.WriteHeader(http.StatusOK)
@@ -250,7 +249,7 @@ func TestAwsAuthCredential_Modify(t *testing.T) {
 			Pattern: "/",
 			Handler: func(w http.ResponseWriter, r *http.Request) {
 				fmt.Println(r.Method, r.URL)
-				if buf, e := ioutil.ReadAll(&io.LimitedReader{R: r.Body, N: 80}); e == nil {
+				if buf, e := io.ReadAll(&io.LimitedReader{R: r.Body, N: 80}); e == nil {
 					fmt.Println("\t", string(buf))
 				}
 				w.WriteHeader(http.StatusOK)

--- a/src/pkg/reg/adapter/azurecr/auth.go
+++ b/src/pkg/reg/adapter/azurecr/auth.go
@@ -17,7 +17,7 @@ package azurecr
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 
@@ -92,7 +92,7 @@ func (a *authorizer) Modify(req *http.Request) error {
 	}
 
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}

--- a/src/pkg/reg/adapter/dockerhub/adapter.go
+++ b/src/pkg/reg/adapter/dockerhub/adapter.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -151,7 +151,7 @@ func (a *adapter) listNamespaces() ([]string, error) {
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -199,7 +199,7 @@ func (a *adapter) CreateNamespace(namespace *model.Namespace) error {
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}
@@ -220,7 +220,7 @@ func (a *adapter) getNamespace(namespace string) (*model.Namespace, error) {
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -381,7 +381,7 @@ func (a *adapter) DeleteManifest(repository, reference string) error {
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}
@@ -402,7 +402,7 @@ func (a *adapter) getRepos(namespace, name string, page, pageSize int) (*ReposRe
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -429,7 +429,7 @@ func (a *adapter) getTags(namespace, repo string, page, pageSize int) (*TagsResp
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/src/pkg/reg/adapter/dockerhub/client.go
+++ b/src/pkg/reg/adapter/dockerhub/client.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 
 	commonhttp "github.com/goharbor/harbor/src/common/http"
@@ -68,7 +67,7 @@ func (c *Client) refreshToken() error {
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}

--- a/src/pkg/reg/adapter/dtr/client.go
+++ b/src/pkg/reg/adapter/dtr/client.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -66,7 +66,7 @@ func (c *Client) getAndIteratePagination(endpoint string, v interface{}) error {
 			return err
 		}
 		defer resp.Body.Close()
-		data, err := ioutil.ReadAll(resp.Body)
+		data, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return err
 		}
@@ -117,7 +117,7 @@ func (c *Client) getRepositories() ([]*model.Repository, error) {
 			return nil, err
 		}
 		defer resp.Body.Close()
-		data, err := ioutil.ReadAll(resp.Body)
+		data, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return nil, err
 		}
@@ -198,7 +198,7 @@ func (c *Client) getNamespaces() ([]Account, error) {
 			return nil, err
 		}
 		defer resp.Body.Close()
-		data, err := ioutil.ReadAll(resp.Body)
+		data, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return nil, err
 		}
@@ -270,7 +270,7 @@ func (c *Client) createRepository(repository string) error {
 		return nil
 	}
 
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}
@@ -313,7 +313,7 @@ func (c *Client) createNamespace(namespace string) error {
 		return nil
 	}
 
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}

--- a/src/pkg/reg/adapter/gitlab/client.go
+++ b/src/pkg/reg/adapter/gitlab/client.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -121,7 +120,7 @@ func (c *Client) GetAndIteratePagination(endpoint string, v interface{}) error {
 			return err
 		}
 		defer resp.Body.Close()
-		data, err := ioutil.ReadAll(resp.Body)
+		data, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return err
 		}

--- a/src/pkg/reg/adapter/googlegcr/adapter.go
+++ b/src/pkg/reg/adapter/googlegcr/adapter.go
@@ -17,7 +17,7 @@ package googlegcr
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/opencontainers/go-digest"
@@ -170,7 +170,7 @@ func (a adapter) listGcrTagsByRef(repository, reference string) ([]string, strin
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, "", err
 	}

--- a/src/pkg/reg/adapter/googlegcr/adapter_test.go
+++ b/src/pkg/reg/adapter/googlegcr/adapter_test.go
@@ -3,7 +3,6 @@ package googlegcr
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -69,7 +68,7 @@ func getMockAdapter(t *testing.T, hasCred, health bool) (*adapter, *httptest.Ser
 			Pattern: "/",
 			Handler: func(w http.ResponseWriter, r *http.Request) {
 				fmt.Println(r.Method, r.URL)
-				if buf, e := ioutil.ReadAll(&io.LimitedReader{R: r.Body, N: 80}); e == nil {
+				if buf, e := io.ReadAll(&io.LimitedReader{R: r.Body, N: 80}); e == nil {
 					fmt.Println("\t", string(buf))
 				}
 				w.WriteHeader(http.StatusOK)

--- a/src/pkg/reg/adapter/harbor/base/chart_registry.go
+++ b/src/pkg/reg/adapter/harbor/base/chart_registry.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"mime/multipart"
 	"net/http"
 	"net/url"
@@ -176,7 +175,7 @@ func (a *Adapter) DownloadChart(name, version, contentURL string) (io.ReadCloser
 		return nil, err
 	}
 	if resp.StatusCode != http.StatusOK {
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return nil, err
 		}
@@ -215,7 +214,7 @@ func (a *Adapter) UploadChart(name, version string, chart io.Reader) error {
 		return err
 	}
 	defer resp.Body.Close()
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}

--- a/src/pkg/reg/adapter/helmhub/chart_registry.go
+++ b/src/pkg/reg/adapter/helmhub/chart_registry.go
@@ -17,7 +17,6 @@ package helmhub
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 
@@ -134,7 +133,7 @@ func (a *adapter) download(version *chartVersion) (io.ReadCloser, error) {
 		return nil, err
 	}
 	if resp.StatusCode != http.StatusOK {
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return nil, err
 		}

--- a/src/pkg/reg/adapter/helmhub/client.go
+++ b/src/pkg/reg/adapter/helmhub/client.go
@@ -3,7 +3,7 @@ package helmhub
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	commonhttp "github.com/goharbor/harbor/src/common/http"
@@ -41,7 +41,7 @@ func (c *Client) fetchCharts() (*chartList, error) {
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -72,7 +72,7 @@ func (c *Client) fetchChartDetail(chartName string) (*chartVersionList, error) {
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -104,7 +104,7 @@ func (c *Client) checkHealthy() error {
 	}
 	defer resp.Body.Close()
 
-	_, err = ioutil.ReadAll(resp.Body)
+	_, err = io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}

--- a/src/pkg/reg/adapter/huawei/huawei_adapter.go
+++ b/src/pkg/reg/adapter/huawei/huawei_adapter.go
@@ -17,7 +17,7 @@ package huawei
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -114,10 +114,10 @@ func (a *adapter) ListNamespaces(query *model.NamespaceQuery) ([]*model.Namespac
 	defer resp.Body.Close()
 	code := resp.StatusCode
 	if code >= 300 || code < 200 {
-		body, _ := ioutil.ReadAll(resp.Body)
+		body, _ := io.ReadAll(resp.Body)
 		return namespaces, fmt.Errorf("[%d][%s]", code, string(body))
 	}
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return namespaces, err
 	}
@@ -199,7 +199,7 @@ func (a *adapter) PrepareForPush(resources []*model.Resource) error {
 		defer resp.Body.Close()
 		code := resp.StatusCode
 		if code >= 300 || code < 200 {
-			body, _ := ioutil.ReadAll(resp.Body)
+			body, _ := io.ReadAll(resp.Body)
 			return fmt.Errorf("[%d][%s]", code, string(body))
 		}
 
@@ -231,10 +231,10 @@ func (a *adapter) GetNamespace(namespaceStr string) (*model.Namespace, error) {
 	defer resp.Body.Close()
 	code := resp.StatusCode
 	if code >= 300 || code < 200 {
-		body, _ := ioutil.ReadAll(resp.Body)
+		body, _ := io.ReadAll(resp.Body)
 		return namespace, fmt.Errorf("[%d][%s]", code, string(body))
 	}
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return namespace, err
 	}

--- a/src/pkg/reg/adapter/huawei/image_registry.go
+++ b/src/pkg/reg/adapter/huawei/image_registry.go
@@ -17,7 +17,7 @@ package huawei
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 	"time"
@@ -48,10 +48,10 @@ func (a *adapter) FetchArtifacts(filters []*model.Filter) ([]*model.Resource, er
 	defer resp.Body.Close()
 	code := resp.StatusCode
 	if code >= 300 || code < 200 {
-		body, _ := ioutil.ReadAll(resp.Body)
+		body, _ := io.ReadAll(resp.Body)
 		return resources, fmt.Errorf("[%d][%s]", code, string(body))
 	}
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return resources, err
 	}
@@ -96,10 +96,10 @@ func (a *adapter) ManifestExist(repository, reference string) (exist bool, desc 
 		if code == 404 {
 			return false, nil, nil
 		}
-		body, _ := ioutil.ReadAll(resp.Body)
+		body, _ := io.ReadAll(resp.Body)
 		return exist, nil, fmt.Errorf("[%d][%s]", code, string(body))
 	}
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return exist, nil, err
 	}
@@ -140,7 +140,7 @@ func (a *adapter) DeleteManifest(repository, reference string) error {
 	defer resp.Body.Close()
 	code := resp.StatusCode
 	if code >= 300 || code < 200 {
-		body, _ := ioutil.ReadAll(resp.Body)
+		body, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf("[%d][%s]", code, string(body))
 	}
 
@@ -219,10 +219,10 @@ func getJwtToken(a *adapter, repository string) (token jwtToken, err error) {
 	defer resp.Body.Close()
 	code := resp.StatusCode
 	if code >= 300 || code < 200 {
-		body, _ := ioutil.ReadAll(resp.Body)
+		body, _ := io.ReadAll(resp.Body)
 		return token, fmt.Errorf("[%d][%s]", code, string(body))
 	}
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return token, err
 	}

--- a/src/pkg/reg/adapter/jfrog/adapter.go
+++ b/src/pkg/reg/adapter/jfrog/adapter.go
@@ -18,7 +18,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 
@@ -300,7 +299,7 @@ func (a *adapter) PushBlob(repository, digest string, size int64, blob io.Reader
 		return a.ackPushBlob(repository, digest, location, rangeSize)
 	}
 
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}
@@ -330,7 +329,7 @@ func (a *adapter) preparePushBlob(repository string) (string, error) {
 		return resp.Header.Get("Docker-Upload-Uuid"), nil
 	}
 
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", err
 	}
@@ -361,7 +360,7 @@ func (a *adapter) ackPushBlob(repository, digest, location, size string) error {
 		return nil
 	}
 
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}

--- a/src/pkg/reg/adapter/jfrog/client.go
+++ b/src/pkg/reg/adapter/jfrog/client.go
@@ -18,7 +18,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	common_http "github.com/goharbor/harbor/src/common/http"
@@ -74,7 +74,7 @@ func (c *client) getDockerRepositories() ([]*repository, error) {
 
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return repositories, err
 	}
@@ -109,7 +109,7 @@ func (c *client) createDockerRepository(name string) error {
 		return nil
 	}
 
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}

--- a/src/pkg/reg/adapter/quay/adapter.go
+++ b/src/pkg/reg/adapter/quay/adapter.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 
@@ -214,7 +213,7 @@ func (a *adapter) createNamespace(namespace *model.Namespace) error {
 		return nil
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}
@@ -235,7 +234,7 @@ func (a *adapter) getNamespace(namespace string) (*model.Namespace, error) {
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -274,12 +273,12 @@ func (a *adapter) PullBlob(repository, digest string) (size int64, blob io.ReadC
 		if size == 0 {
 			var data []byte
 			defer blob.Close()
-			data, err = ioutil.ReadAll(blob)
+			data, err = io.ReadAll(blob)
 			if err != nil {
 				return
 			}
 			size = int64(len(data))
-			blob = ioutil.NopCloser(bytes.NewReader(data))
+			blob = io.NopCloser(bytes.NewReader(data))
 			return size, blob, nil
 		}
 	}

--- a/src/pkg/reg/adapter/tencentcr/adapter_test.go
+++ b/src/pkg/reg/adapter/tencentcr/adapter_test.go
@@ -3,7 +3,6 @@ package tencentcr
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -229,7 +228,7 @@ func getMockAdapter(t *testing.T, hasCred, health bool) (*adapter, *httptest.Ser
 			Pattern: "/",
 			Handler: func(w http.ResponseWriter, r *http.Request) {
 				fmt.Println(r.Method, r.URL)
-				if buf, e := ioutil.ReadAll(&io.LimitedReader{R: r.Body, N: 80}); e == nil {
+				if buf, e := io.ReadAll(&io.LimitedReader{R: r.Body, N: 80}); e == nil {
 					fmt.Println("\t", string(buf))
 				}
 				w.WriteHeader(http.StatusOK)

--- a/src/pkg/reg/adapter/tencentcr/chart_registry.go
+++ b/src/pkg/reg/adapter/tencentcr/chart_registry.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"mime/multipart"
 	"net/http"
 	"strings"
@@ -183,7 +182,7 @@ func (a *adapter) DownloadChart(name, version, contentURL string) (rc io.ReadClo
 		return
 	}
 	if resp.StatusCode != http.StatusOK {
-		body, err = ioutil.ReadAll(resp.Body)
+		body, err = io.ReadAll(resp.Body)
 		if err != nil {
 			return
 		}
@@ -234,7 +233,7 @@ func (a *adapter) UploadChart(name, version string, reader io.Reader) (err error
 
 	// 3. parse response
 	var data []byte
-	data, err = ioutil.ReadAll(resp.Body)
+	data, err = io.ReadAll(resp.Body)
 	if err != nil {
 		return
 	}

--- a/src/pkg/registry/auth/bearer/authorizer.go
+++ b/src/pkg/registry/auth/bearer/authorizer.go
@@ -17,7 +17,7 @@ package bearer
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 
@@ -120,7 +120,7 @@ func (a *authorizer) fetchToken(scopes []*scope) (*token, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/src/pkg/registry/client.go
+++ b/src/pkg/registry/client.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -201,7 +200,7 @@ func (c *client) catalog(url string) ([]string, string, error) {
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, "", err
 	}
@@ -248,7 +247,7 @@ func (c *client) listTags(url string) ([]string, string, error) {
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, "", err
 	}
@@ -301,7 +300,7 @@ func (c *client) PullManifest(repository, reference string, acceptedMediaTypes .
 		return nil, "", err
 	}
 	defer resp.Body.Close()
-	payload, err := ioutil.ReadAll(resp.Body)
+	payload, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, "", err
 	}
@@ -664,7 +663,7 @@ func (c *client) do(req *http.Request) (*http.Response, error) {
 	}
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
 		defer resp.Body.Close()
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return nil, err
 		}

--- a/src/pkg/registry/client_test.go
+++ b/src/pkg/registry/client_test.go
@@ -16,7 +16,7 @@ package registry
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 	"testing"
@@ -319,7 +319,7 @@ func (c *clientTestSuite) TestPullBlob() {
 	c.Require().Nil(err)
 	c.Equal(int64(len(data)), size)
 
-	b, err := ioutil.ReadAll(blob)
+	b, err := io.ReadAll(blob)
 	c.Require().Nil(err)
 	c.EqualValues(data, b)
 }

--- a/src/pkg/scan/export/digest_calculator_test.go
+++ b/src/pkg/scan/export/digest_calculator_test.go
@@ -3,7 +3,6 @@ package export
 import (
 	"crypto/sha256"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -17,7 +16,7 @@ type DigestCalculatorTestSuite struct {
 func (suite *DigestCalculatorTestSuite) TestDigestCalculation() {
 	fileName := "/tmp/testfile.txt"
 	data := []byte("test")
-	ioutil.WriteFile(fileName, data, os.ModePerm)
+	os.WriteFile(fileName, data, os.ModePerm)
 	digestCalc := SHA256ArtifactDigestCalculator{}
 	digest, err := digestCalc.Calculate(fileName)
 	suite.NoError(err)

--- a/src/pkg/scan/job.go
+++ b/src/pkg/scan/job.go
@@ -19,7 +19,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -578,7 +578,7 @@ func makeBearerAuthorization(robotAccount *model.Robot, tokenURL string, reposit
 	}
 	defer resp.Body.Close()
 
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", err
 	}

--- a/src/pkg/scan/rest/v1/client.go
+++ b/src/pkg/scan/rest/v1/client.go
@@ -19,7 +19,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 	"time"
@@ -254,7 +254,7 @@ func reportResponseHandler() responseHandler {
 
 // generalRespHandlerFunc is a handler to cover the general cases
 func generalRespHandlerFunc(expectedCode, code int, resp *http.Response) ([]byte, error) {
-	buf, err := ioutil.ReadAll(resp.Body)
+	buf, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/src/pkg/systemartifact/manager_test.go
+++ b/src/pkg/systemartifact/manager_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -140,7 +139,7 @@ func (suite *ManagerTestSuite) TestRead() {
 
 	dummyRepoFilepath := fmt.Sprintf("/tmp/sys_art_test.dmp_%v", time.Now())
 	data := []byte("test data")
-	err := ioutil.WriteFile(dummyRepoFilepath, data, os.ModePerm)
+	err := os.WriteFile(dummyRepoFilepath, data, os.ModePerm)
 	suite.NoErrorf(err, "Unexpected error when creating test repo file: %v", dummyRepoFilepath)
 
 	repoHandle, err := os.Open(dummyRepoFilepath)
@@ -162,7 +161,7 @@ func (suite *ManagerTestSuite) TestReadSystemArtifactRecordNotFound() {
 
 	dummyRepoFilepath := fmt.Sprintf("/tmp/sys_art_test.dmp_%v", time.Now())
 	data := []byte("test data")
-	err := ioutil.WriteFile(dummyRepoFilepath, data, os.ModePerm)
+	err := os.WriteFile(dummyRepoFilepath, data, os.ModePerm)
 	suite.NoErrorf(err, "Unexpected error when creating test repo file: %v", dummyRepoFilepath)
 
 	repoHandle, err := os.Open(dummyRepoFilepath)

--- a/src/pkg/token/options.go
+++ b/src/pkg/token/options.go
@@ -3,7 +3,7 @@ package token
 import (
 	"crypto/rsa"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/golang-jwt/jwt/v4"
 
@@ -67,7 +67,7 @@ func DefaultTokenOptions() *Options {
 
 // NewOptions create Options based on input parms
 func NewOptions(sm, iss, keyPath string) (*Options, error) {
-	pk, err := ioutil.ReadFile(keyPath)
+	pk, err := os.ReadFile(keyPath)
 	if err != nil {
 		log.Errorf(fmt.Sprintf("failed to read private key %v", err))
 		return nil, err

--- a/src/registryctl/api/health_test.go
+++ b/src/registryctl/api/health_test.go
@@ -15,7 +15,7 @@
 package api
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -28,6 +28,6 @@ func TestHealth(t *testing.T) {
 	req, _ := http.NewRequest("GET", "", nil)
 	Health(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
-	result, _ := ioutil.ReadAll(w.Body)
+	result, _ := io.ReadAll(w.Body)
 	assert.Equal(t, "\"healthy\"", string(result))
 }

--- a/src/registryctl/client/client.go
+++ b/src/registryctl/client/client.go
@@ -16,7 +16,7 @@ package client
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -120,7 +120,7 @@ func (c *client) do(req *http.Request) (*http.Response, error) {
 	}
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
 		defer resp.Body.Close()
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return nil, err
 		}

--- a/src/registryctl/config/config.go
+++ b/src/registryctl/config/config.go
@@ -16,7 +16,6 @@ package config
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/docker/distribution/configuration"
@@ -47,7 +46,7 @@ type Configuration struct {
 func (c *Configuration) Load(yamlFilePath string, detectEnv bool) error {
 	if len(yamlFilePath) != 0 {
 		// Try to load from file first
-		data, err := ioutil.ReadFile(yamlFilePath)
+		data, err := os.ReadFile(yamlFilePath)
 		if err != nil {
 			return err
 		}

--- a/src/server/middleware/blob/put_manifest.go
+++ b/src/server/middleware/blob/put_manifest.go
@@ -15,7 +15,7 @@
 package blob
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/goharbor/harbor/src/lib"
@@ -34,7 +34,7 @@ func PutManifestMiddleware() func(http.Handler) http.Handler {
 		logger := log.G(ctx)
 
 		lib.NopCloseRequest(r) // make the r.Body re-readable
-		body, err := ioutil.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
 		if err != nil {
 			return err
 		}
@@ -64,7 +64,7 @@ func PutManifestMiddleware() func(http.Handler) http.Handler {
 			return err
 		}
 
-		body, err := ioutil.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
 		if err != nil {
 			return err
 		}

--- a/src/server/middleware/cosign/cosign.go
+++ b/src/server/middleware/cosign/cosign.go
@@ -3,7 +3,7 @@ package cosign
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"regexp"
 
@@ -76,7 +76,7 @@ func SignatureMiddleware() func(http.Handler) http.Handler {
 			return nil
 		}
 
-		body, err := ioutil.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
 		if err != nil {
 			return err
 		}

--- a/src/server/middleware/nydus/nydus.go
+++ b/src/server/middleware/nydus/nydus.go
@@ -3,7 +3,7 @@ package nydus
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
@@ -84,7 +84,7 @@ func AcceleratorMiddleware() func(http.Handler) http.Handler {
 			return nil
 		}
 
-		body, err := ioutil.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
 		if err != nil {
 			return err
 		}

--- a/src/server/middleware/quota/util.go
+++ b/src/server/middleware/quota/util.go
@@ -16,7 +16,7 @@ package quota
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 	"time"
@@ -49,7 +49,7 @@ var (
 	unmarshalManifest = func(r *http.Request) (distribution.Manifest, distribution.Descriptor, error) {
 		lib.NopCloseRequest(r)
 
-		body, err := ioutil.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
 		if err != nil {
 			return nil, distribution.Descriptor{}, err
 		}

--- a/src/server/middleware/security/auth_proxy_test.go
+++ b/src/server/middleware/security/auth_proxy_test.go
@@ -17,7 +17,7 @@ package security
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -89,7 +89,7 @@ func newAuthProxyTestServer() (*httptest.Server, error) {
 		}
 
 		var review v1beta1.TokenReview
-		bodyData, _ := ioutil.ReadAll(r.Body)
+		bodyData, _ := io.ReadAll(r.Body)
 		if err := json.Unmarshal(bodyData, &review); err != nil {
 			http.Error(w, fmt.Sprintf("failed to decode body: %v", err), http.StatusBadRequest)
 			return

--- a/src/testing/server/v2.0/handler/handler.go
+++ b/src/testing/server/v2.0/handler/handler.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 
@@ -102,7 +101,7 @@ func (suite *Suite) GetJSON(url string, js interface{}, headers ...map[string]st
 	}
 
 	if res.StatusCode >= http.StatusOK && res.StatusCode < http.StatusBadRequest {
-		data, err := ioutil.ReadAll(res.Body)
+		data, err := io.ReadAll(res.Body)
 		if err != nil {
 			return res, err
 		}
@@ -112,7 +111,7 @@ func (suite *Suite) GetJSON(url string, js interface{}, headers ...map[string]st
 			return res, err
 		}
 
-		res.Body = ioutil.NopCloser(bytes.NewBuffer(data))
+		res.Body = io.NopCloser(bytes.NewBuffer(data))
 	}
 
 	return res, nil


### PR DESCRIPTION
Signed-off-by: yanggang <gang.yang@daocloud.io>

/kind cleanup
We should clean all io/util package according the url: https://go.dev/doc/go1.16#ioutil
