### PR TITLE
fix: skip to push system artifact for empty CSV file

### DIFF
--- a/src/controller/scandataexport/execution.go
+++ b/src/controller/scandataexport/execution.go
@@ -185,9 +185,7 @@ func (c *controller) convertToExportExecStatus(ctx context.Context, exec *task.E
 	if userName, ok := exec.ExtraAttrs[export.UserNameAttribute]; ok {
 		execStatus.UserName = userName.(string)
 	}
-	// Do not define the 'status_message' as const because this is not the final solution,
-	// should refactor this part.
-	if statusMessage, ok := exec.ExtraAttrs["status_message"]; ok {
+	if statusMessage, ok := exec.ExtraAttrs[export.StatusMessageAttribute]; ok {
 		execStatus.StatusMessage = statusMessage.(string)
 	}
 	artifactExists := c.isCsvArtifactPresent(ctx, exec.ID, execStatus.ExportDataDigest)

--- a/src/pkg/scan/export/constants.go
+++ b/src/pkg/scan/export/constants.go
@@ -4,14 +4,15 @@ package export
 type CsvJobVendorID string
 
 const (
-	ProjectIDsAttribute = "project_ids"
-	JobNameAttribute    = "job_name"
-	UserNameAttribute   = "user_name"
-	ScanDataExportDir   = "/var/scandata_exports"
-	QueryPageSize       = 100000
-	ArtifactGroupSize   = 10000
-	DigestKey           = "artifact_digest"
-	CreateTimestampKey  = "create_ts"
-	Vendor              = "SCAN_DATA_EXPORT"
-	CsvJobVendorIDKey   = CsvJobVendorID("vendorId")
+	ProjectIDsAttribute    = "project_ids"
+	JobNameAttribute       = "job_name"
+	UserNameAttribute      = "user_name"
+	StatusMessageAttribute = "status_message"
+	ScanDataExportDir      = "/var/scandata_exports"
+	QueryPageSize          = 100000
+	ArtifactGroupSize      = 10000
+	DigestKey              = "artifact_digest"
+	CreateTimestampKey     = "create_ts"
+	Vendor                 = "SCAN_DATA_EXPORT"
+	CsvJobVendorIDKey      = CsvJobVendorID("vendorId")
 )

--- a/src/server/v2.0/handler/scanexport.go
+++ b/src/server/v2.0/handler/scanexport.go
@@ -160,13 +160,6 @@ func (se *scanDataExportAPI) DownloadScanData(ctx context.Context, params operat
 		return se.SendError(ctx, err)
 	}
 
-	// check if the CSV artifact for the execution exists
-	if !execution.FilePresent {
-		return middleware.ResponderFunc(func(writer http.ResponseWriter, producer runtime.Producer) {
-			writer.WriteHeader(http.StatusNotFound)
-		})
-	}
-
 	// check if the execution being downloaded is owned by the current user
 	secContext, err := se.GetSecurityContext(ctx)
 	if err != nil {
@@ -176,6 +169,13 @@ func (se *scanDataExportAPI) DownloadScanData(ctx context.Context, params operat
 	if secContext.GetUsername() != execution.UserName {
 		return middleware.ResponderFunc(func(writer http.ResponseWriter, producer runtime.Producer) {
 			writer.WriteHeader(http.StatusForbidden)
+		})
+	}
+
+	// check if the CSV artifact for the execution exists
+	if !execution.FilePresent {
+		return middleware.ResponderFunc(func(writer http.ResponseWriter, producer runtime.Producer) {
+			writer.WriteHeader(http.StatusNotFound)
 		})
 	}
 

--- a/src/server/v2.0/handler/scanexport_test.go
+++ b/src/server/v2.0/handler/scanexport_test.go
@@ -514,7 +514,7 @@ func (suite *ScanExportTestSuite) TestDownloadScanDataNoCsvFilePresent() {
 		StartTime:        startTime,
 		EndTime:          endTime,
 		ExportDataDigest: "datadigest",
-		UserName:         "test-user",
+		UserName:         "test-user1",
 		FilePresent:      false,
 	}
 	mock.OnAnything(suite.scanExportCtl, "GetExecution").Return(execution, nil)


### PR DESCRIPTION
1. Skip to push system artifact to the distribution when the exported CSV file is empty.
2. Add status message for cve export execution.

Signed-off-by: chlins <chenyuzh@vmware.com>

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes https://github.com/goharbor/harbor/issues/17700

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
