### PR TITLE
add new workflow for nightly image scan

### DIFF
--- a/.github/workflows/nightly-trivy-scan.yml
+++ b/.github/workflows/nightly-trivy-scan.yml
@@ -1,0 +1,38 @@
+name: Trivy Nightly Scan
+on:
+  schedule:
+    - cron: '0 2 * * *' # run at 2 AM UTC
+
+
+jobs:
+  nightly-scan:
+    name: Trivy Scan nightly
+    strategy:
+      fail-fast: false
+      matrix:
+        # maintain the versions of harbor that need to be actively
+        # security scanned
+        # TODO have to add 2.7 version also once it is released
+        versions: [dev]
+        # list of images that need to be scanned
+        images: [harbor-core, harbor-db, harbor-exporter, harbor-jobservice, harbor-log, harbor-portal, harbor-registryctl, prepare]
+    permissions:
+      security-events: write  # for github/codeql-action/upload-sarif to upload SARIF results
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: 'docker.io/goharbor/${{ matrix.images }}:${{ matrix.versions }}'
+          severity: 'CRITICAL,HIGH'
+          format: 'template'
+          template: '@/contrib/sarif.tpl'
+          output: 'trivy-results.sarif'
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: 'trivy-results.sarif'


### PR DESCRIPTION
This PR adds a new workflow that scans the generated docker images for security vulnerabilities using trivy scanner. The workflow is set as nightly, since the security scanning needs to be done daily instead of just on push. This will help to know about reported CVEs proactively. 

Currently the following images are added which can be extended by adding into the workflow matrix
images: 
  - harbor-core
  - harbor-db
  - harbor-exporter
  - harbor-jobservice
  - harbor-log
  - harbor-portal
  - harbor-registryctl
  - prepare
 
tags: `dev`, `v2.6.2` and `1.10.14` 

NOTE: The tests will fail currently as there are a few CVEs reported in the images.

Signed-off-by: Akhil Mohan <akhilerm@gmail.com>

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #17677 

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
