### PR TITLE
[cherry-pick]Fix setup gcloud error

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -9,22 +9,21 @@ on:
           - release-*
         tags:
           - v*
+
 jobs:
   BUILD_PACKAGE:
     env:
         BUILD_PACKAGE: true
     runs-on:
-      #- self-hosted
-      - ubuntu-latest
+      - ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
+      - uses: 'google-github-actions/auth@v0'
+        with:
+          credentials_json: '${{ secrets.GCP_CREDENTIALS }}'
       - uses: google-github-actions/setup-gcloud@v0
         with:
           version: '285.0.0'
-          project_id: ${{ secrets.GCP_PROJECT_ID }}
-          service_account_email: ${{ secrets.GCP_SA_EMAIL }}
-          service_account_key: ${{ secrets.GCP_SA_KEY }}
-          export_default_credentials: true
       - run: gcloud info
       - name: Set up Go 1.17
         uses: actions/setup-go@v1

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Setup env


### PR DESCRIPTION
ubuntu-latest was upgraded from ubuntu-20.04 to ubuntu-22.04, the python version of ubuntu-22.04 is 3.10, but gcloud does not support python 3.10, so ubuntu is fixed to version 20.04

Signed-off-by: Yang Jiao <jiaoya@vmware.com>

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [ ] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [ ] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
