### PR TITLE
Allow robot accounts to create artifacts

### DIFF
--- a/src/portal/src/app/base/left-side-nav/system-robot-accounts/system-robot-util.ts
+++ b/src/portal/src/app/base/left-side-nav/system-robot-accounts/system-robot-util.ts
@@ -82,6 +82,11 @@ export const INITIAL_ACCESSES: FrontAccess[] = [
         checked: true,
     },
     {
+        resource: 'artifact',
+        action: 'create',
+        checked: true,
+    },
+    {
         resource: 'artifact-label',
         action: 'create',
         checked: true,


### PR DESCRIPTION
# Comprehensive Summary of your change
currently the GUI does not support selecting "create artifact" this is needed to allow the robot account to copy artifacts

# Issue being fixed
Addition to #8723 

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
