### PR TITLE
aws auth use default creds when none are supplied

### DIFF
--- a/src/pkg/reg/adapter/awsecr/auth.go
+++ b/src/pkg/reg/adapter/awsecr/auth.go
@@ -26,7 +26,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/credentials"
-	"github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds"
 	"github.com/aws/aws-sdk-go/aws/session"
 	awsecrapi "github.com/aws/aws-sdk-go/service/ecr"
 
@@ -102,8 +101,6 @@ func getAwsSvc(region, accessKey, accessSecret string, insecure bool, forceEndpo
 			accessKey,
 			accessSecret,
 			"")
-	} else {
-		cred = ec2rolecreds.NewCredentials(sess)
 	}
 
 	config := &aws.Config{


### PR DESCRIPTION
# Comprehensive Summary of your change

Harbor should not assume that if AWS Credentials are not defined that the user wants to use `ec2rolecreds`.  Rather, it should allow the AWS SDK to resolve credentials by passing `nil` Credentials:

https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials

This _should_ be backwards compatible because the defualt provider chain does look for: `4. If your application is running on an Amazon EC2 instance, IAM role for Amazon EC2.`

# Issue being fixed
Fixes #15007

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
