### PR TITLE
remove the redundant data from table artifact_blob

### DIFF
--- a/make/migrations/postgresql/0110_2.8.0_schema.up.sql
+++ b/make/migrations/postgresql/0110_2.8.0_schema.up.sql
@@ -1,0 +1,2 @@
+/* remove the redundant data from table artifact_blob */
+delete from artifact_blob afb where not exists (select digest from blob b where b.digest = afb.digest_af);


### PR DESCRIPTION
use sql in the migration process to delete all the useless data of table artifact_blob

Signed-off-by: Wang Yan <wangyan@vmware.com>

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
