### PR TITLE
Skip CI tests when *.md modifications are made

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,6 +19,7 @@ on:
   push:
     paths-ignore:
     - 'docs/**'
+    - '**.md'
 
 jobs:
   UTTEST:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,10 +16,13 @@ env:
 
 on:
   pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
   push:
     paths-ignore:
-    - 'docs/**'
-    - '**.md'
+      - 'docs/**'
+      - '**.md'
 
 jobs:
   UTTEST:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -6,6 +6,9 @@ on:
       - 'docs/**'
       - '**.md'
   pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
   schedule:
     - cron: '0 16 * * 6'
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,6 +2,9 @@ name: "Code scanning - action"
 
 on:
   push:
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
   pull_request:
   schedule:
     - cron: '0 16 * * 6'


### PR DESCRIPTION
No need to do full test if internal documentations is changed! Saves resources and makes the PR test much faster!

Signed-off-by: OrlinVasilev <ovasilev@vmware.com>

- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
