### PR TITLE
fix: fix the time duration type duplicated parse for config

### DIFF
--- a/src/lib/config/metadata/type.go
+++ b/src/lib/config/metadata/type.go
@@ -245,7 +245,8 @@ func (t *DurationType) validate(str string) error {
 }
 
 func (t *DurationType) get(str string) (interface{}, error) {
-	return time.ParseDuration(str)
+	// should not parse the duration to avoid duplicate parse.
+	return str, nil
 }
 
 // parseInt64 returns int64 from string which support scientific notation

--- a/src/lib/config/metadata/type_test.go
+++ b/src/lib/config/metadata/type_test.go
@@ -110,6 +110,17 @@ func TestStringToStringMapType_get(t *testing.T) {
 	assert.Equal(t, map[string]string{"sample": "abc", "another": "welcome"}, result)
 }
 
+func TestDurationType(t *testing.T) {
+	test := &DurationType{}
+	// test get
+	result, err := test.get("5m")
+	assert.Nil(t, err)
+	assert.Equal(t, "5m", result)
+	// test validate
+	assert.Nil(t, test.validate("5m"))
+	assert.NotNil(t, test.validate("100"))
+}
+
 func Test_parseInt64(t *testing.T) {
 	type args struct {
 		str string

--- a/src/lib/config/metadata/value.go
+++ b/src/lib/config/metadata/value.go
@@ -153,10 +153,18 @@ func (c *ConfigureValue) GetDuration() time.Duration {
 			log.Errorf("GetDuration failed, error: %+v", err)
 			return 0
 		}
-		if durationValue, suc := val.(time.Duration); suc {
-			return durationValue
+
+		if durationStr, suc := val.(string); suc {
+			durationVal, err := time.ParseDuration(durationStr)
+			if err != nil {
+				log.Errorf("Parse %s to time duration failed, error: %v", durationStr, err)
+				return 0
+			}
+
+			return durationVal
 		}
 	}
+
 	log.Errorf("GetDuration failed, the current value's metadata is not defined, %+v", c)
 	return 0
 }


### PR DESCRIPTION
Fix the time duration type duplicated parse for config, maintaining the idempotency of set and get operations.

Signed-off-by: chlins <chenyuzh@vmware.com>

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
