### PR TITLE
fix: Don't supress redis error messages to make debugging easier

### DIFF
--- a/src/jobservice/job/impl/gc/util.go
+++ b/src/jobservice/job/impl/gc/util.go
@@ -20,7 +20,7 @@ func delKeys(con redis.Conn, pattern string) error {
 	for {
 		arr, err := redis.Values(con.Do("SCAN", iter, "MATCH", pattern))
 		if err != nil {
-			return fmt.Errorf("error retrieving '%s' keys", pattern)
+			return fmt.Errorf("error retrieving '%s' keys: %s", pattern, err)
 		}
 		iter, err = redis.Int(arr[0], nil)
 		if err != nil {


### PR DESCRIPTION
# Comprehensive Summary of your change

When debugging #17984, the error message of the Garbage Collector was 

````
exit with error: run error: error retrieving 'blobs::*' keys
````

This gave the wrong impression, that something was wrong with the content of redis.

Applying this fix gave

````
error retrieving 'blobs::*' keys: dial tcp: lookup harbor-redis.example.com on 127.0.0.1:53: no such host, pattern blobs::*
````

which points in a completly different direction. This fix prints the original redis error in the error message to avoid such confusion.


# Issue being fixed
Relates #14922 
Relates  #17984

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
