### PR TITLE
#17998: Add option to disable remote OIDC user info fetching

### DIFF
--- a/api/v2.0/swagger.yaml
+++ b/api/v2.0/swagger.yaml
@@ -4269,7 +4269,7 @@ paths:
         '404':
           $ref: '#/responses/404'
         '500':
-          $ref: '#/responses/500'        
+          $ref: '#/responses/500'
   /system/purgeaudit/{purge_id}/log:
     get:
       summary: Get purge job log.
@@ -7793,7 +7793,7 @@ definitions:
       update_time:
         type: string
         format: date-time
-        description: the update time of purge job.        
+        description: the update time of purge job.
   Schedule:
     type: object
     properties:
@@ -8697,7 +8697,7 @@ definitions:
         description: The OIDC group which has the harbor admin privileges
       oidc_group_filter:
         $ref: '#/definitions/StringConfigItem'
-        description: The OIDC group filter which filters out the group doesn't match the regular expression   
+        description: The OIDC group filter which filters out the group doesn't match the regular expression
       oidc_scope:
         $ref: '#/definitions/StringConfigItem'
         description: The scope of the OIDC provider
@@ -8707,6 +8707,9 @@ definitions:
       oidc_verify_cert:
         $ref: '#/definitions/BoolConfigItem'
         description: Verify the OIDC provider's certificate'
+      oidc_disable_remote_user_info:
+        $ref: '#/definitions/BoolConfigItem'
+        description: Disable fetching from the OIDC user info endpoint
       oidc_auto_onboard:
         $ref: '#/definitions/BoolConfigItem'
         description: Auto onboard the OIDC user
@@ -8942,7 +8945,7 @@ definitions:
         type: string
         description: The OIDC group filter which filters out the group name doesn't match the regular expression
         x-omitempty: true
-        x-isnullable: true        
+        x-isnullable: true
       oidc_scope:
         type: string
         description: The scope of the OIDC provider
@@ -8956,6 +8959,11 @@ definitions:
       oidc_verify_cert:
         type: boolean
         description: Verify the OIDC provider's certificate'
+        x-omitempty: true
+        x-isnullable: true
+      oidc_disable_remote_user_info:
+        type: boolean
+        description: Disable fetching from the OIDC user info endpoint
         x-omitempty: true
         x-isnullable: true
       oidc_auto_onboard:
@@ -8997,7 +9005,7 @@ definitions:
         type: string
         description: The audit log forward endpoint
         x-omitempty: true
-        x-isnullable: true  
+        x-isnullable: true
       skip_audit_log_database:
         type: boolean
         description: Skip audit log database
@@ -9404,7 +9412,7 @@ definitions:
   WorkerPool:
     type: object
     description: the worker pool of job service
-    properties: 
+    properties:
       pid:
         type: integer
         description: the process id of jobservice
@@ -9422,13 +9430,13 @@ definitions:
       concurrency:
         type: integer
         description: The concurrency of the work pool
-      host: 
+      host:
         type: string
-        description: The host of the work pool 
+        description: The host of the work pool
   Worker:
     type: object
     description: worker in the pool
-    properties: 
+    properties:
       id:
         type: string
         description: the id of the worker
@@ -9463,7 +9471,7 @@ definitions:
       action:
         type: string
         description: The action of the request, should be stop, pause or resume
-        enum: 
+        enum:
           - stop
           - pause
           - resume

--- a/src/common/const.go
+++ b/src/common/const.go
@@ -111,6 +111,7 @@ const (
 	OIDCCLientID                     = "oidc_client_id"
 	OIDCClientSecret                 = "oidc_client_secret"
 	OIDCVerifyCert                   = "oidc_verify_cert"
+	OIDCDisableRemoteUserInfo        = "oidc_disable_remote_user_info"
 	OIDCAdminGroup                   = "oidc_admin_group"
 	OIDCGroupsClaim                  = "oidc_groups_claim"
 	OIDCGroupFilter                  = "oidc_group_filter"

--- a/src/lib/config/models/model.go
+++ b/src/lib/config/models/model.go
@@ -31,19 +31,20 @@ type HTTPAuthProxy struct {
 
 // OIDCSetting wraps the settings for OIDC auth endpoint
 type OIDCSetting struct {
-	Name               string            `json:"name"`
-	Endpoint           string            `json:"endpoint"`
-	VerifyCert         bool              `json:"verify_cert"`
-	AutoOnboard        bool              `json:"auto_onboard"`
-	ClientID           string            `json:"client_id"`
-	ClientSecret       string            `json:"client_secret"`
-	GroupsClaim        string            `json:"groups_claim"`
-	AdminGroup         string            `json:"admin_group"`
-	GroupFilter        string            `json:"group_filter"`
-	RedirectURL        string            `json:"redirect_url"`
-	Scope              []string          `json:"scope"`
-	UserClaim          string            `json:"user_claim"`
-	ExtraRedirectParms map[string]string `json:"extra_redirect_parms"`
+	Name                  string            `json:"name"`
+	Endpoint              string            `json:"endpoint"`
+	VerifyCert            bool              `json:"verify_cert"`
+	DisableRemoteUserInfo bool              `json:"disable_remote_user_info"`
+	AutoOnboard           bool              `json:"auto_onboard"`
+	ClientID              string            `json:"client_id"`
+	ClientSecret          string            `json:"client_secret"`
+	GroupsClaim           string            `json:"groups_claim"`
+	AdminGroup            string            `json:"admin_group"`
+	GroupFilter           string            `json:"group_filter"`
+	RedirectURL           string            `json:"redirect_url"`
+	Scope                 []string          `json:"scope"`
+	UserClaim             string            `json:"user_claim"`
+	ExtraRedirectParms    map[string]string `json:"extra_redirect_parms"`
 }
 
 // QuotaSetting wraps the settings for Quota

--- a/src/pkg/oidc/helper.go
+++ b/src/pkg/oidc/helper.go
@@ -267,9 +267,12 @@ func UserInfoFromToken(ctx context.Context, token *Token) (*UserInfo, error) {
 	if err != nil {
 		return nil, err
 	}
-	remote, err := userInfoFromRemote(ctx, token, setting)
-	if err != nil {
-		log.Warningf("Failed to get userInfo by calling remote userinfo endpoint, error: %v ", err)
+	var remote *UserInfo
+	if !setting.DisableRemoteUserInfo {
+		remote, err = userInfoFromRemote(ctx, token, setting)
+		if err != nil {
+			log.Warningf("Failed to get userInfo by calling remote userinfo endpoint, error: %v ", err)
+		}
 	}
 	if remote != nil && local != nil {
 		if remote.Subject != local.Subject {

--- a/src/portal/src/app/base/left-side-nav/config/auth/config-auth.component.html
+++ b/src/portal/src/app/base/left-side-nav/config/auth/config-auth.component.html
@@ -877,6 +877,32 @@
             </clr-checkbox-wrapper>
         </clr-checkbox-container>
         <clr-checkbox-container>
+            <label for="oidc_disable_remote_user_info"
+                >{{ 'CONFIG.OIDC.DISABLE_REMOTE_USER_INFO' | translate }}
+                <clr-tooltip>
+                    <clr-icon
+                        clrTooltipTrigger
+                        shape="info-circle"
+                        size="24"></clr-icon>
+                    <clr-tooltip-content
+                        clrPosition="top-right"
+                        clrSize="lg"
+                        *clrIfOpen>
+                        <span>{{ 'TOOLTIP.DISABLE_REMOTE_USER_INFO' | translate }}</span>
+                    </clr-tooltip-content>
+                </clr-tooltip>
+            </label>
+            <clr-checkbox-wrapper>
+                <input
+                    type="checkbox"
+                    clrCheckbox
+                    name="oidc_disable_remote_user_info"
+                    id="oidc_disable_remote_user_info"
+                    [disabled]="disabled(currentConfig.oidc_disable_remote_user_info)"
+                    [(ngModel)]="currentConfig.oidc_disable_remote_user_info.value" />
+            </clr-checkbox-wrapper>
+        </clr-checkbox-container>
+        <clr-checkbox-container>
             <label for="oidcAutoOnboard"
                 >{{ 'CONFIG.OIDC.OIDC_AUTOONBOARD' | translate }}
                 <clr-tooltip>

--- a/src/portal/src/app/base/left-side-nav/config/config.ts
+++ b/src/portal/src/app/base/left-side-nav/config/config.ts
@@ -100,6 +100,7 @@ export class Configuration {
     oidc_client_id?: StringValueItem;
     oidc_client_secret?: StringValueItem;
     oidc_verify_cert?: BoolValueItem;
+    oidc_disable_remote_user_info?: BoolValueItem;
     oidc_auto_onboard?: BoolValueItem;
     oidc_scope?: StringValueItem;
     oidc_user_claim?: StringValueItem;
@@ -175,6 +176,7 @@ export class Configuration {
         this.oidc_client_id = new StringValueItem('', true);
         this.oidc_client_secret = new StringValueItem('', true);
         this.oidc_verify_cert = new BoolValueItem(false, true);
+        this.oidc_disable_remote_user_info = new BoolValueItem(false, true);
         this.oidc_auto_onboard = new BoolValueItem(false, true);
         this.oidc_scope = new StringValueItem('', true);
         this.oidc_groups_claim = new StringValueItem('', true);

--- a/src/portal/src/app/base/left-side-nav/projects/projects.component.spec.ts
+++ b/src/portal/src/app/base/left-side-nav/projects/projects.component.spec.ts
@@ -158,6 +158,10 @@ describe('ProjectComponent', () => {
                     value: false,
                     editable: true,
                 },
+                oidc_disable_remote_user_info: {
+                    value: false,
+                    editable: true
+                },
                 project_creation_restriction: {
                     value: 'everyone',
                     editable: true,
@@ -217,8 +221,8 @@ describe('ProjectComponent', () => {
         },
     };
     const mockMessageHandlerService = {
-        refresh() {},
-        showSuccess() {},
+        refresh() { },
+        showSuccess() { },
     };
     beforeEach(async () => {
         await TestBed.configureTestingModule({


### PR DESCRIPTION
Thank you for contributing to Harbor!

# Comprehensive Summary of your change
This pull request adds a checkbox to the OIDC configuration page allowing users to disable fetching user info from the remote OIDC user info endpoint.

This PR is a draft because I require guidance on how to implement/solve some of the issues with my changes. I was able to figure out the basics but would need more information on how to persist the configuration in the database, if there is a database migration necessary, ...

I'm willing to dig in deeper if you can point me in the right direction. :)

# Issue being fixed
Fixes #17998

Please indicate you've done the following:
- [X] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [X] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
