### PR TITLE
add match many version pattern test

### DIFF
--- a/src/pkg/reg/util/pattern_test.go
+++ b/src/pkg/reg/util/pattern_test.go
@@ -73,6 +73,16 @@ func TestMatch(t *testing.T) {
 			str:     "1.01",
 			match:   false,
 		},
+		{
+			pattern: "v2.[4-6].*", // match v2.4.*~v2.7.* version
+			str:     "v2.4.0",
+			match:   true,
+		},
+		{
+			pattern: "v2.[4-7].*", // match v2.4.*~v2.7.* version
+			str:     "v2.7.0",
+			match:   true,
+		},
 	}
 	for _, c := range cases {
 		match, err := Match(c.pattern, c.str)


### PR DESCRIPTION
Thank you for contributing to Harbor!

# Comprehensive Summary of your change

When I am configuring the replication strategy and want to match certain versions, I can simply set it like this for the time being;
```
# match v2.4.*~v2.7.* version
eg: v2.[4-6].*
```

However, if you need to match certain fixed versions, it cannot be realized. I hope to support the configuration of multiple regular functions, such as: v2.0, v3.0.

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/update"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).

release-note/update