### PR TITLE
fix: remove the scan exports volume

### DIFF
--- a/make/photon/jobservice/Dockerfile
+++ b/make/photon/jobservice/Dockerfile
@@ -17,7 +17,7 @@ WORKDIR /harbor/
 
 USER harbor
 
-VOLUME ["/var/log/jobs/", "/var/scandata_exports"]
+VOLUME ["/var/log/jobs/"]
 
 HEALTHCHECK CMD curl --fail -s http://localhost:8080/api/v1/stats || curl -sk --fail --key /etc/harbor/ssl/job_service.key --cert /etc/harbor/ssl/job_service.crt https://localhost:8443/api/v1/stats || exit 1
 

--- a/make/photon/prepare/templates/docker_compose/docker-compose.yml.jinja
+++ b/make/photon/prepare/templates/docker_compose/docker-compose.yml.jinja
@@ -253,7 +253,6 @@ services:
       - SETUID
     volumes:
       - {{data_volume}}/job_logs:/var/log/jobs:z
-      - {{data_volume}}/scandata_exports:/var/scandata_exports:z
       - type: bind
         source: ./common/config/jobservice/config.yml
         target: /etc/jobservice/config.yml

--- a/make/photon/prepare/utils/jobservice.py
+++ b/make/photon/prepare/utils/jobservice.py
@@ -18,8 +18,6 @@ def prepare_job_service(config_dict):
     # Job log and exported reports are stored in data dir
     job_log_dir = os.path.join('/data', "job_logs")
     prepare_dir(job_log_dir, uid=DEFAULT_UID, gid=DEFAULT_GID)
-    job_log_dir = os.path.join('/data', "scandata_exports")
-    prepare_dir(job_log_dir, uid=DEFAULT_UID, gid=DEFAULT_GID)
 
     # Render Jobservice env
     render_jinja(

--- a/src/pkg/scan/export/constants.go
+++ b/src/pkg/scan/export/constants.go
@@ -8,11 +8,12 @@ const (
 	JobNameAttribute       = "job_name"
 	UserNameAttribute      = "user_name"
 	StatusMessageAttribute = "status_message"
-	ScanDataExportDir      = "/var/scandata_exports"
-	QueryPageSize          = 100000
-	ArtifactGroupSize      = 10000
-	DigestKey              = "artifact_digest"
-	CreateTimestampKey     = "create_ts"
-	Vendor                 = "SCAN_DATA_EXPORT"
-	CsvJobVendorIDKey      = CsvJobVendorID("vendorId")
+	// the scan data is a temporary file, use /tmp directory to avoid the permission issue.
+	ScanDataExportDir  = "/tmp"
+	QueryPageSize      = 100000
+	ArtifactGroupSize  = 10000
+	DigestKey          = "artifact_digest"
+	CreateTimestampKey = "create_ts"
+	Vendor             = "SCAN_DATA_EXPORT"
+	CsvJobVendorIDKey  = CsvJobVendorID("vendorId")
 )


### PR DESCRIPTION
1. Change the Export CVE temporary file directory to /tmp.
2. Remove the scan data export volume in Dockerfile and docker-compose yaml.

Fixes: #18067

Signed-off-by: chlins <chenyuzh@vmware.com>

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #18067

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
