### PR TITLE
Fix setup gcloud error

### DIFF
--- a/.buildbaselog
+++ b/.buildbaselog
@@ -1,5 +1,5 @@
 # Please add memo for logging the reason to trigger build base images action.
-# Note: 
+# Note:
 #    Any modifiction of this file will trigger base images build action.
 
 
@@ -7,6 +7,9 @@
 
 *   Add date here... Add signature here...
 -   Add your reason here...
+
+*   Feb 01 2023 <jiaoya@vmware.com>
+-   Refresh base image
 
 *   Sept 26 2022 <jiaoya@vmware.com>
 -   Refresh base image
@@ -21,4 +24,4 @@
 -   Refresh base image
 
 *   Jul 15 2021 <danfengl@vmware.com>
--   Create this file to trigger build base action in buld-package workflow 
+-   Create this file to trigger build base action in buld-package workflow

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -15,23 +15,22 @@ jobs:
         BUILD_PACKAGE: true
     runs-on:
       #- self-hosted
-      - ubuntu-latest
+      - ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+      - uses: 'google-github-actions/auth@v0'
+        with:
+          credentials_json: '${{ secrets.GCP_CREDENTIALS }}'
       - uses: google-github-actions/setup-gcloud@v0
         with:
           version: '285.0.0'
-          project_id: ${{ secrets.GCP_PROJECT_ID }}
-          service_account_email: ${{ secrets.GCP_SA_EMAIL }}
-          service_account_key: ${{ secrets.GCP_SA_KEY }}
-          export_default_credentials: true
       - run: gcloud info
       - name: Set up Go 1.17
         uses: actions/setup-go@v1
         with:
           go-version: 1.17.9
         id: go
-      - name: setup Docker
+      - name: Setup Docker
         uses: docker-practice/actions-setup-docker@0.0.1
         with:
           docker_version: 18.09


### PR DESCRIPTION
ubuntu-latest was upgraded from ubuntu-20.04 to ubuntu-22.04, the python version of ubuntu-22.04 is 3.10, but gcloud does not support python 3.10, so ubuntu is fixed to version 20.04

Signed-off-by: Yang Jiao <jiaoya@vmware.com>

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
