### PR TITLE
[cherry-pick] fix: update the replication API handler

### DIFF
--- a/src/controller/replication/execution.go
+++ b/src/controller/replication/execution.go
@@ -163,6 +163,12 @@ func (c *controller) markError(ctx context.Context, executionID int64, err error
 }
 
 func (c *controller) Stop(ctx context.Context, id int64) error {
+	// check whether the replication execution existed
+	_, err := c.GetExecution(ctx, id)
+	if err != nil {
+		return err
+	}
+
 	return c.execMgr.Stop(ctx, id)
 }
 

--- a/src/controller/replication/execution_test.go
+++ b/src/controller/replication/execution_test.go
@@ -105,6 +105,21 @@ func (r *replicationTestSuite) TestStart() {
 }
 
 func (r *replicationTestSuite) TestStop() {
+	r.execMgr.On("List", mock.Anything, mock.Anything).Return([]*task.Execution{
+		{
+			ID:         1,
+			VendorType: job.Replication,
+			VendorID:   1,
+			Status:     job.RunningStatus.String(),
+			Metrics: &dao.Metrics{
+				TaskCount:        1,
+				RunningTaskCount: 1,
+			},
+			Trigger:   task.ExecutionTriggerManual,
+			StartTime: time.Time{},
+			EndTime:   time.Time{},
+		},
+	}, nil)
 	r.execMgr.On("Stop", mock.Anything, mock.Anything).Return(nil)
 	err := r.ctl.Stop(nil, 1)
 	r.Require().Nil(err)

--- a/src/server/v2.0/handler/replication.go
+++ b/src/server/v2.0/handler/replication.go
@@ -350,6 +350,12 @@ func (r *replicationAPI) ListReplicationTasks(ctx context.Context, params operat
 	if err := r.RequireSystemAccess(ctx, rbac.ActionList, rbac.ResourceReplication); err != nil {
 		return r.SendError(ctx, err)
 	}
+	// check the existence of the replication execution
+	_, err := r.ctl.GetExecution(ctx, params.ID)
+	if err != nil {
+		return r.SendError(ctx, err)
+	}
+
 	query, err := r.BuildQuery(ctx, nil, params.Sort, params.Page, params.PageSize)
 	if err != nil {
 		return r.SendError(ctx, err)


### PR DESCRIPTION
1. Check execution before stop replication execution.
2. Check execution before list replication tasks.

Signed-off-by: chlins <chenyuzh@vmware.com>

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
