### PR TITLE
[cherry-pick] fix: resolve the oidc or ldap group user cannot export cve

### DIFF
--- a/src/controller/scandataexport/execution.go
+++ b/src/controller/scandataexport/execution.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/goharbor/harbor/src/jobservice/job"
-	"github.com/goharbor/harbor/src/jobservice/logger"
 	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/lib/log"
 	"github.com/goharbor/harbor/src/lib/orm"
@@ -66,6 +65,7 @@ func (c *controller) ListExecutions(ctx context.Context, userName string) ([]*ex
 }
 
 func (c *controller) GetTask(ctx context.Context, executionID int64) (*task.Task, error) {
+	logger := log.GetLogger(ctx)
 	query := q2.New(q2.KeyWords{})
 
 	keywords := make(map[string]interface{})
@@ -90,6 +90,7 @@ func (c *controller) GetTask(ctx context.Context, executionID int64) (*task.Task
 }
 
 func (c *controller) GetExecution(ctx context.Context, executionID int64) (*export.Execution, error) {
+	logger := log.GetLogger(ctx)
 	exec, err := c.execMgr.Get(ctx, executionID)
 	if err != nil {
 		logger.Errorf("Error when fetching execution status for ExecutionId: %d error : %v", executionID, err)
@@ -103,6 +104,7 @@ func (c *controller) GetExecution(ctx context.Context, executionID int64) (*expo
 }
 
 func (c *controller) DeleteExecution(ctx context.Context, executionID int64) error {
+	logger := log.GetLogger(ctx)
 	err := c.execMgr.Delete(ctx, executionID)
 	if err != nil {
 		logger.Errorf("Error when deleting execution  for ExecutionId: %d, error : %v", executionID, err)
@@ -190,12 +192,17 @@ func (c *controller) convertToExportExecStatus(ctx context.Context, exec *task.E
 	if statusMessage, ok := exec.ExtraAttrs["status_message"]; ok {
 		execStatus.StatusMessage = statusMessage.(string)
 	}
-	artifactExists := c.isCsvArtifactPresent(ctx, exec.ID, execStatus.ExportDataDigest)
-	execStatus.FilePresent = artifactExists
+
+	if len(execStatus.ExportDataDigest) > 0 {
+		artifactExists := c.isCsvArtifactPresent(ctx, exec.ID, execStatus.ExportDataDigest)
+		execStatus.FilePresent = artifactExists
+	}
+
 	return execStatus
 }
 
 func (c *controller) isCsvArtifactPresent(ctx context.Context, execID int64, digest string) bool {
+	logger := log.GetLogger(ctx)
 	repositoryName := fmt.Sprintf("scandata_export_%v", execID)
 	exists, err := c.sysArtifactMgr.Exists(ctx, strings.ToLower(export.Vendor), repositoryName, digest)
 	if err != nil {

--- a/src/controller/scandataexport/execution_test.go
+++ b/src/controller/scandataexport/execution_test.go
@@ -97,6 +97,7 @@ func (suite *ScanDataExportExecutionTestSuite) TestGetExecution() {
 	attrs := make(map[string]interface{})
 	attrs[export.JobNameAttribute] = "test-job"
 	attrs[export.UserNameAttribute] = "test-user"
+	attrs[export.DigestKey] = "sha256:d04b98f48e8f8bcc15c6ae5ac050801cd6dcfd428fb5f9e65c4e16e7807340fa"
 	attrs["status_message"] = "test-message"
 	{
 		exec := task.Execution{

--- a/src/jobservice/job/impl/scandataexport/scan_data_export.go
+++ b/src/jobservice/job/impl/scandataexport/scan_data_export.go
@@ -182,14 +182,7 @@ func (sde *ScanDataExport) writeCsvFile(ctx job.Context, params job.Parameters, 
 			return err
 		}
 
-		// check if any projects are specified. If not then fetch all the projects
-		// of which the current user is a project admin.
-		projectIds, err := sde.filterProcessor.ProcessProjectFilter(systemContext, filterCriteria.UserName, filterCriteria.Projects)
-
-		if err != nil {
-			return err
-		}
-
+		projectIds := filterCriteria.Projects
 		if len(projectIds) == 0 {
 			return nil
 		}

--- a/src/server/v2.0/handler/scanexport.go
+++ b/src/server/v2.0/handler/scanexport.go
@@ -54,8 +54,10 @@ func (se *scanDataExportAPI) ExportScanData(ctx context.Context, params operatio
 		return se.SendError(ctx, err)
 	}
 
-	if err := se.RequireProjectAccess(ctx, params.Criteria.Projects[0], rbac.ActionCreate, rbac.ResourceExportCVE); err != nil {
-		return se.SendError(ctx, err)
+	for _, pid := range params.Criteria.Projects {
+		if err := se.RequireProjectAccess(ctx, pid, rbac.ActionCreate, rbac.ResourceExportCVE); err != nil {
+			return se.SendError(ctx, err)
+		}
 	}
 
 	scanDataExportJob := new(models.ScanDataExportJob)

--- a/src/testing/pkg/scan/export/filter_processor.go
+++ b/src/testing/pkg/scan/export/filter_processor.go
@@ -38,29 +38,6 @@ func (_m *FilterProcessor) ProcessLabelFilter(ctx context.Context, labelIDs []in
 	return r0, r1
 }
 
-// ProcessProjectFilter provides a mock function with given fields: ctx, userName, projectsToFilter
-func (_m *FilterProcessor) ProcessProjectFilter(ctx context.Context, userName string, projectsToFilter []int64) ([]int64, error) {
-	ret := _m.Called(ctx, userName, projectsToFilter)
-
-	var r0 []int64
-	if rf, ok := ret.Get(0).(func(context.Context, string, []int64) []int64); ok {
-		r0 = rf(ctx, userName, projectsToFilter)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]int64)
-		}
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, string, []int64) error); ok {
-		r1 = rf(ctx, userName, projectsToFilter)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
 // ProcessRepositoryFilter provides a mock function with given fields: ctx, filter, projectIds
 func (_m *FilterProcessor) ProcessRepositoryFilter(ctx context.Context, filter string, projectIds []int64) ([]int64, error) {
 	ret := _m.Called(ctx, filter, projectIds)


### PR DESCRIPTION
Remove the project filter in the scan data export job as they have been validated by API handler, fix the oidc or ldap group users cannot export cve.

Fixes: #18112

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
