### PR TITLE
bugfix: unknown: cannot convert {project named using numbers} to Text

### DIFF
--- a/src/pkg/reg/adapter/harbor/base/adapter.go
+++ b/src/pkg/reg/adapter/harbor/base/adapter.go
@@ -176,7 +176,7 @@ func (a *Adapter) PrepareForPush(resources []*model.Resource) error {
 	for p := range projects {
 		ps = append(ps, p)
 	}
-	q := fmt.Sprintf("name={%s}", strings.Join(ps, " "))
+	q := fmt.Sprintf("name={\"%s\"}", strings.Join(ps, "\" \""))
 	// get exist projects
 	queryProjects, err := a.Client.ListProjectsWithQuery(q, false)
 	if err != nil {


### PR DESCRIPTION
Thank you for contributing to Harbor!

# Comprehensive Summary of your change

When named a project using numbers, Calling this API will cause an error:

![image](https://user-images.githubusercontent.com/17629142/220574334-6baae18a-b9f2-4354-bdfd-28d5d9c207d8.png)

When I surround the project name with double quotes, the bug disappears:

![image](https://user-images.githubusercontent.com/17629142/220573352-c6931363-bf88-4dc5-9d50-567f19ab0043.png)

Tail the CORE component log found the following error:

```
[ERROR] [/lib/http/error.go:56]: {"errors":[{"code":"UNKNOWN","message":"unknown: cannot convert 10042620 to Text"}]}
```

Similar problems occur when using the Replications function:

![image](https://user-images.githubusercontent.com/17629142/220576535-d378e96d-e9ce-491e-981e-50b0c8f7d46d.png)

A shorter error message on the page:

```
failed to do the prepare work for pushing/uploading resources: list projects with query name={10042620}: http error: code 500, message {"errors":[{"code":"UNKNOWN","message":"internal server error"}]}
```

So, I solved this problem by using double quotes, and the test passed. Few changes.


Please indicate you've done the following:
- [✅ ] Well Written Title and Summary of the PR
- [✅ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [ ✅] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ✅] Made sure tests are passing and test coverage is added if needed.

