### PR TITLE
Add an absolute path for the docker command

### DIFF
--- a/tools/systemd/harbor.service
+++ b/tools/systemd/harbor.service
@@ -8,9 +8,9 @@ Requires=docker.service
 Type=simple
 Restart=on-failure
 RestartSec=5
-ExecStart=docker compose -f /etc/goharbor/harbor/docker-compose.yml up
-ExecStop=docker compose -f /etc/goharbor/harbor/docker-compose.yml down -v
-ExecStopPost=docker compose -f /etc/goharbor/harbor/docker-compose.yml rm -f
+ExecStart=/usr/bin/docker compose -f /etc/goharbor/harbor/docker-compose.yml up
+ExecStop=/usr/bin/docker compose -f /etc/goharbor/harbor/docker-compose.yml down -v
+ExecStopPost=/usr/bin/docker compose -f /etc/goharbor/harbor/docker-compose.yml rm -f
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
# Issue being fixed
Fixes #(issue)
An error occurred not using an absolute path in some old systems.

<img width="917" alt="Snipaste_2023-03-16_00-16-24" src="https://user-images.githubusercontent.com/34529891/225373134-60d57e18-b49b-47f3-9ec3-c3fb17e717fe.png">

Please indicate you've done the following:

Compatible for old systems like CentOS 7 in which an absolute path is still needed. It will throw an error "Executable path is not absolute, ignoring: docker compose ..." if using just a simple command. The systemd version is old and "man 5 systemd.service" says "the first argument must be an absolute path to an executable."

In newer systems like Rocky Linux 8, the systemd version is much newer, and "If the command is not a full (absolute) path, it will be resolved to a full path using a fixed search path determinted at compilation time. Searched directories include /usr/local/bin/, /usr/bin/, /bin/ ... Using an absolute path is recommended to avoid ambiguity." So it is better using an absolute path.


- [ ] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [ ] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
