### PR TITLE
fix: register sweeper retain counts for scan and purge audit log job

### DIFF
--- a/src/jobservice/job/known_jobs.go
+++ b/src/jobservice/job/known_jobs.go
@@ -50,6 +50,8 @@ var (
 	// executionSweeperCount stores the count for execution retained
 	executionSweeperCount = map[string]int64{
 		ScanAllVendorType:               5,
+		ImageScanJobVendorType:          5,
+		PurgeAuditVendorType:            10,
 		ExecSweepVendorType:             10,
 		GarbageCollectionVendorType:     50,
 		SlackJobVendorType:              50,


### PR DESCRIPTION
Register sweeper retain counts for scan and purge audit log job.

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
