### PR TITLE
fix: fix the invalid jobid for scan data export

### DIFF
--- a/src/controller/scandataexport/execution.go
+++ b/src/controller/scandataexport/execution.go
@@ -124,8 +124,8 @@ func (c *controller) Start(ctx context.Context, request export.Request) (executi
 
 	// create a job object and fill with metadata and parameters
 	params := make(map[string]interface{})
-	params["JobId"] = id
-	params["Request"] = request
+	params[export.JobID] = fmt.Sprintf("%d", id)
+	params[export.JobRequest] = request
 	params[export.JobModeKey] = export.JobModeExport
 
 	j := &task.Job{

--- a/src/jobservice/job/impl/scandataexport/scan_data_export_test.go
+++ b/src/jobservice/job/impl/scandataexport/scan_data_export_test.go
@@ -30,8 +30,11 @@ import (
 	tasktesting "github.com/goharbor/harbor/src/testing/pkg/task"
 )
 
-const JobId = float64(100)
-const MockDigest = "mockDigest"
+const (
+	ExecID     int64 = 1000000
+	JobId            = "1000000"
+	MockDigest       = "mockDigest"
+)
 
 type ScanDataExportJobTestSuite struct {
 	htesting.Suite
@@ -80,7 +83,7 @@ func (suite *ScanDataExportJobTestSuite) TestRun() {
 	execAttrs := make(map[string]interface{})
 	execAttrs[export.JobNameAttribute] = "test-job"
 	execAttrs[export.UserNameAttribute] = "test-user"
-	mock.OnAnything(suite.execMgr, "Get").Return(&task.Execution{ID: int64(JobId), ExtraAttrs: execAttrs}, nil)
+	mock.OnAnything(suite.execMgr, "Get").Return(&task.Execution{ID: ExecID, ExtraAttrs: execAttrs}, nil)
 
 	params := job.Parameters{}
 	params[export.JobModeKey] = export.JobModeExport
@@ -93,7 +96,7 @@ func (suite *ScanDataExportJobTestSuite) TestRun() {
 	err := suite.job.Run(ctx, params)
 	suite.NoError(err)
 	sysArtifactRecordMatcher := testifymock.MatchedBy(func(sa *model.SystemArtifact) bool {
-		return sa.Repository == "scandata_export_100" && sa.Vendor == strings.ToLower(export.Vendor) && sa.Digest == MockDigest
+		return sa.Repository == "scandata_export_1000000" && sa.Vendor == strings.ToLower(export.Vendor) && sa.Digest == MockDigest
 	})
 	suite.sysArtifactMgr.AssertCalled(suite.T(), "Create", mock.Anything, sysArtifactRecordMatcher, mock.Anything)
 
@@ -105,8 +108,8 @@ func (suite *ScanDataExportJobTestSuite) TestRun() {
 		_, ok := m[export.CreateTimestampKey]
 		return attrsMap[export.DigestKey] == MockDigest && ok && attrsMap[export.JobNameAttribute] == "test-job" && attrsMap[export.UserNameAttribute] == "test-user"
 	})
-	suite.execMgr.AssertCalled(suite.T(), "UpdateExtraAttrs", mock.Anything, int64(JobId), extraAttrsMatcher)
-	_, err = os.Stat("/tmp/scandata_export_100.csv")
+	suite.execMgr.AssertCalled(suite.T(), "UpdateExtraAttrs", mock.Anything, ExecID, extraAttrsMatcher)
+	_, err = os.Stat("/tmp/scandata_export_1000000.csv")
 	suite.Truef(os.IsNotExist(err), "Expected CSV file to be deleted")
 
 }
@@ -119,7 +122,7 @@ func (suite *ScanDataExportJobTestSuite) TestRunWithEmptyData() {
 	execAttrs := make(map[string]interface{})
 	execAttrs[export.JobNameAttribute] = "test-job"
 	execAttrs[export.UserNameAttribute] = "test-user"
-	mock.OnAnything(suite.execMgr, "Get").Return(&task.Execution{ID: int64(JobId), ExtraAttrs: execAttrs}, nil)
+	mock.OnAnything(suite.execMgr, "Get").Return(&task.Execution{ID: ExecID, ExtraAttrs: execAttrs}, nil)
 
 	params := job.Parameters{}
 	params[export.JobModeKey] = export.JobModeExport
@@ -132,7 +135,7 @@ func (suite *ScanDataExportJobTestSuite) TestRunWithEmptyData() {
 	extraAttrsMatcher := testifymock.MatchedBy(func(attrsMap map[string]interface{}) bool {
 		return attrsMap["status_message"] == "No vulnerabilities found or matched" && attrsMap[export.JobNameAttribute] == "test-job" && attrsMap[export.UserNameAttribute] == "test-user"
 	})
-	suite.execMgr.AssertCalled(suite.T(), "UpdateExtraAttrs", mock.Anything, int64(JobId), extraAttrsMatcher)
+	suite.execMgr.AssertCalled(suite.T(), "UpdateExtraAttrs", mock.Anything, ExecID, extraAttrsMatcher)
 }
 
 func (suite *ScanDataExportJobTestSuite) TestRunAttributeUpdateError() {
@@ -160,7 +163,7 @@ func (suite *ScanDataExportJobTestSuite) TestRunAttributeUpdateError() {
 	err := suite.job.Run(ctx, params)
 	suite.Error(err)
 	sysArtifactRecordMatcher := testifymock.MatchedBy(func(sa *model.SystemArtifact) bool {
-		return sa.Repository == "scandata_export_100" && sa.Vendor == strings.ToLower(export.Vendor) && sa.Digest == MockDigest
+		return sa.Repository == "scandata_export_1000000" && sa.Vendor == strings.ToLower(export.Vendor) && sa.Digest == MockDigest
 	})
 	suite.sysArtifactMgr.AssertCalled(suite.T(), "Create", mock.Anything, sysArtifactRecordMatcher, mock.Anything)
 
@@ -172,8 +175,8 @@ func (suite *ScanDataExportJobTestSuite) TestRunAttributeUpdateError() {
 		_, ok := m[export.CreateTimestampKey]
 		return attrsMap[export.DigestKey] == MockDigest && ok && attrsMap[export.JobNameAttribute] == "test-job" && attrsMap[export.UserNameAttribute] == "test-user"
 	})
-	suite.execMgr.AssertNotCalled(suite.T(), "UpdateExtraAttrs", mock.Anything, int64(JobId), extraAttrsMatcher)
-	_, err = os.Stat("/tmp/scandata_export_100.csv")
+	suite.execMgr.AssertNotCalled(suite.T(), "UpdateExtraAttrs", mock.Anything, ExecID, extraAttrsMatcher)
+	_, err = os.Stat("/tmp/scandata_export_1000000.csv")
 	suite.Truef(os.IsNotExist(err), "Expected CSV file to be deleted")
 
 }
@@ -207,7 +210,7 @@ func (suite *ScanDataExportJobTestSuite) TestRunWithCriteria() {
 		execAttrs := make(map[string]interface{})
 		execAttrs[export.JobNameAttribute] = "test-job"
 		execAttrs[export.UserNameAttribute] = "test-user"
-		mock.OnAnything(suite.execMgr, "Get").Return(&task.Execution{ID: int64(JobId), ExtraAttrs: execAttrs}, nil).Once()
+		mock.OnAnything(suite.execMgr, "Get").Return(&task.Execution{ID: ExecID, ExtraAttrs: execAttrs}, nil).Once()
 
 		repoCandidates := []int64{1}
 		artCandidates := []*artifact.Artifact{{Artifact: artpkg.Artifact{ID: 1, Digest: "digest1"}}}
@@ -236,7 +239,7 @@ func (suite *ScanDataExportJobTestSuite) TestRunWithCriteria() {
 		err := suite.job.Run(ctx, params)
 		suite.NoError(err)
 		sysArtifactRecordMatcher := testifymock.MatchedBy(func(sa *model.SystemArtifact) bool {
-			return sa.Repository == "scandata_export_100" && sa.Vendor == strings.ToLower(export.Vendor) && sa.Digest == MockDigest
+			return sa.Repository == "scandata_export_1000000" && sa.Vendor == strings.ToLower(export.Vendor) && sa.Digest == MockDigest
 		})
 		suite.sysArtifactMgr.AssertCalled(suite.T(), "Create", mock.Anything, sysArtifactRecordMatcher, mock.Anything)
 
@@ -248,8 +251,8 @@ func (suite *ScanDataExportJobTestSuite) TestRunWithCriteria() {
 			_, ok := m[export.CreateTimestampKey]
 			return attrsMap[export.DigestKey] == MockDigest && ok
 		})
-		suite.execMgr.AssertCalled(suite.T(), "UpdateExtraAttrs", mock.Anything, int64(JobId), extraAttrsMatcher)
-		_, err = os.Stat("/tmp/scandata_export_100.csv")
+		suite.execMgr.AssertCalled(suite.T(), "UpdateExtraAttrs", mock.Anything, ExecID, extraAttrsMatcher)
+		_, err = os.Stat("/tmp/scandata_export_1000000.csv")
 
 		exportParamsMatcher := testifymock.MatchedBy(func(params export.Params) bool {
 			return reflect.DeepEqual(params.CVEIds, criteria.CVEIds)
@@ -271,7 +274,7 @@ func (suite *ScanDataExportJobTestSuite) TestRunWithCriteria() {
 		execAttrs := make(map[string]interface{})
 		execAttrs[export.JobNameAttribute] = "test-job"
 		execAttrs[export.UserNameAttribute] = "test-user"
-		mock.OnAnything(suite.execMgr, "Get").Return(&task.Execution{ID: int64(JobId), ExtraAttrs: execAttrs}, nil).Once()
+		mock.OnAnything(suite.execMgr, "Get").Return(&task.Execution{ID: ExecID, ExtraAttrs: execAttrs}, nil).Once()
 
 		repoCandidate1 := &selector.Candidate{NamespaceID: 1}
 		repoCandidates := []*selector.Candidate{repoCandidate1}
@@ -298,7 +301,7 @@ func (suite *ScanDataExportJobTestSuite) TestRunWithCriteria() {
 		err := suite.job.Run(ctx, params)
 		suite.NoError(err)
 		sysArtifactRecordMatcher := testifymock.MatchedBy(func(sa *model.SystemArtifact) bool {
-			return sa.Repository == "scandata_export_100" && sa.Vendor == strings.ToLower(export.Vendor) && sa.Digest == MockDigest
+			return sa.Repository == "scandata_export_1000000" && sa.Vendor == strings.ToLower(export.Vendor) && sa.Digest == MockDigest
 		})
 		suite.sysArtifactMgr.AssertCalled(suite.T(), "Create", mock.Anything, sysArtifactRecordMatcher, mock.Anything)
 		m := make(map[string]interface{})
@@ -309,8 +312,8 @@ func (suite *ScanDataExportJobTestSuite) TestRunWithCriteria() {
 			_, ok := m[export.CreateTimestampKey]
 			return attrsMap[export.DigestKey] == MockDigest && ok
 		})
-		suite.execMgr.AssertCalled(suite.T(), "UpdateExtraAttrs", mock.Anything, int64(JobId), extraAttrsMatcher)
-		_, err = os.Stat("/tmp/scandata_export_100.csv")
+		suite.execMgr.AssertCalled(suite.T(), "UpdateExtraAttrs", mock.Anything, ExecID, extraAttrsMatcher)
+		_, err = os.Stat("/tmp/scandata_export_1000000.csv")
 
 		exportParamsMatcher := testifymock.MatchedBy(func(params export.Params) bool {
 			return reflect.DeepEqual(params.CVEIds, criteria.CVEIds)
@@ -334,7 +337,7 @@ func (suite *ScanDataExportJobTestSuite) TestRunWithCriteriaForRepositoryIdFilte
 		execAttrs := make(map[string]interface{})
 		execAttrs[export.JobNameAttribute] = "test-job"
 		execAttrs[export.UserNameAttribute] = "test-user"
-		mock.OnAnything(suite.execMgr, "Get").Return(&task.Execution{ID: int64(JobId), ExtraAttrs: execAttrs}, nil).Once()
+		mock.OnAnything(suite.execMgr, "Get").Return(&task.Execution{ID: ExecID, ExtraAttrs: execAttrs}, nil).Once()
 
 		mock.OnAnything(suite.filterProcessor, "ProcessRepositoryFilter").Return([]int64{1}, errors.New("test error")).Once()
 		mock.OnAnything(suite.filterProcessor, "ProcessTagFilter").Return([]*artifact.Artifact{{Artifact: artpkg.Artifact{ID: 1}}}, nil).Once()
@@ -360,11 +363,11 @@ func (suite *ScanDataExportJobTestSuite) TestRunWithCriteriaForRepositoryIdFilte
 		err := suite.job.Run(ctx, params)
 		suite.Error(err)
 		sysArtifactRecordMatcher := testifymock.MatchedBy(func(sa *model.SystemArtifact) bool {
-			return sa.Repository == "scandata_export_100" && sa.Vendor == strings.ToLower(export.Vendor) && sa.Digest == MockDigest
+			return sa.Repository == "scandata_export_1000000" && sa.Vendor == strings.ToLower(export.Vendor) && sa.Digest == MockDigest
 		})
 		suite.sysArtifactMgr.AssertNotCalled(suite.T(), "Create", mock.Anything, sysArtifactRecordMatcher, mock.Anything)
-		suite.execMgr.AssertNotCalled(suite.T(), "UpdateExtraAttrs", mock.Anything, int64(JobId), mock.Anything)
-		_, err = os.Stat("/tmp/scandata_export_100.csv")
+		suite.execMgr.AssertNotCalled(suite.T(), "UpdateExtraAttrs", mock.Anything, ExecID, mock.Anything)
+		_, err = os.Stat("/tmp/scandata_export_1000000.csv")
 
 		suite.exportMgr.AssertNotCalled(suite.T(), "Fetch", mock.Anything, mock.Anything)
 
@@ -384,7 +387,7 @@ func (suite *ScanDataExportJobTestSuite) TestRunWithCriteriaForRepositoryIdFilte
 		execAttrs := make(map[string]interface{})
 		execAttrs[export.JobNameAttribute] = "test-job"
 		execAttrs[export.UserNameAttribute] = "test-user"
-		mock.OnAnything(suite.execMgr, "Get").Return(&task.Execution{ID: int64(JobId), ExtraAttrs: execAttrs}, nil).Once()
+		mock.OnAnything(suite.execMgr, "Get").Return(&task.Execution{ID: ExecID, ExtraAttrs: execAttrs}, nil).Once()
 
 		mock.OnAnything(suite.filterProcessor, "ProcessRepositoryFilter").Return([]int64{}, nil).Once()
 		mock.OnAnything(suite.filterProcessor, "ProcessTagFilter").Return([]*artifact.Artifact{}, nil).Once()
@@ -410,11 +413,11 @@ func (suite *ScanDataExportJobTestSuite) TestRunWithCriteriaForRepositoryIdFilte
 		err := suite.job.Run(ctx, params)
 		suite.NoError(err)
 		sysArtifactRecordMatcher := testifymock.MatchedBy(func(sa *model.SystemArtifact) bool {
-			return sa.Repository == "scandata_export_100" && sa.Vendor == strings.ToLower(export.Vendor) && sa.Digest == MockDigest
+			return sa.Repository == "scandata_export_1000000" && sa.Vendor == strings.ToLower(export.Vendor) && sa.Digest == MockDigest
 		})
 		suite.sysArtifactMgr.AssertNotCalled(suite.T(), "Create", mock.Anything, sysArtifactRecordMatcher, mock.Anything)
-		suite.execMgr.AssertCalled(suite.T(), "UpdateExtraAttrs", mock.Anything, int64(JobId), mock.Anything)
-		_, err = os.Stat("/tmp/scandata_export_100.csv")
+		suite.execMgr.AssertCalled(suite.T(), "UpdateExtraAttrs", mock.Anything, ExecID, mock.Anything)
+		_, err = os.Stat("/tmp/scandata_export_1000000.csv")
 
 		suite.exportMgr.AssertNotCalled(suite.T(), "Fetch", mock.Anything, mock.Anything)
 
@@ -436,7 +439,7 @@ func (suite *ScanDataExportJobTestSuite) TestRunWithCriteriaForRepositoryIdWithT
 		execAttrs := make(map[string]interface{})
 		execAttrs[export.JobNameAttribute] = "test-job"
 		execAttrs[export.UserNameAttribute] = "test-user"
-		mock.OnAnything(suite.execMgr, "Get").Return(&task.Execution{ID: int64(JobId), ExtraAttrs: execAttrs}, nil).Once()
+		mock.OnAnything(suite.execMgr, "Get").Return(&task.Execution{ID: ExecID, ExtraAttrs: execAttrs}, nil).Once()
 
 		mock.OnAnything(suite.filterProcessor, "ProcessRepositoryFilter").Return([]int64{1}, nil).Once()
 		mock.OnAnything(suite.filterProcessor, "ProcessTagFilter").Return(nil, errors.New("test error")).Once()
@@ -462,11 +465,11 @@ func (suite *ScanDataExportJobTestSuite) TestRunWithCriteriaForRepositoryIdWithT
 		err := suite.job.Run(ctx, params)
 		suite.Error(err)
 		sysArtifactRecordMatcher := testifymock.MatchedBy(func(sa *model.SystemArtifact) bool {
-			return sa.Repository == "scandata_export_100" && sa.Vendor == strings.ToLower(export.Vendor) && sa.Digest == MockDigest
+			return sa.Repository == "scandata_export_1000000" && sa.Vendor == strings.ToLower(export.Vendor) && sa.Digest == MockDigest
 		})
 		suite.sysArtifactMgr.AssertNotCalled(suite.T(), "Create", mock.Anything, sysArtifactRecordMatcher, mock.Anything)
-		suite.execMgr.AssertNotCalled(suite.T(), "UpdateExtraAttrs", mock.Anything, int64(JobId), mock.Anything)
-		_, err = os.Stat("/tmp/scandata_export_100.csv")
+		suite.execMgr.AssertNotCalled(suite.T(), "UpdateExtraAttrs", mock.Anything, ExecID, mock.Anything)
+		_, err = os.Stat("/tmp/scandata_export_1000000.csv")
 
 		suite.exportMgr.AssertNotCalled(suite.T(), "Fetch", mock.Anything, mock.Anything)
 
@@ -486,7 +489,7 @@ func (suite *ScanDataExportJobTestSuite) TestRunWithCriteriaForRepositoryIdWithT
 		execAttrs := make(map[string]interface{})
 		execAttrs[export.JobNameAttribute] = "test-job"
 		execAttrs[export.UserNameAttribute] = "test-user"
-		mock.OnAnything(suite.execMgr, "Get").Return(&task.Execution{ID: int64(JobId), ExtraAttrs: execAttrs}, nil).Once()
+		mock.OnAnything(suite.execMgr, "Get").Return(&task.Execution{ID: ExecID, ExtraAttrs: execAttrs}, nil).Once()
 
 		mock.OnAnything(suite.filterProcessor, "ProcessRepositoryFilter").Return([]int64{}, nil).Once()
 		mock.OnAnything(suite.filterProcessor, "ProcessTagFilter").Return(nil, nil).Once()
@@ -512,11 +515,11 @@ func (suite *ScanDataExportJobTestSuite) TestRunWithCriteriaForRepositoryIdWithT
 		err := suite.job.Run(ctx, params)
 		suite.NoError(err)
 		sysArtifactRecordMatcher := testifymock.MatchedBy(func(sa *model.SystemArtifact) bool {
-			return sa.Repository == "scandata_export_100" && sa.Vendor == strings.ToLower(export.Vendor) && sa.Digest == MockDigest
+			return sa.Repository == "scandata_export_1000000" && sa.Vendor == strings.ToLower(export.Vendor) && sa.Digest == MockDigest
 		})
 		suite.sysArtifactMgr.AssertNotCalled(suite.T(), "Create", mock.Anything, sysArtifactRecordMatcher, mock.Anything)
-		suite.execMgr.AssertCalled(suite.T(), "UpdateExtraAttrs", mock.Anything, int64(JobId), mock.Anything)
-		_, err = os.Stat("/tmp/scandata_export_100.csv")
+		suite.execMgr.AssertCalled(suite.T(), "UpdateExtraAttrs", mock.Anything, ExecID, mock.Anything)
+		_, err = os.Stat("/tmp/scandata_export_1000000.csv")
 
 		suite.exportMgr.AssertNotCalled(suite.T(), "Fetch", mock.Anything, mock.Anything)
 
@@ -538,11 +541,11 @@ func (suite *ScanDataExportJobTestSuite) TestExportDigestCalculationErrorsOut() 
 	err := suite.job.Run(ctx, params)
 	suite.Error(err)
 	sysArtifactRecordMatcher := testifymock.MatchedBy(func(sa *model.SystemArtifact) bool {
-		return sa.Repository == "scandata_export_100" && sa.Vendor == strings.ToLower(export.Vendor) && sa.Digest == MockDigest
+		return sa.Repository == "scandata_export_1000000" && sa.Vendor == strings.ToLower(export.Vendor) && sa.Digest == MockDigest
 	})
 	suite.sysArtifactMgr.AssertNotCalled(suite.T(), "Create", mock.Anything, sysArtifactRecordMatcher, mock.Anything)
 	suite.execMgr.AssertNotCalled(suite.T(), "UpdateExtraAttrs")
-	_, err = os.Stat("/tmp/scandata_export_100.csv")
+	_, err = os.Stat("/tmp/scandata_export_1000000.csv")
 	suite.Truef(os.IsNotExist(err), "Expected CSV file to be deleted")
 }
 

--- a/src/pkg/scan/export/manager.go
+++ b/src/pkg/scan/export/manager.go
@@ -56,6 +56,8 @@ group by
 	`
 	JobModeExport = "export"
 	JobModeKey    = "mode"
+	JobID         = "JobId"
+	JobRequest    = "Request"
 )
 
 var (


### PR DESCRIPTION
Change the JobId param type from int to string, use int will bring some problems for encode/decode type mismatch which generate the invalid repository name.

Fixes: #18380

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #18380

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
