### PR TITLE
[cherry-pick] fix: escape the event data for slack webhook payload

### DIFF
--- a/src/pkg/notifier/handler/notification/slack_handler.go
+++ b/src/pkg/notifier/handler/notification/slack_handler.go
@@ -121,7 +121,7 @@ func (s *SlackHandler) convert(payLoad *model.Payload) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("marshal from eventData %v failed: %v", payLoad.EventData, err)
 	}
-	data["EventData"] = "```" + strings.Replace(string(eventData), `"`, `\"`, -1) + "```"
+	data["EventData"] = "```" + escapeEventData(string(eventData)) + "```"
 
 	st, _ := template.New("slack").Parse(SlackBodyTemplate)
 	var slackBuf bytes.Buffer
@@ -129,4 +129,12 @@ func (s *SlackHandler) convert(payLoad *model.Payload) (string, error) {
 		return "", fmt.Errorf("%v", err)
 	}
 	return slackBuf.String(), nil
+}
+
+func escapeEventData(str string) string {
+	// escape " to \"
+	str = strings.Replace(str, `"`, `\"`, -1)
+	// escape \\" to \\\"
+	str = strings.Replace(str, `\\"`, `\\\"`, -1)
+	return str
 }

--- a/src/pkg/notifier/handler/notification/slack_handler_test.go
+++ b/src/pkg/notifier/handler/notification/slack_handler_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/goharbor/harbor/src/common/dao"
 	"github.com/goharbor/harbor/src/pkg/notification"
 	policy_model "github.com/goharbor/harbor/src/pkg/notification/policy/model"
 	"github.com/goharbor/harbor/src/pkg/notifier/event"
@@ -16,7 +15,7 @@ import (
 )
 
 func TestSlackHandler_Handle(t *testing.T) {
-	dao.PrepareTestForPostgresSQL()
+
 	hookMgr := notification.HookManager
 	defer func() {
 		notification.HookManager = hookMgr
@@ -106,4 +105,33 @@ func TestSlackHandler_IsStateful(t *testing.T) {
 func TestSlackHandler_Name(t *testing.T) {
 	handler := &SlackHandler{}
 	assert.Equal(t, "Slack", handler.Name())
+}
+
+func Test_escapeEventData(t *testing.T) {
+	type args struct {
+		str string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: `escape "`,
+			args: args{str: `{"foo":"bar"}`},
+			want: `{\"foo\":\"bar\"}`,
+		},
+		{
+			name: `escape \\"`,
+			args: args{str: `{\"foo\":\"bar\"}`},
+			want: `{\\\"foo\\\":\\\"bar\\\"}`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := escapeEventData(tt.args.str); got != tt.want {
+				t.Errorf("escapeEventData() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }


### PR DESCRIPTION
Escape the event data of slack webhook as original payload is invalid when send to slack.

Fixes: #18423

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #18423

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
