### PR TITLE
fix: add default payload_format for http type webhook

### DIFF
--- a/api/v2.0/swagger.yaml
+++ b/api/v2.0/swagger.yaml
@@ -8553,6 +8553,7 @@ definitions:
         description: Whether or not to skip cert verify.
       payload_format:
         $ref: '#/definitions/PayloadFormatType'
+        description: The payload format of webhook, by default is Default for http type.
   WebhookPolicy:
     type: object
     description: The webhook policy object

--- a/src/server/v2.0/handler/webhook.go
+++ b/src/server/v2.0/handler/webhook.go
@@ -406,7 +406,7 @@ func (n *webhookAPI) validateTargets(policy *policy_model.Policy) (bool, error) 
 	if len(policy.Targets) == 0 {
 		return false, errors.New(nil).WithMessage("empty notification target with policy %s", policy.Name).WithCode(errors.BadRequestCode)
 	}
-	for _, target := range policy.Targets {
+	for i, target := range policy.Targets {
 		url, err := utils.ParseEndpoint(target.Address)
 		if err != nil {
 			return false, errors.New(err).WithCode(errors.BadRequestCode)
@@ -425,6 +425,10 @@ func (n *webhookAPI) validateTargets(policy *policy_model.Policy) (bool, error) 
 
 		if len(target.PayloadFormat) > 0 && !isPayloadFormatSupported(target.PayloadFormat) {
 			return false, errors.New(nil).WithMessage("unsupported payload format type: %s", target.PayloadFormat).WithCode(errors.BadRequestCode)
+		}
+		// set payload format to Default is not specified when the type is http
+		if len(target.PayloadFormat) == 0 && target.Type == "http" {
+			policy.Targets[i].PayloadFormat = "Default"
 		}
 	}
 	return true, nil


### PR DESCRIPTION
1. Add migration SQL to handle the lost payload format for old policies.
2. Set payload format to 'Default' if not specified for http webhook in the API handler.
3. Fix the migration SQL of notification_job.

Fixes: #18401,#18453

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #18401,#18453

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
