### PR TITLE
[cherry-pick] fix: correct the retention webhook payload

### DIFF
--- a/src/controller/event/handler/webhook/artifact/retention.go
+++ b/src/controller/event/handler/webhook/artifact/retention.go
@@ -121,8 +121,8 @@ func (r *RetentionHandler) constructRetentionPayload(event *event.RetentionEvent
 		Operator: execution.Trigger,
 		EventData: &model.EventData{
 			Retention: &evtModel.Retention{
-				Total:             task.Total,
-				Retained:          task.Retained,
+				Total:             event.Total,
+				Retained:          event.Retained,
 				HarborHostname:    hostname,
 				ProjectName:       event.Deleted[0].Target.Namespace,
 				RetentionPolicyID: execution.PolicyID,
@@ -140,8 +140,11 @@ func (r *RetentionHandler) constructRetentionPayload(event *event.RetentionEvent
 		}
 		if len(target.Tags) != 0 {
 			deletedArtifact.NameAndTag = target.Repository + ":" + target.Tags[0]
+		} else {
+			// use digest if no tag
+			deletedArtifact.NameAndTag = target.Repository + "@" + target.Digest
 		}
-		payload.EventData.Retention.DeletedArtifact = []*evtModel.ArtifactInfo{deletedArtifact}
+		payload.EventData.Retention.DeletedArtifact = append(payload.EventData.Retention.DeletedArtifact, deletedArtifact)
 	}
 
 	for _, v := range md.Rules {

--- a/src/controller/event/metadata/retention.go
+++ b/src/controller/event/metadata/retention.go
@@ -25,6 +25,8 @@ func (r *RetentionMetaData) Resolve(evt *event.Event) error {
 		Status:    r.Status,
 		Deleted:   r.Deleted,
 		TaskID:    r.TaskID,
+		Total:     r.Total,
+		Retained:  r.Retained,
 	}
 
 	evt.Topic = event2.TopicTagRetention

--- a/src/controller/event/topic.go
+++ b/src/controller/event/topic.go
@@ -371,6 +371,8 @@ type RetentionEvent struct {
 	OccurAt   time.Time
 	Status    string
 	Deleted   []*selector.Result
+	Total     int
+	Retained  int
 }
 
 func (r *RetentionEvent) String() string {


### PR DESCRIPTION
Fix the incorrect number of total and retained in the retention webhook payload, and completes the deleted_artifacts field.

Fixes: #18428

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #18428

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
