### PR TITLE
fix: fix the regexp of execution status outdate key

### DIFF
--- a/src/pkg/task/dao/execution.go
+++ b/src/pkg/task/dao/execution.go
@@ -55,7 +55,7 @@ var (
 	// execStatusOutdateKeyRegex is the regex for the execution status outdate key,
 	// the regex used to parse exec id and vendor type from the key.
 	// e.g. execution:id:100:vendor:REPLICATION:status_outdate
-	execStatusOutdateKeyRegex = regexp.MustCompile(`execution:id:(\d+):vendor:([A-Z_]+):status_outdate`)
+	execStatusOutdateKeyRegex = regexp.MustCompile(`execution:id:(\d+):vendor:([A-Z0-9_]+):status_outdate`)
 )
 
 // ExecutionStatusChangePostFunc is the function called after the execution status changed

--- a/src/pkg/task/dao/execution_test.go
+++ b/src/pkg/task/dao/execution_test.go
@@ -431,7 +431,8 @@ func Test_extractExecIDVendorFromKey(t *testing.T) {
 		{"invalid format", args{"invalid:foo:bar"}, 0, "", true},
 		{"invalid execution id", args{"execution:id:12abc:vendor:GC:status_outdate"}, 0, "", true},
 		{"invalid vendor type", args{"execution:id:100:vendor:foo:status_outdate"}, 0, "", true},
-		{"valid", args{"execution:id:100:vendor:GARBAGE_COLLECTION:status_outdate"}, 100, "GARBAGE_COLLECTION", false},
+		{"valid 1", args{"execution:id:100:vendor:GARBAGE_COLLECTION:status_outdate"}, 100, "GARBAGE_COLLECTION", false},
+		{"valid 2", args{"execution:id:100:vendor:P2P_PREHEAT:status_outdate"}, 100, "P2P_PREHEAT", false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Update the regexp of execution status outdate key to resolve the P2P_PREHEAT execution status not be refreshed.

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
