### PR TITLE
[cherry-pick] fix: fix error bitsize of jobservice reaper scan locks

### DIFF
--- a/src/jobservice/worker/cworker/reaper.go
+++ b/src/jobservice/worker/cworker/reaper.go
@@ -245,7 +245,7 @@ func (r *reaper) scanLocks(key string, handler func(k string, v int64) error) er
 		}
 
 		// Get next cursor
-		cursor, err = strconv.ParseInt(string(reply[0].([]uint8)), 10, 16)
+		cursor, err = strconv.ParseInt(string(reply[0].([]uint8)), 10, 64)
 		if err != nil {
 			return errors.Wrap(err, "scan locks")
 		}
@@ -253,7 +253,7 @@ func (r *reaper) scanLocks(key string, handler func(k string, v int64) error) er
 		if values, ok := reply[1].([]interface{}); ok {
 			for i := 0; i < len(values); i += 2 {
 				k := string(values[i].([]uint8))
-				lc, err := strconv.ParseInt(string(values[i+1].([]uint8)), 10, 16)
+				lc, err := strconv.ParseInt(string(values[i+1].([]uint8)), 10, 64)
 				if err != nil {
 					// Ignore and continue
 					logger.Errorf("Malformed lock object for %s: %v", k, err)


### PR DESCRIPTION
Change the bitSize from 16 to 64 in the jobservice reaper, the 16 is too small when the redis cursor over the max value of int16.

Fixes: #18486

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
