### PR TITLE
fix: clean the redis if the execution is not found

### DIFF
--- a/src/pkg/task/dao/execution.go
+++ b/src/pkg/task/dao/execution.go
@@ -476,6 +476,14 @@ func scanAndRefreshOutdateStatus(ctx context.Context) {
 
 		statusChanged, currentStatus, err := ExecDAO.RefreshStatus(ctx, execID)
 		if err != nil {
+			// no need to refresh and should clean cache if the execution is not found
+			if errors.IsNotFoundErr(err) {
+				if err = cache.Default().Delete(ctx, key); err != nil {
+					log.Errorf("failed to delete the key %s in cache, error: %v", key, err)
+				}
+				succeed++
+				continue
+			}
 			log.Errorf("failed to refresh the status of execution %d, error: %v", execID, err)
 			failed++
 			continue

--- a/src/pkg/task/sweep_manager.go
+++ b/src/pkg/task/sweep_manager.go
@@ -139,7 +139,7 @@ func (sm *sweepManager) ListCandidates(ctx context.Context, vendorType string, r
 			n = n + 1
 		}
 
-		sql = `SELECT id FROM execution WHERE vendor_type = ? AND vendor_id = ? AND start_time < ? AND status IN (?,?,?)`
+		sql = `SELECT id FROM execution WHERE vendor_type = ? AND vendor_id = ? AND start_time < ? AND status IN (?,?,?) ORDER BY id`
 		// default page size is 100000
 		q2 := &q.Query{PageSize: int64(defaultPageSize)}
 		for i := n; i >= 1; i-- {


### PR DESCRIPTION
Delete the execution outdated status key in the redis when the execution is not found.

Fixes: #18511

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #18511

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
