### PR TITLE
[cherry-pick] fix: update stopped execution status immediately instead of async update

### DIFF
--- a/src/pkg/task/hook.go
+++ b/src/pkg/task/hook.go
@@ -107,8 +107,9 @@ func (h *HookHandler) Handle(ctx context.Context, sc *job.StatusChange) error {
 			logger.Errorf("failed to run the task status change post function for task %d: %v", task.ID, err)
 		}
 	}
-	// execution status refresh interval <= 0 means update the status immediately
-	if config.GetExecutionStatusRefreshIntervalSeconds() <= 0 {
+	// 1. execution status refresh interval <= 0 means update the status immediately
+	// 2. if the status is Stopped, we should also update the status immediately to avoid long wait time for user
+	if config.GetExecutionStatusRefreshIntervalSeconds() <= 0 || sc.Status == job.StoppedStatus.String() {
 		// update execution status immediately which may have optimistic lock
 		statusChanged, currentStatus, err := h.executionDAO.RefreshStatus(ctx, task.ExecutionID)
 		if err != nil {


### PR DESCRIPTION
Update the stopped execution status immediately becasue the user experience is not good if wait long time when stop or reschedule a job.

Fixes: #18526

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #18526

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
