### PR TITLE
fix: link to Github's rate limiting documentation.

### DIFF
--- a/make/harbor.yml.tmpl
+++ b/make/harbor.yml.tmpl
@@ -102,7 +102,7 @@ trivy:
   # Anonymous downloads from GitHub are subject to the limit of 60 requests per hour. Normally such rate limit is enough
   # for production operations. If, for any reason, it's not enough, you could increase the rate limit to 5000
   # requests per hour by specifying the GitHub access token. For more details on GitHub rate limiting please consult
-  # https://developer.github.com/v3/#rate-limiting
+  # https://docs.github.com/rest/overview/resources-in-the-rest-api#rate-limiting
   #
   # You can create a GitHub token by following the instructions in
   # https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line


### PR DESCRIPTION
The link Github's rate limiting documentation in the template for harbor.yml file appear to be old and is redirected to root page of Github's rest api documentation.

# Issue being fixed
The new link in this PR has been updated to point to the correct documentation.