### PR TITLE
fix: error log use wrong variable err

### DIFF
--- a/src/jobservice/mgt/manager.go
+++ b/src/jobservice/mgt/manager.go
@@ -243,7 +243,7 @@ func (bm *basicManager) GetPeriodicExecution(pID string, q *query.Parameter) (re
 	for _, eID := range executionIDs {
 		t := job.NewBasicTrackerWithID(bm.ctx, eID, bm.namespace, bm.pool, nil, nil)
 		if er := t.Load(); er != nil {
-			logger.Errorf("track job %s error: %s", eID, err)
+			logger.Errorf("track job %s error: %s", eID, er)
 			continue
 		}
 


### PR DESCRIPTION
Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)
At harbor/src/jobservice/mgt/manager.go(161).  logger.Errorf should log the er variable returned by t.Load(),  which is assigned to the `er` variable. However, the err variable is referenced instead. 
