### PR TITLE
fix: improve the performance of list artifacts

### DIFF
--- a/make/migrations/postgresql/0120_2.9.0_schema.up.sql
+++ b/make/migrations/postgresql/0120_2.9.0_schema.up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS idx_task_extra_attrs_report_uuids ON task USING gin ((extra_attrs::jsonb->'report_uuids'));

--- a/src/pkg/task/dao/task_test.go
+++ b/src/pkg/task/dao/task_test.go
@@ -112,6 +112,27 @@ func (t *taskDAOTestSuite) TestList() {
 	t.Require().Len(tasks, 0)
 }
 
+func (t *taskDAOTestSuite) TestListScanTasksByReportUUID() {
+	// should not exist if non set
+	tasks, err := t.taskDAO.ListScanTasksByReportUUID(t.ctx, "fake-report-uuid")
+	t.Require().Nil(err)
+	t.Require().Len(tasks, 0)
+	// create one with report uuid
+	taskID, err := t.taskDAO.Create(t.ctx, &Task{
+		ExecutionID: t.executionID,
+		Status:      "success",
+		StatusCode:  1,
+		ExtraAttrs:  `{"report_uuids": ["fake-report-uuid"]}`,
+	})
+	t.Require().Nil(err)
+	defer t.taskDAO.Delete(t.ctx, taskID)
+	// should exist as created
+	tasks, err = t.taskDAO.ListScanTasksByReportUUID(t.ctx, "fake-report-uuid")
+	t.Require().Nil(err)
+	t.Require().Len(tasks, 1)
+	t.Equal(taskID, tasks[0].ID)
+}
+
 func (t *taskDAOTestSuite) TestGet() {
 	// not exist
 	_, err := t.taskDAO.Get(t.ctx, 10000)

--- a/src/pkg/task/mock_task_dao_test.go
+++ b/src/pkg/task/mock_task_dao_test.go
@@ -182,6 +182,32 @@ func (_m *mockTaskDAO) List(ctx context.Context, query *q.Query) ([]*dao.Task, e
 	return r0, r1
 }
 
+// ListScanTasksByReportUUID provides a mock function with given fields: ctx, uuid
+func (_m *mockTaskDAO) ListScanTasksByReportUUID(ctx context.Context, uuid string) ([]*dao.Task, error) {
+	ret := _m.Called(ctx, uuid)
+
+	var r0 []*dao.Task
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) ([]*dao.Task, error)); ok {
+		return rf(ctx, uuid)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string) []*dao.Task); ok {
+		r0 = rf(ctx, uuid)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*dao.Task)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, uuid)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // ListStatusCount provides a mock function with given fields: ctx, executionID
 func (_m *mockTaskDAO) ListStatusCount(ctx context.Context, executionID int64) ([]*dao.StatusCount, error) {
 	ret := _m.Called(ctx, executionID)

--- a/src/pkg/task/mock_task_manager_test.go
+++ b/src/pkg/task/mock_task_manager_test.go
@@ -199,6 +199,32 @@ func (_m *mockTaskManager) List(ctx context.Context, query *q.Query) ([]*Task, e
 	return r0, r1
 }
 
+// ListScanTasksByReportUUID provides a mock function with given fields: ctx, uuid
+func (_m *mockTaskManager) ListScanTasksByReportUUID(ctx context.Context, uuid string) ([]*Task, error) {
+	ret := _m.Called(ctx, uuid)
+
+	var r0 []*Task
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) ([]*Task, error)); ok {
+		return rf(ctx, uuid)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string) []*Task); ok {
+		r0 = rf(ctx, uuid)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*Task)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, uuid)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // Stop provides a mock function with given fields: ctx, id
 func (_m *mockTaskManager) Stop(ctx context.Context, id int64) error {
 	ret := _m.Called(ctx, id)

--- a/src/pkg/task/task.go
+++ b/src/pkg/task/task.go
@@ -64,6 +64,9 @@ type Manager interface {
 	UpdateStatusInBatch(ctx context.Context, jobIDs []string, status string, batchSize int) error
 	// ExecutionIDsByVendorAndStatus retrieve execution id by vendor type and status
 	ExecutionIDsByVendorAndStatus(ctx context.Context, vendorType, status string) ([]int64, error)
+	// ListScanTasksByReportUUID lists scan tasks by report uuid, although it's a specific case but it will be
+	// more suitable to support multi database in the future.
+	ListScanTasksByReportUUID(ctx context.Context, uuid string) (tasks []*Task, err error)
 }
 
 // NewManager creates an instance of the default task manager
@@ -222,6 +225,20 @@ func (m *manager) Get(ctx context.Context, id int64) (*Task, error) {
 
 func (m *manager) List(ctx context.Context, query *q.Query) ([]*Task, error) {
 	tasks, err := m.dao.List(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	var ts []*Task
+	for _, task := range tasks {
+		t := &Task{}
+		t.From(task)
+		ts = append(ts, t)
+	}
+	return ts, nil
+}
+
+func (m *manager) ListScanTasksByReportUUID(ctx context.Context, uuid string) ([]*Task, error) {
+	tasks, err := m.dao.ListScanTasksByReportUUID(ctx, uuid)
 	if err != nil {
 		return nil, err
 	}

--- a/src/pkg/task/task_test.go
+++ b/src/pkg/task/task_test.go
@@ -147,6 +147,19 @@ func (t *taskManagerTestSuite) TestList() {
 	t.dao.AssertExpectations(t.T())
 }
 
+func (t *taskManagerTestSuite) TestListScanTasksByReportUUID() {
+	t.dao.On("ListScanTasksByReportUUID", mock.Anything, mock.Anything).Return([]*dao.Task{
+		{
+			ID: 1,
+		},
+	}, nil)
+	tasks, err := t.mgr.ListScanTasksByReportUUID(nil, "uuid")
+	t.Require().Nil(err)
+	t.Require().Len(tasks, 1)
+	t.Equal(int64(1), tasks[0].ID)
+	t.dao.AssertExpectations(t.T())
+}
+
 func TestTaskManagerTestSuite(t *testing.T) {
 	suite.Run(t, &taskManagerTestSuite{})
 }

--- a/src/testing/pkg/task/manager.go
+++ b/src/testing/pkg/task/manager.go
@@ -201,6 +201,32 @@ func (_m *Manager) List(ctx context.Context, query *q.Query) ([]*task.Task, erro
 	return r0, r1
 }
 
+// ListScanTasksByReportUUID provides a mock function with given fields: ctx, uuid
+func (_m *Manager) ListScanTasksByReportUUID(ctx context.Context, uuid string) ([]*task.Task, error) {
+	ret := _m.Called(ctx, uuid)
+
+	var r0 []*task.Task
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) ([]*task.Task, error)); ok {
+		return rf(ctx, uuid)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string) []*task.Task); ok {
+		r0 = rf(ctx, uuid)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*task.Task)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, uuid)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // Stop provides a mock function with given fields: ctx, id
 func (_m *Manager) Stop(ctx context.Context, id int64) error {
 	ret := _m.Called(ctx, id)


### PR DESCRIPTION
1. Change the query for listing tasks of scan which can use the db index.
2. Add the gin index for task.extra_attrs.report_uuids

Fixes: #18013

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

## Situation

The issue is that when the db has the large number of tasks(scan or other), the API of list artifacts will be quite slow when set the query parameter `with_scan_overview=true`, and also cost many db CPU resource. The root cause for the problem is that when querying scan reports, it is necessary to look up the scan tasks to obtain their status. However, the previous lookup method resulted in a full table scan of the database, which caused slow response times and increased resource utilization in cases with large amounts of data.

## Improve

The data size of testing environment.

Artifacts: 100000+
Tasks: 500000+

Testing API: `https://harbor.domain/api/v2.0/projects/project-001/repositories/repository-100/artifacts?with_tag=false&with_scan_overview=true&with_label=false&with_accessory=false&page_size=50&page=1`

| Metric | Before | After |
| --- | ---: | ---: |
| API response time | 28s+  | <0.1s |
| DB CPU Usage | ~300% | < 1% |

# Issue being fixed
Fixes
- #18013
- #18598

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
