### PR TITLE
Fix message prompt under the header

### DIFF
--- a/src/portal/src/app/base/harbor-shell/harbor-shell.component.html
+++ b/src/portal/src/app/base/harbor-shell/harbor-shell.component.html
@@ -1,32 +1,4 @@
 <clr-main-container>
-    <!--<div class="clr-row scanner-info" *ngIf="showScannerInfo && isSystemAdmin">
-        <div class="clr-col-2"></div>
-        <div class="clr-col text-center">
-            <clr-icon shape="info-standard" size="20"></clr-icon>
-            <span class="ml-05"
-                >{{ 'SCANNER.HELP_INFO_1' | translate }}
-                <a
-                    rel="noopener noreferrer"
-                    target="_blank"
-                    href="{{ scannerDocUrl }}"
-                    >{{ 'SCANNER.HELP_INFO_2' | translate }}</a
-                >
-            </span>
-        </div>
-        <div class="clr-col-2 right">
-            <a
-                class="all-scanners"
-                href="#"
-                routerLink="/harbor/interrogation-services/scanners"
-                >{{ 'SCANNER.ALL_SCANNERS' | translate }}</a
-            >
-            <clr-icon
-                (click)="closeInfo()"
-                class="close-icon"
-                shape="times"
-                size="24"></clr-icon>
-        </div>
-    </div>-->
     <app-app-level-alerts></app-app-level-alerts>
     <navigator
         (showAccountSettingsModal)="openModal($event)"
@@ -39,7 +11,7 @@
             [class.content-area-override]="!shouldOverrideContent"
             [class.start-content-padding]="shouldOverrideContent"
             (scroll)="publishScrollEvent()">
-            <global-message></global-message>
+            <global-message class="global-msg"></global-message>
             <!-- Only appear when searching -->
             <search-result></search-result>
             <router-outlet></router-outlet>

--- a/src/portal/src/app/base/harbor-shell/harbor-shell.component.scss
+++ b/src/portal/src/app/base/harbor-shell/harbor-shell.component.scss
@@ -38,3 +38,11 @@ clr-vertical-nav {
 .font-size-13 {
     font-size: 13px;
 }
+
+.global-msg {
+    position: absolute;
+    top: 0;
+    left: 2rem;
+    right: 2rem;
+    z-index: 600;
+}


### PR DESCRIPTION
1. Fixes #18601

Currently, the message prompts the mounted on the right page, if the users scroll the page to the bottom, the message will be covered.

Before:
![image](https://user-images.githubusercontent.com/30999793/234757540-c9fc42e1-11a1-4aa8-bf0f-982e651bb80e.png)

After:
<img width="1672" alt="image" src="https://user-images.githubusercontent.com/30999793/234757672-e59876ec-ef82-4bb6-8207-37d8f992887f.png">

The message prompts are now fixed under the header, it is not scrollable with the page

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
