### PR TITLE
fix: non-ASCII chars in swagger.yaml

### DIFF
--- a/api/v2.0/swagger.yaml
+++ b/api/v2.0/swagger.yaml
@@ -239,7 +239,7 @@ paths:
           schema:
             $ref: '#/definitions/ConfigurationsResponse'
         '401':
-          description: User need to log in first.ß
+          description: User need to log in first.
         '403':
           description: User does not have permission of admin role.
         '500':
@@ -4451,9 +4451,9 @@ paths:
           schema:
             $ref: '#/definitions/Schedule'
           description: |
-            The purge job's schedule, it is a json object. ｜
-            The sample format is ｜
-            {"parameters":{"audit_retention_hour":168,"dry_run":true, "include_operations":"create,delete,pull"},"schedule":{"type":"Hourly","cron":"0 0 * * * *"}} ｜
+            The purge job's schedule, it is a json object. |
+            The sample format is |
+            {"parameters":{"audit_retention_hour":168,"dry_run":true, "include_operations":"create,delete,pull"},"schedule":{"type":"Hourly","cron":"0 0 * * * *"}} |
             the include_operation should be a comma separated string, e.g. create,delete,pull, if it is empty, no operation will be purged.
       tags:
         - purge
@@ -4481,9 +4481,9 @@ paths:
           schema:
             $ref: '#/definitions/Schedule'
           description: |
-            The purge job's schedule, it is a json object. ｜
-            The sample format is ｜
-            {"parameters":{"audit_retention_hour":168,"dry_run":true, "include_operations":"create,delete,pull"},"schedule":{"type":"Hourly","cron":"0 0 * * * *"}} ｜
+            The purge job's schedule, it is a json object. |
+            The sample format is |
+            {"parameters":{"audit_retention_hour":168,"dry_run":true, "include_operations":"create,delete,pull"},"schedule":{"type":"Hourly","cron":"0 0 * * * *"}} |
             the include_operation should be a comma separated string, e.g. create,delete,pull, if it is empty, no operation will be purged.
       tags:
         - purge


### PR DESCRIPTION

Thank you for contributing to Harbor!

# Comprehensive Summary of your change
There are a `ß` char and some U+ff5c "｜" in the swagger.yaml. The character U+ff5c "｜" could be confused with the ASCII character U+007c "|".

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
