### PR TITLE
fix: sweep executions of image scan job

### DIFF
--- a/make/migrations/postgresql/0120_2.9.0_schema.up.sql
+++ b/make/migrations/postgresql/0120_2.9.0_schema.up.sql
@@ -1,1 +1,7 @@
 CREATE INDEX IF NOT EXISTS idx_task_extra_attrs_report_uuids ON task USING gin ((extra_attrs::jsonb->'report_uuids'));
+
+/* Set the vendor_id of IMAGE_SCAN to the artifact id instead of scanner id, which facilitates execution sweep */
+UPDATE execution SET vendor_id = (extra_attrs -> 'artifact' ->> 'id')::integer
+WHERE jsonb_path_exists(extra_attrs::jsonb, '$.artifact.id')
+AND vendor_id IN (SELECT id FROM scanner_registration)
+AND vendor_type = 'IMAGE_SCAN';

--- a/src/controller/scan/base_controller.go
+++ b/src/controller/scan/base_controller.go
@@ -294,7 +294,7 @@ func (bc *basicController) Scan(ctx context.Context, artifact *ar.Artifact, opti
 				"name": r.Name,
 			},
 		}
-		executionID, err := bc.execMgr.Create(ctx, job.ImageScanJobVendorType, r.ID, task.ExecutionTriggerManual, extraAttrs)
+		executionID, err := bc.execMgr.Create(ctx, job.ImageScanJobVendorType, artifact.ID, task.ExecutionTriggerManual, extraAttrs)
 		if err != nil {
 			return err
 		}

--- a/src/jobservice/job/known_jobs.go
+++ b/src/jobservice/job/known_jobs.go
@@ -49,7 +49,8 @@ const (
 var (
 	// executionSweeperCount stores the count for execution retained
 	executionSweeperCount = map[string]int64{
-		ScanAllVendorType:               5,
+		ImageScanJobVendorType:          1,
+		ScanAllVendorType:               1,
 		PurgeAuditVendorType:            10,
 		ExecSweepVendorType:             10,
 		GarbageCollectionVendorType:     50,


### PR DESCRIPTION
1. Change the SCAN_ALL job execution retain counts from 5 to 1(per current design, only one report be stored for every artifact, so retain latest 1 is enough).
2. Enable the sweep for IMAGE_SCAN job(retain latest 1).

Fixes: #18633

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #18633

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
