### PR TITLE
Add support for TLSv1.3 in nginx configurations

### DIFF
--- a/make/photon/prepare/templates/nginx/nginx.https.conf.jinja
+++ b/make/photon/prepare/templates/nginx/nginx.https.conf.jinja
@@ -58,7 +58,7 @@ http {
     ssl_certificate_key {{ssl_cert_key}};
 
     # Recommendations from https://raymii.org/s/tutorials/Strong_SSL_Security_On_nginx.html
-    ssl_protocols TLSv1.2;
+    ssl_protocols TLSv1.2 TLSv1.3;
     ssl_ciphers '!aNULL:kECDH+AESGCM:ECDH+AESGCM:RSA+AESGCM:kECDH+AES:ECDH+AES:RSA+AES:';
     ssl_prefer_server_ciphers on;
     ssl_session_cache shared:SSL:10m;

--- a/make/photon/prepare/templates/portal/nginx.conf.jinja
+++ b/make/photon/prepare/templates/portal/nginx.conf.jinja
@@ -22,7 +22,7 @@ http {
         ssl_certificate_key /etc/harbor/tls/portal.key;
 
         # Recommendations from https://raymii.org/s/tutorials/Strong_SSL_Security_On_nginx.html
-        ssl_protocols TLSv1.2;
+        ssl_protocols TLSv1.2 TLSv1.3;
         ssl_ciphers '!aNULL:kECDH+AESGCM:ECDH+AESGCM:RSA+AESGCM:kECDH+AES:ECDH+AES:RSA+AES:';
         ssl_prefer_server_ciphers on;
         ssl_session_cache shared:SSL:10m;


### PR DESCRIPTION
Thank you for contributing to Harbor!

# Comprehensive Summary of your change
This PR enables `TLSv1.3` by default in the nginx configuration. This way the configuration follows the [linked recommendations](https://raymii.org/s/tutorials/Strong_SSL_Security_On_nginx.html#toc_0) and the [nginx default configuration](https://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_protocols).

# Issue being fixed
Fixes #18358

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).