### PR TITLE
fix: patch migration SQL by code

### DIFF
--- a/make/migrations/postgresql/0101_2.7.3_schema.up.sql
+++ b/make/migrations/postgresql/0101_2.7.3_schema.up.sql
@@ -1,1 +1,0 @@
-CREATE INDEX IF NOT EXISTS idx_task_extra_attrs_report_uuids ON task USING gin ((extra_attrs::jsonb->'report_uuids'));


### PR DESCRIPTION
Using code to patch the migration SQL instead of migration SQL file by go-migrate, the latter way will bring the potential upgrade issue, refer to code comments for more details.

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
