### PR TITLE
fix: clean up scan executions and reports after deleting artifact

### DIFF
--- a/src/controller/event/handler/init.go
+++ b/src/controller/event/handler/init.go
@@ -70,6 +70,7 @@ func init() {
 	// internal
 	_ = notifier.Subscribe(event.TopicPullArtifact, &internal.Handler{})
 	_ = notifier.Subscribe(event.TopicPushArtifact, &internal.Handler{})
+	_ = notifier.Subscribe(event.TopicDeleteArtifact, &internal.Handler{})
 
 	_ = task.RegisterTaskStatusChangePostFunc(job.ReplicationVendorType, func(ctx context.Context, taskID int64, status string) error {
 		notification.AddEvent(ctx, &metadata.ReplicationMetaData{


### PR DESCRIPTION
Cleanup the associated resources(scan executions and scan reports) after deletion of artifact.

Fixes: #18634

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #18634

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
