### PR TITLE
update text of tooltip, highlight the issue when using cli secrets in

### DIFF
--- a/src/portal/src/i18n/lang/de-de-lang.json
+++ b/src/portal/src/i18n/lang/de-de-lang.json
@@ -132,7 +132,7 @@
         "RENAME_SUCCESS": "Umbenennen erfolgreich!",
         "RENAME_CONFIRM_INFO": "Warnung, ändern des Namens auf admin@harbor.local, dies kann nicht rückgängig gemacht werden.",
         "CLI_PASSWORD": "CLI Secret",
-        "CLI_PASSWORD_TIP": "Das CLI Secret kann als Passwort mittels docker/helm cli verwendet werden, um auf Harbor zuzugreifen.",
+        "CLI_PASSWORD_TIP": "Das CLI-Secret kann als Passwort für den Docker- oder Helm-Client verwendet werden. Bei aktiviertem OIDC-Autorisierungsmodus empfehlen wir dringend die Verwendung von Robot-Zugängen, da CLI-Secrets von der Gültigkeit des ID-Tokens abhängen und regelmäßiges Anmelden über die Benutzeroberfläche erfordern.",
         "COPY_SUCCESS": "Kopieren erfolgreich",
         "COPY_ERROR": "Kopieren fehlgeschlagen",
         "ADMIN_CLI_SECRET_BUTTON": "ERZEUGE SECRET",

--- a/src/portal/src/i18n/lang/en-us-lang.json
+++ b/src/portal/src/i18n/lang/en-us-lang.json
@@ -132,7 +132,7 @@
         "RENAME_SUCCESS": "Rename success!",
         "RENAME_CONFIRM_INFO": "Warning, changing the name to admin@harbor.local can not be undone.",
         "CLI_PASSWORD": "CLI secret",
-        "CLI_PASSWORD_TIP": "You can use this cli secret as password when using docker/helm cli to access Harbor.",
+        "CLI_PASSWORD_TIP": "The CLI secret can be used as a password, for Docker or Helm client. With the OIDC auth mode enabled, we strongly recommend using robot accounts, as CLI secrets depend on the validity of the ID token and require the user to regularly log in to the UI to refresh the token.",
         "COPY_SUCCESS": "copy success",
         "COPY_ERROR": "copy failed",
         "ADMIN_CLI_SECRET_BUTTON": "GENERATE SECRET",

--- a/src/portal/src/i18n/lang/es-es-lang.json
+++ b/src/portal/src/i18n/lang/es-es-lang.json
@@ -132,7 +132,7 @@
         "RENAME_SUCCESS": "Rename success!",
         "RENAME_CONFIRM_INFO": "Warning, changing the name to admin@harbor.local can not be undone.",
         "CLI_PASSWORD": "CLI secreto",
-        "CLI_PASSWORD_TIP": "Puede utilizar este generador CLI secreto como utilizando Docker / Helm CLI para acceder a puerto.",
+        "CLI_PASSWORD_TIP": "El secreto CLI puede utilizarse como contraseña, para Docker o para el cliente Helm. Con el modo de autenticación de OIDC activado, recomendamos encarecidamente usar cuentas de robot, ya que los secretos de CLI dependen de la validez del token de ID y requieren que el usuario inicie sesión regularmente en la interfaz de usuario para actualizar el token.",
         "COPY_SUCCESS": "Copiar el éxito",
         "COPY_ERROR": "Copia no",
         "ADMIN_CLI_SECRET_BUTTON": "GENERATE SECRET",


### PR DESCRIPTION
This PR adds a bit more context and clarification to the users who are planning to use CLI secrets together with OIDC.

and it goes like this:
_The CLI secret can be used as a password, for Docker or Helm client. With the OIDC auth mode enabled, we strongly recommend using robot accounts, as CLI secrets depend on the validity of the ID token and require the user to regularly log in to the UI to refresh the token_

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/update"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
