### PR TITLE
Return error when proxy cache get too many request error(429)

### DIFF
--- a/src/controller/proxy/controller.go
+++ b/src/controller/proxy/controller.go
@@ -166,6 +166,9 @@ func (c *controller) UseLocalManifest(ctx context.Context, art lib.ArtifactInfo,
 	remoteRepo := getRemoteRepo(art)
 	exist, desc, err := remote.ManifestExist(remoteRepo, getReference(art)) // HEAD
 	if err != nil {
+		if errors.IsRateLimitError(err) && a != nil { // if rate limit, use local if it exists, otherwise return error
+			return true, nil, nil
+		}
 		return false, nil, err
 	}
 	if !exist || desc == nil {

--- a/src/lib/errors/const.go
+++ b/src/lib/errors/const.go
@@ -27,6 +27,8 @@ const (
 	ForbiddenCode = "FORBIDDEN"
 	// MethodNotAllowedCode ...
 	MethodNotAllowedCode = "METHOD_NOT_ALLOWED"
+	// RateLimitCode
+	RateLimitCode = "TOO_MANY_REQUEST"
 	// PreconditionCode ...
 	PreconditionCode = "PRECONDITION"
 	// GeneralCode ...
@@ -104,4 +106,9 @@ func IsConflictErr(err error) bool {
 
 func IsChallengesUnsupportedErr(err error) bool {
 	return IsErr(err, ChallengesUnsupportedCode)
+}
+
+// IsRateLimitError checks whether the err chains contains rate limit error
+func IsRateLimitError(err error) bool {
+	return IsErr(err, RateLimitCode)
 }

--- a/src/lib/http/error.go
+++ b/src/lib/http/error.go
@@ -37,6 +37,7 @@ var (
 		errors.MethodNotAllowedCode:            http.StatusMethodNotAllowed,
 		errors.DENIED:                          http.StatusForbidden,
 		errors.NotFoundCode:                    http.StatusNotFound,
+		errors.RateLimitCode:                   http.StatusTooManyRequests,
 		errors.ConflictCode:                    http.StatusConflict,
 		errors.PreconditionCode:                http.StatusPreconditionFailed,
 		errors.ViolateForeignKeyConstraintCode: http.StatusPreconditionFailed,

--- a/src/pkg/registry/client.go
+++ b/src/pkg/registry/client.go
@@ -678,6 +678,8 @@ func (c *client) do(req *http.Request) (*http.Response, error) {
 			code = errors.ForbiddenCode
 		case http.StatusNotFound:
 			code = errors.NotFoundCode
+		case http.StatusTooManyRequests:
+			code = errors.RateLimitCode
 		}
 		return nil, errors.New(nil).WithCode(code).
 			WithMessage(message)


### PR DESCRIPTION
  Add 429 too many request error in http error
  Fixes #18707

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
