### PR TITLE
build image: db and redis report error Permission denied.

### DIFF
--- a/make/photon/db/Dockerfile
+++ b/make/photon/db/Dockerfile
@@ -9,7 +9,7 @@ COPY ./make/photon/db/initdb.sh /initdb.sh
 COPY ./make/photon/db/upgrade.sh /upgrade.sh
 COPY ./make/photon/db/docker-healthcheck.sh /docker-healthcheck.sh
 COPY ./make/photon/db/initial-registry.sql /docker-entrypoint-initdb.d/
-RUN chown -R postgres:postgres /docker-entrypoint.sh /docker-healthcheck.sh /docker-entrypoint-initdb.d \
+RUN chown -R postgres:postgres /docker-entrypoint.sh /docker-healthcheck.sh /docker-entrypoint-initdb.d /initdb.sh \
     && chmod u+x /docker-entrypoint.sh /docker-healthcheck.sh
 
 ENTRYPOINT ["/docker-entrypoint.sh", "13", "14"]

--- a/make/photon/redis/Dockerfile
+++ b/make/photon/redis/Dockerfile
@@ -7,6 +7,7 @@ WORKDIR /var/lib/redis
 COPY ./make/photon/redis/docker-healthcheck /usr/bin/
 COPY ./make/photon/redis/redis.conf /etc/redis.conf
 RUN chmod +x /usr/bin/docker-healthcheck \
+    && chown redis:redis /usr/bin/docker-healthcheck \
     && chown redis:redis /etc/redis.conf
 
 HEALTHCHECK CMD ["docker-healthcheck"]


### PR DESCRIPTION
build image: db and redis report error Permission denied.

"/docker-entrypoint.sh: line 4: //initdb.sh: Permission denied"

"/usr/bin/docker-healthcheck: Permission denied"