### PR TITLE
build image: db report error Permission denied.

### DIFF
--- a/make/photon/db/Dockerfile
+++ b/make/photon/db/Dockerfile
@@ -9,7 +9,7 @@ COPY ./make/photon/db/initdb.sh /initdb.sh
 COPY ./make/photon/db/upgrade.sh /upgrade.sh
 COPY ./make/photon/db/docker-healthcheck.sh /docker-healthcheck.sh
 COPY ./make/photon/db/initial-registry.sql /docker-entrypoint-initdb.d/
-RUN chown -R postgres:postgres /docker-entrypoint.sh /docker-healthcheck.sh /docker-entrypoint-initdb.d \
+RUN chown -R postgres:postgres /docker-entrypoint.sh /docker-healthcheck.sh /docker-entrypoint-initdb.d /initdb.sh \
     && chmod u+x /docker-entrypoint.sh /docker-healthcheck.sh
 
 ENTRYPOINT ["/docker-entrypoint.sh", "13", "14"]


### PR DESCRIPTION
After I built the image in ubuntu arm64, executing install.sh reported the following error：

use command “docker logs harbor-db” get msg:

```
root@ubuntu:/opt/harbor# docker logs harbor-db
/docker-entrypoint.sh: line 4: //initdb.sh: Permission denied
/docker-entrypoint.sh: line 4: //initdb.sh: Permission denied
...
```