### PR TITLE
build image: redis report error Permission denied. 

### DIFF
--- a/make/photon/redis/Dockerfile
+++ b/make/photon/redis/Dockerfile
@@ -7,6 +7,7 @@ WORKDIR /var/lib/redis
 COPY ./make/photon/redis/docker-healthcheck /usr/bin/
 COPY ./make/photon/redis/redis.conf /etc/redis.conf
 RUN chmod +x /usr/bin/docker-healthcheck \
+    && chown redis:redis /usr/bin/docker-healthcheck \
     && chown redis:redis /etc/redis.conf
 
 HEALTHCHECK CMD ["docker-healthcheck"]


### PR DESCRIPTION
After I built the image in ubuntu arm64, executing install.sh reported the following error：

use command "docker inspect redis" get msg:

```
root@ubuntu:/opt/harbor# docker inspect redis | head -40
...
                "Log": [
                    {
                        "Start": "2023-05-30T16:12:21.285448326+08:00",
                        "End": "2023-05-30T16:12:21.362951136+08:00",
                        "ExitCode": 126,
                        "Output": "/bin/bash: /usr/bin/docker-healthcheck: Permission denied\n"
                    },
                    {
                        "Start": "2023-05-30T16:12:51.374365936+08:00",
                        "End": "2023-05-30T16:12:51.450547046+08:00",
                        "ExitCode": 126,
                        "Output": "/bin/bash: /usr/bin/docker-healthcheck: Permission denied\n"
                    },
...
```