### PR TITLE
Remove wrong format for boolean value in api definition

### DIFF
--- a/api/v2.0/swagger.yaml
+++ b/api/v2.0/swagger.yaml
@@ -291,7 +291,6 @@ paths:
           description: The project is public or private.
           required: false
           type: boolean
-          format: int32
         - name: owner
           in: query
           description: The name of project owner.


### PR DESCRIPTION
Thank you for contributing to Harbor!

# Comprehensive Summary of your change

type: boolean cannot be used with a format of int32

This for example hinders parsing of the api definition by other tools such as https://github.com/OpenAPITools/openapi-generator

# Issue being fixed


Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
