### PR TITLE
[cherry-pick][2.7] fix: add retry on the caller of v2DeleteManifest instead within v2DeleteManifest

### DIFF
--- a/src/jobservice/job/impl/gc/garbage_collection.go
+++ b/src/jobservice/job/impl/gc/garbage_collection.go
@@ -282,7 +282,18 @@ func (gc *GarbageCollector) sweep(ctx job.Context) error {
 				// Harbor cannot know the existing tags in the backend from its database, so let the v2 DELETE manifest to remove all of them.
 				gc.logger.Infof("[%d/%d] delete the manifest with registry v2 API: %s, %s, %s",
 					idx, total, art.RepositoryName, blob.ContentType, blob.Digest)
-				if err := v2DeleteManifest(gc.logger, art.RepositoryName, blob.Digest); err != nil {
+				if err := retry.Retry(func() error {
+					return ignoreNotFound(func() error {
+						err := v2DeleteManifest(art.RepositoryName, blob.Digest)
+						// if the system is in read-only mode, return an Abort error to skip retrying
+						if err == readonly.Err {
+							return retry.Abort(err)
+						}
+						return err
+					})
+				}, retry.Callback(func(err error, sleep time.Duration) {
+					gc.logger.Infof("[%d/%d] failed to exec v2DeleteManifest, error: %v, will retry again after: %s", idx, total, err, sleep)
+				})); err != nil {
 					gc.logger.Errorf("[%d/%d] failed to delete manifest with v2 API, %s, %s, %v", idx, total, art.RepositoryName, blob.Digest, err)
 					if err := ignoreNotFound(func() error {
 						return gc.markDeleteFailed(ctx, blob)


### PR DESCRIPTION
# Comprehensive Summary of your change

Cherry pick to release 2.7 for #18662

# Issue being fixed
Fixes #18381

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
