### PR TITLE
[cherry-pick] disable external redis using acl username auth on release-2.8.0

### DIFF
--- a/make/harbor.yml.tmpl
+++ b/make/harbor.yml.tmpl
@@ -182,8 +182,6 @@ _version: 2.8.0
 #   #  <host_sentinel1>:<port_sentinel1>,<host_sentinel2>:<port_sentinel2>,<host_sentinel3>:<port_sentinel3>
 #   host: redis:6379
 #   password: 
-#   # Redis AUTH command was extended in Redis 6, it is possible to use it in the two-arguments AUTH <username> <password> form.
-#   # username:
 #   # sentinel_master_set must be set to support redis+sentinel
 #   #sentinel_master_set:
 #   # db_index 0 is for core, it's unchangeable

--- a/make/photon/prepare/migrations/version_2_8_0/harbor.yml.jinja
+++ b/make/photon/prepare/migrations/version_2_8_0/harbor.yml.jinja
@@ -389,12 +389,6 @@ external_redis:
   #  <host_sentinel1>:<port_sentinel1>,<host_sentinel2>:<port_sentinel2>,<host_sentinel3>:<port_sentinel3>
   host: {{ external_redis.host }}
   password: {{ external_redis.password }}
-  # Redis AUTH command was extended in Redis 6, it is possible to use it in the two-arguments AUTH <username> <password> form.
-  {% if external_redis.username is defined %}
-  username: {{ external_redis.username }}
-  {% else %}
-  # username:
-  {% endif %}
   # sentinel_master_set must be set to support redis+sentinel
   #sentinel_master_set:
   # db_index 0 is for core, it's unchangeable
@@ -411,8 +405,6 @@ external_redis:
 #   #  <host_sentinel1>:<port_sentinel1>,<host_sentinel2>:<port_sentinel2>,<host_sentinel3>:<port_sentinel3>
 #   host: redis:6379
 #   password:
-#   # Redis AUTH command was extended in Redis 6, it is possible to use it in the two-arguments AUTH <username> <password> form.
-#   # username:
 #   # sentinel_master_set must be set to support redis+sentinel
 #   #sentinel_master_set:
 #   # db_index 0 is for core, it's unchangeable

--- a/make/photon/prepare/utils/configs.py
+++ b/make/photon/prepare/utils/configs.py
@@ -386,9 +386,8 @@ def get_redis_url(db, redis=None):
     kwargs['db_part'] = db and ("/%s" % db) or ""
     kwargs['sentinel_part'] = kwargs.get('sentinel_master_set', None) and ("/" + kwargs['sentinel_master_set']) or ''
     kwargs['password_part'] = quote(str(kwargs.get('password', None)), safe='') and (':%s@' % quote(str(kwargs['password']), safe='')) or ''
-    kwargs['username_part'] = kwargs.get('username', None) or ''
 
-    return "{scheme}://{username_part}{password_part}{host}{sentinel_part}{db_part}".format(**kwargs) + get_redis_url_param(kwargs)
+    return "{scheme}://{password_part}{host}{sentinel_part}{db_part}".format(**kwargs) + get_redis_url_param(kwargs)
 
 
 def get_redis_url_param(redis=None):


### PR DESCRIPTION
Thank you for contributing to Harbor!

# Comprehensive Summary of your change
- introduced by: https://github.com/goharbor/harbor/pull/18364
- affect version: v2.8.0, v2.8.1, v2.8.2
- impact: distribution performance

Note: distribution configuration (until v2.8.2) only support auth by password
- https://pkg.go.dev/github.com/distribution/distribution/v3/configuration
- https://github.com/distribution/distribution/blob/7c354a4b40feeea21d7eeae4de91c8ff7951e672/registry/handlers/app.go#L530

# Issue being fixed
Fixes 

Please indicate you've done the following:
- [ ] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [ ] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
