### PR TITLE
enable notary v2 policy checker

### DIFF
--- a/src/server/middleware/util/util.go
+++ b/src/server/middleware/util/util.go
@@ -63,12 +63,14 @@ func SkipPolicyChecking(r *http.Request, projectID, artID int64) (bool, error) {
 	secCtx, ok := security.FromContext(r.Context())
 
 	// 1, scanner pull access can bypass.
-	// 2, cosign pull can bypass, it needs to pull the manifest before pushing the signature.
+	// 2, cosign/notation pull can bypass, it needs to pull the manifest before pushing the signature.
 	// 3, pull cosign signature can bypass.
 	if ok && secCtx.Name() == "v2token" {
 		if secCtx.Can(r.Context(), rbac.ActionScannerPull, project.NewNamespace(projectID).Resource(rbac.ResourceRepository)) ||
 			(secCtx.Can(r.Context(), rbac.ActionPush, project.NewNamespace(projectID).Resource(rbac.ResourceRepository)) &&
-				strings.Contains(r.UserAgent(), "cosign")) {
+				strings.Contains(r.UserAgent(), "cosign")) ||
+			(secCtx.Can(r.Context(), rbac.ActionPush, project.NewNamespace(projectID).Resource(rbac.ResourceRepository)) &&
+				strings.Contains(r.UserAgent(), "notation")) {
 			return true, nil
 		}
 	}

--- a/src/server/registry/route.go
+++ b/src/server/registry/route.go
@@ -54,7 +54,7 @@ func RegisterRoutes() {
 		Path("/*/manifests/:reference").
 		Middleware(metric.InjectOpIDMiddleware(metric.ManifestOperationID)).
 		Middleware(repoproxy.ManifestMiddleware()).
-		Middleware(contenttrust.Cosign()).
+		Middleware(contenttrust.ContentTrust()).
 		Middleware(vulnerable.Middleware()).
 		HandlerFunc(getManifest)
 	root.NewRoute().
@@ -62,7 +62,7 @@ func RegisterRoutes() {
 		Path("/*/manifests/:reference").
 		Middleware(metric.InjectOpIDMiddleware(metric.ManifestOperationID)).
 		Middleware(repoproxy.ManifestMiddleware()).
-		Middleware(contenttrust.Cosign()).
+		Middleware(contenttrust.ContentTrust()).
 		Middleware(vulnerable.Middleware()).
 		HandlerFunc(getManifest)
 	root.NewRoute().

--- a/tests/apitests/python/test_project_level_policy_content_trust.py
+++ b/tests/apitests/python/test_project_level_policy_content_trust.py
@@ -45,7 +45,7 @@ class TestProjects(unittest.TestCase):
             4. Image(IA) should exist;
             5. Pull image(IA) successfully;
             6. Enable content trust in project(PA) configuration;
-            7. Pull image(IA) failed and the reason is "The image is not signed in Cosign".
+            7. Pull image(IA) failed and the reason is "The image is not signed".
         Tear down:
             1. Delete repository(RA) by user(UA);
             2. Delete project(PA);
@@ -79,12 +79,12 @@ class TestProjects(unittest.TestCase):
         self.project.update_project(TestProjects.project_content_trust_id, metadata = {"enable_content_trust_cosign": "true"}, **TestProjects.USER_CONTENT_TRUST_CLIENT)
         self.project.get_project(TestProjects.project_content_trust_id)
 
-        #7. Pull image(IA) failed and the reason is "The image is not signed in Cosign".
+        #7. Pull image(IA) failed and the reason is "The image is not signed".
         docker_image_clean_all()
         restart_process("containerd")
         restart_process("dockerd")
         time.sleep(30)
-        pull_harbor_image(harbor_server, ADMIN_CLIENT["username"], ADMIN_CLIENT["password"], TestProjects.repo_name, tag, expected_error_message = "The image is not signed in Cosign")
+        pull_harbor_image(harbor_server, ADMIN_CLIENT["username"], ADMIN_CLIENT["password"], TestProjects.repo_name, tag, expected_error_message = "The image is not signed")
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/robot-cases/Group1-Nightly/Common.robot
+++ b/tests/robot-cases/Group1-Nightly/Common.robot
@@ -773,7 +773,7 @@ Test Case - Cosign And Cosign Deployment Security Policy
     Go Into Project  project${d}
     Go Into Repo  project${d}  ${image}
     Should Not Be Signed By Cosign  ${tag}
-    Cannot Pull Image  ${ip}  ${user}  ${pwd}  project${d}  ${image}:${tag}  err_msg=The image is not signed in Cosign.
+    Cannot Pull Image  ${ip}  ${user}  ${pwd}  project${d}  ${image}:${tag}  err_msg=The image is not signed.
     Cosign Generate Key Pair
     Cosign Verify  ${ip}/project${d}/${image}:${tag}  ${false}
 


### PR DESCRIPTION
add notary v2 pull policy, when it enables, the artifact cannot be pull without the notation signature.

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
