### PR TITLE
artifact - No need to check len when ranging over slice

### DIFF
--- a/src/controller/artifact/controller.go
+++ b/src/controller/artifact/controller.go
@@ -636,29 +636,25 @@ func (c *controller) Walk(ctx context.Context, root *Artifact, walkFn func(*Arti
 				if !walked[child.Digest] {
 					queue.PushBack(child)
 				}
-				if len(child.Accessories) != 0 {
-					for _, acc := range child.Accessories {
-						accArt, err := c.Get(ctx, acc.GetData().ArtifactID, option)
-						if err != nil {
-							return err
-						}
-						if !walked[accArt.Digest] {
-							queue.PushBack(accArt)
-						}
+				for _, acc := range child.Accessories {
+					accArt, err := c.Get(ctx, acc.GetData().ArtifactID, option)
+					if err != nil {
+						return err
+					}
+					if !walked[accArt.Digest] {
+						queue.PushBack(accArt)
 					}
 				}
 			}
 		}
 
-		if len(artifact.Accessories) > 0 {
-			for _, acc := range artifact.Accessories {
-				accArt, err := c.Get(ctx, acc.GetData().ArtifactID, option)
-				if err != nil {
-					return err
-				}
-				if !walked[accArt.Digest] {
-					queue.PushBack(accArt)
-				}
+		for _, acc := range artifact.Accessories {
+			accArt, err := c.Get(ctx, acc.GetData().ArtifactID, option)
+			if err != nil {
+				return err
+			}
+			if !walked[accArt.Digest] {
+				queue.PushBack(accArt)
 			}
 		}
 	}


### PR DESCRIPTION
Thank you for contributing to Harbor!

# Comprehensive Summary of your change

Drop extra condition to check for unrequired len of slice.

# Issue being fixed
Fixes #(issue)
No issue, just an optimization (maybe).
I'm not sure how exactly the golang compiler works so feel free to educate me :).
I know that slice keeps an internal track of the slice lenght so i'm pretty sure that check for len for empty objects should be faster than calling range. But i went ahead and risk it just to get a second opinion.
With the increase of SBOMs and Signatures, it should be faster just to drop the check and go for the cycle. It is easy on the eyes also.

Can you comment?

/release-note/ignore-for-release

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
