### PR TITLE
scanner - Do not add unsuported artifacts to scan queue

### DIFF
--- a/src/controller/scan/base_controller.go
+++ b/src/controller/scan/base_controller.go
@@ -192,16 +192,8 @@ func (bc *basicController) collectScanningArtifacts(ctx context.Context, r *scan
 			return nil
 		}
 
-		supported := hasCapability(r, a)
-
-		if !supported && a.IsImageIndex() {
-			// image index not supported by the scanner, so continue to walk its children
-			return nil
-		}
-
-		artifacts = append(artifacts, a)
-
-		if supported {
+		if hasCapability(r, a) {
+			artifacts = append(artifacts, a)
 			scannable = true
 			return ar.ErrSkip // this artifact supported by the scanner, skip to walk its children
 		}


### PR DESCRIPTION
Thank you for contributing to Harbor!

# Comprehensive Summary of your change
When  collectScanningArtifacts is run, the Scannel will return supported bool if the current artifact is scanneable. If it is scaneable this artifact should be added to the artifacts to be scanned and skipped otherwise.

It looks like the artifact might be added to the artifacts to be scanned list even if it is not supported by the remote Scanner.

# Issue being fixed
Fixes #(issue)
Not exactly sure it fixes my issue. I dont know how to reproduce, but here is a reference on why I was investigating this:
https://github.com/goharbor/harbor/issues/18455

/release-note/enhancement

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/update"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed. (still understanding how to do this, tried with a couple of images and signatures and looks ok)
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
