### PR TITLE
refactor: replace the gc redigo client to the standard cache

### DIFF
--- a/src/jobservice/job/impl/gc/util.go
+++ b/src/jobservice/job/impl/gc/util.go
@@ -15,43 +15,26 @@
 package gc
 
 import (
-	"fmt"
+	"context"
 
-	"github.com/gomodule/redigo/redis"
-
+	"github.com/goharbor/harbor/src/lib/cache"
 	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/pkg/registry"
 )
 
 // delKeys ...
-func delKeys(con redis.Conn, pattern string) error {
-	iter := 0
-	keys := make([]string, 0)
-	for {
-		arr, err := redis.Values(con.Do("SCAN", iter, "MATCH", pattern))
-		if err != nil {
-			return fmt.Errorf("error retrieving '%s' keys: %s", pattern, err)
-		}
-		iter, err = redis.Int(arr[0], nil)
-		if err != nil {
-			return fmt.Errorf("unexpected type for Int, got type %T", err)
-		}
-		k, err := redis.Strings(arr[1], nil)
-		if err != nil {
-			return fmt.Errorf("converts an array command reply to a []string %v", err)
-		}
-		keys = append(keys, k...)
+func delKeys(ctx context.Context, c cache.Cache, pattern string) error {
+	iter, err := c.Scan(ctx, pattern)
+	if err != nil {
+		return errors.Wrap(err, "failed to scan keys")
+	}
 
-		if iter == 0 {
-			break
+	for iter.Next(ctx) {
+		if err := c.Delete(ctx, iter.Val()); err != nil {
+			return errors.Wrap(err, "failed to clean registry cache")
 		}
 	}
-	for _, key := range keys {
-		_, err := con.Do("DEL", key)
-		if err != nil {
-			return fmt.Errorf("failed to clean registry cache %v", err)
-		}
-	}
+
 	return nil
 }
 


### PR DESCRIPTION
Refactor the clean redis logic in the GC job, replace the redigo client to the lib cache interface which can simplify operations.

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
