### PR TITLE
Fix wrong scanned artifact count when there are multiple report for an artifact

### DIFF
--- a/src/pkg/securityhub/dao/security.go
+++ b/src/pkg/securityhub/dao/security.go
@@ -48,10 +48,9 @@ order by s.critical_cnt desc, s.high_cnt desc, s.medium_cnt desc, s.low_cnt desc
 limit 5`
 
 	// sql to query the scanned artifact count
-	scannedArtifactCountSQL = `select count(1) 
-           from artifact a 
-      left join scan_report s on a.digest = s.digest 
-          where s.registration_uuid= ? and s.uuid is not null`
+	scannedArtifactCountSQL = `select count(1)
+from artifact
+where exists (select 1 from scan_report s where artifact.digest = s.digest and s.registration_uuid = ?) `
 
 	// sql to query the dangerous CVEs
 	dangerousCVESQL = `select vr.*

--- a/src/pkg/securityhub/dao/security_test.go
+++ b/src/pkg/securityhub/dao/security_test.go
@@ -68,6 +68,7 @@ func (suite *SecurityDaoTestSuite) TearDownTest() {
 		`delete from scan_report where uuid = 'uuid'`,
 		`delete from artifact where digest = 'digest1001'`,
 		`delete from scanner_registration where uuid='ruuid'`,
+		`delete from scanner_registration where uuid='uuid2'`,
 		`delete from vulnerability_record where cve_id='2023-4567-12345'`,
 		`delete from report_vulnerability_record where report_uuid='ruuid'`,
 		`delete from vulnerability_record where registration_uuid ='uuid2'`,


### PR DESCRIPTION
 
Fix wrong scanned artifact count when there are multiple report for an artifact

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
