### PR TITLE
[cherry-pick]Fix APITEST_DB_PROXY_CACHE x509

### DIFF
--- a/tests/apitests/python/test_proxy_cache.py
+++ b/tests/apitests/python/test_proxy_cache.py
@@ -75,7 +75,7 @@ class TestProxyCache(unittest.TestCase):
             registry = "https://cicd.harbor.vmwarecna.net"
             index_for_ctr = dict(image = "busybox", tag = "1.32.0")
 
-        registry_id, _ = self.registry.create_registry(registry, name=_random_name(registry_type), registry_type=registry_type, access_key = access_key, access_secret = access_secret, insecure=False, **ADMIN_CLIENT)
+        registry_id, _ = self.registry.create_registry(registry, name=_random_name(registry_type), registry_type=registry_type, access_key = access_key, access_secret = access_secret, insecure=True, **ADMIN_CLIENT)
 
         print("registry_id:", registry_id)
 


### PR DESCRIPTION
Fix APITEST_DB_PROXY_CACHE x509, Because cicd.harbor.vmwarecna uses a self-signed certificate.

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [ ] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [ ] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
