### PR TITLE
fix image name extraction

### DIFF
--- a/src/controller/event/handler/webhook/artifact/replication.go
+++ b/src/controller/event/handler/webhook/artifact/replication.go
@@ -216,9 +216,9 @@ func constructReplicationPayload(ctx context.Context, event *event.ReplicationEv
 
 func getMetadataFromResource(resource string) (namespace, nameAndTag string) {
 	// Usually resource format likes 'library/busybox:v1', but it could be 'busybox:v1' in docker registry
-        // It also could be 'library/bitnami/fluentd:1.13.3-debian-10-r0' so we need to split resource to only 2 parts
+	// It also could be 'library/bitnami/fluentd:1.13.3-debian-10-r0' so we need to split resource to only 2 parts
 	// possible namespace and image name which may include slashes for example: bitnami/fluentd:1.13.3-debian-10-r0
-	meta := strings.SplitN(resource, "/", 2)	
+	meta := strings.SplitN(resource, "/", 2)
 	if len(meta) == 1 {
 		return "", meta[0]
 	}

--- a/src/controller/event/handler/webhook/artifact/replication.go
+++ b/src/controller/event/handler/webhook/artifact/replication.go
@@ -216,7 +216,9 @@ func constructReplicationPayload(ctx context.Context, event *event.ReplicationEv
 
 func getMetadataFromResource(resource string) (namespace, nameAndTag string) {
 	// Usually resource format likes 'library/busybox:v1', but it could be 'busybox:v1' in docker registry
-	meta := strings.Split(resource, "/")
+        // It also could be 'library/bitnami/fluentd:1.13.3-debian-10-r0' so we need to split resource to only 2 parts
+	// possible namespace and image name which may include slashes for example: bitnami/fluentd:1.13.3-debian-10-r0
+	meta := strings.SplitN(resource, "/", 2)	
 	if len(meta) == 1 {
 		return "", meta[0]
 	}

--- a/src/controller/event/handler/webhook/artifact/replication_test.go
+++ b/src/controller/event/handler/webhook/artifact/replication_test.go
@@ -146,3 +146,21 @@ func TestIsLocalRegistry(t *testing.T) {
 	}
 	assert.False(t, isLocalRegistry(reg2))
 }
+
+func TestReplicationHandler_ShortResourceName(t *testing.T) {
+	namespace, resource := getMetadataFromResource("busybox:v1")
+	assert.Equal(t, "", namespace)
+	assert.Equal(t, "busybox:v1", resource)
+}
+
+func TestReplicationHandler_NormalResourceName(t *testing.T) {
+	namespace, resource := getMetadataFromResource("library/busybox:v1")
+	assert.Equal(t, "library", namespace)
+	assert.Equal(t, "busybox:v1", resource)
+}
+
+func TestReplicationHandler_LongResourceName(t *testing.T) {
+	namespace, resource := getMetadataFromResource("library/bitnami/fluentd:1.13.3-debian-10-r0")
+	assert.Equal(t, "library", namespace)
+	assert.Equal(t, "bitnami/fluentd:1.13.3-debian-10-r0", resource)
+}


### PR DESCRIPTION
It also could be 'library/bitnami/fluentd:1.13.3-debian-10-r0' so we need to split resource to only 2 parts - possible namespace and image name which may include slashes for example - namespace: library, image: bitnami/fluentd:1.13.3-debian-10-r0

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
