### PR TITLE
add validate webhhook address

### DIFF
--- a/tests/apitests/python/test_webhook_crud.py
+++ b/tests/apitests/python/test_webhook_crud.py
@@ -58,14 +58,8 @@ class TestProjects(unittest.TestCase):
             type = "slack",
             auth_header = "aaa"
         )
-        target_2 = v2_swagger_client.WebhookTargetObject(
-            address = "https://202.10.12.13",
-            skip_cert_verify = False,
-            type = "http",
-            auth_header = "aaa"
-        )
         #This need to be removed once issue #13378 fixed.
-        policy_id, policy_name = self.webhook.create_webhook(self.project_id, [target_1, target_2], **self.USER_CLIENT)
+        policy_id, policy_name = self.webhook.create_webhook(self.project_id, [target_1], **self.USER_CLIENT)
         target_1 = v2_swagger_client.WebhookTargetObject(
             address = "https://hooks.slack.com/services/new",
             skip_cert_verify = True,


### PR DESCRIPTION
Thank you for contributing to Harbor!

# Comprehensive Summary of your change

The currently created wehook does not verify whether the address is available, and the jobserver fails to execute after saving.


# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
