### PR TITLE
add jobid to logger

### DIFF
--- a/api/v2.0/swagger.yaml
+++ b/api/v2.0/swagger.yaml
@@ -7888,6 +7888,9 @@ definitions:
       job_status:
         type: string
         description: the status of gc job.
+      job_id:
+        type: string
+        description: the id of gc job.
       deleted:
         type: boolean
         description: if gc job was deleted.

--- a/src/server/v2.0/handler/model/gc.go
+++ b/src/server/v2.0/handler/model/gc.go
@@ -46,6 +46,7 @@ type GCHistory struct {
 	Parameters   string         `json:"job_parameters"`
 	Status       string         `json:"job_status"`
 	UUID         string         `json:"-"`
+	JobID        string         `json:"job_id"`
 	Deleted      bool           `json:"deleted"`
 	CreationTime time.Time      `json:"creation_time"`
 	UpdateTime   time.Time      `json:"update_time"`
@@ -60,6 +61,7 @@ func (h *GCHistory) ToSwagger() *models.GCHistory {
 		JobParameters: h.Parameters,
 		Deleted:       h.Deleted,
 		JobStatus:     h.Status,
+		JobID:         h.JobID,
 		Schedule: &models.ScheduleObj{
 			// covert MANUAL to Manual because the type of the ScheduleObj
 			// must be 'Hourly', 'Daily', 'Weekly', 'Custom', 'Manual' and 'None'

--- a/tests/apitests/python/test_project_level_policy_content_trust.py
+++ b/tests/apitests/python/test_project_level_policy_content_trust.py
@@ -84,7 +84,7 @@ class TestProjects(unittest.TestCase):
         restart_process("containerd")
         restart_process("dockerd")
         time.sleep(30)
-        pull_harbor_image(harbor_server, ADMIN_CLIENT["username"], ADMIN_CLIENT["password"], TestProjects.repo_name, tag, expected_error_message = "The image is not signed")
+        pull_harbor_image(harbor_server, ADMIN_CLIENT["username"], ADMIN_CLIENT["password"], TestProjects.repo_name, tag, expected_error_message = "The image is not signed by cosign")
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/robot-cases/Group1-Nightly/Common.robot
+++ b/tests/robot-cases/Group1-Nightly/Common.robot
@@ -773,7 +773,7 @@ Test Case - Cosign And Cosign Deployment Security Policy
     Go Into Project  project${d}
     Go Into Repo  project${d}  ${image}
     Should Not Be Signed By Cosign  ${tag}
-    Cannot Pull Image  ${ip}  ${user}  ${pwd}  project${d}  ${image}:${tag}  err_msg=The image is not signed.
+    Cannot Pull Image  ${ip}  ${user}  ${pwd}  project${d}  ${image}:${tag}  err_msg=The image is not signed by cosign.
     Cosign Generate Key Pair
     Cosign Verify  ${ip}/project${d}/${image}:${tag}  ${false}
 


### PR DESCRIPTION
Thank you for contributing to Harbor!

# Comprehensive Summary of your change

background:
    When I view the gc job log from the ui, because my log has a lot of content, the loading is very slow, and I cannot view it in real time; therefore, I want to enter the jobserver pod to view the gc job log, but the log file is named after the job_id. I can't get job_id from ui.

solution:
     In order to solve the problem of viewing the gc job, I think that the job_id can be output to the log file, so that the job_id can be viewed from the ui.

# Issue being fixed
Fixes #(issue) https://github.com/goharbor/harbor/issues/18999

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
