### PR TITLE
core: skip scheduling tasks if JOBSERVICE_URL is not set

### DIFF
--- a/src/core/main.go
+++ b/src/core/main.go
@@ -261,6 +261,10 @@ func main() {
 	// Scheduling of system artifact depends on the jobservice, where gorountine is used to avoid the circular
 	// dependencies between core and jobservice.
 	go func() {
+		if config.InternalJobServiceURL() == "" {
+			log.Info("JOBSERVICE_URL is not configured, skip scheduling tasks")
+			return
+		}
 		url := config.InternalJobServiceURL() + "/api/v1/stats"
 		checker := health.HTTPStatusCodeHealthChecker(http.MethodGet, url, nil, 60*time.Second, http.StatusOK)
 		options := []retry.Option{


### PR DESCRIPTION
Thank you for contributing to Harbor!

# Comprehensive Summary of your change

Skip scheduling tasks if JOBSERVICE_URL is not set, this can avoid printing much error logs for about 5 minutes until health check failed.

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
