### PR TITLE
fix accessory import issue

### DIFF
--- a/src/jobservice/main.go
+++ b/src/jobservice/main.go
@@ -32,6 +32,11 @@ import (
 	"github.com/goharbor/harbor/src/lib/cache"
 	cfgLib "github.com/goharbor/harbor/src/lib/config"
 	tracelib "github.com/goharbor/harbor/src/lib/trace"
+	_ "github.com/goharbor/harbor/src/pkg/accessory/model/base"
+	_ "github.com/goharbor/harbor/src/pkg/accessory/model/cosign"
+	_ "github.com/goharbor/harbor/src/pkg/accessory/model/notation"
+	_ "github.com/goharbor/harbor/src/pkg/accessory/model/nydus"
+	_ "github.com/goharbor/harbor/src/pkg/accessory/model/subject"
 	_ "github.com/goharbor/harbor/src/pkg/config/inmemory"
 	_ "github.com/goharbor/harbor/src/pkg/config/rest"
 )


### PR DESCRIPTION
fixes #19041

The issuse was introduced by https://github.com/goharbor/harbor/pull/17087. To move the import to main since the anonymous imports only allowed at main in go-cilint.

Fixes it:
To add the anonymous imports at the jobservice main since the gc job needs to remove accessory when to delete an artifact

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
