### PR TITLE
add job_id to gc task api

### DIFF
--- a/api/v2.0/swagger.yaml
+++ b/api/v2.0/swagger.yaml
@@ -7889,6 +7889,9 @@ definitions:
       job_status:
         type: string
         description: the status of gc job.
+      job_id:
+        type: string
+        description: the id of gc job.
       deleted:
         type: boolean
         description: if gc job was deleted.
@@ -7909,6 +7912,9 @@ definitions:
       job_name:
         type: string
         description: the job name of purge job.
+      job_id:
+        type: string
+        description: the id of the running job
       job_kind:
         type: string
         description: the job kind of purge job.

--- a/src/server/v2.0/handler/model/gc.go
+++ b/src/server/v2.0/handler/model/gc.go
@@ -46,6 +46,7 @@ type GCHistory struct {
 	Parameters   string         `json:"job_parameters"`
 	Status       string         `json:"job_status"`
 	UUID         string         `json:"-"`
+	JobID        string         `json:"job_id"`
 	Deleted      bool           `json:"deleted"`
 	CreationTime time.Time      `json:"creation_time"`
 	UpdateTime   time.Time      `json:"update_time"`
@@ -60,6 +61,7 @@ func (h *GCHistory) ToSwagger() *models.GCHistory {
 		JobParameters: h.Parameters,
 		Deleted:       h.Deleted,
 		JobStatus:     h.Status,
+		JobID:         h.JobID,
 		Schedule: &models.ScheduleObj{
 			// covert MANUAL to Manual because the type of the ScheduleObj
 			// must be 'Hourly', 'Daily', 'Weekly', 'Custom', 'Manual' and 'None'

--- a/src/server/v2.0/handler/model/jobservice.go
+++ b/src/server/v2.0/handler/model/jobservice.go
@@ -31,6 +31,7 @@ type ExecHistory struct {
 	ID           int64          `json:"id"`
 	Name         string         `json:"job_name"`
 	Kind         string         `json:"job_kind"`
+	JobID        string         `json:"job_id"`
 	Parameters   string         `json:"job_parameters"`
 	Status       string         `json:"job_status"`
 	UUID         string         `json:"-"`
@@ -45,6 +46,7 @@ func (h *ExecHistory) ToSwagger() *models.ExecHistory {
 		ID:            h.ID,
 		JobName:       h.Name,
 		JobKind:       h.Kind,
+		JobID:         h.JobID,
 		JobParameters: h.Parameters,
 		Deleted:       h.Deleted,
 		JobStatus:     h.Status,


### PR DESCRIPTION
Thank you for contributing to Harbor!

# Comprehensive Summary of your change

background:
    When I view the gc job log from the ui, because my log has a lot of content, the loading is very slow, and I cannot view it in real time; therefore, I want to enter the jobserver pod to view the gc job log, but the log file is named after the job_id. I can't get job_id from ui.

solution:
     In order to solve the problem of viewing the gc job, I think that the job_id can be output to the log file, so that the job_id can be viewed from the ui.

# Issue being fixed
Fixes #(issue) https://github.com/goharbor/harbor/issues/18999

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
