### PR TITLE
[cherry-pick] fix: fix replication list projects with pure numberic name

### DIFF
--- a/src/pkg/reg/adapter/harbor/base/adapter.go
+++ b/src/pkg/reg/adapter/harbor/base/adapter.go
@@ -176,7 +176,8 @@ func (a *Adapter) PrepareForPush(resources []*model.Resource) error {
 	for p := range projects {
 		ps = append(ps, p)
 	}
-	q := fmt.Sprintf("name={%s}", strings.Join(ps, " "))
+	// query by project name, decorate the name as string to avoid parsed as int by server in case of pure numbers as project name
+	q := fmt.Sprintf("name={'%s'}", strings.Join(ps, " "))
 	// get exist projects
 	queryProjects, err := a.Client.ListProjectsWithQuery(q, false)
 	if err != nil {


### PR DESCRIPTION
Quote the project name when listing projects in the replication, resolve the issue of pure number name of project.

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes https://github.com/goharbor/harbor/issues/19027

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
