### PR TITLE
fix: skip to delete scan reports if the digest still referenced

### DIFF
--- a/src/controller/event/handler/internal/artifact_test.go
+++ b/src/controller/event/handler/internal/artifact_test.go
@@ -35,6 +35,8 @@ import (
 	"github.com/goharbor/harbor/src/pkg/tag"
 	tagmodel "github.com/goharbor/harbor/src/pkg/tag/model/tag"
 	scannerCtlMock "github.com/goharbor/harbor/src/testing/controller/scanner"
+	"github.com/goharbor/harbor/src/testing/mock"
+	artMock "github.com/goharbor/harbor/src/testing/pkg/artifact"
 	projectMock "github.com/goharbor/harbor/src/testing/pkg/project"
 	reportMock "github.com/goharbor/harbor/src/testing/pkg/scan/report"
 	taskMock "github.com/goharbor/harbor/src/testing/pkg/task"
@@ -50,6 +52,7 @@ type ArtifactHandlerTestSuite struct {
 	scannerCtl     scanner.Controller
 	reportMgr      *reportMock.Manager
 	execMgr        *taskMock.ExecutionManager
+	artMgr         *artMock.Manager
 }
 
 // TestArtifactHandler tests ArtifactHandler.
@@ -66,7 +69,8 @@ func (suite *ArtifactHandlerTestSuite) SetupSuite() {
 	suite.scannerCtl = &scannerCtlMock.Controller{}
 	suite.execMgr = &taskMock.ExecutionManager{}
 	suite.reportMgr = &reportMock.Manager{}
-	suite.handler = &Handler{execMgr: suite.execMgr, reportMgr: suite.reportMgr}
+	suite.artMgr = &artMock.Manager{}
+	suite.handler = &Handler{execMgr: suite.execMgr, reportMgr: suite.reportMgr, artMgr: suite.artMgr}
 
 	// mock artifact
 	_, err := pkg.ArtifactMgr.Create(suite.ctx, &artifact.Artifact{ID: 1, RepositoryID: 1})
@@ -163,6 +167,7 @@ func (suite *ArtifactHandlerTestSuite) TestOnDelete() {
 	suite.execMgr.On("DeleteByVendor", suite.ctx, "IMAGE_SCAN", int64(1)).Return(nil).Times(1)
 	suite.execMgr.On("DeleteByVendor", suite.ctx, "IMAGE_SCAN", int64(2)).Return(nil).Times(1)
 	suite.execMgr.On("DeleteByVendor", suite.ctx, "IMAGE_SCAN", int64(3)).Return(nil).Times(1)
+	suite.artMgr.On("Count", suite.ctx, mock.Anything).Return(int64(0), nil).Times(3)
 	suite.reportMgr.On("DeleteByDigests", suite.ctx, "mock-digest", "ref-1", "ref-2").Return(nil).Times(1)
 	err := suite.handler.onDelete(suite.ctx, evt)
 	suite.Nil(err, "onDelete should return nil")


### PR DESCRIPTION
Avoid to delete the scan reports in case the artifact deleted but still referenced by the other artifacts.

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes https://github.com/goharbor/harbor/issues/19105

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
