### PR TITLE
[cherry-pick] chore: fix incorrect otel timeout in harbor yaml template

### DIFF
--- a/make/harbor.yml.tmpl
+++ b/make/harbor.yml.tmpl
@@ -244,7 +244,8 @@ proxy:
 #   #   url_path: /v1/traces
 #   #   compression: false
 #   #   insecure: true
-#   #   timeout: 10s
+#   #   # timeout is in seconds
+#   #   timeout: 10
 
 # enable purge _upload directories
 upload_purging:

--- a/make/photon/prepare/migrations/version_2_4_0/harbor.yml.jinja
+++ b/make/photon/prepare/migrations/version_2_4_0/harbor.yml.jinja
@@ -493,7 +493,8 @@ trace:
   #   url_path: /v1/traces
   #   compression: false
   #   insecure: true
-  #   timeout: 10s
+  #   # timeout is in seconds
+  #   timeout: 10
   {% endif%}
 {% else %}
 # trace:
@@ -516,5 +517,6 @@ trace:
 #   #   url_path: /v1/traces
 #   #   compression: false
 #   #   insecure: true
-#   #   timeout: 10s
+#   #   # timeout is in seconds
+#   #   timeout: 10
 {% endif %}

--- a/make/photon/prepare/migrations/version_2_5_0/harbor.yml.jinja
+++ b/make/photon/prepare/migrations/version_2_5_0/harbor.yml.jinja
@@ -507,7 +507,8 @@ trace:
   #   url_path: /v1/traces
   #   compression: false
   #   insecure: true
-  #   timeout: 10s
+  #   # timeout is in seconds
+  #   timeout: 10
   {% endif%}
 {% else %}
 # trace:
@@ -530,7 +531,8 @@ trace:
 #   #   url_path: /v1/traces
 #   #   compression: false
 #   #   insecure: true
-#   #   timeout: 10s
+#   #   # timeout is in seconds
+#   #   timeout: 10
 {% endif %}
 
 # enable purge _upload directories

--- a/make/photon/prepare/migrations/version_2_6_0/harbor.yml.jinja
+++ b/make/photon/prepare/migrations/version_2_6_0/harbor.yml.jinja
@@ -507,7 +507,8 @@ trace:
   #   url_path: /v1/traces
   #   compression: false
   #   insecure: true
-  #   timeout: 10s
+  #   # timeout is in seconds
+  #   timeout: 10
   {% endif%}
 {% else %}
 # trace:
@@ -530,7 +531,8 @@ trace:
 #   #   url_path: /v1/traces
 #   #   compression: false
 #   #   insecure: true
-#   #   timeout: 10s
+#   #   # timeout is in seconds
+#   #   timeout: 10
 {% endif %}
 
 # enable purge _upload directories

--- a/make/photon/prepare/migrations/version_2_7_0/harbor.yml.jinja
+++ b/make/photon/prepare/migrations/version_2_7_0/harbor.yml.jinja
@@ -514,7 +514,8 @@ trace:
   #   url_path: /v1/traces
   #   compression: false
   #   insecure: true
-  #   timeout: 10s
+  #   # timeout is in seconds
+  #   timeout: 10
   {% endif%}
 {% else %}
 # trace:
@@ -537,7 +538,8 @@ trace:
 #   #   url_path: /v1/traces
 #   #   compression: false
 #   #   insecure: true
-#   #   timeout: 10s
+#   #   # timeout is in seconds
+#   #   timeout: 10
 {% endif %}
 
 # enable purge _upload directories

--- a/make/photon/prepare/models.py
+++ b/make/photon/prepare/models.py
@@ -179,7 +179,7 @@ class OtelExporter:
         self.url_path = config.get('url_path')
         self.compression = config.get('compression') or False
         self.insecure = config.get('insecure') or False
-        self.timeout = config.get('timeout') or '10s'
+        self.timeout = config.get('timeout') or '10'
 
     def validate(self):
         if not self.endpoint:


### PR DESCRIPTION
Update the incorrect otel timeout sample value in the harbor YAML configuration template.

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes https://github.com/goharbor/harbor/issues/19084

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
