### PR TITLE
[cherry-pick] fix: support customize cache db for business

### DIFF
--- a/make/harbor.yml.tmpl
+++ b/make/harbor.yml.tmpl
@@ -167,6 +167,28 @@ _version: 2.9.0
 #     max_idle_conns: 2
 #     max_open_conns: 0
 
+# Uncomment redis if need to customize redis db
+# redis:
+#   # db_index 0 is for core, it's unchangeable
+#   # registry_db_index: 1
+#   # jobservice_db_index: 2
+#   # trivy_db_index: 5
+#   # it's optional, the db for harbor business misc, by default is 0, uncomment it if you want to change it.
+#   # harbor_db_index: 6
+#   # it's optional, the db for harbor cache layer, by default is 0, uncomment it if you want to change it.
+#   # cache_db_index: 7
+
+# Uncomment redis if need to customize redis db
+# redis:
+#   # db_index 0 is for core, it's unchangeable
+#   # registry_db_index: 1
+#   # jobservice_db_index: 2
+#   # trivy_db_index: 5
+#   # it's optional, the db for harbor business misc, by default is 0, uncomment it if you want to change it.
+#   # harbor_db_index: 6
+#   # it's optional, the db for harbor cache layer, by default is 0, uncomment it if you want to change it.
+#   # cache_layer_db_index: 7
+
 # Uncomment external_redis if using external Redis server
 # external_redis:
 #   # support redis, redis+sentinel
@@ -186,6 +208,10 @@ _version: 2.9.0
 #   jobservice_db_index: 2
 #   trivy_db_index: 5
 #   idle_timeout_seconds: 30
+#   # it's optional, the db for harbor business misc, by default is 0, uncomment it if you want to change it.
+#   # harbor_db_index: 6
+#   # it's optional, the db for harbor cache layer, by default is 0, uncomment it if you want to change it.
+#   # cache_layer_db_index: 7
 
 # Uncomment uaa for trusting the certificate of uaa instance that is hosted via self-signed cert.
 # uaa:

--- a/make/photon/prepare/migrations/version_2_7_0/harbor.yml.jinja
+++ b/make/photon/prepare/migrations/version_2_7_0/harbor.yml.jinja
@@ -371,6 +371,49 @@ external_database:
 #     ssl_mode: disable
 {% endif %}
 
+{% if redis is defined %}
+redis:
+#   # db_index 0 is for core, it's unchangeable
+{% if redis.registry_db_index is defined %}
+  registry_db_index: {{ redis.registry_db_index }}
+{% else %}
+#   # registry_db_index: 1
+{% endif %}
+{% if redis.jobservice_db_index is defined %}
+  jobservice_db_index: {{ redis.jobservice_db_index }}
+{% else %}
+#   # jobservice_db_index: 2
+{% endif %}
+{% if redis.trivy_db_index is defined %}
+  trivy_db_index: {{ redis.trivy_db_index }}
+{% else %}
+#   # trivy_db_index: 5
+{% endif %}
+{% if redis.harbor_db_index is defined %}
+  harbor_db_index: {{ redis.harbor_db_index }}
+{% else %}
+#   # it's optional, the db for harbor business misc, by default is 0, uncomment it if you want to change it.
+#   # harbor_db_index: 6
+{% endif %}
+{% if redis.cache_layer_db_index is defined %}
+  cache_layer_db_index: {{ redis.cache_layer_db_index }}
+{% else %}
+#   # it's optional, the db for harbor cache layer, by default is 0, uncomment it if you want to change it.
+#   # cache_layer_db_index: 7
+{% endif %}
+{% else %}
+# Uncomment redis if need to customize redis db
+# redis:
+#   # db_index 0 is for core, it's unchangeable
+#   # registry_db_index: 1
+#   # jobservice_db_index: 2
+#   # trivy_db_index: 5
+#   # it's optional, the db for harbor business misc, by default is 0, uncomment it if you want to change it.
+#   # harbor_db_index: 6
+#   # it's optional, the db for harbor cache layer, by default is 0, uncomment it if you want to change it.
+#   # cache_layer_db_index: 7
+{% endif %}
+
 {% if external_redis is defined %}
 external_redis:
   # support redis, redis+sentinel
@@ -390,6 +433,18 @@ external_redis:
   jobservice_db_index: {{ external_redis.jobservice_db_index }}
   trivy_db_index: 5
   idle_timeout_seconds: 30
+  {% if external_redis.harbor_db_index is defined %}
+  harbor_db_index: {{ redis.harbor_db_index }}
+  {% else %}
+# # it's optional, the db for harbor business misc, by default is 0, uncomment it if you want to change it.
+# # harbor_db_index: 6
+  {% endif %}
+  {% if external_redis.cache_layer_db_index is defined %}
+  cache_layer_db_index: {{ redis.cache_layer_db_index }}
+  {% else %}
+# # it's optional, the db for harbor cache layer, by default is 0, uncomment it if you want to change it.
+# # cache_layer_db_index: 7
+  {% endif %}
 {% else %}
 # Umcomments external_redis if using external Redis server
 # external_redis:
@@ -406,6 +461,10 @@ external_redis:
 #   jobservice_db_index: 2
 #   trivy_db_index: 5
 #   idle_timeout_seconds: 30
+#   # it's optional, the db for harbor business misc, by default is 0, uncomment it if you want to change it.
+#   # harbor_db_index: 6
+#   # it's optional, the db for harbor cache layer, by default is 0, uncomment it if you want to change it.
+#   # cache_layer_db_index: 7
 {% endif %}
 
 {% if uaa is defined %}

--- a/make/photon/prepare/migrations/version_2_8_0/harbor.yml.jinja
+++ b/make/photon/prepare/migrations/version_2_8_0/harbor.yml.jinja
@@ -381,6 +381,49 @@ external_database:
 #     ssl_mode: disable
 {% endif %}
 
+{% if redis is defined %}
+redis:
+#   # db_index 0 is for core, it's unchangeable
+{% if redis.registry_db_index is defined %}
+  registry_db_index: {{ redis.registry_db_index }}
+{% else %}
+#   # registry_db_index: 1
+{% endif %}
+{% if redis.jobservice_db_index is defined %}
+  jobservice_db_index: {{ redis.jobservice_db_index }}
+{% else %}
+#   # jobservice_db_index: 2
+{% endif %}
+{% if redis.trivy_db_index is defined %}
+  trivy_db_index: {{ redis.trivy_db_index }}
+{% else %}
+#   # trivy_db_index: 5
+{% endif %}
+{% if redis.harbor_db_index is defined %}
+  harbor_db_index: {{ redis.harbor_db_index }}
+{% else %}
+#   # it's optional, the db for harbor business misc, by default is 0, uncomment it if you want to change it.
+#   # harbor_db_index: 6
+{% endif %}
+{% if redis.cache_layer_db_index is defined %}
+  cache_layer_db_index: {{ redis.cache_layer_db_index }}
+{% else %}
+#   # it's optional, the db for harbor cache layer, by default is 0, uncomment it if you want to change it.
+#   # cache_layer_db_index: 7
+{% endif %}
+{% else %}
+# Uncomment redis if need to customize redis db
+# redis:
+#   # db_index 0 is for core, it's unchangeable
+#   # registry_db_index: 1
+#   # jobservice_db_index: 2
+#   # trivy_db_index: 5
+#   # it's optional, the db for harbor business misc, by default is 0, uncomment it if you want to change it.
+#   # harbor_db_index: 6
+#   # it's optional, the db for harbor cache layer, by default is 0, uncomment it if you want to change it.
+#   # cache_layer_db_index: 7
+{% endif %}
+
 {% if external_redis is defined %}
 external_redis:
   # support redis, redis+sentinel
@@ -406,6 +449,18 @@ external_redis:
   jobservice_db_index: {{ external_redis.jobservice_db_index }}
   trivy_db_index: 5
   idle_timeout_seconds: 30
+  {% if external_redis.harbor_db_index is defined %}
+  harbor_db_index: {{ redis.harbor_db_index }}
+  {% else %}
+# # it's optional, the db for harbor business misc, by default is 0, uncomment it if you want to change it.
+# # harbor_db_index: 6
+  {% endif %}
+  {% if external_redis.cache_layer_db_index is defined %}
+  cache_layer_db_index: {{ redis.cache_layer_db_index }}
+  {% else %}
+# # it's optional, the db for harbor cache layer, by default is 0, uncomment it if you want to change it.
+# # cache_layer_db_index: 7
+  {% endif %}
 {% else %}
 # Umcomments external_redis if using external Redis server
 # external_redis:
@@ -424,6 +479,10 @@ external_redis:
 #   jobservice_db_index: 2
 #   trivy_db_index: 5
 #   idle_timeout_seconds: 30
+#   # it's optional, the db for harbor business misc, by default is 0, uncomment it if you want to change it.
+#   # harbor_db_index: 6
+#   # it's optional, the db for harbor cache layer, by default is 0, uncomment it if you want to change it.
+#   # cache_layer_db_index: 7
 {% endif %}
 
 {% if uaa is defined %}

--- a/make/photon/prepare/migrations/version_2_9_0/harbor.yml.jinja
+++ b/make/photon/prepare/migrations/version_2_9_0/harbor.yml.jinja
@@ -378,6 +378,49 @@ external_database:
 #     max_open_conns: 0
 {% endif %}
 
+{% if redis is defined %}
+redis:
+#   # db_index 0 is for core, it's unchangeable
+{% if redis.registry_db_index is defined %}
+  registry_db_index: {{ redis.registry_db_index }}
+{% else %}
+#   # registry_db_index: 1
+{% endif %}
+{% if redis.jobservice_db_index is defined %}
+  jobservice_db_index: {{ redis.jobservice_db_index }}
+{% else %}
+#   # jobservice_db_index: 2
+{% endif %}
+{% if redis.trivy_db_index is defined %}
+  trivy_db_index: {{ redis.trivy_db_index }}
+{% else %}
+#   # trivy_db_index: 5
+{% endif %}
+{% if redis.harbor_db_index is defined %}
+  harbor_db_index: {{ redis.harbor_db_index }}
+{% else %}
+#   # it's optional, the db for harbor business misc, by default is 0, uncomment it if you want to change it.
+#   # harbor_db_index: 6
+{% endif %}
+{% if redis.cache_layer_db_index is defined %}
+  cache_layer_db_index: {{ redis.cache_layer_db_index }}
+{% else %}
+#   # it's optional, the db for harbor cache layer, by default is 0, uncomment it if you want to change it.
+#   # cache_layer_db_index: 7
+{% endif %}
+{% else %}
+# Uncomment redis if need to customize redis db
+# redis:
+#   # db_index 0 is for core, it's unchangeable
+#   # registry_db_index: 1
+#   # jobservice_db_index: 2
+#   # trivy_db_index: 5
+#   # it's optional, the db for harbor business misc, by default is 0, uncomment it if you want to change it.
+#   # harbor_db_index: 6
+#   # it's optional, the db for harbor cache layer, by default is 0, uncomment it if you want to change it.
+#   # cache_layer_db_index: 7
+{% endif %}
+
 {% if external_redis is defined %}
 external_redis:
   # support redis, redis+sentinel
@@ -399,6 +442,18 @@ external_redis:
   jobservice_db_index: {{ external_redis.jobservice_db_index }}
   trivy_db_index: 5
   idle_timeout_seconds: 30
+  {% if external_redis.harbor_db_index is defined %}
+  harbor_db_index: {{ redis.harbor_db_index }}
+  {% else %}
+# # it's optional, the db for harbor business misc, by default is 0, uncomment it if you want to change it.
+# # harbor_db_index: 6
+  {% endif %}
+  {% if external_redis.cache_layer_db_index is defined %}
+  cache_layer_db_index: {{ redis.cache_layer_db_index }}
+  {% else %}
+# # it's optional, the db for harbor cache layer, by default is 0, uncomment it if you want to change it.
+# # cache_layer_db_index: 7
+  {% endif %}
 {% else %}
 # Umcomments external_redis if using external Redis server
 # external_redis:
@@ -417,6 +472,10 @@ external_redis:
 #   jobservice_db_index: 2
 #   trivy_db_index: 5
 #   idle_timeout_seconds: 30
+#   # it's optional, the db for harbor business misc, by default is 0, uncomment it if you want to change it.
+#   # harbor_db_index: 6
+#   # it's optional, the db for harbor cache layer, by default is 0, uncomment it if you want to change it.
+#   # cache_layer_db_index: 7
 {% endif %}
 
 {% if uaa is defined %}

--- a/make/photon/prepare/templates/core/env.jinja
+++ b/make/photon/prepare/templates/core/env.jinja
@@ -1,6 +1,9 @@
 CONFIG_PATH=/etc/core/app.conf
 UAA_CA_ROOT=/etc/core/certificates/uaa_ca.pem
 _REDIS_URL_CORE={{redis_url_core}}
+{% if redis_url_harbor %}
+_REDIS_URL_HARBOR={{redis_url_harbor}}
+{% endif %}
 SYNC_QUOTA=true
 _REDIS_URL_REG={{redis_url_reg}}
 
@@ -84,6 +87,9 @@ TRACE_OTEL_INSECURE={{ trace.otel.insecure }}
 {% endif %}
 
 {% if cache.enabled %}
+{% if redis_url_cache_layer %}
+_REDIS_URL_CACHE_LAYER={{redis_url_cache_layer}}
+{% endif %}
 CACHE_ENABLED=true
 CACHE_EXPIRE_HOURS={{ cache.expire_hours }}
 {% endif %}

--- a/make/photon/prepare/templates/jobservice/env.jinja
+++ b/make/photon/prepare/templates/jobservice/env.jinja
@@ -51,6 +51,9 @@ TRACE_OTEL_INSECURE={{ trace.otel.insecure }}
 
 {% if cache.enabled %}
 _REDIS_URL_CORE={{redis_url_core}}
+{% if redis_url_cache_layer %}
+_REDIS_URL_CACHE_LAYER={{redis_url_cache_layer}}
+{% endif %}
 CACHE_ENABLED=true
 CACHE_EXPIRE_HOURS={{ cache.expire_hours }}
 {% endif %}

--- a/src/controller/quota/controller.go
+++ b/src/controller/quota/controller.go
@@ -262,7 +262,7 @@ func (c *controller) updateUsageByRedis(ctx context.Context, reference, referenc
 		return retry.Abort(ctx.Err())
 	}
 
-	client, err := libredis.GetCoreClient()
+	client, err := libredis.GetHarborClient()
 	if err != nil {
 		return retry.Abort(err)
 	}

--- a/src/jobservice/main.go
+++ b/src/jobservice/main.go
@@ -19,8 +19,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"net/url"
-	"os"
 
 	"github.com/goharbor/harbor/src/common"
 	"github.com/goharbor/harbor/src/jobservice/common/utils"
@@ -29,7 +27,6 @@ import (
 	"github.com/goharbor/harbor/src/jobservice/job/impl"
 	"github.com/goharbor/harbor/src/jobservice/logger"
 	"github.com/goharbor/harbor/src/jobservice/runtime"
-	"github.com/goharbor/harbor/src/lib/cache"
 	cfgLib "github.com/goharbor/harbor/src/lib/config"
 	tracelib "github.com/goharbor/harbor/src/lib/trace"
 	_ "github.com/goharbor/harbor/src/pkg/accessory/model/base"
@@ -45,21 +42,6 @@ func main() {
 	cfgLib.DefaultCfgManager = common.RestCfgManager
 	if err := cfgLib.DefaultMgr().Load(context.Background()); err != nil {
 		panic(fmt.Sprintf("failed to load configuration, error: %v", err))
-	}
-
-	// init cache if cache layer enabled
-	// gc needs to delete artifact by artifact manager, but the artifact cache store in
-	// core redis db so here require core redis url and init default cache.
-	if cfgLib.CacheEnabled() {
-		cacheURL := os.Getenv("_REDIS_URL_CORE")
-		u, err := url.Parse(cacheURL)
-		if err != nil {
-			panic("bad _REDIS_URL_CORE")
-		}
-
-		if err = cache.Initialize(u.Scheme, cacheURL); err != nil {
-			panic(fmt.Sprintf("failed to initialize cache: %v", err))
-		}
 	}
 
 	// Get parameters

--- a/src/lib/cache/cache.go
+++ b/src/lib/cache/cache.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"os"
 	"sync"
 	"time"
 
@@ -136,4 +137,38 @@ func Initialize(typ, addr string) error {
 // Default returns the default cache
 func Default() Cache {
 	return cache
+}
+
+var (
+	// cacheLayer is the global cache layer cache instance.
+	cacheLayer Cache
+	// cacheLayerOnce is the once condition for initializing instance.
+	cacheLayerOnce sync.Once
+)
+
+// LayerCache is the global cache instance for cache layer.
+func LayerCache() Cache {
+	// parse the redis url for cache layer, use the default cache if not specify
+	redisCacheURL := os.Getenv("_REDIS_URL_CACHE_LAYER")
+	if redisCacheURL == "" {
+		if cache != nil {
+			return cache
+		}
+		// use the core url if cache layer url not found
+		redisCacheURL = os.Getenv("_REDIS_URL_CORE")
+	}
+
+	u, err := url.Parse(redisCacheURL)
+	if err != nil {
+		log.Fatal("failed to parse the redis url for cache layer, bad _REDIS_URL_CACHE_LAYER")
+	}
+
+	cacheLayerOnce.Do(func() {
+		cacheLayer, err = New(u.Scheme, Address(redisCacheURL), Prefix("cache:"))
+		if err != nil {
+			log.Fatalf("failed to initialize cache for cache layer, err: %v", err)
+		}
+	})
+
+	return cacheLayer
 }

--- a/src/lib/redis/client_test.go
+++ b/src/lib/redis/client_test.go
@@ -41,22 +41,22 @@ func TestGetRegistryClient(t *testing.T) {
 	}
 }
 
-func TestGetCoreClient(t *testing.T) {
+func TestGetHarborClient(t *testing.T) {
 	// failure case with invalid address
-	t.Setenv("_REDIS_URL_CORE", "invalid-address")
-	client, err := GetCoreClient()
+	t.Setenv("_REDIS_URL_HARBOR", "invalid-address")
+	client, err := GetHarborClient()
 	assert.Error(t, err)
 	assert.Nil(t, client)
 
 	// normal case with valid address
-	t.Setenv("_REDIS_URL_CORE", "redis://localhost:6379/0")
-	client, err = GetCoreClient()
+	t.Setenv("_REDIS_URL_HARBOR", "redis://localhost:6379/0")
+	client, err = GetHarborClient()
 	assert.NoError(t, err)
 	assert.NotNil(t, client)
 
 	// multiple calls should return the same client
 	for i := 0; i < 10; i++ {
-		newClient, err := GetCoreClient()
+		newClient, err := GetHarborClient()
 		assert.NoError(t, err)
 		assert.Equal(t, client, newClient)
 	}

--- a/src/pkg/cached/base_manager.go
+++ b/src/pkg/cached/base_manager.go
@@ -24,27 +24,27 @@ import (
 )
 
 // innerCache is the default cache client,
-// actually it is a wrapper for cache.Default().
+// actually it is a wrapper for cache.LayerCache().
 var innerCache cache.Cache = &cacheClient{}
 
-// cacheClient is a interceptor for cache.Default, in order to implement specific
+// cacheClient is a interceptor for cache.CacheLayer, in order to implement specific
 // case for cache layer.
 type cacheClient struct{}
 
 func (*cacheClient) Contains(ctx context.Context, key string) bool {
-	return cache.Default().Contains(ctx, key)
+	return cache.LayerCache().Contains(ctx, key)
 }
 
 func (*cacheClient) Delete(ctx context.Context, key string) error {
-	return cache.Default().Delete(ctx, key)
+	return cache.LayerCache().Delete(ctx, key)
 }
 
 func (*cacheClient) Fetch(ctx context.Context, key string, value interface{}) error {
-	return cache.Default().Fetch(ctx, key, value)
+	return cache.LayerCache().Fetch(ctx, key, value)
 }
 
 func (*cacheClient) Ping(ctx context.Context) error {
-	return cache.Default().Ping(ctx)
+	return cache.LayerCache().Ping(ctx)
 }
 
 func (*cacheClient) Save(ctx context.Context, key string, value interface{}, expiration ...time.Duration) error {
@@ -57,11 +57,11 @@ func (*cacheClient) Save(ctx context.Context, key string, value interface{}, exp
 		return nil
 	}
 
-	return cache.Default().Save(ctx, key, value, expiration...)
+	return cache.LayerCache().Save(ctx, key, value, expiration...)
 }
 
 func (*cacheClient) Scan(ctx context.Context, match string) (cache.Iterator, error) {
-	return cache.Default().Scan(ctx, match)
+	return cache.LayerCache().Scan(ctx, match)
 }
 
 var _ Manager = &BaseManager{}


### PR DESCRIPTION
Support to configure the customized redis db for cache layer and other misc business for core, by default the behavior is same with previous(stored in db 0).

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes https://github.com/goharbor/harbor/issues/19169

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
