### PR TITLE
Log ensureArtifact ConflictErr

### DIFF
--- a/src/controller/artifact/controller.go
+++ b/src/controller/artifact/controller.go
@@ -227,7 +227,7 @@ func (c *controller) ensureArtifact(ctx context.Context, repository, digest stri
 		if !errors.IsConflictErr(err) {
 			return false, nil, err
 		}
-		log.Debugf("failed to create artifact: %v", err)
+		log.Debugf("failed to create artifact %s@%s: %v", repository, digest, err)
 		// if got conflict error, try to get the artifact again
 		artifact, err = c.artMgr.GetByDigest(ctx, repository, digest)
 		if err != nil {

--- a/src/controller/artifact/controller.go
+++ b/src/controller/artifact/controller.go
@@ -227,6 +227,7 @@ func (c *controller) ensureArtifact(ctx context.Context, repository, digest stri
 		if !errors.IsConflictErr(err) {
 			return false, nil, err
 		}
+		log.Debugf("failed to create artifact: %v", err)
 		// if got conflict error, try to get the artifact again
 		artifact, err = c.artMgr.GetByDigest(ctx, repository, digest)
 		if err != nil {


### PR DESCRIPTION
Thank you for contributing to Harbor!

# Comprehensive Summary of your change

https://github.com/goharbor/harbor/blob/main/src/controller/artifact/controller.go#L230
conflict error will always be overwritten here if GetByDigest returns an error, making it hard to debug the conflict error. This change logs the conflict error before it gets overwritten

# Issue being fixed

Fixes #19293

Please indicate you've done the following:
- [v] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [v] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
