### PR TITLE
redis sentinel mode supports setting password

### DIFF
--- a/src/lib/cache/redis/util.go
+++ b/src/lib/cache/redis/util.go
@@ -44,6 +44,7 @@ func ParseSentinelURL(redisURL string) (*redis.FailoverOptions, error) {
 	o := &redis.FailoverOptions{}
 
 	o.Username, o.Password = getUserPassword(u)
+	o.SentinelUsername, o.SentinelPassword = getUserPassword(u)
 	o.SentinelAddrs = strings.Split(u.Host, ",")
 
 	f := strings.FieldsFunc(u.Path, func(r rune) bool {


### PR DESCRIPTION
Thank you for contributing to Harbor!

# Comprehensive Summary of your change
In actual production, we use the sentinel mode of the harbor redis component and find that the password setting is not supported, the reason is that in the which is modified about PR.
# Issue being fixed
Fixes #(issue)
none
release-note/enhancement
Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
