### PR TITLE
feat: delete repo transaction nesting to small transaction

### DIFF
--- a/src/core/middlewares/middlewares.go
+++ b/src/core/middlewares/middlewares.go
@@ -39,8 +39,9 @@ import (
 )
 
 var (
-	match         = regexp.MustCompile
-	numericRegexp = match(`[0-9]+`)
+	match             = regexp.MustCompile
+	numericRegexp     = match(`[0-9]+`)
+	ProjectRepoRegexp = match(`^/api/v2.0/projects/(?P<project>[a-z0-9-]+)/repositories/(?P<repo>[a-z0-9-]+)$`)
 
 	// The ping endpoint will be blocked when DB conns reach the max open conns of the sql.DB
 	// which will make ping request timeout, so skip the middlewares which will require DB conn.
@@ -54,6 +55,7 @@ var (
 	dbTxSkippers = []middleware.Skipper{
 		middleware.MethodAndPathSkipper(http.MethodPatch, distribution.BlobUploadURLRegexp),
 		middleware.MethodAndPathSkipper(http.MethodPut, distribution.BlobUploadURLRegexp),
+		middleware.MethodAndPathSkipper(http.MethodDelete, ProjectRepoRegexp),
 		func(r *http.Request) bool { // skip tx for GET, HEAD and Options requests
 			m := r.Method
 			return m == http.MethodGet || m == http.MethodHead || m == http.MethodOptions


### PR DESCRIPTION
1. delete repo transaction nesting causes transaction timeouts big transaction rollback
2. small transaction can satisfy delete repo transaction, Many artifacts can be deleted even when timed out

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
