### PR TITLE
Remove duplicated sort fields from order by clause

### DIFF
--- a/src/lib/q/query.go
+++ b/src/lib/q/query.go
@@ -56,7 +56,6 @@ func MustClone(query *Query) *Query {
 	if query != nil {
 		q.PageNumber = query.PageNumber
 		q.PageSize = query.PageSize
-		q.Sorts = query.Sorts
 		for k, v := range query.Keywords {
 			q.Keywords[k] = v
 		}

--- a/src/lib/q/query_test.go
+++ b/src/lib/q/query_test.go
@@ -30,6 +30,7 @@ func TestMustClone(t *testing.T) {
 	}{
 		{"ptr", args{New(KeyWords{"public": "true"})}, New(KeyWords{"public": "true"})},
 		{"nil", args{nil}, New(KeyWords{})},
+		{"sort", args{&Query{Keywords: KeyWords{"public": "true"}, Sorts: []*Sort{NewSort("col-1", true)}}}, &Query{Keywords: KeyWords{"public": "true"}, Sorts: []*Sort{NewSort("col-1", true)}}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

Remove duplicated sort fields from order by clause
In MustClone() it will set Sorts field twice, that will generate two duplicated order by fields in the generated SQL.

For example, in the project list API, the SQL will be(formated):

```
[ORM]2023/09/12 19:26:16  -[Queries/default] - [  OK /    db.Query /     7.1ms] -
 [SELECT T0.`project_id`, T0.`owner_id`, T0.`name`,
 T0.`creation_time`, T0.`update_time`, T0.`deleted`, 
T0.`registry_id` 
FROM `project` T0 
WHERE T0.`deleted` = ? 
ORDER BY T0.`name` ASC, T0.`name` ASC 
LIMIT 50] - `false`
```

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
