### PR TITLE
Escape commas in usernames to fix rbac permissions

### DIFF
--- a/src/common/rbac/project/rbac_user.go
+++ b/src/common/rbac/project/rbac_user.go
@@ -17,6 +17,7 @@ package project
 import (
 	"github.com/goharbor/harbor/src/pkg/permission/types"
 	"github.com/goharbor/harbor/src/pkg/project/models"
+	"strings"
 )
 
 type rbacUser struct {
@@ -28,7 +29,7 @@ type rbacUser struct {
 
 // GetUserName returns username of the visitor
 func (pru *rbacUser) GetUserName() string {
-	return pru.username
+	return strings.ReplaceAll(pru.username, ",", "_")
 }
 
 // GetPolicies returns policies of the visitor

--- a/src/core/api/api_test.go
+++ b/src/core/api/api_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//    http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -62,7 +62,7 @@ var (
 		Passwd: "Harbor12345",
 	}
 	projDeveloper = &usrInfo{
-		Name:   "proj_developer",
+		Name:   "proj_developer,lol",
 		Passwd: "Harbor12345",
 	}
 	projGuest = &usrInfo{


### PR DESCRIPTION
# Comprehensive Summary of your change
This change escape `,` in username which breaks rbac validation.
Which leads to that every user with `,` in his name wasn't able to access an repository via portal or API.


# Issue being fixed
Fixes #19356

Please indicate you've done the following:
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.

