### PR TITLE
support accessory in either order

### DIFF
--- a/src/pkg/accessory/dao/dao.go
+++ b/src/pkg/accessory/dao/dao.go
@@ -32,6 +32,8 @@ type DAO interface {
 	Get(ctx context.Context, id int64) (accessory *Accessory, err error)
 	// Create the accessory
 	Create(ctx context.Context, accessory *Accessory) (id int64, err error)
+	// Update the accessory
+	Update(ctx context.Context, accessory *Accessory) error
 	// Delete the accessory specified by ID
 	Delete(ctx context.Context, id int64) (err error)
 	// DeleteAccessories deletes accessories by query
@@ -101,6 +103,21 @@ func (d *dao) Create(ctx context.Context, acc *Accessory) (int64, error) {
 		}
 	}
 	return id, err
+}
+
+func (d *dao) Update(ctx context.Context, acc *Accessory) error {
+	ormer, err := orm.FromContext(ctx)
+	if err != nil {
+		return err
+	}
+	n, err := ormer.Update(acc, "SubjectArtifactID")
+	if n == 0 {
+		if e := orm.AsConflictError(err, "accessory %s already exists", acc.Digest); e != nil {
+			err = e
+		}
+		return err
+	}
+	return err
 }
 
 func (d *dao) Delete(ctx context.Context, id int64) error {

--- a/src/pkg/accessory/dao/dao_test.go
+++ b/src/pkg/accessory/dao/dao_test.go
@@ -169,6 +169,19 @@ func (d *daoTestSuite) TestCreate() {
 	d.True(errors.IsErr(err, errors.ConflictCode))
 }
 
+func (d *daoTestSuite) TestUpdate() {
+	acc := &Accessory{
+		ID:                d.accID,
+		SubjectArtifactID: 333,
+	}
+	err := d.dao.Update(d.ctx, acc)
+	d.Require().Nil(err)
+
+	accAfter, err := d.dao.Get(d.ctx, d.accID)
+	d.Require().Nil(err)
+	d.Require().Equal(int64(333), accAfter.SubjectArtifactID)
+}
+
 func (d *daoTestSuite) TestDelete() {
 	// happy pass is covered in TearDown
 

--- a/src/pkg/accessory/manager.go
+++ b/src/pkg/accessory/manager.go
@@ -48,6 +48,8 @@ type Manager interface {
 	List(ctx context.Context, query *q.Query) (accs []model.Accessory, err error)
 	// Create the accessory and returns the ID
 	Create(ctx context.Context, accessory model.AccessoryData) (id int64, err error)
+	// Update the accessory
+	Update(ctx context.Context, accessory model.AccessoryData) error
 	// Delete the accessory specified by ID
 	Delete(ctx context.Context, id int64) (err error)
 	// DeleteAccessories deletes accessories according to the query
@@ -148,6 +150,14 @@ func (m *manager) Create(ctx context.Context, accessory model.AccessoryData) (in
 		Type:                  accessory.Type,
 	}
 	return m.dao.Create(ctx, acc)
+}
+
+func (m *manager) Update(ctx context.Context, accessory model.AccessoryData) error {
+	acc := &dao.Accessory{
+		ID:                accessory.ID,
+		SubjectArtifactID: accessory.SubArtifactID,
+	}
+	return m.dao.Update(ctx, acc)
 }
 
 func (m *manager) Delete(ctx context.Context, id int64) error {

--- a/src/pkg/accessory/manager_test.go
+++ b/src/pkg/accessory/manager_test.go
@@ -87,6 +87,16 @@ func (m *managerTestSuite) TestCreate() {
 	m.dao.AssertExpectations(m.T())
 }
 
+func (m *managerTestSuite) TestUpdate() {
+	mock.OnAnything(m.dao, "Update").Return(nil)
+	err := m.mgr.Update(nil, model.AccessoryData{
+		ID:            1,
+		SubArtifactID: 2,
+	})
+	m.Require().Nil(err)
+	m.dao.AssertExpectations(m.T())
+}
+
 func (m *managerTestSuite) TestDelete() {
 	mock.OnAnything(m.dao, "Delete").Return(nil)
 	err := m.mgr.Delete(nil, 1)

--- a/src/server/middleware/subject/subject.go
+++ b/src/server/middleware/subject/subject.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 
 	"github.com/docker/distribution/manifest/schema2"
+	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 
 	"github.com/goharbor/harbor/src/controller/artifact"
@@ -28,6 +29,7 @@ import (
 	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/lib/log"
 	"github.com/goharbor/harbor/src/lib/orm"
+	"github.com/goharbor/harbor/src/lib/q"
 	"github.com/goharbor/harbor/src/pkg/accessory"
 	"github.com/goharbor/harbor/src/pkg/accessory/model"
 	"github.com/goharbor/harbor/src/server/middleware"
@@ -147,6 +149,34 @@ func Middleware() func(http.Handler) http.Handler {
 				}
 			}
 			w.Header().Set("OCI-Subject", subjectArt.Digest)
+		} else {
+			// In certain cases, the OCI client may push the subject artifact and accessory in either order.
+			// Therefore, it is necessary to handle situations where the client pushes the accessory ahead of the subject artifact.
+			digest := digest.FromBytes(body)
+			accs, err := accessory.Mgr.List(ctx, q.New(q.KeyWords{"SubjectArtifactDigest": digest}))
+			if err != nil {
+				logger.Errorf("failed to list accessory artifact: %s, error: %v", digest, err)
+				return err
+			}
+			if len(accs) <= 0 {
+				return nil
+			}
+			art, err := artifact.Ctl.GetByReference(ctx, info.Repository, digest.String(), nil)
+			if err != nil {
+				logger.Errorf("failed to list artifact: %s, error: %v", digest, err)
+				return err
+			}
+			if art != nil {
+				for _, acc := range accs {
+					accData := model.AccessoryData{
+						ID:            acc.GetData().ID,
+						SubArtifactID: art.ID,
+					}
+					if err := accessory.Mgr.Update(ctx, accData); err != nil {
+						return err
+					}
+				}
+			}
 		}
 
 		return nil

--- a/src/testing/pkg/accessory/dao/dao.go
+++ b/src/testing/pkg/accessory/dao/dao.go
@@ -154,6 +154,20 @@ func (_m *DAO) List(ctx context.Context, query *q.Query) ([]*dao.Accessory, erro
 	return r0, r1
 }
 
+// Update provides a mock function with given fields: ctx, accessory
+func (_m *DAO) Update(ctx context.Context, accessory *dao.Accessory) error {
+	ret := _m.Called(ctx, accessory)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, *dao.Accessory) error); ok {
+		r0 = rf(ctx, accessory)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 type mockConstructorTestingTNewDAO interface {
 	mock.TestingT
 	Cleanup(func())

--- a/src/testing/pkg/accessory/manager.go
+++ b/src/testing/pkg/accessory/manager.go
@@ -158,6 +158,20 @@ func (_m *Manager) List(ctx context.Context, query *q.Query) ([]model.Accessory,
 	return r0, r1
 }
 
+// Update provides a mock function with given fields: ctx, _a1
+func (_m *Manager) Update(ctx context.Context, _a1 model.AccessoryData) error {
+	ret := _m.Called(ctx, _a1)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, model.AccessoryData) error); ok {
+		r0 = rf(ctx, _a1)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 type mockConstructorTestingTNewManager interface {
 	mock.TestingT
 	Cleanup(func())


### PR DESCRIPTION
In certain cases, the OCI client may push the subject artifact and accessory in either order. Therefore, it is necessary to handle situations where the client pushes the accessory ahead of the subject artifact.

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes https://github.com/goharbor/harbor/issues/19345

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
