### PR TITLE
Add label's description as tooltip

### DIFF
--- a/src/portal/src/app/base/project/repository/artifact/artifact-list-page/artifact-list/artifact-list-tab/artifact-list-tab.component.html
+++ b/src/portal/src/app/base/project/repository/artifact/artifact-list-page/artifact-list/artifact-list-tab/artifact-list-tab.component.html
@@ -430,7 +430,8 @@
                         <hbr-label-piece
                             *ngIf="artifact.labels?.length"
                             [label]="artifact.labels[0]"
-                            [labelWidth]="90">
+                            [labelWidth]="90"
+                            [withTooltip]="true">
                         </hbr-label-piece>
                         <div
                             class="signpost-item"
@@ -447,7 +448,8 @@
                                         class="margin-5px">
                                         <hbr-label-piece
                                             [labelWidth]="130"
-                                            [label]="label">
+                                            [label]="label"
+                                            [withTooltip]="true">
                                         </hbr-label-piece>
                                     </div>
                                 </clr-signpost-content>

--- a/src/portal/src/app/shared/components/label/label-piece/label-piece.component.html
+++ b/src/portal/src/app/shared/components/label/label-piece/label-piece.component.html
@@ -1,18 +1,27 @@
-<label
-    class="label"
-    [ngStyle]="{
-        'background-color': labelColor?.color,
-        color: labelColor?.textColor,
-        border: labelColor?.color === '#FFFFFF' ? '1px solid #A1A1A1' : 'none'
-    }"
-    [style.max-width.px]="labelWidth">
-    <span>
-        <clr-icon
-            *ngIf="hasIcon && label.scope === 'p'"
-            shape="organization"></clr-icon>
-        <clr-icon
-            *ngIf="hasIcon && label.scope === 'g'"
-            shape="administrator"></clr-icon>
-    </span>
-    <span class="label-name">{{ label.name }}</span>
-</label>
+<clr-tooltip>
+    <label
+        clrTooltipTrigger
+        class="label"
+        [ngStyle]="{
+            'background-color': labelColor?.color,
+            color: labelColor?.textColor,
+            border: labelColor?.color === '#FFFFFF' ? '1px solid #A1A1A1' : 'none'
+        }"
+        [style.max-width.px]="labelWidth">
+        <span>
+            <clr-icon
+                *ngIf="hasIcon && label.scope === 'p'"
+                shape="organization"></clr-icon>
+            <clr-icon
+                *ngIf="hasIcon && label.scope === 'g'"
+                shape="administrator"></clr-icon>
+        </span>
+        <span class="label-name">{{ label.name }}</span>
+    </label>
+    <clr-tooltip-content
+        [clrPosition]="'right'"
+        *ngIf="withTooltip && label.description && label.description !== ''"
+        >
+        <span>{{ label.description }}</span>
+    </clr-tooltip-content>
+</clr-tooltip>

--- a/src/portal/src/app/shared/components/label/label-piece/label-piece.component.html
+++ b/src/portal/src/app/shared/components/label/label-piece/label-piece.component.html
@@ -5,7 +5,8 @@
         [ngStyle]="{
             'background-color': labelColor?.color,
             color: labelColor?.textColor,
-            border: labelColor?.color === '#FFFFFF' ? '1px solid #A1A1A1' : 'none'
+            border:
+                labelColor?.color === '#FFFFFF' ? '1px solid #A1A1A1' : 'none'
         }"
         [style.max-width.px]="labelWidth">
         <span>
@@ -20,8 +21,7 @@
     </label>
     <clr-tooltip-content
         [clrPosition]="'right'"
-        *ngIf="withTooltip && label.description && label.description !== ''"
-        >
+        *ngIf="withTooltip && label.description">
         <span>{{ label.description }}</span>
     </clr-tooltip-content>
 </clr-tooltip>

--- a/src/portal/src/app/shared/components/label/label-piece/label-piece.component.ts
+++ b/src/portal/src/app/shared/components/label/label-piece/label-piece.component.ts
@@ -24,6 +24,7 @@ export class LabelPieceComponent implements OnChanges {
     @Input() label: Label;
     @Input() labelWidth: number;
     @Input() hasIcon: boolean = true;
+    @Input() withTooltip: boolean = false;
     labelColor: { [key: string]: string };
 
     ngOnChanges(): void {


### PR DESCRIPTION
# Comprehensive Summary of your change

Adds a tooltip showing the label's description on artifact-list-page. I believe it is not relevant to show it anywhere else (and from what I've tried it often result in broken UI).

Please find a video of how it looks: https://github.com/goharbor/harbor/assets/48765390/54669aaa-6324-4669-9967-80727fb49e64

Note that I'm a complete noob with Frontend/JS/Angular, therefore please let me know if you believe there is a more elegant way to do this.

Please indicate you've done the following:
- [X] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [X] Accepted the DCO. Commits without the DCO will delay acceptance.
- [X] Made sure tests are passing and test coverage is added if needed.
- [X] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
