### PR TITLE
feat: enhance the replication webhook payload

### DIFF
--- a/src/controller/event/handler/webhook/artifact/replication.go
+++ b/src/controller/event/handler/webhook/artifact/replication.go
@@ -191,6 +191,7 @@ func constructReplicationPayload(ctx context.Context, event *event.ReplicationEv
 			Type:       task.ResourceType,
 			Status:     task.Status,
 			NameAndTag: nameAndTag,
+			References: strings.Split(task.References, ","),
 		}
 		payload.EventData.Replication.SuccessfulArtifact = []*ctlModel.ArtifactInfo{succeedArtifact}
 	}
@@ -199,6 +200,7 @@ func constructReplicationPayload(ctx context.Context, event *event.ReplicationEv
 			Type:       task.ResourceType,
 			Status:     task.Status,
 			NameAndTag: nameAndTag,
+			References: strings.Split(task.References, ","),
 		}
 		payload.EventData.Replication.FailedArtifact = []*ctlModel.ArtifactInfo{failedArtifact}
 	}

--- a/src/controller/event/model/event.go
+++ b/src/controller/event/model/event.go
@@ -35,10 +35,11 @@ type Replication struct {
 
 // ArtifactInfo describe info of artifact
 type ArtifactInfo struct {
-	Type       string `json:"type"`
-	Status     string `json:"status"`
-	NameAndTag string `json:"name_tag"`
-	FailReason string `json:"fail_reason,omitempty"`
+	Type       string   `json:"type"`
+	Status     string   `json:"status"`
+	NameAndTag string   `json:"name_tag"`
+	References []string `json:"references"`
+	FailReason string   `json:"fail_reason,omitempty"`
 }
 
 // ReplicationResource describes replication resource info

--- a/src/controller/replication/execution.go
+++ b/src/controller/replication/execution.go
@@ -296,6 +296,7 @@ func convertTask(task *task.Task) *Task {
 		ResourceType:        task.GetStringFromExtraAttrs("resource_type"),
 		SourceResource:      task.GetStringFromExtraAttrs("source_resource"),
 		DestinationResource: task.GetStringFromExtraAttrs("destination_resource"),
+		References:          task.GetStringFromExtraAttrs("references"),
 		Operation:           task.GetStringFromExtraAttrs("operation"),
 		JobID:               task.JobID,
 		CreationTime:        task.CreationTime,

--- a/src/controller/replication/execution_test.go
+++ b/src/controller/replication/execution_test.go
@@ -199,6 +199,7 @@ func (r *replicationTestSuite) TestListTasks() {
 				"resource_type":        "artifact",
 				"source_resource":      "library/hello-world",
 				"destination_resource": "library/hello-world",
+				"references":           "v1,v2,v3",
 				"operation":            "copy",
 			},
 		},
@@ -211,6 +212,7 @@ func (r *replicationTestSuite) TestListTasks() {
 	r.Equal("artifact", tasks[0].ResourceType)
 	r.Equal("library/hello-world", tasks[0].SourceResource)
 	r.Equal("library/hello-world", tasks[0].DestinationResource)
+	r.Equal("v1,v2,v3", tasks[0].References)
 	r.Equal("copy", tasks[0].Operation)
 	r.taskMgr.AssertExpectations(r.T())
 }
@@ -225,6 +227,7 @@ func (r *replicationTestSuite) TestGetTask() {
 				"resource_type":        "artifact",
 				"source_resource":      "library/hello-world",
 				"destination_resource": "library/hello-world",
+				"references":           "v1,v2,v3",
 				"operation":            "copy",
 			},
 		},
@@ -236,6 +239,7 @@ func (r *replicationTestSuite) TestGetTask() {
 	r.Equal("artifact", task.ResourceType)
 	r.Equal("library/hello-world", task.SourceResource)
 	r.Equal("library/hello-world", task.DestinationResource)
+	r.Equal("v1,v2,v3", task.References)
 	r.Equal("copy", task.Operation)
 	r.taskMgr.AssertExpectations(r.T())
 }

--- a/src/controller/replication/flow/copy.go
+++ b/src/controller/replication/flow/copy.go
@@ -148,7 +148,8 @@ func (c *copyFlow) createTasks(ctx context.Context, srcResources, dstResources [
 			"operation":            "copy",
 			"resource_type":        string(srcResource.Type),
 			"source_resource":      getResourceName(srcResource),
-			"destination_resource": getResourceName(dstResource)}); err != nil {
+			"destination_resource": getResourceName(dstResource),
+			"references":           getResourceReferences(dstResource)}); err != nil {
 			return err
 		}
 

--- a/src/controller/replication/flow/deletion.go
+++ b/src/controller/replication/flow/deletion.go
@@ -93,7 +93,8 @@ func (d *deletionFlow) createTasks(ctx context.Context, srcResources, dstResourc
 			"operation":            operation,
 			"resource_type":        string(resource.Type),
 			"source_resource":      getResourceName(resource),
-			"destination_resource": getResourceName(dstResources[i])}); err != nil {
+			"destination_resource": getResourceName(dstResources[i]),
+			"references":           getResourceReferences(dstResources[i])}); err != nil {
 			return err
 		}
 	}

--- a/src/controller/replication/flow/stage.go
+++ b/src/controller/replication/flow/stage.go
@@ -152,6 +152,37 @@ func getResourceName(res *model.Resource) string {
 	return fmt.Sprintf("%s [%d item(s) in total]", meta.Repository.Name, n)
 }
 
+// getResourceReferences gets the string lists of the resource reference, use tag name first or digest if no tag
+// e.g v1,v2,dev,sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08
+func getResourceReferences(res *model.Resource) string {
+	if res == nil {
+		return ""
+	}
+	meta := res.Metadata
+	if meta == nil {
+		return ""
+	}
+
+	references := make([]string, 0)
+	if len(meta.Artifacts) > 0 {
+		for _, artifact := range meta.Artifacts {
+			// contains tags
+			if len(artifact.Tags) > 0 {
+				references = append(references, artifact.Tags...)
+				continue
+			}
+			// contains no tag, use digest
+			if len(artifact.Digest) > 0 {
+				references = append(references, artifact.Digest)
+			}
+		}
+	} else {
+		references = append(references, meta.Vtags...)
+	}
+
+	return strings.Join(references, ",")
+}
+
 // repository:a/b/c/image namespace:n replaceCount: -1 -> n/image
 // repository:a/b/c/image namespace:n replaceCount: 0 -> n/a/b/c/image
 // repository:a/b/c/image namespace:n replaceCount: 1 -> n/b/c/image

--- a/src/controller/replication/model.go
+++ b/src/controller/replication/model.go
@@ -43,6 +43,7 @@ type Task struct {
 	ResourceType        string
 	SourceResource      string
 	DestinationResource string
+	References          string
 	Operation           string
 	JobID               string
 	CreationTime        time.Time


### PR DESCRIPTION
Add the new filed 'references' to the replication webhook payload, which can help user better know the replicated artifact tags or digests. (references is the lists of the artifact tag name or digest if no tag)

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes https://github.com/goharbor/harbor/issues/19035

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
