### PR TITLE
fix: Accessibility - change color for WCAG AA

### DIFF
--- a/src/portal/src/app/base/left-side-nav/interrogation-services/vulnerability-database/security-hub.component.scss
+++ b/src/portal/src/app/base/left-side-nav/interrogation-services/vulnerability-database/security-hub.component.scss
@@ -4,12 +4,12 @@
 
 .label-critical {
   background:#a8242f;
-  color:#ffffff;
+  color:#fff;
 }
 
 .label-danger {
   background:#d83818!important;
-  color:#ffffff!important;
+  color:#fff!important;
 }
 
 .label-medium {
@@ -19,12 +19,12 @@
 
 .label-low {
   background: #005c8a;
-  color:#ffffff;
+  color:#fff;
 }
 
 .label-none {
   background-color: #737373;
-  color:#ffffff;
+  color:#fff;
 }
 
 .no-border {

--- a/src/portal/src/app/base/left-side-nav/interrogation-services/vulnerability-database/security-hub.component.scss
+++ b/src/portal/src/app/base/left-side-nav/interrogation-services/vulnerability-database/security-hub.component.scss
@@ -3,28 +3,28 @@
 }
 
 .label-critical {
-  background:#a8242f;
-  color:#fff;
+  background:#ff4d2e;
+  color:#000;
 }
 
 .label-danger {
-  background:#d83818!important;
-  color:#fff!important;
+  background:#ff8f3d!important;
+  color:#000!important;
 }
 
 .label-medium {
-  background-color: orange;
-  color:#621501;
+  background-color: #ffce66;
+  color:#000;
 }
 
 .label-low {
-  background: #005c8a;
-  color:#fff;
+  background: #fff1ad;
+  color:#000;
 }
 
 .label-none {
-  background-color: #737373;
-  color:#fff;
+  background-color: #2ec0ff;
+  color:#000;
 }
 
 .no-border {

--- a/src/portal/src/app/base/left-side-nav/interrogation-services/vulnerability-database/security-hub.component.scss
+++ b/src/portal/src/app/base/left-side-nav/interrogation-services/vulnerability-database/security-hub.component.scss
@@ -3,14 +3,13 @@
 }
 
 .label-critical {
-  background:red;
-  color:#621501;
+  background:#a8242f;
+  color:#ffffff;
 }
 
-
 .label-danger {
-  background:#e64524!important;
-  color:#621501!important;
+  background:#d83818!important;
+  color:#ffffff!important;
 }
 
 .label-medium {
@@ -19,13 +18,13 @@
 }
 
 .label-low {
-  background: #007CBB;
-  color:#cab6b1;
+  background: #005c8a;
+  color:#ffffff;
 }
 
 .label-none {
-  background-color: grey;
-  color:#bad7ba;
+  background-color: #737373;
+  color:#ffffff;
 }
 
 .no-border {

--- a/src/portal/src/app/base/left-side-nav/interrogation-services/vulnerability-database/vulnerability-summary/vulnerability-summary.component.scss
+++ b/src/portal/src/app/base/left-side-nav/interrogation-services/vulnerability-database/vulnerability-summary/vulnerability-summary.component.scss
@@ -64,16 +64,14 @@ $row-height: 48px;
   align-items: center;
 }
 
-
 .label-critical {
-  background:red;
-  color:#621501;
+  background:#a8242f;
+  color:#ffffff;
 }
 
-
 .label-danger {
-  background:#e64524!important;
-  color:#621501!important;
+  background:#d83818!important;
+  color:#ffffff!important;
 }
 
 .label-medium {
@@ -82,13 +80,13 @@ $row-height: 48px;
 }
 
 .label-low {
-  background: #007CBB;
-  color:#cab6b1;
+  background: #005c8a;
+  color:#ffffff;
 }
 
 .label-none {
-  background-color: grey;
-  color:#bad7ba;
+  background-color: #737373;
+  color:#ffffff;
 }
 
 .no-border {

--- a/src/portal/src/app/base/left-side-nav/interrogation-services/vulnerability-database/vulnerability-summary/vulnerability-summary.component.scss
+++ b/src/portal/src/app/base/left-side-nav/interrogation-services/vulnerability-database/vulnerability-summary/vulnerability-summary.component.scss
@@ -66,12 +66,12 @@ $row-height: 48px;
 
 .label-critical {
   background:#a8242f;
-  color:#ffffff;
+  color:#fff;
 }
 
 .label-danger {
   background:#d83818!important;
-  color:#ffffff!important;
+  color:#fff!important;
 }
 
 .label-medium {
@@ -81,12 +81,12 @@ $row-height: 48px;
 
 .label-low {
   background: #005c8a;
-  color:#ffffff;
+  color:#fff;
 }
 
 .label-none {
   background-color: #737373;
-  color:#ffffff;
+  color:#fff;
 }
 
 .no-border {

--- a/src/portal/src/app/base/left-side-nav/interrogation-services/vulnerability-database/vulnerability-summary/vulnerability-summary.component.scss
+++ b/src/portal/src/app/base/left-side-nav/interrogation-services/vulnerability-database/vulnerability-summary/vulnerability-summary.component.scss
@@ -65,28 +65,28 @@ $row-height: 48px;
 }
 
 .label-critical {
-  background:#a8242f;
-  color:#fff;
+  background:#ff4d2e;
+  color:#000;
 }
 
 .label-danger {
-  background:#d83818!important;
-  color:#fff!important;
+  background:#ff8f3d!important;
+  color:#000!important;
 }
 
 .label-medium {
-  background-color: orange;
-  color:#621501;
+  background-color: #ffce66;
+  color:#000;
 }
 
 .label-low {
-  background: #005c8a;
-  color:#fff;
+  background: #fff1ad;
+  color:#000;
 }
 
 .label-none {
-  background-color: #737373;
-  color:#fff;
+  background-color: #2ec0ff;
+  color:#000;
 }
 
 .no-border {

--- a/src/portal/src/app/base/project/repository/artifact/artifact-additions/artifact-vulnerabilities/artifact-vulnerabilities.component.scss
+++ b/src/portal/src/app/base/project/repository/artifact/artifact-additions/artifact-vulnerabilities/artifact-vulnerabilities.component.scss
@@ -20,12 +20,12 @@
 
 .label-critical {
   background:#a8242f;
-  color:#ffffff;
+  color:#fff;
 }
 
 .label-danger {
   background:#d83818!important;
-  color:#ffffff!important;
+  color:#fff!important;
 }
 
 .label-medium {
@@ -35,12 +35,12 @@
 
 .label-low {
   background: #005c8a;
-  color:#ffffff;
+  color:#fff;
 }
 
 .label-none {
   background-color: #737373;
-  color:#ffffff;
+  color:#fff;
 }
 
 .no-border {

--- a/src/portal/src/app/base/project/repository/artifact/artifact-additions/artifact-vulnerabilities/artifact-vulnerabilities.component.scss
+++ b/src/portal/src/app/base/project/repository/artifact/artifact-additions/artifact-vulnerabilities/artifact-vulnerabilities.component.scss
@@ -19,28 +19,28 @@
 }
 
 .label-critical {
-  background:#a8242f;
-  color:#fff;
+  background:#ff4d2e;
+  color:#000;
 }
 
 .label-danger {
-  background:#d83818!important;
-  color:#fff!important;
+  background:#ff8f3d!important;
+  color:#000!important;
 }
 
 .label-medium {
-  background-color: orange;
-  color:#621501;
+  background-color: #ffce66;
+  color:#000;
 }
 
 .label-low {
-  background: #005c8a;
-  color:#fff;
+  background: #fff1ad;
+  color:#000;
 }
 
 .label-none {
-  background-color: #737373;
-  color:#fff;
+  background-color: #2ec0ff;
+  color:#000;
 }
 
 .no-border {

--- a/src/portal/src/app/base/project/repository/artifact/artifact-additions/artifact-vulnerabilities/artifact-vulnerabilities.component.scss
+++ b/src/portal/src/app/base/project/repository/artifact/artifact-additions/artifact-vulnerabilities/artifact-vulnerabilities.component.scss
@@ -19,14 +19,13 @@
 }
 
 .label-critical {
-  background:red;
-  color:#621501;
+  background:#a8242f;
+  color:#ffffff;
 }
 
-
 .label-danger {
-  background:#e64524!important;
-  color:#621501!important;
+  background:#d83818!important;
+  color:#ffffff!important;
 }
 
 .label-medium {
@@ -35,13 +34,13 @@
 }
 
 .label-low {
-  background: #007CBB;
-  color:#cab6b1;
+  background: #005c8a;
+  color:#ffffff;
 }
 
 .label-none {
-  background-color: grey;
-  color:#bad7ba;
+  background-color: #737373;
+  color:#ffffff;
 }
 
 .no-border {

--- a/src/portal/src/app/base/project/repository/artifact/vulnerability-scanning/result-tip-histogram/result-tip-histogram.component.scss
+++ b/src/portal/src/app/base/project/repository/artifact/vulnerability-scanning/result-tip-histogram/result-tip-histogram.component.scss
@@ -54,23 +54,23 @@ $twenty-two-pixel: 18px;
 }
 
 .bar-block-critical {
-    background-color: #a8242f;
+    background-color: #ff4d2e;
 }
 
 .bar-block-high {
-    background-color: #d83818;
+    background-color: #ff8f3d;
 }
 
 .bar-block-medium {
-    background-color: orange;
+    background-color: #ffce66;
 }
 
 .bar-block-low {
-    background-color: #005c8a;
+    background-color: #fff1ad;
 }
 
 .bar-block-none {
-    background-color: green;
+    background-color: #2ec0ff;
 }
 
 .bar-block-unknown {

--- a/src/portal/src/app/base/project/repository/artifact/vulnerability-scanning/result-tip-histogram/result-tip-histogram.component.scss
+++ b/src/portal/src/app/base/project/repository/artifact/vulnerability-scanning/result-tip-histogram/result-tip-histogram.component.scss
@@ -54,11 +54,11 @@ $twenty-two-pixel: 18px;
 }
 
 .bar-block-critical {
-    background-color: red;
+    background-color: #a8242f;
 }
 
 .bar-block-high {
-    background-color: #e64524;
+    background-color: #d83818;
 }
 
 .bar-block-medium {
@@ -66,7 +66,7 @@ $twenty-two-pixel: 18px;
 }
 
 .bar-block-low {
-    background-color: #007CBB;
+    background-color: #005c8a;
 }
 
 .bar-block-none {

--- a/src/portal/src/app/base/project/repository/artifact/vulnerability-scanning/scanning.scss
+++ b/src/portal/src/app/base/project/repository/artifact/vulnerability-scanning/scanning.scss
@@ -158,12 +158,12 @@ hr{
 
 .label-critical {
   background:#a8242f;
-  color:#ffffff;
+  color:#fff;
 }
 
 .label-danger {
   background:#d83818!important;
-  color:#ffffff!important;
+  color:#fff!important;
 }
 
 .label-medium {
@@ -173,12 +173,12 @@ hr{
 
 .label-low {
   background: #005c8a;
-  color:#ffffff;
+  color:#fff;
 }
 
 .label-none {
   background-color: #737373;
-  color:#ffffff;
+  color:#fff;
 }
 
 .no-border {

--- a/src/portal/src/app/base/project/repository/artifact/vulnerability-scanning/scanning.scss
+++ b/src/portal/src/app/base/project/repository/artifact/vulnerability-scanning/scanning.scss
@@ -157,29 +157,28 @@ hr{
 }
 
 .label-critical {
-    background:red;
-    color:#621501;
+  background:#a8242f;
+  color:#ffffff;
 }
 
-
 .label-danger {
-    background:#e64524!important;
-    color:#621501!important;
+  background:#d83818!important;
+  color:#ffffff!important;
 }
 
 .label-medium {
-    background-color: orange;
-    color:#621501;
+  background-color: orange;
+  color:#621501;
 }
 
 .label-low {
-    background: #007CBB;
-    color:#cab6b1;
+  background: #005c8a;
+  color:#ffffff;
 }
 
 .label-none {
-    background-color: grey;
-    color:#bad7ba;
+  background-color: #737373;
+  color:#ffffff;
 }
 
 .no-border {

--- a/src/portal/src/app/base/project/repository/artifact/vulnerability-scanning/scanning.scss
+++ b/src/portal/src/app/base/project/repository/artifact/vulnerability-scanning/scanning.scss
@@ -157,28 +157,28 @@ hr{
 }
 
 .label-critical {
-  background:#a8242f;
-  color:#fff;
+    background:#ff4d2e;
+    color:#000;
 }
 
 .label-danger {
-  background:#d83818!important;
-  color:#fff!important;
+    background:#ff8f3d!important;
+    color:#000!important;
 }
 
 .label-medium {
-  background-color: orange;
-  color:#621501;
+    background-color: #ffce66;
+    color:#000;
 }
 
 .label-low {
-  background: #005c8a;
-  color:#fff;
+    background: #fff1ad;
+    color:#000;
 }
 
 .label-none {
-  background-color: #737373;
-  color:#fff;
+    background-color: #2ec0ff;
+    color:#000;
 }
 
 .no-border {


### PR DESCRIPTION
# Comprehensive Summary of your change

Changed the label token foreground and background to comply with WCAG AA (or AAA when possible).

Before: 
![image](https://github.com/goharbor/harbor/assets/2413436/4b5c977f-3340-4552-9c4f-f9e64e1ae94f)
After:
![image](https://github.com/goharbor/harbor/assets/2413436/318408fe-1716-4843-a68d-ddd8d68215eb)

Using https://webaim.org/resources/contrastchecker/ as a testing tool, only `label-medium` was OK for WCAG AA for normal content.

# Issue being fixed
No existing issue (I preferred to file a PR first). This could relate to #12327

# Notes
I don't have any Sass skill so far and tried to apply a homogeneous patch where such labels were duplicated. Please let me know if I missed something.

`result-tip-histogram.component.scss` didn't have any issue, but I preferred to match the colors changed elsewhere.

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation" << I'm not sure I have the rights to label the PR.
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
