### PR TITLE
perf: optimize the trigger retention API

### DIFF
--- a/src/controller/retention/controller_test.go
+++ b/src/controller/retention/controller_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/goharbor/harbor/src/common/dao"
 	"github.com/goharbor/harbor/src/jobservice/job"
+	"github.com/goharbor/harbor/src/lib"
 	"github.com/goharbor/harbor/src/lib/orm"
 	"github.com/goharbor/harbor/src/lib/q"
 	"github.com/goharbor/harbor/src/pkg/retention"
@@ -238,6 +239,7 @@ func (s *ControllerTestSuite) TestExecution() {
 		projectManager: projectMgr,
 		repositoryMgr:  repositoryMgr,
 		scheduler:      retentionScheduler,
+		wp:             lib.NewWorkerPool(10),
 	}
 
 	p1 := &policy.Metadata{


### PR DESCRIPTION
Enhance the API for triggering retention by optimizing it from synchronous to asynchronous to solve the problem of slow response in the case of a large number of tasks.

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes https://github.com/goharbor/harbor/issues/18504

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
