### PR TITLE
Use absolute path for the profile.cov

### DIFF
--- a/tests/coverage4gotest.sh
+++ b/tests/coverage4gotest.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 set -x
 set -e
-echo "mode: set" >>profile.cov
+profile_path=$(pwd)/profile.cov
+echo "profile.cov path: $profile_path"
+
+echo "mode: set" >>"$profile_path"
 
 deps=""
 cd $(dirname $(find . -name go.mod))
@@ -33,7 +36,7 @@ do
 	go test -race -v -cover -coverprofile=profile.tmp -coverpkg "$deps" $package
 	if [ -f profile.tmp ]	
 	then
-		cat profile.tmp | tail -n +2 >> profile.cov
+		cat profile.tmp | tail -n +2 >> "$profile_path"
 		rm profile.tmp
 	fi	
 done


### PR DESCRIPTION
There's a path change introduced by #19508 which may impact showing the coverage on codecov.
This commit makes sure the profile.cov is referenced as absolute path in `coverage4gotest.sh`

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
