### PR TITLE
Give a uniform name to container name

### DIFF
--- a/make/photon/prepare/templates/docker_compose/docker-compose.yml.jinja
+++ b/make/photon/prepare/templates/docker_compose/docker-compose.yml.jinja
@@ -25,7 +25,7 @@ services:
       - harbor
   registry:
     image: goharbor/registry-photon:{{reg_version}}
-    container_name: registry
+    container_name: harbor-registry
     restart: always
     cap_drop:
       - ALL
@@ -69,7 +69,7 @@ services:
         tag: "registry"
   registryctl:
     image: goharbor/harbor-registryctl:{{version}}
-    container_name: registryctl
+    container_name: harbor-registryctl
     env_file:
       - ./common/config/registryctl/env
     restart: always
@@ -266,7 +266,7 @@ services:
 {% if external_redis == False %}
   redis:
     image: goharbor/redis-photon:{{redis_version}}
-    container_name: redis
+    container_name: harbor-redis
     restart: always
     cap_drop:
       - ALL
@@ -288,7 +288,7 @@ services:
 {% endif %}
   proxy:
     image: goharbor/nginx-photon:{{version}}
-    container_name: nginx
+    container_name: harbor-nginx
     restart: always
     cap_drop:
       - ALL


### PR DESCRIPTION
# Comprehensive Summary of the change

Give a uniform name to container_name, preventing container name confusion when multiple projects exist in the system.

eg: nginx, redis

After the modification, the containers in this project will have a uniform naming convention.

- harbor-jobservice
- harbor-nginx
- harbor-core
- harbor-portal
- harbor-db
- harbor-registryctl
- harbor-redis
- harbor-registry
- harbor-log

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
