### PR TITLE
[release-note/docs] swagger.yaml "repositoryName" parameter description update

### DIFF
--- a/api/v2.0/swagger.yaml
+++ b/api/v2.0/swagger.yaml
@@ -6240,7 +6240,7 @@ parameters:
   repositoryName:
     name: repository_name
     in: path
-    description: The name of the repository. If it contains slash, encode it with URL encoding. e.g. a/b -> a%252Fb
+    description: The name of the repository. If it contains slash, encode it twice over with URL encoding. e.g. a/b -> a%2Fb -> a%252Fb
     required: true
     type: string
   reference:


### PR DESCRIPTION
Thank you for contributing to Harbor!

# Comprehensive Summary of your change

This is a one line change to the swagger.yaml file in order to update the description of the repositoryName parameter. As described in the linked issue, the forward slashes in the repo name parameter need to be double encoded. 

# Issue being fixed
Fixes #19635

Please indicate you've done the following:
- [ ] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [ ] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
