### PR TITLE
[cherry-pick] fix: increase beego max memory and upload size (#19578)

### DIFF
--- a/src/common/const.go
+++ b/src/common/const.go
@@ -226,4 +226,14 @@ const (
 	UIMaxLengthLimitedOfNumber = 10
 	// ExecutionStatusRefreshIntervalSeconds is the interval seconds for refreshing execution status
 	ExecutionStatusRefreshIntervalSeconds = "execution_status_refresh_interval_seconds"
+
+	// Beego web config
+	// BeegoMaxMemoryBytes is the max memory(bytes) of the beego web config
+	BeegoMaxMemoryBytes = "beego_max_memory_bytes"
+	// DefaultBeegoMaxMemoryBytes sets default max memory to 128GB
+	DefaultBeegoMaxMemoryBytes = 1 << 37
+	// BeegoMaxUploadSizeBytes is the max upload size(bytes) of the beego web config
+	BeegoMaxUploadSizeBytes = "beego_max_upload_size_bytes"
+	// DefaultBeegoMaxUploadSizeBytes sets default max upload size to 128GB
+	DefaultBeegoMaxUploadSizeBytes = 1 << 37
 )

--- a/src/core/main.go
+++ b/src/core/main.go
@@ -125,8 +125,6 @@ func main() {
 
 	web.BConfig.WebConfig.Session.SessionOn = true
 	web.BConfig.WebConfig.Session.SessionName = config.SessionCookieName
-	web.BConfig.MaxMemory = 1 << 35     // (32GB)
-	web.BConfig.MaxUploadSize = 1 << 35 // (32GB)
 	// the core db used for beego session
 	redisCoreURL := os.Getenv("_REDIS_URL_CORE")
 	if len(redisCoreURL) > 0 {
@@ -161,6 +159,12 @@ func main() {
 	log.Info("initializing configurations...")
 	config.Init()
 	log.Info("configurations initialization completed")
+
+	// default beego max memory and max upload size is 128GB, consider from some AI related image would be large,
+	// also support customize it from the environment variables if the default value cannot satisfy some scenarios.
+	web.BConfig.MaxMemory = config.GetBeegoMaxMemoryBytes()
+	web.BConfig.MaxUploadSize = config.GetBeegoMaxUploadSizeBytes()
+
 	metricCfg := config.Metric()
 	if metricCfg.Enabled {
 		metric.RegisterCollectors()

--- a/src/lib/config/metadata/metadatalist.go
+++ b/src/lib/config/metadata/metadatalist.go
@@ -14,7 +14,11 @@
 
 package metadata
 
-import "github.com/goharbor/harbor/src/common"
+import (
+	"fmt"
+
+	"github.com/goharbor/harbor/src/common"
+)
 
 // Item - Configure item include default value, type, env name
 type Item struct {
@@ -191,5 +195,8 @@ var (
 		{Name: common.SessionTimeout, Scope: UserScope, Group: BasicGroup, EnvKey: "SESSION_TIMEOUT", DefaultValue: "60", ItemType: &Int64Type{}, Editable: true, Description: `The session timeout in minutes`},
 
 		{Name: common.ExecutionStatusRefreshIntervalSeconds, Scope: SystemScope, Group: BasicGroup, EnvKey: "EXECUTION_STATUS_REFRESH_INTERVAL_SECONDS", DefaultValue: "30", ItemType: &Int64Type{}, Editable: false, Description: `The interval seconds to refresh the execution status`},
+
+		{Name: common.BeegoMaxMemoryBytes, Scope: SystemScope, Group: BasicGroup, EnvKey: "BEEGO_MAX_MEMORY_BYTES", DefaultValue: fmt.Sprintf("%d", common.DefaultBeegoMaxMemoryBytes), ItemType: &Int64Type{}, Editable: false, Description: `The bytes for limiting the beego max memory, default is 128GB`},
+		{Name: common.BeegoMaxUploadSizeBytes, Scope: SystemScope, Group: BasicGroup, EnvKey: "BEEGO_MAX_UPLOAD_SIZE_BYTES", DefaultValue: fmt.Sprintf("%d", common.DefaultBeegoMaxUploadSizeBytes), ItemType: &Int64Type{}, Editable: false, Description: `The bytes for limiting the beego max upload size, default it 128GB`},
 	}
 )

--- a/src/lib/config/systemconfig.go
+++ b/src/lib/config/systemconfig.go
@@ -151,6 +151,16 @@ func WithNotary() bool {
 	return DefaultMgr().Get(backgroundCtx, common.WithNotary).GetBool()
 }
 
+// GetBeegoMaxMemoryBytes returns the max memory bytes of beego config
+func GetBeegoMaxMemoryBytes() int64 {
+	return DefaultMgr().Get(backgroundCtx, common.BeegoMaxMemoryBytes).GetInt64()
+}
+
+// GetBeegoMaxUploadSizeBytes returns the max upload size bytes of beego config
+func GetBeegoMaxUploadSizeBytes() int64 {
+	return DefaultMgr().Get(backgroundCtx, common.BeegoMaxUploadSizeBytes).GetInt64()
+}
+
 // WithTrivy returns a bool value to indicate if Harbor's deployed with Trivy.
 func WithTrivy() bool {
 	return DefaultMgr().Get(backgroundCtx, common.WithTrivy).GetBool()


### PR DESCRIPTION
1. Increase the default beego max memory and upload size from 32GB to 128GB.
2. Support customize the two beego configs from env.




(cherry picked from commit 553c85eed04aea65db3336be45a628ce022148fb)

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
