### PR TITLE
Give the slack queue enough priority

### DIFF
--- a/src/jobservice/job/priority.go
+++ b/src/jobservice/job/priority.go
@@ -42,8 +42,6 @@ func (ps *defaultSampler) For(job string) uint {
 	// As an example, sample job has the lowest priority
 	case SampleJob:
 		return 1
-	case SlackJobVendorType:
-		return 1
 		// add more cases here if specified job priority is required
 	// case XXX:
 	//	return 2000

--- a/src/jobservice/job/priority_test.go
+++ b/src/jobservice/job/priority_test.go
@@ -49,5 +49,5 @@ func (suite *PrioritySamplerSuite) Test() {
 	suite.Equal(defaultPriority, p3, "Job priority for %s", ReplicationVendorType)
 
 	p4 := suite.sampler.For(SlackJobVendorType)
-	suite.Equal((uint)(1), p4, "Job priority for %s", SlackJobVendorType)
+	suite.Equal(defaultPriority, p4, "Job priority for %s", SlackJobVendorType)
 }


### PR DESCRIPTION
We noticed slack jobs are not being processed when we have a lot of image scans running. This should prevent that from happening.

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
