### PR TITLE
Fix OpenAPI Specification structural error

### DIFF
--- a/api/v2.0/swagger.yaml
+++ b/api/v2.0/swagger.yaml
@@ -4850,7 +4850,6 @@ paths:
         '200':
           description: Get scheduler status successfully.
           schema:
-            type: object
             $ref: '#/definitions/SchedulerStatus'
         '401':
           $ref: '#/responses/401'


### PR DESCRIPTION
# Comprehensive Summary of your change
The reference definition [SchedulerStatus](https://github.com/goharbor/harbor/blob/v2.10.0/api/v2.0/swagger.yaml#L9742) already has `type: object`, so remove the duplicated `type: object` under schema which cause the structural error.

# Issue being fixed
Fixes #19781

Please indicate you've done the following:
- [X] Well Written Title and Summary of the PR
- [X] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [X] Accepted the DCO. Commits without the DCO will delay acceptance.
- [X] Made sure tests are passing and test coverage is added if needed.
- [X] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
