### PR TITLE
Fix manifest list never being stored in proxy-cache projects 

### DIFF
--- a/src/server/middleware/repoproxy/proxy.go
+++ b/src/server/middleware/repoproxy/proxy.go
@@ -304,6 +304,10 @@ func proxyManifestHead(ctx context.Context, w http.ResponseWriter, ctl proxy.Con
 		// Then GET the image by digest, in order to associate the tag with the digest
 		// Ensure tag after head request, make sure tags in proxy cache keep update
 		bCtx := orm.Context()
+		_, err := ctl.ProxyManifest(ctx, art, remote)
+		if err != nil {
+			log.Debugf("Failed to ensure proxy manifest %+v , error %v", art, err)
+		}
 		for i := 0; i < ensureTagMaxRetry; i++ {
 			time.Sleep(ensureTagInterval)
 			bArt := lib.ArtifactInfo{ProjectName: art.ProjectName, Repository: art.Repository, Digest: string(desc.Digest)}


### PR DESCRIPTION
 Fix manifest list never being stored in proxy-cache projects  by looking up the manifest on HEAD requests

# Comprehensive Summary of your change

My understanding is that when docker (or containerd) requests a manifest list in a proxy-cache project, the client never makes a GET request for the manifest list. It makes a HEAD request for the manifest list, then makes a GET request for the platform architecture specific digest. As a result, the manifest list is never persisted in the storage layer, only in the redis cache layer. When the cache expires, this forces a new remote lookup for future requests instead of being able to rely on the storage, which is the purpose of the proxy-cache.

# Issue being fixed
This may or may not also fix #19609, but it does seem related.

Please indicate you've done the following:
- [X] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
