### PR TITLE
Update swagger.yaml bad request permission: helm-chart:read

### DIFF
--- a/api/v2.0/swagger.yaml
+++ b/api/v2.0/swagger.yaml
@@ -7761,7 +7761,7 @@ definitions:
     properties:
       resource:
         type: string
-        description: The resource of the access. Possible resources are *, artifact, artifact-addition, artifact-label, audit-log, catalog, configuration, distribution, garbage-collection, helm-chart, helm-chart-version, helm-chart-version-label, immutable-tag, label, ldap-user, log, member, metadata, notification-policy, preheat-instance, preheat-policy, project, quota, registry, replication, replication-adapter, replication-policy, repository, robot, scan, scan-all, scanner, system-volumes, tag, tag-retention, user, user-group or "" (for self-reference).
+        description: The resource of the access. Possible resources are not up to date..
       action:
         type: string
         description: The action of the access. Possible actions are *, pull, push, create, read, update, delete, list, operate, scanner-pull and stop.

--- a/api/v2.0/swagger.yaml
+++ b/api/v2.0/swagger.yaml
@@ -7761,7 +7761,7 @@ definitions:
     properties:
       resource:
         type: string
-        description: The resource of the access. Possible resources are not up to date..
+        description: The resource of the access. Possible resources are listed here for system and project level https://github.com/goharbor/harbor/blob/main/src/common/rbac/const.go 
       action:
         type: string
         description: The action of the access. Possible actions are *, pull, push, create, read, update, delete, list, operate, scanner-pull and stop.


### PR DESCRIPTION
https://github.com/goharbor/harbor/discussions/20093
https://github.com/goharbor/harbor/commit/738fde7d3bd8f201711907a826630b3fe5d13e16

I wasn't sure if this was auto-generated. I didn't see the swagger comments on any where else except in the yaml. I added the url itself, so hopefully that is always the most recent.

