### PR TITLE
fix: panic due to mark retention task error

### DIFF
--- a/src/controller/replication/execution.go
+++ b/src/controller/replication/execution.go
@@ -154,11 +154,11 @@ func (c *controller) Start(ctx context.Context, policy *replicationmodel.Policy,
 func (c *controller) markError(ctx context.Context, executionID int64, err error) {
 	logger := log.GetLogger(ctx)
 	// try to stop the execution first in case that some tasks are already created
-	if err := c.execMgr.StopAndWait(ctx, executionID, 10*time.Second); err != nil {
-		logger.Errorf("failed to stop the execution %d: %v", executionID, err)
+	if stopErr := c.execMgr.StopAndWait(ctx, executionID, 10*time.Second); stopErr != nil {
+		logger.Errorf("failed to stop the execution %d: %v", executionID, stopErr)
 	}
-	if err := c.execMgr.MarkError(ctx, executionID, err.Error()); err != nil {
-		logger.Errorf("failed to mark error for the execution %d: %v", executionID, err)
+	if markErr := c.execMgr.MarkError(ctx, executionID, err.Error()); markErr != nil {
+		logger.Errorf("failed to mark error for the execution %d: %v", executionID, markErr)
 	}
 }
 

--- a/src/controller/retention/controller.go
+++ b/src/controller/retention/controller.go
@@ -280,12 +280,12 @@ func (r *defaultController) TriggerRetentionExec(ctx context.Context, policyID i
 		if num, err := r.launcher.Launch(ctx, p, id, dryRun); err != nil {
 			logger.Errorf("failed to launch the retention jobs, err: %v", err)
 
-			if err = r.execMgr.StopAndWait(ctx, id, 10*time.Second); err != nil {
-				logger.Errorf("failed to stop the retention execution %d: %v", id, err)
+			if stopErr := r.execMgr.StopAndWait(ctx, id, 10*time.Second); stopErr != nil {
+				logger.Errorf("failed to stop the retention execution %d: %v", id, stopErr)
 			}
 
-			if err = r.execMgr.MarkError(ctx, id, err.Error()); err != nil {
-				logger.Errorf("failed to mark error for the retention execution %d: %v", id, err)
+			if markErr := r.execMgr.MarkError(ctx, id, err.Error()); markErr != nil {
+				logger.Errorf("failed to mark error for the retention execution %d: %v", id, markErr)
 			}
 		} else if num == 0 {
 			// no candidates, mark the execution as done directly

--- a/src/controller/scandataexport/execution.go
+++ b/src/controller/scandataexport/execution.go
@@ -165,11 +165,11 @@ func (c *controller) Start(ctx context.Context, request export.Request) (executi
 func (c *controller) markError(ctx context.Context, executionID int64, err error) {
 	logger := log.GetLogger(ctx)
 	// try to stop the execution first in case that some tasks are already created
-	if err := c.execMgr.StopAndWait(ctx, executionID, 10*time.Second); err != nil {
-		logger.Errorf("failed to stop the execution %d: %v", executionID, err)
+	if stopErr := c.execMgr.StopAndWait(ctx, executionID, 10*time.Second); stopErr != nil {
+		logger.Errorf("failed to stop the execution %d: %v", executionID, stopErr)
 	}
-	if err := c.execMgr.MarkError(ctx, executionID, err.Error()); err != nil {
-		logger.Errorf("failed to mark error for the execution %d: %v", executionID, err)
+	if markErr := c.execMgr.MarkError(ctx, executionID, err.Error()); markErr != nil {
+		logger.Errorf("failed to mark error for the execution %d: %v", executionID, markErr)
 	}
 }
 

--- a/src/controller/systemartifact/execution.go
+++ b/src/controller/systemartifact/execution.go
@@ -119,11 +119,11 @@ func (c *controller) createCleanupTask(ctx context.Context, jobParams job.Parame
 
 func (c *controller) markError(ctx context.Context, executionID int64, err error) {
 	// try to stop the execution first in case that some tasks are already created
-	if err := c.execMgr.StopAndWait(ctx, executionID, 10*time.Second); err != nil {
-		log.Errorf("failed to stop the execution %d: %v", executionID, err)
+	if stopErr := c.execMgr.StopAndWait(ctx, executionID, 10*time.Second); stopErr != nil {
+		log.Errorf("failed to stop the execution %d: %v", executionID, stopErr)
 	}
-	if err := c.execMgr.MarkError(ctx, executionID, err.Error()); err != nil {
-		log.Errorf("failed to mark error for the execution %d: %v", executionID, err)
+	if markErr := c.execMgr.MarkError(ctx, executionID, err.Error()); markErr != nil {
+		log.Errorf("failed to mark error for the execution %d: %v", executionID, markErr)
 	}
 }
 


### PR DESCRIPTION
Clarify err assignment to prevent panic caused by overwriting.

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes https://github.com/goharbor/harbor/issues/20129

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
