### PR TITLE
Fixed an issue where the scan stop button can only be clicked once

### DIFF
--- a/src/portal/src/app/base/project/repository/artifact/artifact-list-page/artifact-list/artifact-list-tab/artifact-list-tab.component.ts
+++ b/src/portal/src/app/base/project/repository/artifact/artifact-list-page/artifact-list/artifact-list-tab/artifact-list-tab.component.ts
@@ -907,7 +907,7 @@ export class ArtifactListTabComponent implements OnInit, OnDestroy {
         this.scanStoppedArtifactLength += 1;
         // all selected scan action has stopped
         if (this.scanStoppedArtifactLength === this.onStopScanArtifactsLength) {
-            this.onSendingScanCommand = e;
+            this.onSendingStopScanCommand = e;
         }
     }
 
@@ -923,7 +923,7 @@ export class ArtifactListTabComponent implements OnInit, OnDestroy {
         this.sbomStoppedArtifactLength += 1;
         // all selected scan action has stopped
         if (this.sbomStoppedArtifactLength === this.onStopSbomArtifactsLength) {
-            this.onSendingSbomCommand = e;
+            this.onSendingStopSbomCommand = e;
         }
     }
 


### PR DESCRIPTION
The scan stop button will be disabled forever once it got clicked no matter the action is failed or successful.

# Issue being fixed
Fixes #20303

Please indicate you've done the following:
- [X] Well Written Title and Summary of the PR
- [X] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [X] Accepted the DCO. Commits without the DCO will delay acceptance.
- [X] Made sure tests are passing and test coverage is added if needed.
- [X] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
