### PR TITLE
fix: label pop up with overflow control

### DIFF
--- a/src/portal/src/app/shared/components/label/label-signpost/label-signpost.component.scss
+++ b/src/portal/src/app/shared/components/label/label-signpost/label-signpost.component.scss
@@ -16,6 +16,8 @@ clr-signpost {
             .signpost-content-body {
                 padding-bottom: 6px;
                 padding-top: 6px;
+                height: 10rem;
+                overflow-y: scroll;
             }
         }
     }


### PR DESCRIPTION
# Summary of your change
- We tried to fix the style issue mentioned in issue #19817.
- We add some inner style to overwrite the Clarity UI.
- We set the height of the pop-up to be fixed, so the scroll bar will be displayed.

# Issue being fixed
Fixes #(19817)
