### PR TITLE
Fixes-20537 SBOM tab should not exist when the artifact is  helm package

### DIFF
--- a/src/portal/src/app/base/project/repository/artifact/artifact-additions/artifact-additions.component.ts
+++ b/src/portal/src/app/base/project/repository/artifact/artifact-additions/artifact-additions.component.ts
@@ -59,7 +59,10 @@ export class ArtifactAdditionsComponent implements AfterViewChecked, OnInit {
     }
 
     hasScannerSupportSBOM(): boolean {
-        return this.artifactListPageService.hasScannerSupportSBOM();
+        if (this.additionLinks && this.additionLinks[ADDITIONS.SBOMS]) {
+            return true;
+        }
+        return false;
     }
 
     getVulnerability(): AdditionLink {

--- a/src/portal/src/app/base/project/repository/artifact/sbom-scanning/sbom-scan.component.spec.ts
+++ b/src/portal/src/app/base/project/repository/artifact/sbom-scanning/sbom-scan.component.spec.ts
@@ -179,8 +179,8 @@ describe('ResultSbomComponent (inline template)', () => {
         component.artifactDigest = mockedSbomDigest;
         component.sbomDigest = mockedSbomDigest;
         component.accessories = mockedAccessories;
+        fixture.detectChanges();
         fixture.whenStable().then(() => {
-            fixture.detectChanges();
             const el: HTMLElement =
                 fixture.nativeElement.querySelector('.tip-block');
             expect(el).not.toBeNull();


### PR DESCRIPTION
Hide SBOM tab  when the artifact is  helm package

Fixes #20537


Please indicate you've done the following:
- [X] Well Written Title and Summary of the PR
- [X] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [X] Accepted the DCO. Commits without the DCO will delay acceptance.
- [X] Made sure tests are passing and test coverage is added if needed.
- [X] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
