### PR TITLE
New feature: star project

### DIFF
--- a/src/controller/project/controller.go
+++ b/src/controller/project/controller.go
@@ -64,6 +64,7 @@ type Controller interface {
 	Update(ctx context.Context, project *models.Project) error
 	// ListRoles lists the roles of user for the specific project
 	ListRoles(ctx context.Context, projectID int64, u *commonmodels.User) ([]int, error)
+	UpdateStarStatus(ctx context.Context, projectID int64, isStarred bool) error
 }
 
 // NewController creates an instance of the default project controller
@@ -363,4 +364,18 @@ func (c *controller) loadOwners(ctx context.Context, projects models.Projects) e
 	}
 
 	return nil
+}
+
+func (c *controller) UpdateStarStatus(ctx context.Context, projectID int64, isStarred bool) error {
+	// Get the project to ensure it exists
+	project, err := c.Get(ctx, projectID)
+	if err != nil {
+			return err
+	}
+
+	// Update the star status in the project's metadata
+	project.Metadata["isStarred"] = strconv.FormatBool(isStarred)
+
+	// Save the updated project
+	return c.Update(ctx, project)
 }

--- a/src/portal/src/app/base/left-side-nav/projects/list-project/list-project.component.html
+++ b/src/portal/src/app/base/left-side-nav/projects/list-project/list-project.component.html
@@ -35,6 +35,16 @@
                 </button>
                 <div class="dropdown-divider"></div>
                 <button
+                  id="toggle-star-project"
+                  type="button"
+                  class="btn btn-secondary"
+                  [class.active]="isStarred(selectedRow)"
+                  (click)="toggleStar(selectedRow)">
+                  <clr-icon shape="star" size="16"></clr-icon>&nbsp;
+                  <span>{{ isStarred(selectedRow) ? 'PROJECT.UNSTAR' : 'PROJECT.STAR' | translate }}</span>
+                </button>
+                <div class="dropdown-divider"></div>
+                <button
                     id="delete-project"
                     type="button"
                     class="btn btn-secondary"

--- a/src/portal/src/app/base/left-side-nav/projects/list-project/list-project.component.ts
+++ b/src/portal/src/app/base/left-side-nav/projects/list-project/list-project.component.ts
@@ -416,4 +416,12 @@ export class ListProjectComponent implements OnDestroy {
             this.canClickExport = true;
         }, INTERVAL);
     }
+
+    // toggle star
+    toggleStar(project): void {
+      project.isStarred = !project.isStarred;
+      this.proService.updateStarStatus(project.id, project.isStarred).subscribe({
+        error: (err) => console.error('Failed to update star status', err)
+      });
+    }
 }

--- a/src/portal/src/app/shared/services/project.service.ts
+++ b/src/portal/src/app/shared/services/project.service.ts
@@ -90,6 +90,7 @@ export abstract class ProjectService {
     abstract checkProjectExists(projectName: string): Observable<any>;
     abstract checkProjectMember(projectId: number): Observable<any>;
     abstract getProjectSummary(projectId: number): Observable<any>;
+    abstract updateStarStatus(projectId: number, isStarred: boolean): Observable<any>;
 }
 
 /**
@@ -256,4 +257,13 @@ export class ProjectDefaultService extends ProjectService {
             )
             .pipe(catchError(error => observableThrowError(error)));
     }
+
+    public updateStarStatus(projectId: number, isStarred: boolean): Observable<any> {
+      const baseUrl: string = `${CURRENT_BASE_HREF}/projects/${projectId}/star-status`;
+      return this.http
+          .put(baseUrl, { isStarred: isStarred }, HTTP_JSON_OPTIONS)
+          .pipe(
+              catchError(error => observableThrowError(error))
+          );
+  }
 }

--- a/src/server/v2.0/handler/project.go
+++ b/src/server/v2.0/handler/project.go
@@ -818,6 +818,20 @@ func getProjectRegistrySummary(ctx context.Context, p *project.Project, summary 
 	}
 }
 
+func (a *projectAPI) UpdateStarStatusHandler(ctx context.Context, params operation.UpdateStarStatusParams) middleware.Responder {
+	if err := a.RequireProjectAccess(ctx, params.ProjectID, rbac.ActionUpdate); err != nil {
+			return a.SendError(ctx, err)
+	}
+
+	// Call the UpdateStarStatus method from the controller
+	err := a.controller.UpdateStarStatus(ctx, params.ProjectID, params.Body.IsStarred)
+	if err != nil {
+			return a.SendError(ctx, err)
+	}
+
+	return operation.NewUpdateStarStatusNoContent()
+}
+
 // Returns the highest role in the role list.
 // This func should be removed once we deprecate the "current_user_role_id" in project API
 // A user can have multiple roles and they may not have a strict ranking relationship


### PR DESCRIPTION
# Summary
This pull request introduces the "Star Project" feature to the project management interface. This new feature allows users to mark specific projects as "starred," making them quickly accessible from a potentially large list of projects. This functionality aims to enhance user experience by allowing users to easily keep track of and navigate to their frequently accessed or favorite projects.

# Key functionalities
- We make it like the delete functionality, user can select the projects they want to star, or say pinpoint, and add these projects as star projects.

# Issues
- We cannot add the database fields so this feature is not complete.