### PR TITLE
fix: update the execution sweep sql to resolve the exec deletion conflict

### DIFF
--- a/src/pkg/task/sweep_manager.go
+++ b/src/pkg/task/sweep_manager.go
@@ -176,7 +176,7 @@ func (sm *sweepManager) Clean(ctx context.Context, execIDs []int64) error {
 		return errors.Wrap(err, "failed to delete tasks")
 	}
 	// delete executions
-	sql = fmt.Sprintf("DELETE FROM execution WHERE id IN (%s)", orm.ParamPlaceholderForIn(len(params)))
+	sql = fmt.Sprintf("DELETE FROM execution WHERE id IN (%s) AND id NOT IN (SELECT DISTINCT execution_id FROM task)", orm.ParamPlaceholderForIn(len(params)))
 	_, err = ormer.Raw(sql, params...).Exec()
 	if err != nil {
 		return errors.Wrap(err, "failed to delete executions")


### PR DESCRIPTION
Resolve the execution deletion conflict when there are tasks still referenced by the execution, remained execs can wait for next sweep cycle.

# Comprehensive Summary of your change

# Issue being fixed
Fixes 
- https://github.com/goharbor/harbor/issues/20593
- https://github.com/goharbor/harbor/issues/19494

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
