### PR TITLE
fix: hide the scan related button when installation without scanner

### DIFF
--- a/src/portal/src/app/base/project/repository/artifact/artifact-list-page/artifact-list/artifact-list-tab/artifact-list-tab.component.html
+++ b/src/portal/src/app/base/project/repository/artifact/artifact-list-page/artifact-list/artifact-list-tab/artifact-list-tab.component.html
@@ -15,6 +15,7 @@
             <clr-dg-action-bar class="action-bar">
                 <div>
                     <button
+                        *ngIf="hasEnabledScanner"
                         id="scan-btn"
                         [clrLoading]="scanBtnState"
                         type="button"
@@ -68,6 +69,7 @@
                             <button
                                 clrDropdownItem
                                 id="stop-scan"
+                                *ngIf="hasEnabledScanner"
                                 [clrLoading]="stopBtnState"
                                 type="button"
                                 class="btn btn-secondary scan-btn action-dropdown-item"
@@ -97,6 +99,7 @@
                                 <span>{{ 'SBOM.STOP' | translate }}</span>
                             </button>
                             <div
+                                *ngIf="hasEnabledScanner || hasEnabledSbom()"
                                 class="dropdown-divider"
                                 role="separator"
                                 aria-hidden="true"></div>


### PR DESCRIPTION
Hide the scan related button when installation without scanner.

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes https://github.com/goharbor/harbor/issues/20615

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
