### PR TITLE
update gencerts to allow for subject override

### DIFF
--- a/make/photon/prepare/commands/gencerts.py
+++ b/make/photon/prepare/commands/gencerts.py
@@ -13,7 +13,9 @@ gen_tls_script = pathlib.Path(__file__).parent.parent.joinpath('scripts/gencert.
 @click.command()
 @click.option('-p', '--path', required=True, type=str,help='the path to store generated cert files')
 @click.option('-d', '--days', default='365', type=str, help='the expired time for cert')
-def gencert(path, days):
+@click.option('-s', '--subject', default='/C=CN/ST=Beijing/L=Beijing/O=VMware', 
+              type=str, help='the subject information for certs')
+def gencert(path, days, subject):
     """
     gencert command will generate cert files for internal TLS
     """
@@ -26,7 +28,7 @@ def gencert(path, days):
     if not os.path.exists(path):
         click.echo('path {} not exist, create it...'.format(path))
         os.makedirs(path, exist_ok=True)
-    with Popen([gen_tls_script, days], stdout=PIPE, stderr=STDOUT, cwd=path) as p:
+    with Popen([gen_tls_script, days, subject], stdout=PIPE, stderr=STDOUT, cwd=path) as p:
         for line in p.stdout:
             click.echo(line, nl=False)
     if p.returncode != 0:

--- a/make/photon/prepare/scripts/gencert.sh
+++ b/make/photon/prepare/scripts/gencert.sh
@@ -1,105 +1,55 @@
 #! /bin/bash
 set -e
 
-if [ -z "$1" ]; then
-    echo "No argument supplied set days to 365"
-    DAYS=365
-else
-    echo "No argument supplied set days to $1"
-    DAYS=$1
-fi
-
+DAYS=365
+SUBJECT=/C=CN/ST=Beijing/L=Beijing/O=VMware
 CA_KEY="harbor_internal_ca.key"
 CA_CRT="harbor_internal_ca.crt"
+INTERNAL_TLS_LIST=(
+        "proxy" 
+        "portal" 
+        "core" 
+        "job_service" 
+        "registry" 
+        "registryctl" 
+        "trivy_adapter" 
+        "harbor_db")
+
+if [ "$#" -eq 0 ]; then
+    echo "No arguments provided. Using default values."
+    echo DAYS=$DAYS
+    echo SUBJECT=$SUBJECT
+else
+    if [ -n "$1" ]; then
+        echo "argument supplied set days to $1"
+        DAYS=$1
+    fi
+
+    if [ -n "$2" ]; then
+        echo "argument supplied set subject to $2"
+        SUBJECT=$2
+    fi
+fi
 
 # CA key and certificate
 if [[ ! -f $CA_KEY && ! -f $CA_CRT ]]; then
-openssl req -x509 -nodes -days $DAYS -newkey rsa:4096 \
-        -keyout $CA_KEY -out $CA_CRT \
-        -subj "/C=CN/ST=Beijing/L=Beijing/O=VMware"
+    openssl req -x509 -nodes -days $DAYS -newkey rsa:4096 \
+            -keyout $CA_KEY -out $CA_CRT \
+            -subj "${SUBJECT}"
 else
     echo "$CA_KEY and $CA_CRT exist, use them to generate certs"
 fi
 
-# generate proxy key and csr
-openssl req -new -newkey rsa:4096 -nodes -sha256 \
-        -keyout proxy.key \
-        -out proxy.csr \
-        -subj "/C=CN/ST=Beijing/L=Beijing/O=VMware/CN=proxy"
+# generate csr, key and cert files
+for internal_tls in "${INTERNAL_TLS_LIST[@]}"; do
+    openssl req -new -newkey rsa:4096 -nodes -sha256 \
+            -keyout ${internal_tls}.key \
+            -out ${internal_tls}.csr \
+            -subj "${SUBJECT}/CN=${internal_tls}"
 
-# Sign proxy
-echo subjectAltName = DNS.1:proxy > extfile.cnf
-openssl x509 -req -days $DAYS -sha256 -in proxy.csr -CA harbor_internal_ca.crt -CAkey harbor_internal_ca.key -CAcreateserial -extfile extfile.cnf -out proxy.crt
+    echo subjectAltName = DNS.1:${internal_tls} > extfile.cnf
 
-# generate portal key and csr
-openssl req -new -newkey rsa:4096 -nodes -sha256 \
-        -keyout portal.key \
-        -out portal.csr \
-        -subj "/C=CN/ST=Beijing/L=Beijing/O=VMware/CN=portal"
-
-# Sign portal
-echo subjectAltName = DNS.1:portal > extfile.cnf
-openssl x509 -req -days $DAYS -sha256 -in portal.csr -CA harbor_internal_ca.crt -CAkey harbor_internal_ca.key -CAcreateserial -extfile extfile.cnf -out portal.crt
-
-# generate core key and csr
-openssl req -new \
-        -newkey rsa:4096 -nodes -sha256 -keyout core.key \
-        -out core.csr \
-        -subj "/C=CN/ST=Beijing/L=Beijing/O=VMware/CN=core"
-
-# Sign core csr with CA certificate and key
-echo subjectAltName = DNS.1:core > extfile.cnf
-openssl x509 -req -days $DAYS -sha256 -in core.csr -CA harbor_internal_ca.crt -CAkey harbor_internal_ca.key -CAcreateserial -extfile extfile.cnf -out core.crt
-
-
-# job_service key
-openssl req -new \
-        -newkey rsa:4096 -nodes -sha256 -keyout job_service.key \
-        -out job_service.csr \
-        -subj "/C=CN/ST=Beijing/L=Beijing/O=VMware/CN=jobservice"
-
-# sign job_service csr with CA certificate and key
-echo subjectAltName = DNS.1:jobservice > extfile.cnf
-openssl x509 -req -days $DAYS -sha256 -in job_service.csr -CA harbor_internal_ca.crt -CAkey harbor_internal_ca.key -CAcreateserial -extfile extfile.cnf -out job_service.crt
-
-# generate registry key
-openssl req -new \
-        -newkey rsa:4096 -nodes -sha256 -keyout registry.key \
-        -out registry.csr \
-        -subj "/C=CN/ST=Beijing/L=Beijing/O=VMware/CN=registry"
-
-# sign registry csr with CA certificate and key
-echo subjectAltName = DNS.1:registry > extfile.cnf
-openssl x509 -req -days $DAYS -sha256 -in registry.csr -CA harbor_internal_ca.crt -CAkey harbor_internal_ca.key -CAcreateserial -extfile extfile.cnf -out registry.crt
-
-# generate registryctl key
-openssl req -new \
-        -newkey rsa:4096 -nodes -sha256 -keyout registryctl.key \
-        -out registryctl.csr \
-        -subj "/C=CN/ST=Beijing/L=Beijing/O=VMware/CN=registryctl"
-
-# sign registryctl csr with CA certificate and key
-echo subjectAltName = DNS.1:registryctl > extfile.cnf
-openssl x509 -req -days $DAYS -sha256 -in registryctl.csr -CA harbor_internal_ca.crt -CAkey harbor_internal_ca.key -CAcreateserial -extfile extfile.cnf -out registryctl.crt
-
-
-# generate trivy_adapter key
-openssl req -new \
-        -newkey rsa:4096 -nodes -sha256 -keyout trivy_adapter.key \
-        -out trivy_adapter.csr \
-        -subj "/C=CN/ST=Beijing/L=Beijing/O=VMware/CN=trivy-adapter"
-
-# sign trivy_adapter csr with CA certificate and key
-echo subjectAltName = DNS.1:trivy-adapter > extfile.cnf
-openssl x509 -req -days $DAYS -sha256 -in trivy_adapter.csr -CA harbor_internal_ca.crt -CAkey harbor_internal_ca.key -CAcreateserial -extfile extfile.cnf -out trivy_adapter.crt
-
-
-# generate harbor_db key
-openssl req -new \
-        -newkey rsa:4096 -nodes -sha256 -keyout harbor_db.key \
-        -out harbor_db.csr \
-        -subj "/C=CN/ST=Beijing/L=Beijing/O=VMware/CN=harbor_db"
-
-# sign harbor_db csr with CA certificate and key
-echo subjectAltName = DNS.1:harbor_db > extfile.cnf
-openssl x509 -req -days $DAYS -sha256 -in harbor_db.csr -CA harbor_internal_ca.crt -CAkey harbor_internal_ca.key -CAcreateserial -extfile extfile.cnf -out harbor_db.crt
+    openssl x509 -req -days $DAYS -sha256 -in ${internal_tls}.csr \
+        -CA $CA_CRT -CAkey $CA_KEY -CAcreateserial \
+        -extfile extfile.cnf -out ${internal_tls}.crt
+done


### PR DESCRIPTION
# Comprehensive Summary of your change

Hi,

While setting up harbor for the first time I ran into an issue with the goharbor/prepare gencerts utility in which I was unable to specify my own "subject" line for the internal TLS certificates. Is it possible to update gencerts.{sh,py} to support a --subject option like this:

```bash
docker run -v /:/hostfs goharbor/prepare gencert -p /tmp/cert_test -s "/C=US/ST=California/L=Mountain View/O=VMware"
```

This merge has the implementation that worked for me. I also updated the script to use a loop since each cert is generated with the same 3 commands.

If this is something that can be updated, It would be very cool to be able to help contribute to this project!

#### Tests

To test this change, I built goharbor/prepare:dev with the following documentation [Build Harbor from Source Code](https://goharbor.io/docs/2.0.0/build-customize-contribute/compile-guide/) and ran the following after building:

```bash
docker run -v /:/hostfs goharbor/prepare:dev gencert -p /tmp/cert_test -d 12 --subject "/C=US/ST=California/L=Mountain View/O=VMware"
```

This resulted in the following directory being created + certs/keys/csr files

```bash
egg蛋ada harbor on  main [?]
❯ ls /tmp/cert_test
core.crt       harbor_db.csr           job_service.crt  portal.key    registry.csr     trivy_adapter.crt
core.csr       harbor_db.key           job_service.csr  proxy.crt     registryctl.crt  trivy_adapter.csr
core.key       harbor_internal_ca.crt  job_service.key  proxy.csr     registryctl.csr  trivy_adapter.key
extfile.cnf    harbor_internal_ca.key  portal.crt       proxy.key     registryctl.key
harbor_db.crt  harbor_internal_ca.srl  portal.csr       registry.crt  registry.key
```

Inspecting the certs, the --day and --subject parameters worked as expected

```bash
egg蛋ada harbor on  main [?]
❯ docker run -v /:/hostfs goharbor/prepare:dev gencert -p /tmp/cert_test -d 12 --subject "/C=US/ST=California/L=Mountain View/O=VMware" > /dev/null; find /tmp/cert_test/ -name "*.crt" -exec openssl x509 -in {} -noout -subject -dates \;
subject=C = US, ST = California, L = Mountain View, O = VMware
notBefore=Jun 19 23:21:09 2024 GMT
notAfter=Jul  1 23:21:09 2024 GMT
subject=C = US, ST = California, L = Mountain View, O = VMware, CN = proxy
notBefore=Jun 19 23:21:09 2024 GMT
notAfter=Jul  1 23:21:09 2024 GMT
subject=C = US, ST = California, L = Mountain View, O = VMware, CN = portal
notBefore=Jun 19 23:21:12 2024 GMT
notAfter=Jul  1 23:21:12 2024 GMT
subject=C = US, ST = California, L = Mountain View, O = VMware, CN = core
notBefore=Jun 19 23:21:13 2024 GMT
notAfter=Jul  1 23:21:13 2024 GMT
subject=C = US, ST = California, L = Mountain View, O = VMware, CN = job_service
notBefore=Jun 19 23:21:16 2024 GMT
notAfter=Jul  1 23:21:16 2024 GMT
subject=C = US, ST = California, L = Mountain View, O = VMware, CN = registry
notBefore=Jun 19 23:21:17 2024 GMT
notAfter=Jul  1 23:21:17 2024 GMT
subject=C = US, ST = California, L = Mountain View, O = VMware, CN = registryctl
notBefore=Jun 19 23:21:19 2024 GMT
notAfter=Jul  1 23:21:19 2024 GMT
subject=C = US, ST = California, L = Mountain View, O = VMware, CN = trivy_adapter
notBefore=Jun 19 23:21:22 2024 GMT
notAfter=Jul  1 23:21:22 2024 GMT
subject=C = US, ST = California, L = Mountain View, O = VMware, CN = harbor_db
notBefore=Jun 19 23:21:23 2024 GMT
notAfter=Jul  1 23:21:23 2024 GMT
```

Running the utility without any parameters uses the expected defaults

```bash
egg蛋ada harbor on  main [?]
❯ docker run -v /:/hostfs goharbor/prepare:dev gencert -p /tmp/cert_test > /dev/null; find /tmp/cert_test/ -name "*.crt" -exec openssl x509 -in {} -noout -subject -dates \;                                                     
subject=C = CN, ST = Beijing, L = Beijing, O = VMware
notBefore=Jun 19 23:22:13 2024 GMT
notAfter=Jun 19 23:22:13 2025 GMT
subject=C = CN, ST = Beijing, L = Beijing, O = VMware, CN = proxy
notBefore=Jun 19 23:22:13 2024 GMT
notAfter=Jun 19 23:22:13 2025 GMT
subject=C = CN, ST = Beijing, L = Beijing, O = VMware, CN = portal
notBefore=Jun 19 23:22:14 2024 GMT
notAfter=Jun 19 23:22:14 2025 GMT
subject=C = CN, ST = Beijing, L = Beijing, O = VMware, CN = core
notBefore=Jun 19 23:22:16 2024 GMT
notAfter=Jun 19 23:22:16 2025 GMT
subject=C = CN, ST = Beijing, L = Beijing, O = VMware, CN = job_service
notBefore=Jun 19 23:22:19 2024 GMT
notAfter=Jun 19 23:22:19 2025 GMT
subject=C = CN, ST = Beijing, L = Beijing, O = VMware, CN = registry
notBefore=Jun 19 23:22:19 2024 GMT
notAfter=Jun 19 23:22:19 2025 GMT
subject=C = CN, ST = Beijing, L = Beijing, O = VMware, CN = registryctl
notBefore=Jun 19 23:22:21 2024 GMT
notAfter=Jun 19 23:22:21 2025 GMT
subject=C = CN, ST = Beijing, L = Beijing, O = VMware, CN = trivy_adapter
notBefore=Jun 19 23:22:25 2024 GMT
notAfter=Jun 19 23:22:25 2025 GMT
subject=C = CN, ST = Beijing, L = Beijing, O = VMware, CN = harbor_db
notBefore=Jun 19 23:22:27 2024 GMT
notAfter=Jun 19 23:22:27 2025 GMT
```

# Issue being fixed
There is no issue associated with this PR. I apologize if this PR is preemptive and an issue should have been filed first. Due to the limited amount of change I figured that it might be alright.

Please indicate you've done the following:
- [X] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
  - I have not submitted many PRs on github and did not see an option to add a label before submitting. I will look after I create the PR to see if that can be updated.
- [X] Accepted the DCO. Commits without the DCO will delay acceptance.
  - I amended my commit to have the --signoff option, I think that will do the needful (sorry have not done that one before).
- [X] Made sure tests are passing and test coverage is added if needed.
   - I saw that there were go tests for things in src/ but I wasn't totally sure how/if there were any testing frameworks for the prepare scripts.
- [X] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
  - I don't think any documentation needs to be updated. The current docs do not specify the options (other that -p in the example).

