### PR TITLE
feat: expose ssl_protocols from nginx configuration in harbor.yml

### DIFF
--- a/make/harbor.yml.tmpl
+++ b/make/harbor.yml.tmpl
@@ -16,6 +16,8 @@ https:
   # The path of cert and key files for nginx
   certificate: /your/certificate/path
   private_key: /your/private/key/path
+  # configure ssl protocols (default: TLSv1.2 TLSv1.3)
+  # ssl_protocols: TLSv1.2 TLSv1.3
   # enable strong ssl ciphers (default: false)
   # strong_ssl_ciphers: false
 
@@ -206,7 +208,7 @@ _version: 2.11.0
 #   # host for redis+sentinel:
 #   #  <host_sentinel1>:<port_sentinel1>,<host_sentinel2>:<port_sentinel2>,<host_sentinel3>:<port_sentinel3>
 #   host: redis:6379
-#   password: 
+#   password:
 #   # Redis AUTH command was extended in Redis 6, it is possible to use it in the two-arguments AUTH <username> <password> form.
 #   # there's a known issue when using external redis username ref:https://github.com/goharbor/harbor/issues/18892
 #   # if you care about the image pull/push performance, please refer to this https://github.com/goharbor/harbor/wiki/Harbor-FAQs#external-redis-username-password-usage

--- a/make/photon/prepare/templates/nginx/nginx.https.conf.jinja
+++ b/make/photon/prepare/templates/nginx/nginx.https.conf.jinja
@@ -63,7 +63,11 @@ http {
     ssl_certificate_key {{ssl_cert_key}};
 
     # Recommendations from https://raymii.org/s/tutorials/Strong_SSL_Security_On_nginx.html
+{% if ssl_protocols is defined %}
+    ssl_protocols {{ssl_protocols}};
+{% else %}
     ssl_protocols TLSv1.2 TLSv1.3;
+{% endif %}
 {% if strong_ssl_ciphers %}
     ssl_ciphers ECDHE+AESGCM:DHE+AESGCM:ECDHE+RSA+SHA256:DHE+RSA+SHA256:!AES128;
 {% else %}

--- a/make/photon/prepare/templates/portal/nginx.conf.jinja
+++ b/make/photon/prepare/templates/portal/nginx.conf.jinja
@@ -27,7 +27,11 @@ http {
         ssl_certificate /etc/harbor/tls/portal.crt;
         ssl_certificate_key /etc/harbor/tls/portal.key;
 
+    {% if ssl_protocols is defined %}
+        ssl_protocols {{ssl_protocols}};
+    {% else %}
         ssl_protocols TLSv1.2 TLSv1.3;
+    {% endif %}
     {% if strong_ssl_ciphers %}
         ssl_ciphers ECDHE+AESGCM:DHE+AESGCM:ECDHE+RSA+SHA256:DHE+RSA+SHA256:!AES128;
     {% else %}

--- a/make/photon/prepare/utils/configs.py
+++ b/make/photon/prepare/utils/configs.py
@@ -299,11 +299,16 @@ def parse_yaml_config(config_file_path, with_trivy):
             external_database=config_dict['external_database'])
     else:
         config_dict['internal_tls'] = InternalTLS()
+
+    # ssl_protocols config
+    if https_config:
+        config_dict['ssl_protocols'] = https_config.get('ssl_protocols')
+
     # the configure item apply to internal and external tls communication
     # for compatibility, user could configure the strong_ssl_ciphers either in https section or under internal_tls section,
     # but it is more reasonable to configure it in https_config
     if https_config:
-        config_dict['strong_ssl_ciphers'] = https_config.get('strong_ssl_ciphers') 
+        config_dict['strong_ssl_ciphers'] = https_config.get('strong_ssl_ciphers')
     else:
         config_dict['strong_ssl_ciphers'] = False
 

--- a/make/photon/prepare/utils/nginx.py
+++ b/make/photon/prepare/utils/nginx.py
@@ -64,6 +64,7 @@ def render_nginx_template(config_dict):
             ssl_cert_key=SSL_CERT_KEY_PATH,
             internal_tls=config_dict['internal_tls'],
             metric=config_dict['metric'],
+            ssl_protocols=config_dict['ssl_protocols'],
             strong_ssl_ciphers=config_dict['strong_ssl_ciphers'],
             ip_family=config_dict['ip_family'])
         location_file_pattern = CUSTOM_NGINX_LOCATION_FILE_PATTERN_HTTPS

--- a/make/photon/prepare/utils/portal.py
+++ b/make/photon/prepare/utils/portal.py
@@ -17,5 +17,6 @@ def prepare_portal(config_dict):
         ip_family=config_dict['ip_family'],
         uid=DEFAULT_UID,
         gid=DEFAULT_GID,
+        ssl_protocols=config_dict['ssl_protocols'],
         strong_ssl_ciphers=config_dict['strong_ssl_ciphers']
         )


### PR DESCRIPTION
Thank you for contributing to Harbor!

# Comprehensive Summary of your change
This PR adds `ssl_protocols` as a new configuration option to `harbor.yml`. This allows users to customize the nginx protocols - by default both TLSv1.2 and TLSv1.3 will be allowed, but one can restrict this to TLSv1.3 only.

There is no need to update the `ssl_ciphers` based on the configured `ssl_protocols` because nginx automatically disables unsupported ciphers. I tested the following combinations in a local nginx instance:

- (Default) Neither `ssl_protocols` nor `strong_ssl_ciphers` configured - both protocols and all ciphers will be accepted
- `ssl_protocols` unset, `strong_ssl_ciphers` enabled - both protocols will be accepted, with a restricted list of ciphers
- `ssl_protocols` set to TLSv1.3, `strong_ssl_ciphers` disabled - only TLSv1.3 connections will be accepted
- `ssl_protocols` set to TLSv1.3, `strong_ssl_ciphers` enabled - only TLSv1.3 connections will be accepted

# Issue being fixed
Fixes #20627 

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).