### PR TITLE
[cherry-pick] fix: disable the scan related button when installation without scanner or scanner deactived

### DIFF
--- a/src/portal/src/app/base/project/repository/artifact/artifact-list-page/artifact-list-page.service.ts
+++ b/src/portal/src/app/base/project/repository/artifact/artifact-list-page/artifact-list-page.service.ts
@@ -127,6 +127,12 @@ export class ArtifactListPageService {
                             ClrLoadingState.ERROR
                         );
                     }
+                } else {
+                    this.updateStates(
+                        false,
+                        ClrLoadingState.ERROR,
+                        ClrLoadingState.ERROR
+                    );
                 }
             },
             error => {

--- a/src/portal/src/app/base/project/repository/artifact/artifact-list-page/artifact-list/artifact-list-tab/artifact-list-tab.component.html
+++ b/src/portal/src/app/base/project/repository/artifact/artifact-list-page/artifact-list/artifact-list-tab/artifact-list-tab.component.html
@@ -34,7 +34,6 @@
                         <span>{{ 'VULNERABILITY.SCAN_NOW' | translate }}</span>
                     </button>
                     <button
-                        *ngIf="hasEnabledSbom()"
                         id="generate-sbom-btn"
                         [clrLoading]="generateSbomBtnState"
                         type="button"
@@ -82,7 +81,6 @@
                             <button
                                 clrDropdownItem
                                 id="stop-sbom-btn"
-                                *ngIf="hasEnabledSbom()"
                                 [clrLoading]="stopBtnState"
                                 type="button"
                                 class="btn btn-secondary scan-btn action-dropdown-item"


### PR DESCRIPTION
Disable the scan related button when installation without scanner or scanner deactived.

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [ ] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [ ] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
