### PR TITLE
Add configuration for ldap group sync in background

### DIFF
--- a/api/v2.0/swagger.yaml
+++ b/api/v2.0/swagger.yaml
@@ -8897,6 +8897,9 @@ definitions:
       ldap_group_search_scope:
         $ref: '#/definitions/IntegerConfigItem'
         description: The scope to search ldap group. ''0-LDAP_SCOPE_BASE, 1-LDAP_SCOPE_ONELEVEL, 2-LDAP_SCOPE_SUBTREE''
+      ldap_group_sync_in_background:
+        $ref: '#/definitions/BoolConfigItem'
+        description: Sync LDAP group information in background.
       ldap_scope:
         $ref: '#/definitions/IntegerConfigItem'
         description: The scope to search ldap users,'0-LDAP_SCOPE_BASE, 1-LDAP_SCOPE_ONELEVEL, 2-LDAP_SCOPE_SUBTREE'
@@ -9085,6 +9088,11 @@ definitions:
       ldap_group_search_scope:
         type: integer
         description: The scope to search ldap group. ''0-LDAP_SCOPE_BASE, 1-LDAP_SCOPE_ONELEVEL, 2-LDAP_SCOPE_SUBTREE''
+        x-omitempty: true
+        x-isnullable: true
+      ldap_group_sync_in_background:
+        type: boolean
+        description: Sync LDAP group information in background.
         x-omitempty: true
         x-isnullable: true
       ldap_scope:

--- a/src/common/const.go
+++ b/src/common/const.go
@@ -134,6 +134,7 @@ const (
 	OIDCGroupType                     = 3
 	LDAPGroupAdminDn                  = "ldap_group_admin_dn"
 	LDAPGroupMembershipAttribute      = "ldap_group_membership_attribute"
+	LDAPGroupSyncInBackground         = "ldap_group_sync_in_background"
 	DefaultRegistryControllerEndpoint = "http://registryctl:8080"
 	DefaultPortalURL                  = "http://portal:8080"
 	DefaultRegistryCtlURL             = "http://registryctl:8080"

--- a/src/lib/config/metadata/metadatalist.go
+++ b/src/lib/config/metadata/metadatalist.go
@@ -96,6 +96,7 @@ var (
 		{Name: common.LDAPURL, Scope: UserScope, Group: LdapBasicGroup, EnvKey: "LDAP_URL", DefaultValue: "", ItemType: &NonEmptyStringType{}, Editable: false, Description: `The URL of LDAP server`},
 		{Name: common.LDAPVerifyCert, Scope: UserScope, Group: LdapBasicGroup, EnvKey: "LDAP_VERIFY_CERT", DefaultValue: "true", ItemType: &BoolType{}, Editable: false, Description: `Whether verify your OIDC server certificate, disable it if your OIDC server is hosted via self-hosted certificate.`},
 		{Name: common.LDAPGroupMembershipAttribute, Scope: UserScope, Group: LdapBasicGroup, EnvKey: "LDAP_GROUP_MEMBERSHIP_ATTRIBUTE", DefaultValue: "memberof", ItemType: &StringType{}, Editable: true, Description: `The user attribute to identify the group membership`},
+		{Name: common.LDAPGroupSyncInBackground, Scope: UserScope, Group: LdapBasicGroup, EnvKey: "LDAP_GROUP_SYNC_BACKGROUND", DefaultValue: "false", ItemType: &BoolType{}, Editable: true, Description: `Sync LDAP group information to Harbor in background`},
 
 		{Name: common.MaxJobWorkers, Scope: SystemScope, Group: BasicGroup, EnvKey: "MAX_JOB_WORKERS", DefaultValue: "10", ItemType: &IntType{}, Editable: false},
 		{Name: common.ScanAllPolicy, Scope: UserScope, Group: BasicGroup, EnvKey: "", DefaultValue: "", ItemType: &MapType{}, Editable: false, Description: `The policy to scan images`},

--- a/src/lib/config/models/model.go
+++ b/src/lib/config/models/model.go
@@ -94,6 +94,7 @@ type GroupConf struct {
 	SearchScope         int    `json:"ldap_group_search_scope"`
 	AdminDN             string `json:"ldap_group_admin_dn,omitempty"`
 	MembershipAttribute string `json:"ldap_group_membership_attribute,omitempty"`
+	SyncInBackground    bool   `json:"ldap_group_sync_in_background,omitempty"`
 }
 
 type GDPRSetting struct {

--- a/src/lib/config/userconfig.go
+++ b/src/lib/config/userconfig.go
@@ -81,6 +81,7 @@ func LDAPGroupConf(ctx context.Context) (*cfgModels.GroupConf, error) {
 		SearchScope:         mgr.Get(ctx, common.LDAPGroupSearchScope).GetInt(),
 		AdminDN:             mgr.Get(ctx, common.LDAPGroupAdminDn).GetString(),
 		MembershipAttribute: mgr.Get(ctx, common.LDAPGroupMembershipAttribute).GetString(),
+		SyncInBackground:    mgr.Get(ctx, common.LDAPGroupSyncInBackground).GetBool(),
 	}, nil
 }
 

--- a/src/pkg/usergroup/manager.go
+++ b/src/pkg/usergroup/manager.go
@@ -83,11 +83,13 @@ func (m *manager) Get(ctx context.Context, id int) (*model.UserGroup, error) {
 func (m *manager) Populate(ctx context.Context, userGroups []model.UserGroup) ([]int, error) {
 	ugList := make([]int, 0)
 	for _, group := range userGroups {
-		err := m.Onboard(ctx, &group)
-		if err != nil {
-			// log the current error and continue
-			log.Warningf("failed to onboard user group %+v, error %v, continue with other user groups", group, err)
-			continue
+		if group.ID == 0 {
+			err := m.Onboard(ctx, &group)
+			if err != nil {
+				// log the current error and continue
+				log.Warningf("failed to onboard user group %+v, error %v, continue with other user groups", group, err)
+				continue
+			}
 		}
 		if group.ID > 0 {
 			ugList = append(ugList, group.ID)

--- a/src/portal/src/app/base/left-side-nav/config/auth/config-auth.component.html
+++ b/src/portal/src/app/base/left-side-nav/config/auth/config-auth.component.html
@@ -498,6 +498,35 @@
                 </option>
             </select>
         </clr-select-container>
+       <clr-checkbox-container>
+            <label for="ldapGroupSyncInBackground"
+                >{{ 'CONFIG.LDAP.GROUP_SYNC_IN_BACKGROUND' | translate }}
+                <clr-tooltip>
+                    <clr-icon
+                        clrTooltipTrigger
+                        shape="info-circle"
+                        size="24"></clr-icon>
+                    <clr-tooltip-content
+                        clrPosition="top-right"
+                        clrSize="lg"
+                        *clrIfOpen>
+                        <span>{{
+                            'CONFIG.LDAP.GROUP_SYNC_IN_BACKGROUND_INFO' | translate
+                        }}</span>
+                    </clr-tooltip-content>
+                </clr-tooltip>
+            </label>
+            <clr-checkbox-wrapper>
+                <input
+                    type="checkbox"
+                    clrCheckbox
+                    name="ldapGroupSyncInBackground"
+                    id="ldapGroupSyncInBackground"
+                    [ngModel]="currentConfig.ldap_group_sync_in_background.value"
+                    [disabled]="disabled(currentConfig.ldap_group_sync_in_background)"
+                    (ngModelChange)="setLdapGroupSyncInBackgroundValue($event)" />
+            </clr-checkbox-wrapper>
+        </clr-checkbox-container>
     </section>
     <clr-checkbox-container *ngIf="showSelfReg">
         <label for="selfReg"

--- a/src/portal/src/app/base/left-side-nav/config/auth/config-auth.component.ts
+++ b/src/portal/src/app/base/left-side-nav/config/auth/config-auth.component.ts
@@ -132,6 +132,10 @@ export class ConfigurationAuthComponent implements OnInit {
         this.currentConfig.ldap_verify_cert.value = $event;
     }
 
+    setLdapGroupSyncInBackgroundValue($event: any) {
+        this.currentConfig.ldap_group_sync_in_background.value = $event;
+    }
+
     public pingTestServer(): void {
         if (this.testingOnGoing) {
             return; // Should not come here

--- a/src/portal/src/app/base/left-side-nav/config/config.ts
+++ b/src/portal/src/app/base/left-side-nav/config/config.ts
@@ -72,6 +72,7 @@ export class Configuration {
     ldap_group_search_scope: NumberValueItem;
     ldap_group_membership_attribute: StringValueItem;
     ldap_group_admin_dn: StringValueItem;
+    ldap_group_sync_in_background: BoolValueItem;
     uaa_client_id: StringValueItem;
     uaa_client_secret?: StringValueItem;
     uaa_endpoint: StringValueItem;

--- a/src/portal/src/i18n/lang/de-de-lang.json
+++ b/src/portal/src/i18n/lang/de-de-lang.json
@@ -927,8 +927,9 @@
             "LDAP_GROUP_MEMBERSHIP": "LDAP Gruppenmitgliedschaft",
             "LDAP_GROUP_MEMBERSHIP_INFO": "Dass Attribut, das die Mitglieder einer LDAP-Gruppe identifiziert. Standardwert ist memberof, in manchen LDAP Servern kann es \"ismemberof\" sein. Das Feld darf nicht leer sein, sofern eine LDAP Gruppen Funktion eingesetzt wird.",
             "GROUP_SCOPE": "LDAP Gruppen Search Scope",
-            "GROUP_SCOPE_INFO": "Der Scope mit dem nach Gruppen gesucht wird. Standard ist Subtree."
-
+            "GROUP_SCOPE_INFO": "Der Scope mit dem nach Gruppen gesucht wird. Standard ist Subtree.",
+            "GROUP_SYNC_IN_BACKGROUND": "LDAP Group Sync in Background",
+            "GROUP_SYNC_IN_BACKGROUND_INFO": "Enable this option to sync LDAP group information in background to avoid timeout when there are too many groups. If disabled, the LDAP group information will be synced when the user logs in."               
         },
         "UAA": {
             "ENDPOINT": "UAA Endpunkt",

--- a/src/portal/src/i18n/lang/en-us-lang.json
+++ b/src/portal/src/i18n/lang/en-us-lang.json
@@ -928,7 +928,9 @@
             "LDAP_GROUP_MEMBERSHIP": "LDAP Group Membership",
             "LDAP_GROUP_MEMBERSHIP_INFO": "The attribute indicates the membership of LDAP group, default value is memberof, in some LDAP server it could be \"ismemberof\". This field cannot be empty if you need to enable the LDAP group related feature.",
             "GROUP_SCOPE": "LDAP Group Search Scope",
-            "GROUP_SCOPE_INFO": "The scope to search for groups, select Subtree by default."
+            "GROUP_SCOPE_INFO": "The scope to search for groups, select Subtree by default.",
+          "GROUP_SYNC_IN_BACKGROUND": "LDAP Group Sync in Background",
+            "GROUP_SYNC_IN_BACKGROUND_INFO": "Enable this option to sync LDAP group information in background to avoid timeout when there are too many groups. If disabled, the LDAP group information will be synced when the user logs in."
 
         },
         "UAA": {

--- a/src/portal/src/i18n/lang/es-es-lang.json
+++ b/src/portal/src/i18n/lang/es-es-lang.json
@@ -927,7 +927,9 @@
             "LDAP_GROUP_MEMBERSHIP": "LDAP Group Membership",
             "LDAP_GROUP_MEMBERSHIP_INFO": "The attribute indicates the membership of LDAP group, default value is memberof, in some LDAP server it could be \"ismemberof\". This field cannot be empty if you need to enable the LDAP group related feature.",
             "GROUP_SCOPE": "LDAP Group Search Scope",
-            "GROUP_SCOPE_INFO": "The scope to search for groups, select Subtree by default."
+            "GROUP_SCOPE_INFO": "The scope to search for groups, select Subtree by default.",
+          "GROUP_SYNC_IN_BACKGROUND": "LDAP Group Sync in Background",
+            "GROUP_SYNC_IN_BACKGROUND_INFO": "Enable this option to sync LDAP group information in background to avoid timeout when there are too many groups. If disabled, the LDAP group information will be synced when the user logs in."                
         },
         "UAA": {
             "ENDPOINT": "UAA Endpoint",

--- a/src/portal/src/i18n/lang/fr-fr-lang.json
+++ b/src/portal/src/i18n/lang/fr-fr-lang.json
@@ -927,7 +927,10 @@
             "LDAP_GROUP_MEMBERSHIP": "Appartenance au groupe LDAP",
             "LDAP_GROUP_MEMBERSHIP_INFO": "L'attribut indique l'appartenance au groupe LDAP ; la valeur par défaut est \"memberOf\", dans certains LDAP cela peut être \"isMemberOf\"",
             "GROUP_SCOPE": "Scope des groupes LDAP",
-            "GROUP_SCOPE_INFO": "Scope dans lequel faire la recherche, 'subtree' par défaut."
+            "GROUP_SCOPE_INFO": "Scope dans lequel faire la recherche, 'subtree' par défaut.",
+          "GROUP_SYNC_IN_BACKGROUND": "LDAP Group Sync in Background",
+            "GROUP_SYNC_IN_BACKGROUND_INFO": "Enable this option to sync LDAP group information in background to avoid timeout when there are too many groups. If disabled, the LDAP group information will be synced when the user logs in."      
+
         },
         "UAA": {
             "ENDPOINT": "Endpoint UAA",

--- a/src/portal/src/i18n/lang/ko-kr-lang.json
+++ b/src/portal/src/i18n/lang/ko-kr-lang.json
@@ -925,7 +925,9 @@
             "LDAP_GROUP_MEMBERSHIP": "LDAP Group 멤버쉽",
             "LDAP_GROUP_MEMBERSHIP_INFO": "속성은 LDAP 그룹의 멤버십을 나타내며 기본값은 memberof이며 일부 LDAP 서버에서는 \"ismemberof\"일 수 있습니다. LDAP 그룹 관련 기능을 활성화해야 하는 경우 이 필드를 비워둘 수 없습니다.",
             "GROUP_SCOPE": "LDAP 그룹 검색 범위",
-            "GROUP_SCOPE_INFO": "그룹을 검색할 범위는 기본적으로 Subtree를 선택합니다."
+            "GROUP_SCOPE_INFO": "그룹을 검색할 범위는 기본적으로 Subtree를 선택합니다.",
+          "GROUP_SYNC_IN_BACKGROUND": "LDAP Group Sync in Background",
+            "GROUP_SYNC_IN_BACKGROUND_INFO": "Enable this option to sync LDAP group information in background to avoid timeout when there are too many groups. If disabled, the LDAP group information will be synced when the user logs in."
 
         },
         "UAA": {

--- a/src/portal/src/i18n/lang/pt-br-lang.json
+++ b/src/portal/src/i18n/lang/pt-br-lang.json
@@ -924,7 +924,10 @@
             "LDAP_GROUP_MEMBERSHIP": "Filiação de Grupo LDAP",
             "LDAP_GROUP_MEMBERSHIP_INFO": "Atributo que informa a lista de grupos do usuário. Se não informado, o nome \"memberof\" será usado. Alguns servidores LDAP utilizam o atributo \"ismemberof\". This field cannot be empty if you need to enable the LDAP group related feature.",
             "GROUP_SCOPE": "LDAP Group Search Scope",
-            "GROUP_SCOPE_INFO": "O escopo que deve ser utilizado na busca por grupos, utiliza Subtree por padrão."
+            "GROUP_SCOPE_INFO": "O escopo que deve ser utilizado na busca por grupos, utiliza Subtree por padrão.",
+          "GROUP_SYNC_IN_BACKGROUND": "LDAP Group Sync in Background",
+            "GROUP_SYNC_IN_BACKGROUND_INFO": "Enable this option to sync LDAP group information in background to avoid timeout when there are too many groups. If disabled, the LDAP group information will be synced when the user logs in."
+
 
         },
         "UAA": {

--- a/src/portal/src/i18n/lang/tr-tr-lang.json
+++ b/src/portal/src/i18n/lang/tr-tr-lang.json
@@ -927,7 +927,9 @@
             "LDAP_GROUP_MEMBERSHIP": "LDAP Grup Üyeliği",
             "LDAP_GROUP_MEMBERSHIP_INFO": "Öznitelik, LDAP grubunun üyeliğini gösterir, varsayılan değer memberof, bazı LDAP sunucularında \"ismemberof\" olabilir. This field cannot be empty if you need to enable the LDAP group related feature.",
             "GROUP_SCOPE": "LDAP Group Search Scope",
-            "GROUP_SCOPE_INFO": "Grupları aramak için kapsamı, Varsayılan olarak Alt Ağaç'ı seçin."
+            "GROUP_SCOPE_INFO": "Grupları aramak için kapsamı, Varsayılan olarak Alt Ağaç'ı seçin.",
+          "GROUP_SYNC_IN_BACKGROUND": "LDAP Group Sync in Background",
+            "GROUP_SYNC_IN_BACKGROUND_INFO": "Enable this option to sync LDAP group information in background to avoid timeout when there are too many groups. If disabled, the LDAP group information will be synced when the user logs in."
 
         },
         "UAA": {

--- a/src/portal/src/i18n/lang/zh-cn-lang.json
+++ b/src/portal/src/i18n/lang/zh-cn-lang.json
@@ -864,7 +864,7 @@
         "SESSION_TIMEOUT": "会话过期时间（分钟）",
         "SESSION_TIMEOUT_INFO": "设置 Harbor UI 的会话过期时间。默认值为60分钟。",
         "AUTH_MODE": "认证模式",
-        "PRIMARY_AUTH_MODE": "Primary Auth Mode",
+        "PRIMARY_AUTH_MODE": "首选认证模式",
         "PRO_CREATION_RESTRICTION": "项目创建",
         "SELF_REGISTRATION": "允许自注册",
         "AUTH_MODE_DB": "数据库",
@@ -926,7 +926,9 @@
             "LDAP_GROUP_MEMBERSHIP": "LDAP 组成员",
             "LDAP_GROUP_MEMBERSHIP_INFO": "LDAP组成员的membership属性，默认为 memberof, 在某些LDAP服务器会变为 ismemberof。如果要开启LDAP组功能，则此项必填",
             "GROUP_SCOPE": "LDAP组搜索范围",
-            "GROUP_SCOPE_INFO": "搜索组的范围，默认值为\"子树\""
+            "GROUP_SCOPE_INFO": "搜索组的范围，默认值为\"子树\"",
+            "GROUP_SYNC_IN_BACKGROUND": "LDAP组后台同步",
+            "GROUP_SYNC_IN_BACKGROUND_INFO": "在LDAP组数量较多的情况下，会导致用户登录超时，打开这个选项可以在后台同步组信息，如果未开启，则在用户登录的时候同步LDAP组信息。"
         },
         "UAA": {
             "ENDPOINT": "UAA Endpoint",

--- a/src/portal/src/i18n/lang/zh-tw-lang.json
+++ b/src/portal/src/i18n/lang/zh-tw-lang.json
@@ -925,7 +925,10 @@
       "LDAP_GROUP_MEMBERSHIP": "LDAP 群組成員資格",
       "LDAP_GROUP_MEMBERSHIP_INFO": "表示 LDAP 群組成員資格的屬性，預設值為 memberof，在某些 LDAP 伺服器中可能為 \"ismemberof\"。如果您需要啟用 LDAP 群組相關功能，此欄位不能為空。",
       "GROUP_SCOPE": "LDAP 群組搜尋範圍",
-      "GROUP_SCOPE_INFO": "搜尋群組的範圍，預設選擇子樹。"
+      "GROUP_SCOPE_INFO": "搜尋群組的範圍，預設選擇子樹。",
+      "GROUP_SYNC_IN_BACKGROUND": "LDAP Group Sync in Background",
+      "GROUP_SYNC_IN_BACKGROUND_INFO": "Enable this option to sync LDAP group information in background to avoid timeout when there are too many groups. If disabled, the LDAP group information will be synced when the user logs in."
+
     },
     "UAA": {
       "ENDPOINT": "UAA 端點",


### PR DESCRIPTION
 for better performance with large amount of ldap group

UI change in LDAP configuration: add a configuration item in `LDAP Group Sync in Background`
![Screenshot 2024-06-27 at 18 07 05](https://github.com/goharbor/harbor/assets/2696760/9a9006e4-c4da-46c7-a6a3-2751376050a2)


The screenshot is the compare between the sync group in background and sync group at login, with 1000 user groups and slow response ldap server, it will exceed 60 sec and timeout., when the sync group in background is true, the login is fast.

![Screenshot 2024-06-27 at 16 54 34](https://github.com/goharbor/harbor/assets/2696760/3908b8b4-39e1-4389-9937-74fba8dac1d0)


Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [ ] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [ ] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
