### PR TITLE
replaced query.Sorting with query.Sorts

### DIFF
--- a/src/pkg/scan/dao/scanner/registration.go
+++ b/src/pkg/scan/dao/scanner/registration.go
@@ -123,10 +123,18 @@ func ListRegistrations(ctx context.Context, query *q.Query) ([]*Registration, er
 	}
 
 	// Order the list
-	if query.Sorting != "" {
-		qs = qs.OrderBy(query.Sorting)
+	if len(query.Sorts) > 0 {
+		sortKey := ""
+		for _, sort := range query.Sorts {
+			if sort.DESC {
+				sortKey += " -" + sort.Key
+			} else {
+				sortKey += " " + sort.Key
+			}
+		}
+		qs = qs.OrderBy(sortKey)
 	} else {
-		qs = qs.OrderBy("-is_default", "-create_time")
+		qs = qs.OrderBy("-is_default", "-create_time") // -column means descending
 	}
 
 	l := make([]*Registration, 0)

--- a/src/pkg/scan/dao/scanner/registration.go
+++ b/src/pkg/scan/dao/scanner/registration.go
@@ -121,22 +121,6 @@ func ListRegistrations(ctx context.Context, query *q.Query) ([]*Registration, er
 	if err != nil {
 		return nil, err
 	}
-
-	// Order the list
-	if len(query.Sorts) > 0 {
-		sortKey := ""
-		for _, sort := range query.Sorts {
-			if sort.DESC {
-				sortKey += " -" + sort.Key
-			} else {
-				sortKey += " " + sort.Key
-			}
-		}
-		qs = qs.OrderBy(sortKey)
-	} else {
-		qs = qs.OrderBy("-is_default", "-create_time") // -column means descending
-	}
-
 	l := make([]*Registration, 0)
 	_, err = qs.All(&l)
 


### PR DESCRIPTION
Fixes #19569 

Replaced deprecated `query.Sorting` with `query.Sorts` in `src/pkg/scan/dao/scanner/registration.go`
