### PR TITLE
fix(gc): align the blobs in the artifact trash and useless blobs

### DIFF
--- a/src/jobservice/job/impl/gc/garbage_collection_test.go
+++ b/src/jobservice/job/impl/gc/garbage_collection_test.go
@@ -231,6 +231,7 @@ func (suite *gcTestSuite) TestRun() {
 	}, nil)
 	suite.artifactCtl.On("Delete").Return(nil)
 	suite.artrashMgr.On("Filter").Return([]model.ArtifactTrash{}, nil)
+	suite.artrashMgr.On("List").Return([]model.ArtifactTrash{}, nil)
 
 	mock.OnAnything(suite.projectCtl, "List").Return([]*proModels.Project{
 		{
@@ -309,6 +310,7 @@ func (suite *gcTestSuite) TestMark() {
 			ManifestMediaType: schema2.MediaTypeManifest,
 		},
 	}, nil)
+	suite.artrashMgr.On("List").Return([]model.ArtifactTrash{}, nil)
 
 	mock.OnAnything(suite.projectCtl, "List").Return([]*proModels.Project{
 		{

--- a/src/pkg/artifactrash/dao/dao.go
+++ b/src/pkg/artifactrash/dao/dao.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/lib/orm"
+	"github.com/goharbor/harbor/src/lib/q"
 	"github.com/goharbor/harbor/src/pkg/artifactrash/model"
 )
 
@@ -34,6 +35,8 @@ type DAO interface {
 	Filter(ctx context.Context, cutOff time.Time) (arts []model.ArtifactTrash, err error)
 	// Flush cleans the trash table record, which creation_time must be less than or equal to the cut-off.
 	Flush(ctx context.Context, cutOff time.Time) (err error)
+	// List lists the artifact trash by query.
+	List(ctx context.Context, query *q.Query) (arts []model.ArtifactTrash, err error)
 }
 
 // New returns an instance of the default DAO
@@ -109,4 +112,19 @@ func (d *dao) Flush(ctx context.Context, cutOff time.Time) (err error) {
 		return err
 	}
 	return nil
+}
+
+// List lists the artifact trash by query.
+func (d *dao) List(ctx context.Context, query *q.Query) (arts []model.ArtifactTrash, err error) {
+	arts = []model.ArtifactTrash{}
+	qs, err := orm.QuerySetter(ctx, &model.ArtifactTrash{}, query)
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err = qs.All(&arts); err != nil {
+		return nil, err
+	}
+
+	return arts, nil
 }

--- a/src/pkg/artifactrash/manager.go
+++ b/src/pkg/artifactrash/manager.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/goharbor/harbor/src/lib/q"
 	"github.com/goharbor/harbor/src/pkg/artifactrash/dao"
 	"github.com/goharbor/harbor/src/pkg/artifactrash/model"
 )
@@ -39,6 +40,8 @@ type Manager interface {
 	// Flush cleans the trash table record, which creation_time is not in the time window.
 	// The unit of timeWindow is hour, the represent cut-off is time.now() - timeWindow * time.Hours
 	Flush(ctx context.Context, timeWindow int64) (err error)
+	// List lists the artifact trash by query.
+	List(ctx context.Context, query *q.Query) (arts []model.ArtifactTrash, err error)
 }
 
 // NewManager returns an instance of the default manager
@@ -66,4 +69,8 @@ func (m *manager) Filter(ctx context.Context, timeWindow int64) (arts []model.Ar
 
 func (m *manager) Flush(ctx context.Context, timeWindow int64) (err error) {
 	return m.dao.Flush(ctx, time.Now().Add(-time.Duration(timeWindow)*time.Hour))
+}
+
+func (m *manager) List(ctx context.Context, query *q.Query) (arts []model.ArtifactTrash, err error) {
+	return m.dao.List(ctx, query)
 }

--- a/src/testing/pkg/artifactrash/manager.go
+++ b/src/testing/pkg/artifactrash/manager.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/mock"
 
+	"github.com/goharbor/harbor/src/lib/q"
 	"github.com/goharbor/harbor/src/pkg/artifactrash/model"
 )
 
@@ -35,4 +36,10 @@ func (f *FakeManager) Filter(ctx context.Context, timeWindow int64) (arts []mode
 func (f *FakeManager) Flush(ctx context.Context, timeWindow int64) (err error) {
 	args := f.Called()
 	return args.Error(0)
+}
+
+// List ...
+func (f *FakeManager) List(ctx context.Context, query *q.Query) (arts []model.ArtifactTrash, err error) {
+	args := f.Called()
+	return args.Get(0).([]model.ArtifactTrash), args.Error(1)
 }


### PR DESCRIPTION
During the GC mark stage, blobs corresponding to newly deleted artifacts during the query process are removed to ensure the consistency of data in trash and blobs and prevent dirty data from being left behind.

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes https://github.com/goharbor/harbor/issues/20711

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
