### PR TITLE
registry-photon: transparently pass arguments in entrypoint.sh.

### DIFF
--- a/make/photon/registry/Dockerfile
+++ b/make/photon/registry/Dockerfile
@@ -16,5 +16,6 @@ HEALTHCHECK CMD curl --fail -s http://localhost:5000 || curl -k --fail -s https:
 USER harbor
 
 ENTRYPOINT ["/home/harbor/entrypoint.sh"]
+CMD ["serve", "/etc/registry/config.yml"]
 
 VOLUME ["/storage"]

--- a/make/photon/registry/entrypoint.sh
+++ b/make/photon/registry/entrypoint.sh
@@ -10,4 +10,4 @@ set -e
 
 /home/harbor/install_cert.sh
 
-exec /usr/bin/registry_DO_NOT_USE_GC serve /etc/registry/config.yml
+exec /usr/bin/registry_DO_NOT_USE_GC $@


### PR DESCRIPTION
# Comprehensive Summary of your change

Transparently pass arguments of the `registry-photon` image's `entrypoint.sh` to the registry binary to allow for user-overridable arguments for it.

# Issue being fixed

This issue on `harbor-helm` fully details the problem: https://github.com/goharbor/harbor-helm/issues/1801

TL;DR: it'd be nice to be able to pass arguments to the `registry` binary in the `registry-photon` Docker image (most notably the config path) while still ensuring all the current and future setup steps in `entrypoint.sh` will still get executed.

Please indicate you've done the following:
- [X] Well Written Title and Summary of the PR
     - the linked issue should explain the problem clearly enough
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
    - I can't label the PR from the creation stage...
- [X] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
    - works with current state of the upstream `goharbor/harbor-helm` chart on my machine ™️ 
- [X] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
    - this change should be completely backwards-compatible.
