### PR TITLE
Disable edit default quota button when not editable

### DIFF
--- a/src/portal/src/app/base/left-side-nav/project-quotas/project-quotas/project-quotas.component.html
+++ b/src/portal/src/app/base/left-side-nav/project-quotas/project-quotas/project-quotas.component.html
@@ -25,6 +25,7 @@
                         <button
                             id="open-edit"
                             class="btn btn-link btn-sm default-quota-edit-button"
+                            [disabled]="!allConfig.storage_per_project.editable"
                             (click)="editDefaultQuota(quotaHardLimitValue)">
                             {{ 'QUOTA.EDIT' | translate }}
                         </button>

--- a/src/portal/src/app/base/left-side-nav/project-quotas/project-quotas/project-quotas.component.spec.ts
+++ b/src/portal/src/app/base/left-side-nav/project-quotas/project-quotas/project-quotas.component.spec.ts
@@ -111,12 +111,21 @@ describe('ProjectQuotasComponent', () => {
         await fixture.whenStable();
         const openEditButton: HTMLButtonElement =
             fixture.nativeElement.querySelector('#open-edit');
+        expect(openEditButton.disabled).toBeFalse();
         openEditButton.dispatchEvent(new Event('click'));
         fixture.detectChanges();
         await fixture.whenStable();
         const modal: HTMLElement =
             fixture.nativeElement.querySelector('clr-modal');
         expect(modal).toBeTruthy();
+    });
+    it('edit quota should be disabled when storage per project not editable', async () => {
+        component.config.storage_per_project.editable = false;
+        fixture.detectChanges();
+        await fixture.whenStable();
+        const openEditButton: HTMLButtonElement =
+            fixture.nativeElement.querySelector('#open-edit');
+        expect(openEditButton.disabled).toBeTrue();
     });
     it('should call navigate function', async () => {
         // wait getting list and rendering


### PR DESCRIPTION
# Comprehensive summary of your change

The PR disables the edit button for the default quota space per project when the configuration property `storage_per_project` is set to **not** editable, which is e.g. the case when the environment variable `CONFIG_OVERRIDE_JSON` is set for the core.

# Issue being fixed

Currently the edit button is always enabled and the modal dialog for changing the default quota space always opens. When however the property `storage_per_project` is not editable, a submission in the modal dialog will lead to the error message `Save abort because nothing changed` being displayed, and the modal dialog can only be exited by clicking the cancel button.

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
