### PR TITLE
fix: update e2e test engine images

### DIFF
--- a/tests/test-engine-image/Dockerfile.common
+++ b/tests/test-engine-image/Dockerfile.common
@@ -22,20 +22,20 @@ RUN apt-get update && apt-get install -y software-properties-common && \
 
 RUN pwd && mkdir /tool/binary && \
     # Install CONTAINERD
-    CONTAINERD_VERSION=1.7.14 &&  \
+    CONTAINERD_VERSION=1.7.20 &&  \
     wget https://github.com/containerd/containerd/releases/download/v$CONTAINERD_VERSION/containerd-$CONTAINERD_VERSION-linux-amd64.tar.gz && \
     tar zxvf containerd-$CONTAINERD_VERSION-linux-amd64.tar.gz && \
     cd bin && cp -f containerd ctr /tool/binary/ && \
     # docker compose
-    curl -L "https://github.com/docker/compose/releases/download/v2.26.1/docker-compose-$(uname -s)-$(uname -m)" -o /tool/binary/docker-compose && \
+    curl -L "https://github.com/docker/compose/releases/download/v2.29.1/docker-compose-$(uname -s)-$(uname -m)" -o /tool/binary/docker-compose && \
     chmod +x /tool/binary/docker-compose && \
     # Install helm
-    HELM_VERSION=3.14.3 && wget https://get.helm.sh/helm-v$HELM_VERSION-linux-amd64.tar.gz && \
+    HELM_VERSION=3.15.3 && wget https://get.helm.sh/helm-v$HELM_VERSION-linux-amd64.tar.gz && \
     tar zxvf helm-v$HELM_VERSION-linux-amd64.tar.gz && \
     ls || pwd && \
     mv linux-amd64/helm /tool/binary/helm && \
     # Install ORAS
-    ORAS_VERSION=1.1.0 && curl -LO https://github.com/deislabs/oras/releases/download/v$ORAS_VERSION/oras_${ORAS_VERSION}_linux_amd64.tar.gz && \
+    ORAS_VERSION=1.2.0 && curl -LO https://github.com/deislabs/oras/releases/download/v$ORAS_VERSION/oras_${ORAS_VERSION}_linux_amd64.tar.gz && \
     mkdir -p oras-install/  && \
     tar -zxf oras_${ORAS_VERSION}_*.tar.gz -C oras-install/  && \
     mv oras-install/oras /tool/binary/ && \
@@ -54,13 +54,13 @@ RUN pwd && mkdir /tool/binary && \
     WASM_TO_OCI_VERSION=0.1.2 && wget https://github.com/engineerd/wasm-to-oci/releases/download/v${WASM_TO_OCI_VERSION}/linux-amd64-wasm-to-oci && \
     chmod +x linux-amd64-wasm-to-oci && mv linux-amd64-wasm-to-oci /tool/binary/wasm-to-oci && \
     # Install imgpkg
-    IMGPKG_VERSION=0.41.1 && wget https://github.com/vmware-tanzu/carvel-imgpkg/releases/download/v$IMGPKG_VERSION/imgpkg-linux-amd64 && \
+    IMGPKG_VERSION=0.43.0 && wget https://github.com/vmware-tanzu/carvel-imgpkg/releases/download/v$IMGPKG_VERSION/imgpkg-linux-amd64 && \
     mv imgpkg-linux-amd64 /tool/binary/imgpkg && chmod +x /tool/binary/imgpkg && \
     # Install cosign
-    COSIGN_VERSION=2.2.3 && wget https://github.com/sigstore/cosign/releases/download/v$COSIGN_VERSION/cosign-linux-amd64 && \
+    COSIGN_VERSION=2.4.0 && wget https://github.com/sigstore/cosign/releases/download/v$COSIGN_VERSION/cosign-linux-amd64 && \
     mv cosign-linux-amd64 /tool/binary/cosign && chmod +x /tool/binary/cosign && \
     # # Install notation
-    NOTATION_VERSION=1.1.0 && wget https://github.com/notaryproject/notation/releases/download/v$NOTATION_VERSION/notation_${NOTATION_VERSION}_linux_amd64.tar.gz && \
+    NOTATION_VERSION=1.1.1 && wget https://github.com/notaryproject/notation/releases/download/v$NOTATION_VERSION/notation_${NOTATION_VERSION}_linux_amd64.tar.gz && \
     tar zxvf notation_${NOTATION_VERSION}_linux_amd64.tar.gz && \
     mv notation /tool/binary/notation && chmod +x /tool/binary/notation && \
     pwd

--- a/tests/test-engine-image/Dockerfile.ui_test
+++ b/tests/test-engine-image/Dockerfile.ui_test
@@ -41,8 +41,8 @@ RUN pip3 install --upgrade pip pyasn1 google-apitools==0.5.31 gsutil \
     requests dbbot robotframework-seleniumlibrary robotframework-pabot \
     robotframework-JSONLibrary hurry.filesize --upgrade && \
     apt-get clean all
-# Upgrade chromedriver version to 123.0.6312.86
-RUN wget -N https://storage.googleapis.com/chrome-for-testing-public/123.0.6312.86/linux64/chromedriver-linux64.zip && \
+# Upgrade chromedriver version to 127.0.6533.99
+RUN wget -N https://storage.googleapis.com/chrome-for-testing-public/127.0.6533.99/linux64/chromedriver-linux64.zip && \
     unzip -j chromedriver-linux64.zip && \
     chmod +x chromedriver && \
     mv -f chromedriver /usr/local/share/chromedriver && \
@@ -51,7 +51,7 @@ RUN wget -N https://storage.googleapis.com/chrome-for-testing-public/123.0.6312.
 
 RUN pwd && ls && \
     # Install docker
-    DOCKER_VERSION=26.0.0 && wget https://download.docker.com/linux/static/stable/x86_64/docker-$DOCKER_VERSION.tgz && \
+    DOCKER_VERSION=27.1.1 && wget https://download.docker.com/linux/static/stable/x86_64/docker-$DOCKER_VERSION.tgz && \
     tar --strip-components=1 -xvzf docker-$DOCKER_VERSION.tgz -C /usr/bin &&  \
     rm docker-$DOCKER_VERSION.tgz
 


### PR DESCRIPTION
1. bump up CONTAINERD_VERSION to 1.7.20
2. bump up docker compose version to v2.29.1
3. bump up HELM_VERSION to 3.15.3
4. bump up ORAS_VERSION to 1.2.0 
5. bump up IMGPKG_VERSION to 0.43.0
6. bump up COSIGN_VERSION to 2.4.0
7. bump up NOTATION_VERSION to 1.1.1
8. bump up DOCKER_VERSION to 27.1.1
9. Upgrade chromedriver version to 127.0.6533.99

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #20613

Please indicate you've done the following:
- [ ] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [ ] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
