### PR TITLE
fix: adds labels for multiple selected artifacts

### DIFF
--- a/src/portal/src/app/base/project/repository/artifact/artifact-list-page/artifact-list/artifact-list-tab/artifact-list-tab.component.ts
+++ b/src/portal/src/app/base/project/repository/artifact/artifact-list-page/artifact-list/artifact-list-tab/artifact-list-tab.component.ts
@@ -547,7 +547,7 @@ export class ArtifactListTabComponent implements OnInit, OnDestroy {
                             this.errorHandlerService.error(err);
                         },
                     });
-            })
+            });
         }
     }
     removeLabel(label: Label) {

--- a/src/portal/src/app/base/project/repository/artifact/artifact-list-page/artifact-list/artifact-list-tab/artifact-list-tab.component.ts
+++ b/src/portal/src/app/base/project/repository/artifact/artifact-list-page/artifact-list/artifact-list-tab/artifact-list-tab.component.ts
@@ -527,25 +527,27 @@ export class ArtifactListTabComponent implements OnInit, OnDestroy {
     }
     addLabel(label: Label) {
         if (!this.inprogress) {
-            const params: NewArtifactService.AddLabelParams = {
-                projectName: this.projectName,
-                repositoryName: dbEncodeURIComponent(this.repoName),
-                reference: this.selectedRow[0].digest,
-                label: label,
-            };
             this.inprogress = true;
-            this.newArtifactService
-                .addLabel(params)
-                .pipe(finalize(() => (this.inprogress = false)))
-                .subscribe({
-                    next: res => {
-                        this.refresh();
-                    },
-                    error: err => {
-                        this.refresh();
-                        this.errorHandlerService.error(err);
-                    },
-                });
+            this.selectedRow.forEach((artifact: Artifact) => {
+                const params: NewArtifactService.AddLabelParams = {
+                    projectName: this.projectName,
+                    repositoryName: dbEncodeURIComponent(this.repoName),
+                    reference: artifact.digest,
+                    label: label,
+                };
+                this.newArtifactService
+                    .addLabel(params)
+                    .pipe(finalize(() => (this.inprogress = false)))
+                    .subscribe({
+                        next: res => {
+                            this.refresh();
+                        },
+                        error: err => {
+                            this.refresh();
+                            this.errorHandlerService.error(err);
+                        },
+                    });
+            })
         }
     }
     removeLabel(label: Label) {


### PR DESCRIPTION
Thank you for contributing to Harbor!

# Comprehensive Summary of your change   
When selecting multiple artifacts and adding a label for these, only the first selected artifact gets labeled. Current frontend code is adding the label only to the first selected artifact. This PR is fixing this by iterating the array and adding the label to each selected artifact.

![output](https://github.com/user-attachments/assets/1dc73a48-9ae9-4113-b303-cd4b46873234)

# Issue being fixed
Fixes #20681

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
