### PR TITLE
conditionally enable ipv6 listen directives in nginx configs

### DIFF
--- a/make/photon/prepare/templates/docker_compose/docker-compose.yml.jinja
+++ b/make/photon/prepare/templates/docker_compose/docker-compose.yml.jinja
@@ -314,6 +314,9 @@ services:
 {% endif %}
     networks:
       - harbor
+      {% if ip_family.ipv6.enabled %}
+      - harbor_ipv6
+      {% endif %}
     ports:
       - {{http_port}}:8080
 {% if protocol == 'https' %}
@@ -399,4 +402,8 @@ services:
 networks:
   harbor:
     external: false
-
+  {% if ip_family.ipv6.enabled %}
+  harbor_ipv6:
+    external: false
+    enable_ipv6: true
+  {% endif %}

--- a/make/photon/prepare/templates/nginx/nginx.http.conf.jinja
+++ b/make/photon/prepare/templates/nginx/nginx.http.conf.jinja
@@ -47,7 +47,12 @@ http {
   }
 
   server {
+    {% if ip_family.ipv4.enabled %}
     listen 8080;
+    {% endif %}
+    {% if ip_family.ipv6.enabled %}
+    listen [::]:8080;
+    {% endif %}
     server_tokens off;
     # disable any limits to avoid HTTP 413 for large image uploads
     client_max_body_size 0;
@@ -200,7 +205,12 @@ http {
   }
 
   server {
+    {% if ip_family.ipv4.enabled %}
     listen 9090;
+    {% endif %}
+    {% if ip_family.ipv6.enabled %}
+    listen [::]:9090;
+    {% endif %}
     location = /metrics {
       if ($arg_comp = core) { proxy_pass http://core_metrics; }
       if ($arg_comp = jobservice) { proxy_pass http://js_metrics; }

--- a/make/photon/prepare/templates/nginx/nginx.https.conf.jinja
+++ b/make/photon/prepare/templates/nginx/nginx.https.conf.jinja
@@ -214,7 +214,12 @@ http {
     }
   }
   server {
+      {% if ip_family.ipv4.enabled %}
       listen 8080;
+      {% endif %}
+      {% if ip_family.ipv6.enabled %}
+      listen [::]:8080;
+      {% endif %}
       #server_name harbordomain.com;
       return 308 https://{{https_redirect}}$request_uri;
   }
@@ -236,7 +241,12 @@ http {
   }
 
   server {
+    {% if ip_family.ipv4.enabled %}
     listen 9090;
+    {% endif %}
+    {% if ip_family.ipv6.enabled %}
+    listen [::]:9090;
+    {% endif %}
     location = {{ metric.path }} {
       if ($arg_comp = core) { proxy_pass http://core_metrics; }
       if ($arg_comp = jobservice) { proxy_pass http://js_metrics; }

--- a/make/photon/prepare/templates/portal/nginx.conf.jinja
+++ b/make/photon/prepare/templates/portal/nginx.conf.jinja
@@ -36,7 +36,12 @@ http {
         ssl_prefer_server_ciphers on;
         ssl_session_cache shared:SSL:10m;
 {% else %}
+    {% if ip_family.ipv4.enabled %}
         listen 8080;
+    {% endif %}
+    {% if ip_family.ipv6.enabled %}
+        listen [::]:8080;
+    {% endif %}
 {% endif %}
         server_name  localhost;
 

--- a/make/photon/prepare/utils/docker_compose.py
+++ b/make/photon/prepare/utils/docker_compose.py
@@ -23,6 +23,7 @@ def prepare_docker_compose(configs, with_trivy):
         'http_port': configs['http_port'],
         'external_redis': configs['external_redis'],
         'external_database': configs['external_database'],
+        'ip_family': configs['ip_family'],
         'with_trivy': with_trivy,
     }
 

--- a/make/photon/prepare/utils/nginx.py
+++ b/make/photon/prepare/utils/nginx.py
@@ -75,7 +75,8 @@ def render_nginx_template(config_dict):
             uid=DEFAULT_UID,
             gid=DEFAULT_GID,
             internal_tls=config_dict['internal_tls'],
-            metric=config_dict['metric'])
+            metric=config_dict['metric'],
+            ip_family=config_dict['ip_family'])
         location_file_pattern = CUSTOM_NGINX_LOCATION_FILE_PATTERN_HTTP
     copy_nginx_location_configs_if_exist(nginx_template_ext_dir, nginx_confd_dir, location_file_pattern)
 


### PR DESCRIPTION
# Enable ipv6 according to config file

Harbor has added the ability to configure external ipv6 since a3e1b1eb7983ea9897fcbb999bec1a10c053849d, but has only added it to the https-side of the proxy.
Therefore a `curl -LI6 http://my-harbor.tld` returns:
`curl: (7) Failed to connect to my-harbor.tld port 80 after 6 ms: Couldn't connect to server`

This PR tries to fix that by adding it to the other listen directives in the nginx configs.

Related #11399

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
