### PR TITLE
Bypass 404 errors when fetching artifacts

### DIFF
--- a/src/pkg/reg/adapter/native/adapter.go
+++ b/src/pkg/reg/adapter/native/adapter.go
@@ -148,7 +148,11 @@ func (a *Adapter) FetchArtifacts(filters []*model.Filter) ([]*model.Resource, er
 		runner.AddTask(func() error {
 			artifacts, err := a.listArtifacts(repo.Name, filters)
 			if err != nil {
-				return fmt.Errorf("failed to list artifacts of repository %s: %v", repo.Name, err)
+                if err.(type) == errors.NotFoundCode {
+                    return nil
+                } else {
+                    return fmt.Errorf("failed to list artifacts of repository %s: %v", repo.Name, err)
+                }
 			}
 			if len(artifacts) == 0 {
 				return nil


### PR DESCRIPTION
Thank you for contributing to Harbor!

# Comprehensive Summary of your change

Modifies the FetchArtifacts function in the native adapter (used exclusively by the replication controller) to ignore 404s.

This allows for replication to succeed against registries that may have dangling manifests (e.g. repositories with no images/tags)
