### PR TITLE
Update comments in template file of installation configurations

### DIFF
--- a/make/harbor.yml.tmpl
+++ b/make/harbor.yml.tmpl
@@ -48,7 +48,7 @@ harbor_admin_password: Harbor12345
 
 # Harbor DB configuration
 database:
-  # The password for the root user of Harbor DB. Change this before any production use.
+  # The password for the user('postgres' by default) of Harbor DB. Change this before any production use.
   password: root123
   # The maximum number of connections in the idle connection pool. If it <=0, no idle connections are retained.
   max_idle_conns: 100


### PR DESCRIPTION
Update comments in template file of installation configurations.
Current descriptions make users a little bit confused about the 'root user'.
