### PR TITLE
replace type assertion with errors.As for unauthorizedError handling

### DIFF
--- a/src/core/service/token/token.go
+++ b/src/core/service/token/token.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/beego/beego/v2/server/web"
 
+	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/lib/log"
 )
 
@@ -44,7 +45,8 @@ func (h *Handler) Get() {
 	}
 	token, err := tokenCreator.Create(request)
 	if err != nil {
-		if _, ok := err.(*unauthorizedError); ok {
+		var unAuthErr *unauthorizedError
+		if errors.As(err, &unAuthErr) {
 			h.CustomAbort(http.StatusUnauthorized, "")
 		}
 		log.Errorf("Unexpected error when creating the token, error: %v", err)


### PR DESCRIPTION
Thank you for contributing to Harbor!

# Description
This PR refactors the error handling logic to replace the type assertion err.(*unauthorizedError) with errors.As. This change improves the handling of errors that may be wrapped, making the code more robust and easier to maintain.

# change
- Replaced `err.(*unauthorizedError)` with `errors.As` to check for the unauthorized error type.
