### PR TITLE
Fix postgres script permissions

### DIFF
--- a/make/photon/db/Dockerfile
+++ b/make/photon/db/Dockerfile
@@ -9,8 +9,9 @@ COPY ./make/photon/db/initdb.sh /initdb.sh
 COPY ./make/photon/db/upgrade.sh /upgrade.sh
 COPY ./make/photon/db/docker-healthcheck.sh /docker-healthcheck.sh
 COPY ./make/photon/db/initial-registry.sql /docker-entrypoint-initdb.d/
-RUN chown -R postgres:postgres /docker-entrypoint.sh /docker-healthcheck.sh /docker-entrypoint-initdb.d \
-    && chmod u+x /docker-entrypoint.sh /docker-healthcheck.sh
+RUN chown -R postgres:postgres /docker-entrypoint.sh /initdb.sh /upgrade.sh \
+    /docker-healthcheck.sh /docker-entrypoint-initdb.d \
+    && chmod u+x /initdb.sh /upgrade.sh /docker-entrypoint.sh /docker-healthcheck.sh
 
 ENTRYPOINT ["/docker-entrypoint.sh", "14", "15"]
 HEALTHCHECK CMD ["/docker-healthcheck.sh"]


### PR DESCRIPTION
The initdb.sh and the upgrade.sh scripts in the postgres image were not owned by the postgres user, which made them failing with permission denied errors in some local builds.

# Comprehensive Summary of your change
Adding the scripts to the appropriate user and fixing the permissions resolved the issue.

# Issue being fixed
[Fixes #21006
](https://github.com/goharbor/harbor/issues/21006)
Please indicate you've done the following:
- [X] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [X] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [X] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
