### PR TITLE
Fix Default Horizontal Scrollbar in Replication Page

### DIFF
--- a/src/portal/src/app/base/left-side-nav/replication/replication/list-replication-rule/list-replication-rule.component.html
+++ b/src/portal/src/app/base/left-side-nav/replication/replication/list-replication-rule/list-replication-rule.component.html
@@ -122,17 +122,17 @@
             </ng-template>
         </clr-dg-column>
         <clr-dg-column [clrDgSortBy]="'speed'">
-            <ng-template [clrDgHideableColumn]="{ hidden: hiddenArray[7] }">
+            <ng-template [clrDgHideableColumn]="{ hidden: hiddenArray[6] }">
                 {{ 'REPLICATION.BANDWIDTH' | translate }}
             </ng-template>
         </clr-dg-column>
         <clr-dg-column [clrDgField]="'description'">
-            <ng-template [clrDgHideableColumn]="{ hidden: hiddenArray[8] }">
+            <ng-template [clrDgHideableColumn]="{ hidden: hiddenArray[7] }">
                 {{ 'REPLICATION.DESCRIPTION' | translate }}
             </ng-template>
         </clr-dg-column>
         <clr-dg-column>
-            <ng-template [clrDgHideableColumn]="{ hidden: hiddenArray[6] }">
+            <ng-template [clrDgHideableColumn]="{ hidden: hiddenArray[8] }">
                 {{ 'REPLICATION.REPLICATION_TRIGGER' | translate }}
             </ng-template>
         </clr-dg-column>

--- a/src/portal/src/app/base/left-side-nav/replication/replication/list-replication-rule/list-replication-rule.component.html
+++ b/src/portal/src/app/base/left-side-nav/replication/replication/list-replication-rule/list-replication-rule.component.html
@@ -121,11 +121,6 @@
                 {{ 'REPLICATION.DES_REPO_FLATTENING' | translate }}
             </ng-template>
         </clr-dg-column>
-        <clr-dg-column>
-            <ng-template [clrDgHideableColumn]="{ hidden: hiddenArray[6] }">
-                {{ 'REPLICATION.REPLICATION_TRIGGER' | translate }}
-            </ng-template></clr-dg-column
-        >
         <clr-dg-column [clrDgSortBy]="'speed'">
             <ng-template [clrDgHideableColumn]="{ hidden: hiddenArray[7] }">
                 {{ 'REPLICATION.BANDWIDTH' | translate }}
@@ -134,6 +129,11 @@
         <clr-dg-column [clrDgField]="'description'">
             <ng-template [clrDgHideableColumn]="{ hidden: hiddenArray[8] }">
                 {{ 'REPLICATION.DESCRIPTION' | translate }}
+            </ng-template>
+        </clr-dg-column>
+        <clr-dg-column>
+            <ng-template [clrDgHideableColumn]="{ hidden: hiddenArray[6] }">
+                {{ 'REPLICATION.REPLICATION_TRIGGER' | translate }}
             </ng-template>
         </clr-dg-column>
         <clr-dg-placeholder>{{

--- a/src/portal/src/app/base/left-side-nav/replication/replication/list-replication-rule/list-replication-rule.component.ts
+++ b/src/portal/src/app/base/left-side-nav/replication/replication/list-replication-rule/list-replication-rule.component.ts
@@ -100,7 +100,7 @@ export class ListReplicationRuleComponent implements OnInit, OnDestroy {
     paused: boolean = false;
     hiddenArray: boolean[] = getHiddenArrayFromLocalStorage(
         PageSizeMapKeys.LIST_REPLICATION_RULE_COMPONENT,
-        [false, false, false, false, false, false, false, true, true]
+        [false, false, false, false, false, false, true, true, false]
     );
     @ViewChild('datagrid')
     datagrid: ClrDatagrid;


### PR DESCRIPTION
Thank you for contributing to Harbor!

# Comprehensive Summary of your change
- Resolved an issue where a horizontal scrollbar appeared unnecessarily due to the last table column being hidden, leaving a gap. By rearranging the columns so the last declared column is always visible, the scrollbar issue is fixed.
- This simple change ensures the table layout works as expected without any extra scrollbars by default.

## Before
![scroll in replication bug](https://github.com/user-attachments/assets/99b86dbf-2510-42b0-b190-3d1a6979c062)

## After
![fixed scrollbar](https://github.com/user-attachments/assets/39953e22-bd23-4f9b-a137-4a72816c9727)


# Issue being fixed
Fixes Unwanted Scrollbar in Replication page.

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
