### PR TITLE
fix: nil pointer dereference when failed to scan out the quota records from redis

### DIFF
--- a/src/controller/quota/controller.go
+++ b/src/controller/quota/controller.go
@@ -123,6 +123,7 @@ func flushQuota(ctx context.Context) {
 	iter, err := cache.Default().Scan(ctx, "quota:*")
 	if err != nil {
 		log.Errorf("failed to scan out the quota records from redis")
+		return
 	}
 
 	for iter.Next(ctx) {


### PR DESCRIPTION
Signed-off-by: Liang Zheng <zhengliang0901@gmail.com>

# Comprehensive Summary of your change

# Issue being fixed
Fixes [21045](https://github.com/goharbor/harbor/issues/21045)

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
