### PR TITLE
Fixes-21021 Display proxy cache in project configuration page

### DIFF
--- a/src/portal/src/app/base/project/project-config/project-policy-config/project-policy-config.component.html
+++ b/src/portal/src/app/base/project/project-config/project-policy-config/project-policy-config.component.html
@@ -16,6 +16,84 @@
                 {{ 'PROJECT_CONFIG.PUBLIC_POLICY' | translate }}
             </clr-control-helper>
         </clr-checkbox-container>
+        <clr-checkbox-container *ngIf="isSystemAdmin" clrInline>
+            <label class="label-color-input">
+                {{ 'PROJECT.PROXY_CACHE' | translate }}
+            </label>
+            <clr-checkbox-wrapper id="is-project-proxy-cache-enabled">
+                <input
+                    type="checkbox"
+                    clrCheckbox
+                    disabled="!allowUpdateProxyCacheConfiguration"
+                    [(ngModel)]="projectPolicy.ProxyCacheEnabled"
+                    name="project-proxy-cache-enabled" />
+            </clr-checkbox-wrapper>
+            <clr-control-helper class="config-subtext">
+                {{ 'PROJECT.PROXY_CACHE_TOOLTIP' | translate }}
+            </clr-control-helper>
+        </clr-checkbox-container>
+        <div
+            *ngIf="isSystemAdmin && projectPolicy.ProxyCacheEnabled"
+            class="clr-form-control mt-0">
+            <label class="clr-control-label"></label>
+            <div class="clr-select-wrapper row-inline">
+                <label class="clr-control-label">
+                    {{ 'PROJECT.ENDPOINT' | translate }}
+                </label>
+                <select
+                    class="width-164 ml-1"
+                    id="registry"
+                    name="registry"
+                    disabled="!allowUpdateProxyCacheConfiguration"
+                    [(ngModel)]="projectPolicy.RegistryId">
+                    <option class="display-none" value=""></option>
+                    <option *ngFor="let r of registries" [value]="r.id">
+                        {{ r.name }}-{{ r.url }}
+                    </option>
+                </select>
+            </div>
+            <div class="row-inline ml-2" clrInline>
+                <label class="clr-control-label">
+                    {{ 'PROJECT.BANDWIDTH' | translate }}
+                </label>
+                <div
+                    class="clr-control-container ml-1"
+                    [class.clr-error]="bandwidthError">
+                    <input
+                        type="number"
+                        id="bandwidth"
+                        [(ngModel)]="projectPolicy.ProxySpeedKb"
+                        name="bandwidth"
+                        disabled="!allowUpdateProxyCacheConfiguration"
+                        class="clr-input width-164 mr-10 clr-input-underline"
+                        autocomplete="off"
+                        (ngModelChange)="validateBandwidth()" />
+                    <clr-icon
+                        *ngIf="bandwidthError"
+                        class="clr-validate-icon"
+                        shape="exclamation-circle"></clr-icon>
+                    <div class="clr-select-wrapper mr-10 margin-left-05">
+                        <select
+                            id="bandwidth_unit"
+                            name="bandwidth_unit"
+                            disabled="!allowUpdateProxyCacheConfiguration"
+                            [(ngModel)]="speedUnit">
+                            <option
+                                *ngFor="let unit of speedUnits"
+                                [value]="unit.UNIT">
+                                {{ unit.UNIT }}
+                            </option>
+                        </select>
+                    </div>
+                    <clr-control-error
+                        *ngIf="bandwidthError"
+                        class="tooltip-content">
+                        {{ 'PROJECT.SPEED_LIMIT_TIP' | translate }}
+                    </clr-control-error>
+                </div>
+            </div>
+        </div>
+
         <clr-checkbox-container *ngIf="!isProxyCacheProject" clrInline>
             <label
                 ><span>{{ 'PROJECT_CONFIG.SECURITY' | translate }}</span></label

--- a/src/portal/src/app/base/project/project-config/project-policy-config/project-policy-config.component.scss
+++ b/src/portal/src/app/base/project/project-config/project-policy-config/project-policy-config.component.scss
@@ -97,3 +97,15 @@
 .margin-top-05 {
   margin-top: 0.5rem;
 }
+
+.margin-left-05 {
+  margin-left: 0.5rem;
+}
+
+.row-inline {
+  display: flex;
+}
+
+.row-inline label {
+  align-self: end;
+}

--- a/src/portal/src/app/base/project/project-config/project-policy-config/project-policy-config.component.spec.ts
+++ b/src/portal/src/app/base/project/project-config/project-policy-config/project-policy-config.component.spec.ts
@@ -10,6 +10,7 @@ import { of } from 'rxjs';
 import { SharedTestingModule } from '../../../../shared/shared.module';
 import { ErrorHandler } from '../../../../shared/units/error-handler';
 import { MessageHandlerService } from '../../../../shared/services/message-handler.service';
+import { SessionService } from '../../../../shared/services/session.service';
 import { Component, ViewChild } from '@angular/core';
 
 const mockSystemInfo: SystemInfo[] = [
@@ -99,6 +100,14 @@ const userPermissionService = {
         return of(true);
     },
 };
+
+const sessionService = {
+    getCurrentUser() {
+        return of({
+            has_admin_role: true,
+        });
+    },
+};
 describe('ProjectPolicyConfigComponent', () => {
     let fixture: ComponentFixture<TestHostComponent>,
         component: TestHostComponent;
@@ -114,6 +123,7 @@ describe('ProjectPolicyConfigComponent', () => {
                 { provide: ErrorHandler, useClass: MessageHandlerService },
                 { provide: ProjectService, useValue: projectService },
                 { provide: SystemInfoService, useValue: systemInfoService },
+                { provide: SessionService, useValue: sessionService },
                 {
                     provide: UserPermissionService,
                     useValue: userPermissionService,

--- a/src/portal/src/app/base/project/project-config/project-policy-config/project.ts
+++ b/src/portal/src/app/base/project/project-config/project-policy-config/project.ts
@@ -1,6 +1,7 @@
 export class Project {
     project_id: number;
     owner_id?: number;
+    registry_id?: number | null;
     name: string;
     creation_time?: Date | string;
     deleted?: number;
@@ -21,6 +22,7 @@ export class Project {
         auto_scan: string | boolean;
         auto_sbom_generation: string | boolean;
         reuse_sys_cve_allowlist?: string;
+        proxy_speed_kb?: number | null;
     };
     cve_allowlist?: object;
     constructor() {
@@ -30,5 +32,6 @@ export class Project {
         this.metadata.severity = 'low';
         this.metadata.auto_scan = false;
         this.metadata.auto_sbom_generation = false;
+        this.metadata.proxy_speed_kb = -1;
     }
 }

--- a/src/portal/src/app/shared/services/project.service.ts
+++ b/src/portal/src/app/shared/services/project.service.ts
@@ -144,6 +144,7 @@ export class ProjectDefaultService extends ProjectService {
             .put<any>(
                 `${baseUrl}/${projectId}`,
                 {
+                    registry_id: projectPolicy.RegistryId,
                     metadata: {
                         public: projectPolicy.Public ? 'true' : 'false',
                         enable_content_trust: projectPolicy.ContentTrust
@@ -162,6 +163,7 @@ export class ProjectDefaultService extends ProjectService {
                             ? 'true'
                             : 'false',
                         reuse_sys_cve_allowlist: reuseSysCVEVAllowlist,
+                        proxy_speed_kb: projectPolicy.ProxySpeedKb.toString(),
                     },
                     cve_allowlist: projectAllowlist,
                 },


### PR DESCRIPTION
Display proxy cache in project configuration page

# Issue being fixed
Fixes #21021

This PR Only supports to display the values:
![Screenshot 2024-10-15 at 17 55 09](https://github.com/user-attachments/assets/dcee19ec-154a-46b7-8d46-4b3fe45e346d)


Please indicate you've done the following:
- [X] Well Written Title and Summary of the PR
- [X] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [X] Accepted the DCO. Commits without the DCO will delay acceptance.
- [X] Made sure tests are passing and test coverage is added if needed.
- [X] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
