### PR TITLE
Attempt to retrieve manifest from local repo for manifest requests to proxy

### DIFF
--- a/src/controller/proxy/controller.go
+++ b/src/controller/proxy/controller.go
@@ -260,15 +260,6 @@ func (c *controller) UseLocalManifest(ctx context.Context, art lib.ArtifactInfo,
 	return a != nil && string(desc.Digest) == a.Digest, nil, nil
 }
 
-func manifestKey(repo string, art lib.ArtifactInfo) string {
-	// actual redis key format is cache:manifest:<repo name>:<tag> or cache:manifest:<repo name>:sha256:xxxx
-	return "manifest:" + repo + ":" + getReference(art)
-}
-
-func manifestContentTypeKey(rep string, art lib.ArtifactInfo) string {
-	return manifestKey(rep, art) + ":contenttype"
-}
-
 func manifestListKey(repo string, art lib.ArtifactInfo) string {
 	// actual redis key format is cache:manifestlist:<repo name>:<tag> or cache:manifestlist:<repo name>:sha256:xxxx
 	return "manifestlist:" + repo + ":" + getReference(art)

--- a/src/controller/proxy/controller.go
+++ b/src/controller/proxy/controller.go
@@ -270,7 +270,7 @@ func manifestContentTypeKey(rep string, art lib.ArtifactInfo) string {
 }
 
 func manifestListKey(repo string, art lib.ArtifactInfo) string {
-	// actual redis key format is cache:manifest:<repo name>:<tag> or cache:manifest:<repo name>:sha256:xxxx
+	// actual redis key format is cache:manifestlist:<repo name>:<tag> or cache:manifestlist:<repo name>:sha256:xxxx
 	return "manifestlist:" + repo + ":" + getReference(art)
 }
 

--- a/src/controller/proxy/local.go
+++ b/src/controller/proxy/local.go
@@ -43,6 +43,8 @@ type localInterface interface {
 	GetManifest(ctx context.Context, art lib.ArtifactInfo) (*artifact.Artifact, error)
 	// PushBlob push blob to local repo
 	PushBlob(localRepo string, desc distribution.Descriptor, bReader io.ReadCloser) error
+	// PullManifest pulls manifest from local repo, ref can be digest or tag
+	PullManifest(repo string, ref string) (distribution.Manifest, string, error)
 	// PushManifest push manifest to local repo, ref can be digest or tag
 	PushManifest(repo string, ref string, manifest distribution.Manifest) error
 	// CheckDependencies check if the manifest's dependency is ready
@@ -107,6 +109,10 @@ func (l *localHelper) PushBlob(localRepo string, desc distribution.Descriptor, b
 	defer inflightChecker.removeRequest(artName)
 	err := l.registry.PushBlob(localRepo, ref, desc.Size, bReader)
 	return err
+}
+
+func (l *localHelper) PullManifest(repo string, ref string) (distribution.Manifest, string, error) {
+	return l.registry.PullManifest(repo, ref)
 }
 
 func (l *localHelper) PushManifest(repo string, ref string, manifest distribution.Manifest) error {

--- a/src/server/middleware/repoproxy/proxy.go
+++ b/src/server/middleware/repoproxy/proxy.go
@@ -185,12 +185,12 @@ func handleManifest(w http.ResponseWriter, r *http.Request, next http.Handler) e
 	}
 	if useLocal {
 		if man != nil {
-			w.Header().Set(contentLength, fmt.Sprintf("%v", len(man.Content)))
-			w.Header().Set(contentType, man.ContentType)
-			w.Header().Set(dockerContentDigest, man.Digest)
-			w.Header().Set(etag, man.Digest)
+			w.Header().Set(contentLength, fmt.Sprintf("%v", len(man.Content())))
+			w.Header().Set(contentType, man.ContentType())
+			w.Header().Set(dockerContentDigest, man.Digest())
+			w.Header().Set(etag, man.Digest())
 			if r.Method == http.MethodGet {
-				_, err = w.Write(man.Content)
+				_, err = w.Write(man.Content())
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
# Comprehensive Summary of your change

Harbor Proxies will serve manifests located in the local repository if the digest of the local manifest matches the digest of the remote manifest.

# Issue being fixed
Fixes #21122

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
