### PR TITLE
Add manifestcache push for tag and digest to local repository

### DIFF
--- a/src/controller/proxy/controller_test.go
+++ b/src/controller/proxy/controller_test.go
@@ -74,7 +74,8 @@ func (l *localInterfaceMock) PushManifestList(ctx context.Context, repo string, 
 }
 
 func (l *localInterfaceMock) CheckDependencies(ctx context.Context, repo string, man distribution.Manifest) []distribution.Descriptor {
-	panic("implement me")
+	args := l.Called(ctx, repo, man)
+	return args.Get(0).([]distribution.Descriptor)
 }
 
 func (l *localInterfaceMock) DeleteManifest(repo, ref string) {

--- a/src/controller/proxy/manifestcache.go
+++ b/src/controller/proxy/manifestcache.go
@@ -16,6 +16,7 @@ package proxy
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -28,7 +29,7 @@ import (
 
 	"github.com/goharbor/harbor/src/lib"
 	libCache "github.com/goharbor/harbor/src/lib/cache"
-	"github.com/goharbor/harbor/src/lib/errors"
+	libErrors "github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/lib/log"
 )
 
@@ -142,7 +143,7 @@ func (m *ManifestListCache) push(ctx context.Context, repo, reference string, ma
 		}
 	}
 	if len(newMan.References()) == 0 {
-		return errors.New("manifest list doesn't contain any pushed manifest")
+		return libErrors.New("manifest list doesn't contain any pushed manifest")
 	}
 	_, pl, err := newMan.Payload()
 	if err != nil {
@@ -198,10 +199,30 @@ func (m *ManifestCache) CacheContent(ctx context.Context, remoteRepo string, man
 			}
 		}
 	}
-	err := m.local.PushManifest(art.Repository, getReference(art), man)
+
+	err := m.push(art, man)
 	if err != nil {
-		log.Errorf("failed to push manifest, tag: %v, error %v", art.Tag, err)
+		log.Errorf("error occured on manifest push to local: %v", err)
 	}
+}
+
+func (m *ManifestCache) push(art lib.ArtifactInfo, man distribution.Manifest) error {
+	errs := []error{}
+	if len(art.Digest) > 0 {
+		err := m.local.PushManifest(art.Repository, art.Digest, man)
+		if err != nil {
+			log.Errorf("failed to push manifest referencing digest, tag: %v, digest: %v, error %v", art.Tag, art.Digest, err)
+			errs = append(errs, err)
+		}
+	}
+	if len(art.Tag) > 0 {
+		err := m.local.PushManifest(art.Repository, art.Tag, man)
+		if err != nil {
+			log.Errorf("failed to push manifest referencing tag, tag: %v, digest: %v, error %v", art.Tag, art.Digest, err)
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
 }
 
 func (m *ManifestCache) putBlobToLocal(remoteRepo string, localRepo string, desc distribution.Descriptor, r RemoteInterface) error {


### PR DESCRIPTION
# Comprehensive Summary of your change

Harbor Proxies will push a manifest referencing a digest and tag to the local repo if both are known.

# Issue being fixed
Fixes #21122

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
