### PR TITLE
Expose information about registries as metrics

### DIFF
--- a/src/pkg/exporter/collector.go
+++ b/src/pkg/exporter/collector.go
@@ -29,7 +29,7 @@ func newDesc(subsystem, name, help string) *prometheus.Desc {
 	)
 }
 
-func newDescWithLables(subsystem, name, help string, labels ...string) *prometheus.Desc {
+func newDescWithLabels(subsystem, name, help string, labels ...string) *prometheus.Desc {
 	return prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, subsystem, name),
 		help, labels, nil,

--- a/src/pkg/exporter/exporter.go
+++ b/src/pkg/exporter/exporter.go
@@ -49,6 +49,7 @@ func NewExporter(opt *Opt) *Exporter {
 	}
 	err := exporter.RegisterCollector(NewHealthCollect(hbrCli),
 		NewSystemInfoCollector(hbrCli),
+		NewRegistryCollector(),
 		NewProjectCollector(),
 		NewJobServiceCollector(),
 		NewStatisticsCollector(),

--- a/src/pkg/exporter/health_collector.go
+++ b/src/pkg/exporter/health_collector.go
@@ -33,7 +33,7 @@ var (
 		valueType: prometheus.GaugeValue,
 	}
 	harborComponentsHealth = typedDesc{
-		desc:      newDescWithLables("", "up", "Running status of harbor component", "component"),
+		desc:      newDescWithLabels("", "up", "Running status of harbor component", "component"),
 		valueType: prometheus.GaugeValue,
 	}
 )

--- a/src/pkg/exporter/js_collector.go
+++ b/src/pkg/exporter/js_collector.go
@@ -24,15 +24,15 @@ const JobServiceCollectorName = "JobServiceCollector"
 
 var (
 	jobServiceTaskQueueSize = typedDesc{
-		desc:      newDescWithLables("", "task_queue_size", "Total number of tasks", "type"),
+		desc:      newDescWithLabels("", "task_queue_size", "Total number of tasks", "type"),
 		valueType: prometheus.GaugeValue,
 	}
 	jobServiceTaskQueueLatency = typedDesc{
-		desc:      newDescWithLables("", "task_queue_latency", "how long ago the next job to be processed was enqueued", "type"),
+		desc:      newDescWithLabels("", "task_queue_latency", "how long ago the next job to be processed was enqueued", "type"),
 		valueType: prometheus.GaugeValue,
 	}
 	jobServiceConcurrency = typedDesc{
-		desc:      newDescWithLables("", "task_concurrency", "Total number of concurrency on a pool", "type", "pool"),
+		desc:      newDescWithLabels("", "task_concurrency", "Total number of concurrency on a pool", "type", "pool"),
 		valueType: prometheus.GaugeValue,
 	}
 	jobServiceScheduledJobTotal = typedDesc{

--- a/src/pkg/exporter/project_collector.go
+++ b/src/pkg/exporter/project_collector.go
@@ -52,32 +52,32 @@ var (
 )
 var (
 	projectTotal = typedDesc{
-		desc:      newDescWithLables("", "project_total", "Total projects number", "public"),
+		desc:      newDescWithLabels("", "project_total", "Total projects number", "public"),
 		valueType: prometheus.GaugeValue,
 	}
 	projectUsage = typedDesc{
-		desc:      newDescWithLables("", "project_quota_usage_byte", "The used resource of a project", "project_name"),
+		desc:      newDescWithLabels("", "project_quota_usage_byte", "The used resource of a project", "project_name"),
 		valueType: prometheus.GaugeValue,
 	}
 	projectQuote = typedDesc{
-		desc:      newDescWithLables("", "project_quota_byte", "The quota of a project", "project_name"),
+		desc:      newDescWithLabels("", "project_quota_byte", "The quota of a project", "project_name"),
 		valueType: prometheus.GaugeValue,
 	}
 	projectRepoTotal = typedDesc{
-		desc:      newDescWithLables("", "project_repo_total", "Total project repos number", "project_name", "public"),
+		desc:      newDescWithLabels("", "project_repo_total", "Total project repos number", "project_name", "public"),
 		valueType: prometheus.GaugeValue,
 	}
 
 	projectMemberTotal = typedDesc{
-		desc:      newDescWithLables("", "project_member_total", "Total members number of a project", "project_name"),
+		desc:      newDescWithLabels("", "project_member_total", "Total members number of a project", "project_name"),
 		valueType: prometheus.GaugeValue,
 	}
 	artifactPullTotal = typedDesc{
-		desc:      newDescWithLables("", "artifact_pulled", "The pull number of an artifact", "project_name"),
+		desc:      newDescWithLabels("", "artifact_pulled", "The pull number of an artifact", "project_name"),
 		valueType: prometheus.GaugeValue,
 	}
 	projectArtifactTotal = typedDesc{
-		desc:      newDescWithLables("", "project_artifact_total", "Total project artifacts number", "project_name", "public", "artifact_type"),
+		desc:      newDescWithLabels("", "project_artifact_total", "Total project artifacts number", "project_name", "public", "artifact_type"),
 		valueType: prometheus.GaugeValue,
 	}
 )

--- a/src/pkg/exporter/registry_collector.go
+++ b/src/pkg/exporter/registry_collector.go
@@ -1,0 +1,103 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exporter
+
+import (
+	"strconv"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/goharbor/harbor/src/controller/registry"
+	"github.com/goharbor/harbor/src/lib/log"
+	"github.com/goharbor/harbor/src/lib/orm"
+	"github.com/goharbor/harbor/src/lib/q"
+)
+
+// registryCollectorName ...
+const registryCollectorName = "RegistryCollector"
+
+var (
+	registryInfo = typedDesc{
+		desc:      newDescWithLabels("", "registry_info", "Information about the registry", "name", "description", "type", "url", "insecure", "status"),
+		valueType: prometheus.GaugeValue,
+	}
+)
+
+// NewRegistryCollector ...
+func NewRegistryCollector() *RegistryCollector {
+	return &RegistryCollector{
+		regCtl: registry.Ctl,
+	}
+}
+
+// RegistryCollector ...
+type RegistryCollector struct {
+	regCtl registry.Controller
+}
+
+// Describe implements prometheus.Collector
+func (hrc RegistryCollector) Describe(c chan<- *prometheus.Desc) {
+	c <- registryInfo.Desc()
+}
+
+// Collect implements prometheus.Collector
+func (hrc RegistryCollector) Collect(c chan<- prometheus.Metric) {
+	registryMetrics := hrc.getInformation()
+	for _, metric := range registryMetrics {
+		c <- metric
+	}
+}
+
+// GetName returns the name of the registry collector
+func (hrc RegistryCollector) GetName() string {
+	return registryCollectorName
+}
+
+func (hrc RegistryCollector) getInformation() []prometheus.Metric {
+	if CacheEnabled() {
+		if cachedValue, ok := CacheGet(registryCollectorName); ok {
+			return cachedValue.([]prometheus.Metric)
+		}
+	}
+
+	var (
+		result []prometheus.Metric
+		ctx    = orm.Context()
+	)
+
+	regList, err := hrc.regCtl.List(ctx, q.New(q.KeyWords{}))
+	if err != nil {
+		log.Errorf("get public projects error: %v", err)
+		return result
+	}
+
+	for _, r := range regList {
+		// hrc.regCtl.IsHealthy(ctx, r)
+		result = append(result, registryInfo.MustNewConstMetric(1,
+			r.Name,
+			r.Description,
+			r.Type,
+			r.URL,
+			strconv.FormatBool(r.Insecure),
+			r.Status,
+		))
+	}
+
+	if CacheEnabled() {
+		CachePut(registryCollectorName, result)
+	}
+
+	return result
+}

--- a/src/pkg/exporter/statistics_collector.go
+++ b/src/pkg/exporter/statistics_collector.go
@@ -28,39 +28,41 @@ import (
 	"github.com/goharbor/harbor/src/pkg/systemartifact"
 )
 
+// StatisticsCollectorName ...
 const StatisticsCollectorName = "StatisticsCollector"
 
 var (
 	totalUsage = typedDesc{
-		desc:      newDescWithLables("", "statistics_total_storage_consumption", "Total storage used"),
+		desc:      newDescWithLabels("", "statistics_total_storage_consumption", "Total storage used"),
 		valueType: prometheus.GaugeValue,
 	}
 	totalProjectAmount = typedDesc{
-		desc:      newDescWithLables("", "statistics_total_project_amount", "Total amount of projects"),
+		desc:      newDescWithLabels("", "statistics_total_project_amount", "Total amount of projects"),
 		valueType: prometheus.GaugeValue,
 	}
 	publicProjectAmount = typedDesc{
-		desc:      newDescWithLables("", "statistics_public_project_amount", "Amount of public projects"),
+		desc:      newDescWithLabels("", "statistics_public_project_amount", "Amount of public projects"),
 		valueType: prometheus.GaugeValue,
 	}
 	privateProjectAmount = typedDesc{
-		desc:      newDescWithLables("", "statistics_private_project_amount", "Amount of private projects"),
+		desc:      newDescWithLabels("", "statistics_private_project_amount", "Amount of private projects"),
 		valueType: prometheus.GaugeValue,
 	}
 	totalRepoAmount = typedDesc{
-		desc:      newDescWithLables("", "statistics_total_repo_amount", "Total amount of repositories"),
+		desc:      newDescWithLabels("", "statistics_total_repo_amount", "Total amount of repositories"),
 		valueType: prometheus.GaugeValue,
 	}
 	publicRepoAmount = typedDesc{
-		desc:      newDescWithLables("", "statistics_public_repo_amount", "Amount of public repositories"),
+		desc:      newDescWithLabels("", "statistics_public_repo_amount", "Amount of public repositories"),
 		valueType: prometheus.GaugeValue,
 	}
 	privateRepoAmount = typedDesc{
-		desc:      newDescWithLables("", "statistics_private_repo_amount", "Amount of private repositories"),
+		desc:      newDescWithLabels("", "statistics_private_repo_amount", "Amount of private repositories"),
 		valueType: prometheus.GaugeValue,
 	}
 )
 
+// StatisticsCollector ...
 type StatisticsCollector struct {
 	proCtl            project.Controller
 	repoCtl           repository.Controller
@@ -68,6 +70,7 @@ type StatisticsCollector struct {
 	systemArtifactMgr systemartifact.Manager
 }
 
+// NewStatisticsCollector ...
 func NewStatisticsCollector() *StatisticsCollector {
 	return &StatisticsCollector{
 		blobCtl:           blob.Ctl,
@@ -77,10 +80,12 @@ func NewStatisticsCollector() *StatisticsCollector {
 	}
 }
 
+// GetName returns the name of the statistics collector
 func (g StatisticsCollector) GetName() string {
 	return StatisticsCollectorName
 }
 
+// Describe implements prometheus.Collector
 func (g StatisticsCollector) Describe(c chan<- *prometheus.Desc) {
 	c <- totalUsage.Desc()
 }

--- a/src/pkg/exporter/system_collector.go
+++ b/src/pkg/exporter/system_collector.go
@@ -31,7 +31,7 @@ const (
 
 var (
 	harborSysInfo = typedDesc{
-		desc: newDescWithLables("", "system_info", "Information of Harbor system",
+		desc: newDescWithLabels("", "system_info", "Information of Harbor system",
 			"auth_mode",
 			"harbor_version",
 			"self_registration"),


### PR DESCRIPTION
# Comprehensive Summary of your change

With this change all registries are exposed as metrics in the harbor-exporter component.

This looks like this:
```
# HELP harbor_registry_info Information about the registry
# TYPE harbor_registry_info gauge
harbor_registry_info{description="",insecure="false",name="dockerhub",status="healthy",type="docker-hub",url="https://hub.docker.com"} 1
```

# Issue being fixed
Fixes #17531

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [ ] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
