### PR TITLE
Fixed the type in DTR adapter info

### DIFF
--- a/src/pkg/reg/adapter/dtr/adapter.go
+++ b/src/pkg/reg/adapter/dtr/adapter.go
@@ -74,7 +74,7 @@ func newAdapter(registry *model.Registry) *adapter {
 // Info returns information of the registry
 func (a *adapter) Info() (*model.RegistryInfo, error) {
 	return &model.RegistryInfo{
-		Type: model.RegistryTypeAzureAcr,
+		Type: model.RegistryTypeDTR,
 		SupportedResourceTypes: []string{
 			model.ResourceTypeImage,
 		},


### PR DESCRIPTION
Thank you for contributing to Harbor!

# Comprehensive Summary of your change
Previously DTR adapter Info() method returned incorrect adapter type. Now it is fixed and the correct type is returned.

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
