### PR TITLE
feat: allow for configuring the docker hub registry endpoint via API

### DIFF
--- a/src/pkg/reg/adapter/dockerhub/adapter.go
+++ b/src/pkg/reg/adapter/dockerhub/adapter.go
@@ -119,7 +119,7 @@ func (a *adapter) Info() (*model.RegistryInfo, error) {
 func getAdapterInfo() *model.AdapterPattern {
 	info := &model.AdapterPattern{
 		EndpointPattern: &model.EndpointPattern{
-			EndpointType: model.EndpointPatternTypeFix,
+			EndpointType: model.EndpointPatternTypeStandard,
 			Endpoints: []*model.Endpoint{
 				{
 					Key:   "hub.docker.com",

--- a/src/pkg/reg/adapter/dockerhub/adapter.go
+++ b/src/pkg/reg/adapter/dockerhub/adapter.go
@@ -46,6 +46,13 @@ func newAdapter(registry *model.Registry) (adp.Adapter, error) {
 		return nil, err
 	}
 
+	var registryURL string
+	if registry.URL != baseURL {
+		registryURL = registry.URL
+	} else {
+		registryURL = defaultRegistryURL
+	}
+
 	return &adapter{
 		client:   client,
 		registry: registry,

--- a/src/pkg/reg/adapter/dockerhub/consts.go
+++ b/src/pkg/reg/adapter/dockerhub/consts.go
@@ -18,7 +18,7 @@ import "fmt"
 
 const (
 	baseURL             = "https://hub.docker.com"
-	registryURL         = "https://registry-1.docker.io"
+	defaultRegistryURL  = "https://registry-1.docker.io"
 	loginPath           = "/v2/users/login/"
 	listNamespacePath   = "/v2/repositories/namespaces"
 	createNamespacePath = "/v2/orgs/"

--- a/src/portal/src/app/base/left-side-nav/registries/create-edit-endpoint/create-edit-endpoint.component.spec.ts
+++ b/src/portal/src/app/base/left-side-nav/registries/create-edit-endpoint/create-edit-endpoint.component.spec.ts
@@ -523,7 +523,7 @@ describe('CreateEditEndpointComponent (inline template)', () => {
         },
         'docker-hub': {
             endpoint_pattern: {
-                endpoint_type: 'EndpointPatternTypeFix',
+                endpoint_type: 'EndpointPatternTypeStandard',
                 endpoints: [
                     {
                         key: 'hub.docker.com',

--- a/src/portal/src/app/base/left-side-nav/registries/endpoint.component.spec.ts
+++ b/src/portal/src/app/base/left-side-nav/registries/endpoint.component.spec.ts
@@ -513,7 +513,7 @@ describe('EndpointComponent (inline template)', () => {
         },
         'docker-hub': {
             endpoint_pattern: {
-                endpoint_type: 'EndpointPatternTypeFix',
+                endpoint_type: 'EndpointPatternTypeStandard',
                 endpoints: [
                     {
                         key: 'hub.docker.com',


### PR DESCRIPTION
## Comprehensive Summary of your change
This PR adds the possibility to change the registry endpoint of DockerHub via API. This is useful for Harbor instances that run in airgapped environments and have to go through a DMZ or use a reverse proxy to access DockerHub.

**Why not just use a normal Docker Registry type instead of the DockerHub adapter?**

Because of the logic for `library` images which only applies to the Registry Type DockerHub:
 https://github.com/goharbor/harbor/blob/8bf710a4059415096a2fe882af1ab019eb0079b6/src/server/middleware/repoproxy/proxy.go#L128-L144

By allowing to change the registry endpoint for DockerHub, those kinds of environments can still benefit from the `library` substitution logic.

Please indicate you've done the following:
- [X] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
