### PR TITLE
chore(build): remove docker-compose v1

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -16,7 +16,7 @@ Please specify the versions of following systems.
 
 - harbor version: [x.x.x]
 - docker engine version: [y.y.y]
-- docker-compose version: [z.z.z]
+- docker compose version: [z.z.z]
 
 **Additional context:**
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,7 +5,6 @@ env:
    POSTGRESQL_USR: postgres
    POSTGRESQL_PWD: root123
    POSTGRESQL_DATABASE: registry
-   DOCKER_COMPOSE_VERSION: 2.27.1
    HARBOR_ADMIN: admin
    HARBOR_ADMIN_PASSWD: Harbor12345
    CORE_SECRET: tempString
@@ -66,9 +65,6 @@ jobs:
           env
           #sudo apt install -y xvfb
           #xvfb-run ls
-          curl -L https://github.com/docker/compose/releases/download/v${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
-          chmod +x docker-compose
-          sudo mv docker-compose /usr/local/bin
           IP=`hostname -I | awk '{print $1}'`
           echo '{"insecure-registries" : ["'$IP':5000"]}' | sudo tee /etc/docker/daemon.json
           echo "IP=$IP" >> $GITHUB_ENV
@@ -129,11 +125,6 @@ jobs:
           pwd
           env
           df -h
-          #sudo apt install -y xvfb
-          #xvfb-run ls
-          curl -L https://github.com/docker/compose/releases/download/v${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
-          chmod +x docker-compose
-          sudo mv docker-compose /usr/local/bin
       - name: install
         run: |
           cd src/github.com/goharbor/harbor
@@ -184,11 +175,6 @@ jobs:
           pwd
           env
           df -h
-          #sudo apt install -y xvfb
-          #xvfb-run ls
-          curl -L https://github.com/docker/compose/releases/download/v${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
-          chmod +x docker-compose
-          sudo mv docker-compose /usr/local/bin
       - name: install
         run: |
           cd src/github.com/goharbor/harbor
@@ -208,7 +194,6 @@ jobs:
     env:
       APITEST_LDAP: true
     runs-on:
-      #- self-hosted
       - ubuntu-latest
     timeout-minutes: 100
     steps:
@@ -238,11 +223,6 @@ jobs:
           pwd
           env
           df -h
-          #sudo apt install -y xvfb
-          #xvfb-run ls
-          curl -L https://github.com/docker/compose/releases/download/v${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
-          chmod +x docker-compose
-          sudo mv docker-compose /usr/local/bin
       - name: install
         run: |
           cd src/github.com/goharbor/harbor
@@ -290,11 +270,6 @@ jobs:
           pwd
           env
           df -h
-          #sudo apt install -y xvfb
-          #xvfb-run ls
-          curl -L https://github.com/docker/compose/releases/download/v${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
-          chmod +x docker-compose
-          sudo mv docker-compose /usr/local/bin
           IP=`hostname -I | awk '{print $1}'`
           echo '{"insecure-registries" : ["'$IP':5000"]}' | sudo tee /etc/docker/daemon.json
           echo "IP=$IP" >> $GITHUB_ENV

--- a/.github/workflows/conformance_test.yml
+++ b/.github/workflows/conformance_test.yml
@@ -1,6 +1,4 @@
 name: CONFORMANCE_TEST
-env:
-  DOCKER_COMPOSE_VERSION: 1.23.0
 
 on:
   repository_dispatch:
@@ -40,9 +38,6 @@ jobs:
           pwd
           env
           df -h
-          curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
-          chmod +x docker-compose
-          sudo mv docker-compose /usr/local/bin
           IP=`hostname -I | awk '{print $1}'`
           echo '{"insecure-registries" : ["'$IP':5000"]}' | sudo tee /etc/docker/daemon.json
           echo "IP=$IP" >> $GITHUB_ENV

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -348,7 +348,7 @@ If you find a match, you can "subscribe" to it to get notified on updates. If yo
 
 When reporting issues, always include:
 
-* Version of docker engine and docker-compose
+* Version of docker engine and docker-compose-plugin
 * Configuration files of Harbor
 * Log files in /var/log/harbor/
 

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@
 #               remove the base images of Harbor images
 # cleanimage: 	remove Harbor images
 # cleandockercomposefile:
-#				remove specific version docker-compose
+#				remove specific version docker-compose file
 # cleanversiontag:
 #				cleanpackageremove specific version tag
 # cleanpackage: remove online/offline install package
@@ -133,7 +133,7 @@ DOCKERRMIMAGE=$(DOCKERCMD) rmi
 DOCKERPULL=$(DOCKERCMD) pull
 DOCKERIMAGES=$(DOCKERCMD) images
 DOCKERSAVE=$(DOCKERCMD) save
-DOCKERCOMPOSECMD=$(shell which docker-compose)
+DOCKERCOMPOSECMD=$(DOCKERCMD) compose
 DOCKERTAG=$(DOCKERCMD) tag
 
 # go parameters

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ For learning the architecture design of Harbor, check the document [Architecture
 
 **System requirements:**
 
-**On a Linux host:** docker 20.10.10-ce+ and docker-compose 1.18.0+ .
+**On a Linux host:** docker 20.10.10-ce+ and docker-compose-plugin 2.0.0+.
 
 Download binaries of **[Harbor release ](https://github.com/vmware/harbor/releases)** and follow **[Installation & Configuration Guide](https://goharbor.io/docs/latest/install-config/)** to install Harbor.
 

--- a/contrib/deploying_using_docker_machine.md
+++ b/contrib/deploying_using_docker_machine.md
@@ -45,13 +45,13 @@ $ docker-machine scp -r ./config harbor.mydomain.com:$PWD
 Next, build your Harbor images:
 
 ```
-$ docker-compose build
+$ docker compose build
 ```
 
 And finally, spin up your Harbor containers:
 
 ```
-$ docker-compose up -d
+$ docker compose up -d
 ```
 
 Now you should be able to browse `http://harbor.mydomain.com`.

--- a/make/checkenv.sh
+++ b/make/checkenv.sh
@@ -3,7 +3,7 @@
 set -o noglob
 set -e
 
-usage=$'Checking environment for harbor build and install. Include golang, docker and docker-compose.'
+usage=$'Checking environment for harbor build and install. Including golang and docker.'
 
 while [ $# -gt 0 ]; do
         case $1 in

--- a/make/common.sh
+++ b/make/common.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #docker version: 20.10.10+
-#docker-compose version: 1.18.0+
+#docker compose version: 2.0.0+
 #golang version: 1.12.0+
 
 set +e
@@ -103,34 +103,18 @@ function check_docker {
 }
 
 function check_dockercompose {
-	if [! docker compose version] &> /dev/null || [! docker-compose --version] &> /dev/null
+	if [! docker compose --version] &> /dev/null
 	then
-		error "Need to install docker-compose(1.18.0+) or a docker-compose-plugin (https://docs.docker.com/compose/)by yourself first and run this script again."
+		error "Need to install docker-compose-plugin (https://docs.docker.com/compose/)by yourself first and run this script again."
 		exit 1
 	fi
 
-	# either docker compose plugin has been installed
 	if docker compose version &> /dev/null
 	then
 		note "$(docker compose version)"
 		DOCKER_COMPOSE="docker compose"
-
-	# or docker-compose has been installed, check its version
-	elif [[ $(docker-compose --version) =~ (([0-9]+)\.([0-9]+)([\.0-9]*)) ]]
-	then
-		docker_compose_version=${BASH_REMATCH[1]}
-		docker_compose_version_part1=${BASH_REMATCH[2]}
-		docker_compose_version_part2=${BASH_REMATCH[3]}
-
-		note "docker-compose version: $docker_compose_version"
-		# the version of docker-compose does not meet the requirement
-		if [ "$docker_compose_version_part1" -lt 1 ] || ([ "$docker_compose_version_part1" -eq 1 ] && [ "$docker_compose_version_part2" -lt 18 ])
-		then
-			error "Need to upgrade docker-compose package to 1.18.0+."
-			exit 1
-		fi
 	else
-		error "Failed to parse docker-compose version."
+		error "Failed to parse docker compose version."
 		exit 1
 	fi
 }

--- a/make/install.sh
+++ b/make/install.sh
@@ -18,8 +18,7 @@ with_clair=$false
 # trivy is not enabled by default
 with_trivy=$false
 
-# flag to using docker compose v1 or v2, default would using v1 docker-compose
-DOCKER_COMPOSE=docker-compose
+DOCKER_COMPOSE=docker compose
 
 while [ $# -gt 0 ]; do
         case $1 in
@@ -41,7 +40,7 @@ cd $workdir
 h2 "[Step $item]: checking if docker is installed ..."; let item+=1
 check_docker
 
-h2 "[Step $item]: checking docker-compose is installed ..."; let item+=1
+h2 "[Step $item]: checking docker compose is installed ..."; let item+=1
 check_dockercompose
 
 if [ -f harbor*.tar.gz ]

--- a/tests/ci/ut_run.sh
+++ b/tests/ci/ut_run.sh
@@ -9,7 +9,7 @@ export CHROME_BIN=chromium-browser
 #export DISPLAY=:99.0
 #sh -e /etc/init.d/xvfb start
 
-sudo docker-compose -f ./make/docker-compose.test.yml up -d
+sudo docker compose -f ./make/docker-compose.test.yml up -d
 sleep 10
 ./tests/pushimage.sh
 docker ps

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -17,7 +17,7 @@ set -x
 gsutil version -l
 set +x
 
-docker-compose version
+docker compose version
 
 ## -------------------------------------------- Pre-condition --------------------------------------------
 if [[ $DRONE_REPO != "goharbor/harbor" ]]; then


### PR DESCRIPTION
## Motivation
The docker-compose-plugin v2 was released over two years ago and has been available on all major linux distros since docker v20.10.13 in march 2022. V1 has been deprecated since july 2023.

Therefore support for v1 even if it still works shouldn't be continued in my opinion.

## Description of changes

- Remove all `docker-compose` references and replace with `docker compose` plugin
- Remove all references to v1
- Remove installation of docker compose in the CI as it is already a package on the ubuntu runners provided by GitHub: 
https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2004-Readme.md#tools
https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md#tools
https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md#tools

Please indicate you've done the following:
- [X] Well Written Title and Summary of the PR
- [-] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [X] Accepted the DCO. Commits without the DCO will delay acceptance.
- [X] Made sure tests are passing and test coverage is added if needed.
- [X] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
