### PR TITLE
feat(make): restructure makefile for ease of use

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,56 +2,6 @@
 #
 # Targets:
 #
-# all:			prepare env, compile binaries, build images and install images
-# prepare: 		prepare env
-# compile: 		compile core and jobservice code
-#
-# compile_golangimage:
-#			compile from golang image
-#			for example: make compile_golangimage -e GOBUILDIMAGE= \
-#							golang:1.18.5
-# compile_core, compile_jobservice: compile specific binary
-#
-# build:	build Harbor docker images from photon baseimage
-#
-# install:		include compile binaries, build images, prepare specific \
-#				version composefile and startup Harbor instance
-#
-# start:		startup Harbor instance
-#
-# down:			shutdown Harbor instance
-#
-# package_online:
-#				prepare online install package
-#			for example: make package_online -e DEVFLAG=false\
-#							REGISTRYSERVER=reg-bj.goharbor.io \
-#							REGISTRYPROJECTNAME=harborrelease
-#
-# package_offline:
-#				prepare offline install package
-#
-# pushimage:	push Harbor images to specific registry server
-#			for example: make pushimage -e DEVFLAG=false REGISTRYUSER=admin \
-#							REGISTRYPASSWORD=***** \
-#							REGISTRYSERVER=reg-bj.goharbor.io/ \
-#							REGISTRYPROJECTNAME=harborrelease
-#				note**: need add "/" on end of REGISTRYSERVER. If not setting \
-#						this value will push images directly to dockerhub.
-#						 make pushimage -e DEVFLAG=false REGISTRYUSER=goharbor \
-#							REGISTRYPASSWORD=***** \
-#							REGISTRYPROJECTNAME=goharbor
-#
-# clean:        remove binary, Harbor images, specific version docker-compose \
-#               file, specific version tag and online/offline install package
-# cleanbinary:	remove core and jobservice binary
-# cleanbaseimage:
-#               remove the base images of Harbor images
-# cleanimage: 	remove Harbor images
-# cleandockercomposefile:
-#				remove specific version docker-compose
-# cleanversiontag:
-#				cleanpackageremove specific version tag
-# cleanpackage: remove online/offline install package
 #
 # other example:
 #	clean specific version binaries and images:
@@ -62,6 +12,34 @@
 #   By default DEVFLAG=true, if you want to release new version of Harbor, \
 #		should setting the flag to false.
 #				make XXXX -e DEVFLAG=false
+
+#!/usr/bin/env bash
+
+#
+# Makefile with some common workflow for dev, build and test
+#
+
+##@ General
+
+# The help target prints out all targets with their descriptions organized
+# beneath their categories. The categories are represented by '##@' and the
+# target descriptions by '##'. The awk command is responsible for reading the
+# entire set of makefiles included in this invocation, looking for lines of the
+# file as xyz: ## something, and then pretty-format the target and help. Then,
+# if there's a line with ##@ something, that gets pretty-printed as a category.
+# More info on the usage of ANSI control characters for terminal formatting:
+# https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_parameters
+# More info on the awk command:
+# http://linuxcommand.org/lc3_adv_awk.php
+
+# The following help command is Licensed under the Apache License, Version 2.0 (the "License")
+# Copyright 2023 The Kubernetes Authors.
+.PHONY: help
+help: ## Display this help
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+
+.PHONY: all
+all: install ## prepare env, compile binaries, build images and install images
 
 SHELL := /bin/bash
 BUILDPATH=$(CURDIR)
@@ -225,18 +203,6 @@ ifeq ($(shell uname),Darwin)
     SEDCMDI=$(SEDCMD) -i ''
 endif
 
-# package
-TARCMD=$(shell which tar)
-ZIPCMD=$(shell which gzip)
-DOCKERIMGFILE=harbor
-HARBORPKG=harbor
-
-# pull/push image
-PUSHSCRIPTPATH=$(MAKEPATH)
-PUSHSCRIPTNAME=pushimage.sh
-REGISTRYUSER=
-REGISTRYPASSWORD=
-
 # cmds
 DOCKERSAVE_PARA=$(DOCKER_IMAGE_NAME_PREPARE):$(VERSIONTAG) \
 		$(DOCKERIMAGENAME_PORTAL):$(VERSIONTAG) \
@@ -250,20 +216,6 @@ DOCKERSAVE_PARA=$(DOCKER_IMAGE_NAME_PREPARE):$(VERSIONTAG) \
 		$(IMAGENAMESPACE)/nginx-photon:$(VERSIONTAG) \
 		$(IMAGENAMESPACE)/registry-photon:$(VERSIONTAG)
 
-PACKAGE_OFFLINE_PARA=-zcvf harbor-offline-installer-$(PKGVERSIONTAG).tgz \
-					$(HARBORPKG)/$(DOCKERIMGFILE).$(VERSIONTAG).tar.gz \
-					$(HARBORPKG)/prepare \
-					$(HARBORPKG)/LICENSE $(HARBORPKG)/install.sh \
-					$(HARBORPKG)/common.sh \
-					$(HARBORPKG)/harbor.yml.tmpl
-
-PACKAGE_ONLINE_PARA=-zcvf harbor-online-installer-$(PKGVERSIONTAG).tgz \
-					$(HARBORPKG)/prepare \
-					$(HARBORPKG)/LICENSE \
-					$(HARBORPKG)/install.sh \
-					$(HARBORPKG)/common.sh \
-					$(HARBORPKG)/harbor.yml.tmpl
-
 DOCKERCOMPOSE_FILE_OPT=-f $(DOCKERCOMPOSEFILEPATH)/$(DOCKERCOMPOSEFILENAME)
 
 ifeq ($(TRIVYFLAG), true)
@@ -272,110 +224,16 @@ endif
 
 
 RUNCONTAINER=$(DOCKERCMD) run --rm -u $(shell id -u):$(shell id -g) -v $(BUILDPATH):$(BUILDPATH) -w $(BUILDPATH)
+##@ Build
 
-# $1 the name of the docker image
-# $2 the tag of the docker image
-# $3 the command to build the docker image
-define prepare_docker_image
-	@if [ "$(shell ${DOCKERIMAGES} -q $(1):$(2) 2> /dev/null)" == "" ]; then \
-		$(3) && echo "build $(1):$(2) successfully" || (echo "build $(1):$(2) failed" && exit 1) ; \
-	fi
-endef
+.PHONY: install
+install: compile build prepare start ## Compile binaries, build images, prepare env and start Harbor instance
 
-# lint swagger doc
-SPECTRAL_IMAGENAME=$(IMAGENAMESPACE)/spectral
-SPECTRAL_VERSION=v6.14.2
-SPECTRAL_IMAGE_BUILD_CMD=${DOCKERBUILD} -f ${TOOLSPATH}/spectral/Dockerfile --build-arg NODE=${NODEBUILDIMAGE} --build-arg SPECTRAL_VERSION=${SPECTRAL_VERSION} -t ${SPECTRAL_IMAGENAME}:$(SPECTRAL_VERSION) .
-SPECTRAL=$(RUNCONTAINER) $(SPECTRAL_IMAGENAME):$(SPECTRAL_VERSION)
+.PHONY: compile
+compile: check_environment versions_prepare compile_core compile_jobservice compile_registryctl ## Compile core and jobservice code
 
-lint_apis:
-	$(call prepare_docker_image,${SPECTRAL_IMAGENAME},${SPECTRAL_VERSION},${SPECTRAL_IMAGE_BUILD_CMD})
-	$(SPECTRAL) lint ./api/v2.0/swagger.yaml
-
-SWAGGER_IMAGENAME=$(IMAGENAMESPACE)/swagger
-SWAGGER_VERSION=v0.31.0
-SWAGGER=$(RUNCONTAINER) ${SWAGGER_IMAGENAME}:${SWAGGER_VERSION}
-SWAGGER_GENERATE_SERVER=${SWAGGER} generate server --template-dir=$(TOOLSPATH)/swagger/templates --exclude-main --additional-initialism=CVE --additional-initialism=GC --additional-initialism=OIDC
-SWAGGER_IMAGE_BUILD_CMD=${DOCKERBUILD} -f ${TOOLSPATH}/swagger/Dockerfile --build-arg GOLANG=${GOBUILDIMAGE} --build-arg SWAGGER_VERSION=${SWAGGER_VERSION} -t ${SWAGGER_IMAGENAME}:$(SWAGGER_VERSION) .
-
-# $1 the path of swagger spec
-# $2 the path of base directory for generating the files
-# $3 the name of the application
-define swagger_generate_server
-	@echo "generate all the files for API from $(1)"
-	@rm -rf $(2)/{models,restapi}
-	@mkdir -p $(2)
-	@$(SWAGGER_GENERATE_SERVER) -f $(1) -A $(3) --target $(2)
-endef
-
-gen_apis: lint_apis
-	$(call prepare_docker_image,${SWAGGER_IMAGENAME},${SWAGGER_VERSION},${SWAGGER_IMAGE_BUILD_CMD})
-	$(call swagger_generate_server,api/v2.0/swagger.yaml,src/server/v2.0,harbor)
-
-
-MOCKERY_IMAGENAME=$(IMAGENAMESPACE)/mockery
-MOCKERY_VERSION=v2.51.0
-MOCKERY=$(RUNCONTAINER)/src ${MOCKERY_IMAGENAME}:${MOCKERY_VERSION}
-MOCKERY_IMAGE_BUILD_CMD=${DOCKERBUILD} -f ${TOOLSPATH}/mockery/Dockerfile --build-arg GOLANG=${GOBUILDIMAGE} --build-arg MOCKERY_VERSION=${MOCKERY_VERSION} -t ${MOCKERY_IMAGENAME}:$(MOCKERY_VERSION) .
-
-gen_mocks:
-	$(call prepare_docker_image,${MOCKERY_IMAGENAME},${MOCKERY_VERSION},${MOCKERY_IMAGE_BUILD_CMD})
-	${MOCKERY} mockery
-
-mocks_check: gen_mocks
-	@echo checking mocks...
-	@res=$$(git status -s src/ | awk '{ printf("%s\n", $$2) }' | egrep .*.go); \
-	if [ -n "$${res}" ]; then \
-		echo mocks of the interface are out of date... ; \
-		echo "$${res}"; \
-		exit 1; \
-	fi
-
-export VERSIONS_FOR_PREPARE
-versions_prepare:
-	@echo "$$VERSIONS_FOR_PREPARE" > $(MAKE_PREPARE_PATH)/$(PREPARE_VERSION_NAME)
-
-check_environment:
-	@$(MAKEPATH)/$(CHECKENVCMD)
-
-compile_core: gen_apis
-	@echo "compiling binary for core (golang image)..."
-	@echo $(GOBUILDPATHINCONTAINER)
-	@$(DOCKERCMD) run --rm -v $(BUILDPATH):$(GOBUILDPATHINCONTAINER) -w $(GOBUILDPATH_CORE) $(GOBUILDIMAGE) $(GOIMAGEBUILD_CORE) -o $(GOBUILDPATHINCONTAINER)/$(GOBUILDMAKEPATH_CORE)/$(CORE_BINARYNAME)
-	@echo "Done."
-
-compile_jobservice:
-	@echo "compiling binary for jobservice (golang image)..."
-	@$(DOCKERCMD) run --rm -v $(BUILDPATH):$(GOBUILDPATHINCONTAINER) -w $(GOBUILDPATH_JOBSERVICE) $(GOBUILDIMAGE) $(GOIMAGEBUILD_COMMON) -o $(GOBUILDPATHINCONTAINER)/$(GOBUILDMAKEPATH_JOBSERVICE)/$(JOBSERVICEBINARYNAME)
-	@echo "Done."
-
-compile_registryctl:
-	@echo "compiling binary for harbor registry controller (golang image)..."
-	@$(DOCKERCMD) run --rm -v $(BUILDPATH):$(GOBUILDPATHINCONTAINER) -w $(GOBUILDPATH_REGISTRYCTL) $(GOBUILDIMAGE) $(GOIMAGEBUILD_COMMON) -o $(GOBUILDPATHINCONTAINER)/$(GOBUILDMAKEPATH_REGISTRYCTL)/$(REGISTRYCTLBINARYNAME)
-	@echo "Done."
-
-compile_standalone_db_migrator:
-	@echo "compiling binary for standalone db migrator (golang image)..."
-	@$(DOCKERCMD) run --rm -v $(BUILDPATH):$(GOBUILDPATHINCONTAINER) -w $(GOBUILDPATH_STANDALONE_DB_MIGRATOR) $(GOBUILDIMAGE) $(GOIMAGEBUILD_COMMON) -o $(GOBUILDPATHINCONTAINER)/$(GOBUILDMAKEPATH_STANDALONE_DB_MIGRATOR)/$(STANDALONE_DB_MIGRATOR_BINARYNAME)
-	@echo "Done."
-
-compile: check_environment versions_prepare compile_core compile_jobservice compile_registryctl
-
-update_prepare_version:
-	@echo "substitute the prepare version tag in prepare file..."
-	@$(SEDCMDI) -e 's/goharbor\/prepare:.*[[:space:]]\+/goharbor\/prepare:$(VERSIONTAG) prepare /' $(MAKEPATH)/prepare ;
-
-gen_tls:
-	@$(DOCKERCMD) run --rm -v /:/hostfs:z $(IMAGENAMESPACE)/prepare:$(VERSIONTAG) gencert -p /etc/harbor/tls/internal
-
-prepare: update_prepare_version
-	@echo "preparing..."
-	@if [ -n "$(GEN_TLS)" ] ; then \
-		$(DOCKERCMD) run --rm -v /:/hostfs:z $(IMAGENAMESPACE)/prepare:$(VERSIONTAG) gencert -p /etc/harbor/tls/internal; \
-	fi
-	@$(MAKEPATH)/$(PREPARECMD) $(PREPARECMD_PARA)
-
-build:
+.PHONY: build
+build:	## Build Harbor docker images from photon baseimage
 # PUSHBASEIMAGE should not be true if BUILD_BASE is not true
 	@if [ "$(PULL_BASE_FROM_DOCKERHUB)" != "true" ] && [ "$(PULL_BASE_FROM_DOCKERHUB)" != "false" ] ; then \
 		echo set PULL_BASE_FROM_DOCKERHUB to true or false.; exit 1; \
@@ -401,10 +259,12 @@ build:
 	 -e REGISTRYUSER=$(REGISTRYUSER) -e REGISTRYPASSWORD=$(REGISTRYPASSWORD) \
 	 -e PUSHBASEIMAGE=$(PUSHBASEIMAGE)
 
-build_standalone_db_migrator: compile_standalone_db_migrator
+.PHONY: build_standalone_db_migrator
+build_standalone_db_migrator: compile_standalone_db_migrator ## Build only the db migrator
 	make -f $(MAKEFILEPATH_PHOTON)/Makefile _build_standalone_db_migrator -e BASEIMAGETAG=$(BASEIMAGETAG) -e VERSIONTAG=$(VERSIONTAG)
 
-build_base_docker:
+.PHONY: build_base_docker
+build_base_docker: ## Build only the docker base image
 	if [ -n "$(REGISTRYUSER)" ] && [ -n "$(REGISTRYPASSWORD)" ] ; then \
 		docker login -u $(REGISTRYUSER) -p $(REGISTRYPASSWORD) ; \
 	else \
@@ -419,15 +279,57 @@ build_base_docker:
 		fi ; \
 	done
 
-pull_base_docker:
-	@for name in $(BUILDBASETARGET); do \
-		echo $$name ; \
-		$(DOCKERPULL) $(BASEIMAGENAMESPACE)/harbor-$$name-base:$(BASEIMAGETAG) ; \
-	done
+.PHONY: compile_core
+compile_core: gen_apis ## Compile the core binary
+	@echo "compiling binary for core (golang image)..."
+	@echo $(GOBUILDPATHINCONTAINER)
+	@$(DOCKERCMD) run --rm -v $(BUILDPATH):$(GOBUILDPATHINCONTAINER) -w $(GOBUILDPATH_CORE) $(GOBUILDIMAGE) $(GOIMAGEBUILD_CORE) -o $(GOBUILDPATHINCONTAINER)/$(GOBUILDMAKEPATH_CORE)/$(CORE_BINARYNAME)
+	@echo "Done."
 
-install: compile build prepare start
+.PHONY: compile_jobservice
+compile_jobservice: ## Compile jobservice binary
+	@echo "compiling binary for jobservice (golang image)..."
+	@$(DOCKERCMD) run --rm -v $(BUILDPATH):$(GOBUILDPATHINCONTAINER) -w $(GOBUILDPATH_JOBSERVICE) $(GOBUILDIMAGE) $(GOIMAGEBUILD_COMMON) -o $(GOBUILDPATHINCONTAINER)/$(GOBUILDMAKEPATH_JOBSERVICE)/$(JOBSERVICEBINARYNAME)
+	@echo "Done."
 
-package_online: update_prepare_version
+.PHONY: compile_registryctl
+compile_registryctl: ## Compile registryctl binary
+	@echo "compiling binary for harbor registry controller (golang image)..."
+	@$(DOCKERCMD) run --rm -v $(BUILDPATH):$(GOBUILDPATHINCONTAINER) -w $(GOBUILDPATH_REGISTRYCTL) $(GOBUILDIMAGE) $(GOIMAGEBUILD_COMMON) -o $(GOBUILDPATHINCONTAINER)/$(GOBUILDMAKEPATH_REGISTRYCTL)/$(REGISTRYCTLBINARYNAME)
+	@echo "Done."
+
+.PHONY: compile_standalone_db_migrator
+compile_standalone_db_migrator: ## Compile standalone db-migrator binary
+	@echo "compiling binary for standalone db migrator (golang image)..."
+	@$(DOCKERCMD) run --rm -v $(BUILDPATH):$(GOBUILDPATHINCONTAINER) -w $(GOBUILDPATH_STANDALONE_DB_MIGRATOR) $(GOBUILDIMAGE) $(GOIMAGEBUILD_COMMON) -o $(GOBUILDPATHINCONTAINER)/$(GOBUILDMAKEPATH_STANDALONE_DB_MIGRATOR)/$(STANDALONE_DB_MIGRATOR_BINARYNAME)
+	@echo "Done."
+
+##@ Package
+
+TARCMD=$(shell which tar)
+ZIPCMD=$(shell which gzip)
+DOCKERIMGFILE=harbor
+HARBORPKG=harbor
+
+PACKAGE_OFFLINE_PARA=-zcvf harbor-offline-installer-$(PKGVERSIONTAG).tgz \
+					$(HARBORPKG)/$(DOCKERIMGFILE).$(VERSIONTAG).tar.gz \
+					$(HARBORPKG)/prepare \
+					$(HARBORPKG)/LICENSE $(HARBORPKG)/install.sh \
+					$(HARBORPKG)/common.sh \
+					$(HARBORPKG)/harbor.yml.tmpl
+
+PACKAGE_ONLINE_PARA=-zcvf harbor-online-installer-$(PKGVERSIONTAG).tgz \
+					$(HARBORPKG)/prepare \
+					$(HARBORPKG)/LICENSE \
+					$(HARBORPKG)/install.sh \
+					$(HARBORPKG)/common.sh \
+					$(HARBORPKG)/harbor.yml.tmpl
+
+.PHONY: package_online
+package_online: update_prepare_version ## Prepare online install package
+	# For example: make package_online -e DEVFLAG=false
+	#                                     REGISTRYSERVER=reg-bj.goharbor.io
+	#                                     REGISTRYPROJECTNAME=harborrelease
 	@echo "packing online package ..."
 	@cp -r make $(HARBORPKG)
 	@if [ -n "$(REGISTRYSERVER)" ] ; then \
@@ -440,7 +342,8 @@ package_online: update_prepare_version
 	@rm -rf $(HARBORPKG)
 	@echo "Done."
 
-package_offline: update_prepare_version compile build
+.PHONY: package_offline
+package_offline: update_prepare_version compile build ## Prepare offline install package
 
 	@echo "packing offline package ..."
 	@cp -r make $(HARBORPKG)
@@ -454,38 +357,24 @@ package_offline: update_prepare_version compile build
 	@rm -rf $(HARBORPKG)
 	@echo "Done."
 
-go_check: gen_apis mocks_check misspell commentfmt lint
+##@ Publish
 
-commentfmt:
-	@echo checking comment format...
-	@res=$$(find . -type d \( -path ./tests \) -prune -o -name '*.go' -print | xargs egrep '(^|\s)\/\/(\S)'|grep -v '//go:generate'); \
-	if [ -n "$${res}" ]; then \
-		echo checking comment format fail.. ; \
-		echo missing whitespace between // and comment body;\
-		echo "$${res}"; \
-		exit 1; \
-	fi
+PUSHSCRIPTPATH=$(MAKEPATH)
+PUSHSCRIPTNAME=pushimage.sh
+REGISTRYUSER=
+REGISTRYPASSWORD=
 
-misspell:
-	@echo checking misspell...
-	@find . -type d \( -path ./tests \) -prune -o -name '*.go' -print | xargs misspell -error
-
-# golangci-lint binary installation or refer to https://golangci-lint.run/usage/install/#local-installation
-# curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.55.2
-GOLANGCI_LINT := $(shell go env GOPATH)/bin/golangci-lint
-lint:
-	@echo checking lint
-	@echo $(GOLANGCI_LINT)
-	@cd ./src/; $(GOLANGCI_LINT) cache clean; $(GOLANGCI_LINT) -v run ./... --timeout=10m;
-
-# go install golang.org/x/vuln/cmd/govulncheck@latest
-GOVULNCHECK := $(shell go env GOPATH)/bin/govulncheck
-govulncheck:
-	@echo golang vulnerability check
-	@cd ./src/; $(GOVULNCHECK) ./...;
-
-
-pushimage:
+.PHONY: pushimage
+pushimage: ## Push Harbor images to specific registry server
+	# For example: make pushimage -e DEVFLAG=false REGISTRYUSER=admin \
+	#  				REGISTRYPASSWORD=***** \
+	#  				REGISTRYSERVER=reg-bj.goharbor.io/ \
+	#  				REGISTRYPROJECTNAME=harborrelease
+	#  	note**: need add "/" on end of REGISTRYSERVER. If not setting \
+	#  			this value will push images directly to dockerhub.
+	#  			 make pushimage -e DEVFLAG=false REGISTRYUSER=goharbor \
+	#  				REGISTRYPASSWORD=***** \
+	#  				REGISTRYPROJECTNAME=goharbor
 	@echo "pushing harbor images ..."
 	@$(DOCKERTAG) $(DOCKER_IMAGE_NAME_PREPARE):$(VERSIONTAG) $(REGISTRYSERVER)$(DOCKER_IMAGE_NAME_PREPARE):$(VERSIONTAG)
 	@$(PUSHSCRIPTPATH)/$(PUSHSCRIPTNAME) $(REGISTRYSERVER)$(DOCKER_IMAGE_NAME_PREPARE):$(VERSIONTAG) \
@@ -517,23 +406,40 @@ pushimage:
 		$(REGISTRYUSER) $(REGISTRYPASSWORD) $(REGISTRYSERVER)
 	@$(DOCKERRMIMAGE) $(REGISTRYSERVER)$(DOCKERIMAGENAME_DB):$(VERSIONTAG)
 
-start:
-	@echo "loading harbor images..."
-	@$(DOCKERCOMPOSECMD) $(DOCKERCOMPOSE_FILE_OPT) up -d
-	@echo "Start complete. You can visit harbor now."
 
-down:
-	@while [ -z "$$CONTINUE" ]; do \
-        read -r -p "Type anything but Y or y to exit. [Y/N]: " CONTINUE; \
-    done ; \
-    [ $$CONTINUE = "y" ] || [ $$CONTINUE = "Y" ] || (echo "Exiting."; exit 1;)
-	@echo "stoping harbor instance..."
-	@$(DOCKERCOMPOSECMD) $(DOCKERCOMPOSE_FILE_OPT) down -v
-	@echo "Done."
+##@ Utility
 
-restart: down prepare start
+.PHONY: prepare
+prepare: update_prepare_version ## Prepare environment for starting a Harbor instance
+	@echo "preparing..."
+	@if [ -n "$(GEN_TLS)" ] ; then \
+		$(DOCKERCMD) run --rm -v /:/hostfs:z $(IMAGENAMESPACE)/prepare:$(VERSIONTAG) gencert -p /etc/harbor/tls/internal; \
+	fi
+	@$(MAKEPATH)/$(PREPARECMD) $(PREPARECMD_PARA)
 
-swagger_client:
+.PHONY: update_prepare_version
+update_prepare_version:
+	@echo "substitute the prepare version tag in prepare file..."
+	@$(SEDCMDI) -e 's/goharbor\/prepare:.*[[:space:]]\+/goharbor\/prepare:$(VERSIONTAG) prepare /' $(MAKEPATH)/prepare ;
+
+# $1 the name of the docker image
+# $2 the tag of the docker image
+# $3 the command to build the docker image
+define prepare_docker_image
+	@if [ "$(shell ${DOCKERIMAGES} -q $(1):$(2) 2> /dev/null)" == "" ]; then \
+		$(3) && echo "build $(1):$(2) successfully" || (echo "build $(1):$(2) failed" && exit 1) ; \
+	fi
+endef
+
+.PHONY: pull_base_docker
+pull_base_docker: ## Pull base docker image
+	@for name in $(BUILDBASETARGET); do \
+		echo $$name ; \
+		$(DOCKERPULL) $(BASEIMAGENAMESPACE)/harbor-$$name-base:$(BASEIMAGETAG) ; \
+	done
+
+.PHONY: swagger_client
+swagger_client: ## Generate swagger client
 	@echo "Generate swagger client"
 	wget https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/4.3.1/openapi-generator-cli-4.3.1.jar -O openapi-generator-cli.jar
 	rm -rf harborclient
@@ -543,32 +449,160 @@ swagger_client:
 	pip install docker -q
 	pip freeze
 
-cleanbinary:
+
+# lint swagger doc
+SPECTRAL_IMAGENAME=$(IMAGENAMESPACE)/spectral
+SPECTRAL_VERSION=v6.14.2
+SPECTRAL_IMAGE_BUILD_CMD=${DOCKERBUILD} -f ${TOOLSPATH}/spectral/Dockerfile --build-arg NODE=${NODEBUILDIMAGE} --build-arg SPECTRAL_VERSION=${SPECTRAL_VERSION} -t ${SPECTRAL_IMAGENAME}:$(SPECTRAL_VERSION) .
+SPECTRAL=$(RUNCONTAINER) $(SPECTRAL_IMAGENAME):$(SPECTRAL_VERSION)
+
+.PHONY: lint_apis
+lint_apis: ## Lint Swagger API
+	$(call prepare_docker_image,${SPECTRAL_IMAGENAME},${SPECTRAL_VERSION},${SPECTRAL_IMAGE_BUILD_CMD})
+	$(SPECTRAL) lint ./api/v2.0/swagger.yaml
+
+SWAGGER_IMAGENAME=$(IMAGENAMESPACE)/swagger
+SWAGGER_VERSION=v0.31.0
+SWAGGER=$(RUNCONTAINER) ${SWAGGER_IMAGENAME}:${SWAGGER_VERSION}
+SWAGGER_GENERATE_SERVER=${SWAGGER} generate server --template-dir=$(TOOLSPATH)/swagger/templates --exclude-main --additional-initialism=CVE --additional-initialism=GC --additional-initialism=OIDC
+SWAGGER_IMAGE_BUILD_CMD=${DOCKERBUILD} -f ${TOOLSPATH}/swagger/Dockerfile --build-arg GOLANG=${GOBUILDIMAGE} --build-arg SWAGGER_VERSION=${SWAGGER_VERSION} -t ${SWAGGER_IMAGENAME}:$(SWAGGER_VERSION) .
+
+# $1 the path of swagger spec
+# $2 the path of base directory for generating the files
+# $3 the name of the application
+define swagger_generate_server
+	@echo "generate all the files for API from $(1)"
+	@rm -rf $(2)/{models,restapi}
+	@mkdir -p $(2)
+	@$(SWAGGER_GENERATE_SERVER) -f $(1) -A $(3) --target $(2)
+endef
+
+.PHONY: gen_apis
+gen_apis: lint_apis ## Generate Swagger API
+	$(call prepare_docker_image,${SWAGGER_IMAGENAME},${SWAGGER_VERSION},${SWAGGER_IMAGE_BUILD_CMD})
+	$(call swagger_generate_server,api/v2.0/swagger.yaml,src/server/v2.0,harbor)
+
+
+MOCKERY_IMAGENAME=$(IMAGENAMESPACE)/mockery
+MOCKERY_VERSION=v2.51.0
+MOCKERY=$(RUNCONTAINER)/src ${MOCKERY_IMAGENAME}:${MOCKERY_VERSION}
+MOCKERY_IMAGE_BUILD_CMD=${DOCKERBUILD} -f ${TOOLSPATH}/mockery/Dockerfile --build-arg GOLANG=${GOBUILDIMAGE} --build-arg MOCKERY_VERSION=${MOCKERY_VERSION} -t ${MOCKERY_IMAGENAME}:$(MOCKERY_VERSION) .
+
+.PHONY: gen_mocks
+gen_mocks: ## Generate Mocks
+	$(call prepare_docker_image,${MOCKERY_IMAGENAME},${MOCKERY_VERSION},${MOCKERY_IMAGE_BUILD_CMD})
+	${MOCKERY} mockery
+
+.PHONY: mocks_check
+mocks_check: gen_mocks ## Check generated mocks
+	@echo checking mocks...
+	@res=$$(git status -s src/ | awk '{ printf("%s\n", $$2) }' | egrep .*.go); \
+	if [ -n "$${res}" ]; then \
+		echo mocks of the interface are out of date... ; \
+		echo "$${res}"; \
+		exit 1; \
+	fi
+
+export VERSIONS_FOR_PREPARE
+versions_prepare:
+	@echo "$$VERSIONS_FOR_PREPARE" > $(MAKE_PREPARE_PATH)/$(PREPARE_VERSION_NAME)
+
+check_environment:
+	@$(MAKEPATH)/$(CHECKENVCMD)
+
+gen_tls:
+	@$(DOCKERCMD) run --rm -v /:/hostfs:z $(IMAGENAMESPACE)/prepare:$(VERSIONTAG) gencert -p /etc/harbor/tls/internal
+
+##@ Instance controls
+start: ## Startup Harbor instance
+	@echo "loading harbor images..."
+	@$(DOCKERCOMPOSECMD) $(DOCKERCOMPOSE_FILE_OPT) up -d
+	@echo "Start complete. You can visit harbor now."
+
+down: ## Shutdown Harbor instance
+	@while [ -z "$$CONTINUE" ]; do \
+        read -r -p "Type anything but Y or y to exit. [Y/N]: " CONTINUE; \
+    done ; \
+    [ $$CONTINUE = "y" ] || [ $$CONTINUE = "Y" ] || (echo "Exiting."; exit 1;)
+	@echo "stoping harbor instance..."
+	@$(DOCKERCOMPOSECMD) $(DOCKERCOMPOSE_FILE_OPT) down -v
+	@echo "Done."
+
+restart: down prepare start ## Restart Harbor instance
+
+##@ Code Quality
+
+.PHONY: go_check
+go_check: gen_apis mocks_check misspell commentfmt lint ## Run all of the following golang checks
+
+.PHONY: commentfmt
+commentfmt: ## Check comment formatting
+	@echo checking comment format...
+	@res=$$(find . -type d \( -path ./tests \) -prune -o -name '*.go' -print | xargs egrep '(^|\s)\/\/(\S)'|grep -v '//go:generate'); \
+	if [ -n "$${res}" ]; then \
+		echo checking comment format fail.. ; \
+		echo missing whitespace between // and comment body;\
+		echo "$${res}"; \
+		exit 1; \
+	fi
+
+.PHONY: misspell
+misspell: # Check for misspellings using misspell utility
+	@echo checking misspell...
+	@find . -type d \( -path ./tests \) -prune -o -name '*.go' -print | xargs misspell -error
+
+# golangci-lint binary installation or refer to https://golangci-lint.run/usage/install/#local-installation
+# curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.55.2
+GOLANGCI_LINT := $(shell go env GOPATH)/bin/golangci-lint
+.PHONY: lint
+lint: ## Lint all files using golangci-lint
+	@echo checking lint
+	@echo $(GOLANGCI_LINT)
+	@cd ./src/; $(GOLANGCI_LINT) cache clean; $(GOLANGCI_LINT) -v run ./... --timeout=10m;
+
+# go install golang.org/x/vuln/cmd/govulncheck@latest
+GOVULNCHECK := $(shell go env GOPATH)/bin/govulncheck
+.PHONY: govulncheck
+govulncheck: ## Check for golang vulnerabilities using govulncheck
+	@echo golang vulnerability check
+	@cd ./src/; $(GOVULNCHECK) ./...;
+
+##@ Clean Up
+
+.PHONY: cleanall
+cleanall: cleanbinary cleanimage cleanbaseimage cleandockercomposefile cleanconfig cleanpackage ## Remove binary, Harbor images, specific version docker-compose file, specific version tag and online/offline install package
+
+.PHONY: cleanbinary
+cleanbinary: ## Remove core and jobservice binary
 	@echo "cleaning binary..."
 	if [ -f $(CORE_BINARYPATH)/$(CORE_BINARYNAME) ] ; then rm $(CORE_BINARYPATH)/$(CORE_BINARYNAME) ; fi
 	if [ -f $(JOBSERVICEBINARYPATH)/$(JOBSERVICEBINARYNAME) ] ; then rm $(JOBSERVICEBINARYPATH)/$(JOBSERVICEBINARYNAME) ; fi
 	if [ -f $(REGISTRYCTLBINARYPATH)/$(REGISTRYCTLBINARYNAME) ] ; then rm $(REGISTRYCTLBINARYPATH)/$(REGISTRYCTLBINARYNAME) ; fi
 	rm -rf make/photon/*/binary/
 
-cleanbaseimage:
-	@echo "cleaning base image for photon..."
-	@for name in $(BUILDBASETARGET); do \
-		$(DOCKERRMIMAGE) -f $(BASEIMAGENAMESPACE)/harbor-$$name-base:$(BASEIMAGETAG) ; \
-	done
-
-cleanimage:
+.PHONY: cleanimage
+cleanimage: ## Remove Harbor images
 	@echo "cleaning image for photon..."
 	- $(DOCKERRMIMAGE) -f $(DOCKERIMAGENAME_CORE):$(VERSIONTAG)
 	- $(DOCKERRMIMAGE) -f $(DOCKERIMAGENAME_DB):$(VERSIONTAG)
 	- $(DOCKERRMIMAGE) -f $(DOCKERIMAGENAME_JOBSERVICE):$(VERSIONTAG)
 	- $(DOCKERRMIMAGE) -f $(DOCKERIMAGENAME_LOG):$(VERSIONTAG)
 
-cleandockercomposefile:
+.PHONY: cleanbaseimage
+cleanbaseimage: ## Remove base image of Harbor images
+	@echo "cleaning base image for photon..."
+	@for name in $(BUILDBASETARGET); do \
+		$(DOCKERRMIMAGE) -f $(BASEIMAGENAMESPACE)/harbor-$$name-base:$(BASEIMAGETAG) ; \
+	done
+
+.PHONY: cleandockercomposefile
+cleandockercomposefile: ## Remove specific version docker-compose
 	@echo "cleaning docker-compose files in $(DOCKERCOMPOSEFILEPATH)"
 	@find $(DOCKERCOMPOSEFILEPATH) -maxdepth 1 -name "docker-compose*.yml" -exec rm -f {} \;
 	@find $(DOCKERCOMPOSEFILEPATH) -maxdepth 1 -name "docker-compose*.yml-e" -exec rm -f {} \;
 
-cleanpackage:
+.PHONY: cleanpackage
+cleanpackage: ## Remove online and offline install package
 	@echo "cleaning harbor install package"
 	@if [ -d $(BUILDPATH)/harbor ] ; then rm -rf $(BUILDPATH)/harbor ; fi
 	@if [ -f $(BUILDPATH)/harbor-online-installer-$(VERSIONTAG).tgz ] ; \
@@ -576,7 +610,8 @@ cleanpackage:
 	@if [ -f $(BUILDPATH)/harbor-offline-installer-$(VERSIONTAG).tgz ] ; \
 	then rm $(BUILDPATH)/harbor-offline-installer-$(VERSIONTAG).tgz ; fi
 
-cleanconfig:
+.PHONY: cleanconfig
+cleanconfig: ## Remove temporary config files
 	@echo "clean generated config files"
 	rm -f $(BUILDPATH)/make/photon/prepare/versions
 	rm -f $(BUILDPATH)/UIVERSION
@@ -586,16 +621,3 @@ cleanconfig:
 	rm -rf $(BUILDPATH)/src/portal/lib/dist
 	rm -f $(BUILDPATH)/src/portal/proxy.config.json
 
-.PHONY: cleanall
-cleanall: cleanbinary cleanimage cleanbaseimage cleandockercomposefile cleanconfig cleanpackage
-
-clean:
-	@echo "  make cleanall:		remove binary, Harbor images, specific version docker-compose"
-	@echo "		file, specific version tag, online and offline install package"
-	@echo "  make cleanbinary:		remove core and jobservice binary"
-	@echo "  make cleanbaseimage:		remove base image of Harbor images"
-	@echo "  make cleanimage:		remove Harbor images"
-	@echo "  make cleandockercomposefile:	remove specific version docker-compose"
-	@echo "  make cleanpackage:		remove online and offline install package"
-
-all: install


### PR DESCRIPTION
# Comprehensive Summary of your change

I "stole" a bit of code from the [kubebuilder](https://github.com/kubernetes-sigs/kubebuilder/blob/master/Makefile) Makefile to have an easier time using make. Furthermore, I took the liberty of restructuring the Makefile a bit. Obviously the copied part is correctly attributed.

Entering `make` or `make help` will now yield the following output:
![image](https://github.com/user-attachments/assets/0960d400-efca-42f0-8249-43f5f3073506)

For compatibilities sake I didn't change anything about the logic in the Makefile and only restructured it slightly and added the necessary comments and sections for easier usage. 

Please indicate you've done the following:
- [X] Well Written Title and Summary of the PR
- [-] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [X] Accepted the DCO. Commits without the DCO will delay acceptance.
- [X] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
