### PR TITLE
fix: ensure data_volume isn't surrounded by quotes

### DIFF
--- a/make/prepare
+++ b/make/prepare
@@ -30,7 +30,7 @@ else
     fi
 fi
 
-data_path=$(grep '^[^#]*data_volume:' $input_dir/harbor.yml | awk '{print $NF}')
+data_path=$(grep '^[^#]*data_volume:' $input_dir/harbor.yml | awk '{print $NF}' | sed 's/"//g')
 
 # If previous secretkeys exist, move it to new location
 previous_secretkey_path=/data/secretkey


### PR DESCRIPTION
# Comprehensive Summary of your change

I'm generating `harbor.yaml` file with erb function `to_yaml`, where strings containing `/` are quoted. It can't be configured. 

When I run `./install.sh` script, it fails on docker volume command due to quotes which aren't removed: 

```sh
prepare base dir is set to /srv/harbor/install
docker: Error response from daemon: create "/srv/harbor/data": "\"/srv/harbor/data\"" includes invalid characters for a local volume name, only "[a-zA-Z0-9][a-zA-Z0-9_.-]" are allowed. If you intended to pass a host directory, use absolute path.
See 'docker run --help'.
```

After editing the `prepare` script to remove quotes on data_volume if present, it works like a charm. The `sed` is already used in other scripts, it shouldn't be a problem to use it.

# Issue being fixed

n/a (no issue opened)

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [ ] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
