### PR TITLE
perf: listAuthorizedProjectIDs should not get metadata

### DIFF
--- a/src/server/v2.0/handler/repository.go
+++ b/src/server/v2.0/handler/repository.go
@@ -153,7 +153,7 @@ func (r *repositoryAPI) listAuthorizedProjectIDs(ctx context.Context) ([]int64, 
 		query.Keywords["public"] = true
 	}
 
-	projects, err := r.proCtl.List(ctx, query)
+	projects, err := r.proCtl.List(ctx, query, project.Detail(false))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The `ListRepositories` interface was taking excessively long to execute. The root cause was that `listAuthorizedProjectIDs` was fetching unnecessary metadata. This PR removes the metadata retrieval from listAuthorizedProjectIDs, thereby improving the overall performance of the interface.

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
