### PR TITLE
fix(distribution): Backport distribution fix 'add bounded concurrency for tag lookup and untag

### DIFF
--- a/make/photon/registry/builder
+++ b/make/photon/registry/builder
@@ -31,6 +31,7 @@ git clone -b $VERSION $DISTRIBUTION_SRC $TEMP
 # add patch redis
 cd $TEMP
 git apply $cur/redis.patch
+git apply $cur/s3-manifest.patch
 cd $cur
 
 echo 'build the registry binary ...'

--- a/make/photon/registry/s3-manifest.patch
+++ b/make/photon/registry/s3-manifest.patch
@@ -1,0 +1,576 @@
+diff --git a/cmd/registry/config-cache.yml b/cmd/registry/config-cache.yml
+index d648303d..72da9d60 100644
+--- a/cmd/registry/config-cache.yml
++++ b/cmd/registry/config-cache.yml
+@@ -12,6 +12,8 @@ storage:
+     maintenance:
+         uploadpurging:
+             enabled: false
++    tag:
++      concurrencylimit: 8
+ http:
+     addr: :5000
+     secret: asecretforlocaldevelopment
+diff --git a/cmd/registry/config-dev.yml b/cmd/registry/config-dev.yml
+index 9539bae4..4e52d4fe 100644
+--- a/cmd/registry/config-dev.yml
++++ b/cmd/registry/config-dev.yml
+@@ -28,6 +28,8 @@ storage:
+     maintenance:
+         uploadpurging:
+             enabled: false
++    tag:
++      concurrencylimit: 8
+ http:
+     addr: :5000
+     debug:
+diff --git a/cmd/registry/config-example.yml b/cmd/registry/config-example.yml
+index c760cd56..2cb40206 100644
+--- a/cmd/registry/config-example.yml
++++ b/cmd/registry/config-example.yml
+@@ -7,6 +7,8 @@ storage:
+     blobdescriptor: inmemory
+   filesystem:
+     rootdirectory: /var/lib/registry
++  tag:
++    concurrencylimit: 8
+ http:
+   addr: :5000
+   headers:
+diff --git a/configuration/configuration.go b/configuration/configuration.go
+index 7076df85..efede8be 100644
+--- a/configuration/configuration.go
++++ b/configuration/configuration.go
+@@ -433,6 +433,8 @@ func (storage Storage) Type() string {
+ 			// allow configuration of delete
+ 		case "redirect":
+ 			// allow configuration of redirect
++		case "tag":
++			// allow configuration of tag
+ 		default:
+ 			storageType = append(storageType, k)
+ 		}
+@@ -446,6 +448,19 @@ func (storage Storage) Type() string {
+ 	return ""
+ }
+ 
++// TagParameters returns the Parameters map for a Storage tag configuration
++func (storage Storage) TagParameters() Parameters {
++	return storage["tag"]
++}
++
++// setTagParameter changes the parameter at the provided key to the new value
++func (storage Storage) setTagParameter(key string, value interface{}) {
++	if _, ok := storage["tag"]; !ok {
++		storage["tag"] = make(Parameters)
++	}
++	storage["tag"][key] = value
++}
++
+ // Parameters returns the Parameters map for a Storage configuration
+ func (storage Storage) Parameters() Parameters {
+ 	return storage[storage.Type()]
+@@ -474,6 +489,8 @@ func (storage *Storage) UnmarshalYAML(unmarshal func(interface{}) error) error {
+ 					// allow configuration of delete
+ 				case "redirect":
+ 					// allow configuration of redirect
++				case "tag":
++					// allow configuration of tag
+ 				default:
+ 					types = append(types, k)
+ 				}
+diff --git a/configuration/configuration_test.go b/configuration/configuration_test.go
+index 48cc9980..5e59acf8 100644
+--- a/configuration/configuration_test.go
++++ b/configuration/configuration_test.go
+@@ -43,6 +43,9 @@ var configStruct = Configuration{
+ 			"host":          nil,
+ 			"port":          42,
+ 		},
++		"tag": Parameters{
++			"concurrencylimit": 10,
++		},
+ 	},
+ 	Auth: Auth{
+ 		"silly": Parameters{
+@@ -149,6 +152,8 @@ storage:
+     secretkey: SUPERSECRET
+     host: ~
+     port: 42
++  tag:
++    concurrencylimit: 10
+ auth:
+   silly:
+     realm: silly
+@@ -537,6 +542,11 @@ func copyConfig(config Configuration) *Configuration {
+ 	for k, v := range config.Storage.Parameters() {
+ 		configCopy.Storage.setParameter(k, v)
+ 	}
++
++	for k, v := range config.Storage.TagParameters() {
++		configCopy.Storage.setTagParameter(k, v)
++	}
++
+ 	configCopy.Reporting = Reporting{
+ 		Bugsnag:  BugsnagReporting{config.Reporting.Bugsnag.APIKey, config.Reporting.Bugsnag.ReleaseStage, config.Reporting.Bugsnag.Endpoint},
+ 		NewRelic: NewRelicReporting{config.Reporting.NewRelic.LicenseKey, config.Reporting.NewRelic.Name, config.Reporting.NewRelic.Verbose},
+diff --git a/docs/configuration.md b/docs/configuration.md
+index 75f52dea..a197a861 100644
+--- a/docs/configuration.md
++++ b/docs/configuration.md
+@@ -152,6 +152,8 @@ storage:
+     chunksize: optional size valye
+     rootdirectory: optional root directory
+   inmemory:  # This driver takes no parameters
++  tag:
++    concurrencylimit: 8
+   delete:
+     enabled: false
+   redirect:
+@@ -554,6 +556,31 @@ layer metadata.
+ > **NOTE**: Formerly, `blobdescriptor` was known as `layerinfo`. While these
+ > are equivalent, `layerinfo` has been deprecated.
+ 
++If `blobdescriptor` is set to `inmemory`, the optional `blobdescriptorsize`
++parameter sets a limit on the number of descriptors to store in the cache.
++The default value is 10000. If this parameter is set to 0, the cache is allowed
++to grow with no size limit.
++
++### `tag`
++
++The `tag` subsection provides configuration to set concurrency limit for tag lookup.
++When user calls into the registry to delete the manifest, which in turn then does a
++lookup for all tags that reference the deleted manifest. To find the tag references,
++the registry will iterate every tag in the repository and read it's link file to check
++if it matches the deleted manifest (i.e. to see if uses the same sha256 digest).
++So, the more tags in repository, the worse the performance will be (as there will
++be more S3 API calls occurring for the tag directory lookups and tag file reads if
++using S3 storage driver).
++
++Therefore, add a single flag `concurrencylimit` to set concurrency limit to optimize tag
++lookup performance under the `tag` section. When a value is not provided or equal to 0,
++`GOMAXPROCS` will be used.
++
++```yaml
++tag:
++  concurrencylimit: 8
++```
++
+ ### `redirect`
+ 
+ The `redirect` subsection provides configuration for managing redirects from
+diff --git a/registry/handlers/app.go b/registry/handlers/app.go
+index bf56cea2..5b0b6aa7 100644
+--- a/registry/handlers/app.go
++++ b/registry/handlers/app.go
+@@ -204,6 +204,21 @@ func NewApp(ctx context.Context, config *configuration.Configuration) *App {
+ 		}
+ 	}
+ 
++	// configure tag lookup concurrency limit
++	if p := config.Storage.TagParameters(); p != nil {
++		l, ok := p["concurrencylimit"]
++		if ok {
++			limit, ok := l.(int)
++			if !ok {
++				panic("tag lookup concurrency limit config key must have a integer value")
++			}
++			if limit < 0 {
++				panic("tag lookup concurrency limit should be a non-negative integer value")
++			}
++			options = append(options, storage.TagLookupConcurrencyLimit(limit))
++		}
++	}
++
+ 	// configure redirects
+ 	var redirectDisabled bool
+ 	if redirectConfig, ok := config.Storage["redirect"]; ok {
+diff --git a/registry/handlers/manifests.go b/registry/handlers/manifests.go
+index 0d8b6588..b115a7ab 100644
+--- a/registry/handlers/manifests.go
++++ b/registry/handlers/manifests.go
+@@ -5,6 +5,7 @@ import (
+ 	"fmt"
+ 	"net/http"
+ 	"strings"
++	"sync"
+ 
+ 	"github.com/distribution/reference"
+ 	"github.com/docker/distribution"
+@@ -16,9 +17,11 @@ import (
+ 	"github.com/docker/distribution/registry/api/errcode"
+ 	v2 "github.com/docker/distribution/registry/api/v2"
+ 	"github.com/docker/distribution/registry/auth"
++	"github.com/docker/distribution/registry/storage"
+ 	"github.com/gorilla/handlers"
+ 	"github.com/opencontainers/go-digest"
+ 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
++	"golang.org/x/sync/errgroup"
+ )
+ 
+ // These constants determine which architecture and OS to choose from a
+@@ -520,12 +523,26 @@ func (imh *manifestHandler) DeleteManifest(w http.ResponseWriter, r *http.Reques
+ 		return
+ 	}
+ 
++	var (
++		errs []error
++		mu   sync.Mutex
++	)
++	g := errgroup.Group{}
++	g.SetLimit(storage.DefaultConcurrencyLimit)
+ 	for _, tag := range referencedTags {
+-		if err := tagService.Untag(imh, tag); err != nil {
+-			imh.Errors = append(imh.Errors, err)
+-			return
+-		}
++		tag := tag
++
++		g.Go(func() error {
++			if err := tagService.Untag(imh, tag); err != nil {
++				mu.Lock()
++				errs = append(errs, err)
++				mu.Unlock()
++			}
++			return nil
++		})
+ 	}
++	_ = g.Wait() // imh will record all errors, so ignore the error of Wait()
++	imh.Errors = errs
+ 
+ 	w.WriteHeader(http.StatusAccepted)
+ }
+diff --git a/registry/storage/registry.go b/registry/storage/registry.go
+index 102abb6e..51d1a85a 100644
+--- a/registry/storage/registry.go
++++ b/registry/storage/registry.go
+@@ -3,6 +3,7 @@ package storage
+ import (
+ 	"context"
+ 	"regexp"
++	"runtime"
+ 
+ 	"github.com/distribution/reference"
+ 	"github.com/docker/distribution"
+@@ -11,6 +12,10 @@ import (
+ 	"github.com/docker/libtrust"
+ )
+ 
++var (
++	DefaultConcurrencyLimit = runtime.GOMAXPROCS(0)
++)
++
+ // registry is the top-level implementation of Registry for use in the storage
+ // package. All instances should descend from this object.
+ type registry struct {
+@@ -20,6 +25,7 @@ type registry struct {
+ 	blobDescriptorCacheProvider  cache.BlobDescriptorCacheProvider
+ 	deleteEnabled                bool
+ 	schema1Enabled               bool
++	tagLookupConcurrencyLimit    int
+ 	resumableDigestEnabled       bool
+ 	schema1SigningKey            libtrust.PrivateKey
+ 	blobDescriptorServiceFactory distribution.BlobDescriptorServiceFactory
+@@ -43,6 +49,13 @@ func EnableRedirect(registry *registry) error {
+ 	return nil
+ }
+ 
++func TagLookupConcurrencyLimit(concurrencyLimit int) RegistryOption {
++	return func(registry *registry) error {
++		registry.tagLookupConcurrencyLimit = concurrencyLimit
++		return nil
++	}
++}
++
+ // EnableDelete is a functional option for NewRegistry. It enables deletion on
+ // the registry.
+ func EnableDelete(registry *registry) error {
+@@ -203,9 +216,14 @@ func (repo *repository) Named() reference.Named {
+ }
+ 
+ func (repo *repository) Tags(ctx context.Context) distribution.TagService {
++	limit := DefaultConcurrencyLimit
++	if repo.tagLookupConcurrencyLimit > 0 {
++		limit = repo.tagLookupConcurrencyLimit
++	}
+ 	tags := &tagStore{
+-		repository: repo,
+-		blobStore:  repo.registry.blobStore,
++		repository:       repo,
++		blobStore:        repo.registry.blobStore,
++		concurrencyLimit: limit,
+ 	}
+ 
+ 	return tags
+diff --git a/registry/storage/tagstore.go b/registry/storage/tagstore.go
+index a3c766b4..bd3ba100 100644
+--- a/registry/storage/tagstore.go
++++ b/registry/storage/tagstore.go
+@@ -3,10 +3,12 @@ package storage
+ import (
+ 	"context"
+ 	"path"
++	"sync"
+ 
+ 	"github.com/docker/distribution"
+ 	storagedriver "github.com/docker/distribution/registry/storage/driver"
+ 	"github.com/opencontainers/go-digest"
++	"golang.org/x/sync/errgroup"
+ )
+ 
+ var _ distribution.TagService = &tagStore{}
+@@ -17,8 +19,9 @@ var _ distribution.TagService = &tagStore{}
+ // which only makes use of the Digest field of the returned distribution.Descriptor
+ // but does not enable full roundtripping of Descriptor objects
+ type tagStore struct {
+-	repository *repository
+-	blobStore  *blobStore
++	repository       *repository
++	blobStore        *blobStore
++	concurrencyLimit int
+ }
+ 
+ // All returns all tags
+@@ -153,26 +156,48 @@ func (ts *tagStore) Lookup(ctx context.Context, desc distribution.Descriptor) ([
+ 		return nil, err
+ 	}
+ 
+-	var tags []string
++	g, ctx := errgroup.WithContext(ctx)
++	g.SetLimit(ts.concurrencyLimit)
++
++	var (
++		tags []string
++		mu   sync.Mutex
++	)
+ 	for _, tag := range allTags {
+-		tagLinkPathSpec := manifestTagCurrentPathSpec{
+-			name: ts.repository.Named().Name(),
+-			tag:  tag,
++		if ctx.Err() != nil {
++			break
+ 		}
++		tag := tag
+ 
+-		tagLinkPath, _ := pathFor(tagLinkPathSpec)
+-		tagDigest, err := ts.blobStore.readlink(ctx, tagLinkPath)
+-		if err != nil {
+-			switch err.(type) {
+-			case storagedriver.PathNotFoundError:
+-				continue
++		g.Go(func() error {
++			tagLinkPathSpec := manifestTagCurrentPathSpec{
++				name: ts.repository.Named().Name(),
++				tag:  tag,
+ 			}
+-			return nil, err
+-		}
+ 
+-		if tagDigest == desc.Digest {
+-			tags = append(tags, tag)
+-		}
++			tagLinkPath, _ := pathFor(tagLinkPathSpec)
++			tagDigest, err := ts.blobStore.readlink(ctx, tagLinkPath)
++			if err != nil {
++				switch err.(type) {
++				case storagedriver.PathNotFoundError:
++					return nil
++				}
++				return err
++			}
++
++			if tagDigest == desc.Digest {
++				mu.Lock()
++				tags = append(tags, tag)
++				mu.Unlock()
++			}
++
++			return nil
++		})
++	}
++
++	err = g.Wait()
++	if err != nil {
++		return nil, err
+ 	}
+ 
+ 	return tags, nil
+diff --git a/vendor/golang.org/x/sync/errgroup/errgroup.go b/vendor/golang.org/x/sync/errgroup/errgroup.go
+new file mode 100644
+index 00000000..b18efb74
+--- /dev/null
++++ b/vendor/golang.org/x/sync/errgroup/errgroup.go
+@@ -0,0 +1,132 @@
++// Copyright 2016 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++// Package errgroup provides synchronization, error propagation, and Context
++// cancelation for groups of goroutines working on subtasks of a common task.
++package errgroup
++
++import (
++	"context"
++	"fmt"
++	"sync"
++)
++
++type token struct{}
++
++// A Group is a collection of goroutines working on subtasks that are part of
++// the same overall task.
++//
++// A zero Group is valid, has no limit on the number of active goroutines,
++// and does not cancel on error.
++type Group struct {
++	cancel func(error)
++
++	wg sync.WaitGroup
++
++	sem chan token
++
++	errOnce sync.Once
++	err     error
++}
++
++func (g *Group) done() {
++	if g.sem != nil {
++		<-g.sem
++	}
++	g.wg.Done()
++}
++
++// WithContext returns a new Group and an associated Context derived from ctx.
++//
++// The derived Context is canceled the first time a function passed to Go
++// returns a non-nil error or the first time Wait returns, whichever occurs
++// first.
++func WithContext(ctx context.Context) (*Group, context.Context) {
++	ctx, cancel := withCancelCause(ctx)
++	return &Group{cancel: cancel}, ctx
++}
++
++// Wait blocks until all function calls from the Go method have returned, then
++// returns the first non-nil error (if any) from them.
++func (g *Group) Wait() error {
++	g.wg.Wait()
++	if g.cancel != nil {
++		g.cancel(g.err)
++	}
++	return g.err
++}
++
++// Go calls the given function in a new goroutine.
++// It blocks until the new goroutine can be added without the number of
++// active goroutines in the group exceeding the configured limit.
++//
++// The first call to return a non-nil error cancels the group's context, if the
++// group was created by calling WithContext. The error will be returned by Wait.
++func (g *Group) Go(f func() error) {
++	if g.sem != nil {
++		g.sem <- token{}
++	}
++
++	g.wg.Add(1)
++	go func() {
++		defer g.done()
++
++		if err := f(); err != nil {
++			g.errOnce.Do(func() {
++				g.err = err
++				if g.cancel != nil {
++					g.cancel(g.err)
++				}
++			})
++		}
++	}()
++}
++
++// TryGo calls the given function in a new goroutine only if the number of
++// active goroutines in the group is currently below the configured limit.
++//
++// The return value reports whether the goroutine was started.
++func (g *Group) TryGo(f func() error) bool {
++	if g.sem != nil {
++		select {
++		case g.sem <- token{}:
++			// Note: this allows barging iff channels in general allow barging.
++		default:
++			return false
++		}
++	}
++
++	g.wg.Add(1)
++	go func() {
++		defer g.done()
++
++		if err := f(); err != nil {
++			g.errOnce.Do(func() {
++				g.err = err
++				if g.cancel != nil {
++					g.cancel(g.err)
++				}
++			})
++		}
++	}()
++	return true
++}
++
++// SetLimit limits the number of active goroutines in this group to at most n.
++// A negative value indicates no limit.
++//
++// Any subsequent call to the Go method will block until it can add an active
++// goroutine without exceeding the configured limit.
++//
++// The limit must not be modified while any goroutines in the group are active.
++func (g *Group) SetLimit(n int) {
++	if n < 0 {
++		g.sem = nil
++		return
++	}
++	if len(g.sem) != 0 {
++		panic(fmt.Errorf("errgroup: modify limit while %v goroutines in the group are still active", len(g.sem)))
++	}
++	g.sem = make(chan token, n)
++}
+diff --git a/vendor/golang.org/x/sync/errgroup/go120.go b/vendor/golang.org/x/sync/errgroup/go120.go
+new file mode 100644
+index 00000000..7d419d37
+--- /dev/null
++++ b/vendor/golang.org/x/sync/errgroup/go120.go
+@@ -0,0 +1,14 @@
++// Copyright 2023 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++//go:build go1.20
++// +build go1.20
++
++package errgroup
++
++import "context"
++
++func withCancelCause(parent context.Context) (context.Context, func(error)) {
++	return context.WithCancelCause(parent)
++}
+diff --git a/vendor/golang.org/x/sync/errgroup/pre_go120.go b/vendor/golang.org/x/sync/errgroup/pre_go120.go
+new file mode 100644
+index 00000000..1795c18a
+--- /dev/null
++++ b/vendor/golang.org/x/sync/errgroup/pre_go120.go
+@@ -0,0 +1,15 @@
++// Copyright 2023 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++//go:build !go1.20
++// +build !go1.20
++
++package errgroup
++
++import "context"
++
++func withCancelCause(parent context.Context) (context.Context, func(error)) {
++	ctx, cancel := context.WithCancel(parent)
++	return ctx, func(error) { cancel() }
++}


### PR DESCRIPTION
# Comprehensive Summary of your change
Hello,

Investigating about a garbage collection taking months/years to finish, I checked the GC logs and found out that the manifest deletion always took ~30s.
So I asked if some people had the same issue on [slack](https://cloud-native.slack.com/archives/CC1E09J6S/p1739279456940169) and I found the issue #12948 talking about it and linking to a [docker distribution PR](https://github.com/distribution/distribution/pull/4329) fixing the issue.
Problem is that it will be probably only be released on Distribution v3 while this version is still in working state after years of work, that's why I decided to cherry-pick the fix https://github.com/distribution/distribution/pull/4329 written by @microyahoo to improve garbage collection manifest deletion.

I tested the fix, and I went from 30s to ~7s to delete a manifest.

A new configuration has been added on distribution configuration side to configure tag deletion concurrency limit, by default it's set to `runtime.GOMAXPROCS(0)`, so it's working without having to modify docker distribution configuration (no need to modify the Helm Chart).

# Issue being fixed
Fixes #12948

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
