### PR TITLE
Iseyer/replicate tags

### DIFF
--- a/src/controller/tag/controller.go
+++ b/src/controller/tag/controller.go
@@ -121,23 +121,23 @@ func (c *controller) Ensure(ctx context.Context, repositoryID, artifactID int64,
 
 		tagID, err = c.Create(ctx, tag)
 
-		attachedArtifact, err := c.artMgr.Get(ctx, tag.ArtifactID)
-		if err != nil {
-			return err
-		}
-
-		e := &metadata.CreateTagEventMetadata{
-			Ctx:              ctx,
-			Tag:              tag.Name,
-			AttachedArtifact: attachedArtifact,
-		}
-
-		notification.AddEvent(ctx, e)
-
 		return err
 	})(orm.SetTransactionOpNameToContext(ctx, "tx-tag-ensure")); err != nil && !errors.IsConflictErr(err) {
 		return 0, err
 	}
+
+	attachedArtifact, err := c.artMgr.Get(ctx, artifactID)
+	if err != nil {
+		return 0, err
+	}
+
+	e := &metadata.CreateTagEventMetadata{
+		Ctx:              ctx,
+		Tag:              name,
+		AttachedArtifact: attachedArtifact,
+	}
+
+	notification.AddEvent(ctx, e)
 
 	return tagID, nil
 }


### PR DESCRIPTION
Currently, harbor does not replicate image tags for event-based replications. Instead, if a new tag is pushed, a replication event is not fired.

This issue is easily replicated: 
- push an image with a tag
- push the same image with a new tag
- watch replication not happen

There should be followup work to correct the issue of webhooks not being fired for tags being created.

# Issue being fixed
Fixes #21623 

Please indicate you've done the following:
- [X] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [X] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
