### PR TITLE
Remove unused mount from test schema helm templates

### DIFF
--- a/src/pkg/chart/testdata/harbor-schema1/templates/core/core-dpl.yaml
+++ b/src/pkg/chart/testdata/harbor-schema1/templates/core/core-dpl.yaml
@@ -178,8 +178,6 @@ spec:
         - name: core-internal-certs
           mountPath: /etc/harbor/ssl/core
         {{- end }}
-        - name: psc
-          mountPath: /etc/core/token
         {{- if .Values.caBundleSecretName }}
 {{ include "harbor.caBundleVolumeMount" . | indent 8 }}
         {{- end }}
@@ -235,8 +233,6 @@ spec:
         secret:
           secretName: {{ template "harbor.internalTLS.core.secretName" . }}
       {{- end }}
-      - name: psc
-        emptyDir: {}
       {{- if .Values.caBundleSecretName }}
 {{ include "harbor.caBundleVolume" . | indent 6 }}
       {{- end }}

--- a/src/pkg/chart/testdata/harbor-schema2/templates/core/core-dpl.yaml
+++ b/src/pkg/chart/testdata/harbor-schema2/templates/core/core-dpl.yaml
@@ -178,8 +178,6 @@ spec:
         - name: core-internal-certs
           mountPath: /etc/harbor/ssl/core
         {{- end }}
-        - name: psc
-          mountPath: /etc/core/token
         {{- if .Values.caBundleSecretName }}
 {{ include "harbor.caBundleVolumeMount" . | indent 8 }}
         {{- end }}
@@ -235,8 +233,6 @@ spec:
         secret:
           secretName: {{ template "harbor.internalTLS.core.secretName" . }}
       {{- end }}
-      - name: psc
-        emptyDir: {}
       {{- if .Values.caBundleSecretName }}
 {{ include "harbor.caBundleVolume" . | indent 6 }}
       {{- end }}


### PR DESCRIPTION
Thank you for contributing to Harbor!

# Comprehensive Summary of your change
Remove the /etc/core/token mount from test schema template since it's not used anymore

# Issue being fixed
Fixes #21706

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [X] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [X] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
