### PR TITLE
fix: limit the file size of the cnai model processor

### DIFF
--- a/src/controller/artifact/processor/cnai/cnai_test.go
+++ b/src/controller/artifact/processor/cnai/cnai_test.go
@@ -207,7 +207,7 @@ func (p *ProcessorTestSuite) TestAbstractAddition() {
 				p.Require().NoError(err)
 				r.On("PullManifest", mock.Anything, mock.Anything).Return(manifest, "", nil)
 			},
-			expectContent: `[{"name":"config.json","type":"file","size":50},{"name":"model","type":"directory","children":[{"name":"weights.bin","type":"file","size":100}]}]`,
+			expectContent: `[{"name":"model","type":"directory","children":[{"name":"weights.bin","type":"file","size":100}]},{"name":"config.json","type":"file","size":50}]`,
 			expectType:    "application/json; charset=utf-8",
 		},
 	}

--- a/src/controller/artifact/processor/cnai/parser/files.go
+++ b/src/controller/artifact/processor/cnai/parser/files.go
@@ -100,8 +100,12 @@ func traverseFileNode(node *FileNode) []FileList {
 		})
 	}
 
-	// sort the children by name.
+	// sort the children by type (directories first) and then by name.
 	sort.Slice(children, func(i, j int) bool {
+		if children[i].Type != children[j].Type {
+			return children[i].Type == TypeDirectory
+		}
+
 		return children[i].Name < children[j].Name
 	})
 

--- a/src/controller/artifact/processor/cnai/parser/files_test.go
+++ b/src/controller/artifact/processor/cnai/parser/files_test.go
@@ -142,11 +142,6 @@ func TestFilesParser(t *testing.T) {
 			expectedType: contentTypeJSON,
 			expectedOutput: []FileList{
 				{
-					Name: "README.md",
-					Type: TypeFile,
-					Size: 100,
-				},
-				{
 					Name: "models",
 					Type: TypeDirectory,
 					Children: []FileList{
@@ -173,6 +168,11 @@ func TestFilesParser(t *testing.T) {
 							},
 						},
 					},
+				},
+				{
+					Name: "README.md",
+					Type: TypeFile,
+					Size: 100,
 				},
 			},
 		},

--- a/src/go.mod
+++ b/src/go.mod
@@ -79,7 +79,7 @@ require (
 )
 
 require (
-	github.com/CloudNativeAI/model-spec v0.0.1
+	github.com/CloudNativeAI/model-spec v0.0.3
 	github.com/prometheus/client_model v0.6.1
 	go.pinniped.dev v0.37.0
 )

--- a/src/go.sum
+++ b/src/go.sum
@@ -40,8 +40,8 @@ github.com/Azure/go-ntlmssp v0.0.0-20221128193559-754e69321358/go.mod h1:chxPXzS
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/toml v1.2.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/CloudNativeAI/model-spec v0.0.1 h1:BgVIStKTLuL1DrLC5A/gmHcR8TEhFCDz9+fYdCUa/CY=
-github.com/CloudNativeAI/model-spec v0.0.1/go.mod h1:3U/4zubBfbUkW59ATSg41HnkYyKrKUcKFH/cVdoPQnk=
+github.com/CloudNativeAI/model-spec v0.0.3 h1:5mvgFQ+3pyupzxYjtV5XAeg9zRe6+46pLPBFNHlOrqE=
+github.com/CloudNativeAI/model-spec v0.0.3/go.mod h1:3U/4zubBfbUkW59ATSg41HnkYyKrKUcKFH/cVdoPQnk=
 github.com/FZambia/sentinel v1.1.0 h1:qrCBfxc8SvJihYNjBWgwUI93ZCvFe/PJIPTHKmlp8a8=
 github.com/FZambia/sentinel v1.1.0/go.mod h1:ytL1Am/RLlAoAXG6Kj5LNuw/TRRQrv2rt2FT26vP5gI=
 github.com/HdrHistogram/hdrhistogram-go v1.1.2/go.mod h1:yDgFjdqOqDEKOvasDdhWNXYg9BVp4O+o5f6V/ehm6Oo=

--- a/src/lib/errors/const.go
+++ b/src/lib/errors/const.go
@@ -47,6 +47,8 @@ const (
 	MANIFESTINVALID = "MANIFEST_INVALID"
 	// UNSUPPORTED is for digest UNSUPPORTED error
 	UNSUPPORTED = "UNSUPPORTED"
+	// RequestEntityTooLargeCode is the error code for request entity too large error.
+	RequestEntityTooLargeCode = "REQUEST_ENTITY_TOO_LARGE"
 )
 
 // NotFoundError is error for the case of object not found
@@ -92,6 +94,11 @@ func PreconditionFailedError(err error) *Error {
 // UnknownError ...
 func UnknownError(err error) *Error {
 	return New("unknown").WithCode(GeneralCode).WithCause(err)
+}
+
+// RequestEntityTooLargeError is error for the case of request entity too large.
+func RequestEntityTooLargeError(err error) *Error {
+	return New("request entity too large").WithCode(RequestEntityTooLargeCode).WithCause(err)
 }
 
 // IsNotFoundErr returns true when the error is NotFoundError

--- a/src/lib/http/error.go
+++ b/src/lib/http/error.go
@@ -43,6 +43,7 @@ var (
 		errors.ViolateForeignKeyConstraintCode: http.StatusPreconditionFailed,
 		errors.PROJECTPOLICYVIOLATION:          http.StatusPreconditionFailed,
 		errors.GeneralCode:                     http.StatusInternalServerError,
+		errors.RequestEntityTooLargeCode:       http.StatusRequestEntityTooLarge,
 	}
 )
 


### PR DESCRIPTION
Limit the processable file size of CNAI model processor in order to avoid pull large blobs and read them to memory.

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
