### PR TITLE
update robot log level

### DIFF
--- a/src/server/middleware/security/robot.go
+++ b/src/server/middleware/security/robot.go
@@ -68,6 +68,6 @@ func (r *robot) Generate(req *http.Request) security.Context {
 		return nil
 	}
 
-	log.Infof("a robot security context generated for request %s %s", req.Method, req.URL.Path)
+	log.Debugf("a robot security context generated for request %s %s", req.Method, req.URL.Path)
 	return robotCtx.NewSecurityContext(robot)
 }


### PR DESCRIPTION
fix #21762

Harbor logs an informational message when a robot account performs a pull or push operation, as noted in the comments on issue https://github.com/goharbor/harbor/issues/21762.
This behavior can lead to log spamming. To reduce noise, this update changes the log level from 'info' to 'debug' for these operation.

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [ ] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [ ] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
