### PR TITLE
fix 21118

### DIFF
--- a/src/server/v2.0/handler/robot.go
+++ b/src/server/v2.0/handler/robot.go
@@ -177,8 +177,8 @@ func (rAPI *robotAPI) ListRobot(ctx context.Context, params operation.ListRobotP
 
 	var projectID int64
 	var level string
-	// GET /api/v2.0/robots or GET /api/v2.0/robots?level=system to get all of system level robots.
-	// GET /api/v2.0/robots?level=project&project_id=1
+	// GET /api/v2.0/robots or GET /api/v2.0/robots?q=Level=system to get all of system level robots.
+	// GET /api/v2.0/robots?q=Level=project,ProjectID=1
 	if _, ok := query.Keywords["Level"]; ok {
 		if !isValidLevel(query.Keywords["Level"].(string)) {
 			return rAPI.SendError(ctx, errors.New(nil).WithMessage("bad request error level input").WithCode(errors.BadRequestCode))
@@ -189,10 +189,12 @@ func (rAPI *robotAPI) ListRobot(ctx context.Context, params operation.ListRobotP
 				return rAPI.SendError(ctx, errors.BadRequestError(nil).WithMessage("must with project ID when to query project robots"))
 			}
 			pid, err := strconv.ParseInt(query.Keywords["ProjectID"].(string), 10, 64)
-			if err != nil {
-				return rAPI.SendError(ctx, errors.BadRequestError(nil).WithMessage("Project ID must be int type."))
+			if err != nil || pid <= 0 {
+				return rAPI.SendError(ctx, errors.BadRequestError(nil).WithMessage("ProjectID must be a positive integer"))
 			}
 			projectID = pid
+		} else if level == robot.LEVELSYSTEM {
+			query.Keywords["ProjectID"] = 0
 		}
 	} else {
 		level = robot.LEVELSYSTEM


### PR DESCRIPTION
fix #21118
In the current robot API, querying with ?q=level=system returns both system and project-level robots. This change addresses the issue by ensuring that specifying level=system will return only system-level robots.

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [ ] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [ ] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
