### PR TITLE
[CHERRY-PICK] fix: support preheat cnai model artifact

### DIFF
--- a/src/controller/p2p/preheat/enforcer.go
+++ b/src/controller/p2p/preheat/enforcer.go
@@ -28,6 +28,7 @@ import (
 	"github.com/goharbor/harbor/src/controller/scan"
 	"github.com/goharbor/harbor/src/core/service/token"
 	"github.com/goharbor/harbor/src/jobservice/job"
+	"github.com/goharbor/harbor/src/lib"
 	"github.com/goharbor/harbor/src/lib/config"
 	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/lib/log"
@@ -341,13 +342,18 @@ func (de *defaultEnforcer) PreheatArtifact(ctx context.Context, art *artifact.Ar
 
 // getCandidates get the initial candidates by evaluating the policy
 func (de *defaultEnforcer) getCandidates(ctx context.Context, ps *pol.Schema, p *proModels.Project) ([]*selector.Candidate, error) {
+	// Filter the candidates by supported types.
+	var supportedTypes []any
+	for _, t := range lib.SliceToUpper(pr.SupportedTypes) {
+		supportedTypes = append(supportedTypes, t)
+	}
 	// Get the initial candidates
 	// Here we have a hidden filter, the artifact type filter.
 	// Only get the image type at this moment.
 	arts, err := de.artCtl.List(ctx, &q.Query{
 		Keywords: map[string]interface{}{
 			"ProjectID": ps.ProjectID,
-			"Type":      strings.ToUpper(pr.SupportedType),
+			"Type":      q.NewOrList(supportedTypes),
 		},
 	}, &artifact.Option{
 		WithLabel: true,
@@ -433,7 +439,7 @@ func (de *defaultEnforcer) startTask(ctx context.Context, executionID int64, can
 	}
 
 	pi := &pr.PreheatImage{
-		Type: pr.SupportedType,
+		Type: candidate.Kind,
 		URL:  u,
 		Headers: map[string]interface{}{
 			accessCredHeaderKey: cred,
@@ -517,7 +523,7 @@ func (de *defaultEnforcer) toCandidates(ctx context.Context, p *proModels.Projec
 				NamespaceID:           p.ProjectID,
 				Namespace:             p.Name,
 				Repository:            pureRepository(p.Name, a.RepositoryName),
-				Kind:                  pr.SupportedType,
+				Kind:                  strings.ToLower(a.Type),
 				Digest:                a.Digest,
 				Tags:                  []string{t.Name},
 				Labels:                getLabels(a.Labels),

--- a/src/lib/strings.go
+++ b/src/lib/strings.go
@@ -33,3 +33,13 @@ func Title(s string) string {
 	title := cases.Title(language.Und)
 	return title.String(strings.ToLower(s))
 }
+
+// SliceToUpper converts a slice of strings to uppercase.
+func SliceToUpper(s []string) []string {
+	result := make([]string, len(s))
+	for i, str := range s {
+		result[i] = strings.ToUpper(str)
+	}
+
+	return result
+}

--- a/src/lib/strings_test.go
+++ b/src/lib/strings_test.go
@@ -15,6 +15,7 @@
 package lib
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -49,6 +50,59 @@ func TestTitle(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equalf(t, tt.want, Title(tt.args.s), "Title(%v)", tt.args.s)
+		})
+	}
+}
+
+func TestSliceToUpper(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []string
+		expected []string
+	}{
+		{
+			name:     "Empty slice",
+			input:    []string{},
+			expected: []string{},
+		},
+		{
+			name:     "Single element",
+			input:    []string{"hello"},
+			expected: []string{"HELLO"},
+		},
+		{
+			name:     "Multiple elements",
+			input:    []string{"hello", "world", "go"},
+			expected: []string{"HELLO", "WORLD", "GO"},
+		},
+		{
+			name:     "Already uppercase",
+			input:    []string{"HELLO", "WORLD"},
+			expected: []string{"HELLO", "WORLD"},
+		},
+		{
+			name:     "Mixed case",
+			input:    []string{"Hello", "World", "Go"},
+			expected: []string{"HELLO", "WORLD", "GO"},
+		},
+		{
+			name:     "With special characters",
+			input:    []string{"hello!", "world?", "go#"},
+			expected: []string{"HELLO!", "WORLD?", "GO#"},
+		},
+		{
+			name:     "With numbers",
+			input:    []string{"hello123", "world456"},
+			expected: []string{"HELLO123", "WORLD456"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := SliceToUpper(tt.input)
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("SliceToUpper() = %v, want %v", result, tt.expected)
+			}
 		})
 	}
 }

--- a/src/pkg/p2p/preheat/provider/dragonfly.go
+++ b/src/pkg/p2p/preheat/provider/dragonfly.go
@@ -36,7 +36,17 @@ const (
 
 	// dragonflyJobPath is the job path for dragonfly openapi.
 	dragonflyJobPath = "/oapi/v1/jobs"
+)
 
+const (
+	// preheatTypeImage represents the image to the dragonfly cluster.
+	preheatTypeImage = "image"
+
+	// preheatTypeFile represents the file to the dragonfly cluster.
+	preheatTypeFile = "file"
+)
+
+const (
 	// scopeTypeSingleSeedPeer represents preheat image to single seed peer in p2p cluster.
 	scopeTypeSingleSeedPeer = "single_seed_peer"
 
@@ -233,9 +243,9 @@ func (dd *DragonflyDriver) Preheat(preheatingImage *PreheatImage) (*PreheatingSt
 	// Construct the preheat job request by the given parameters of the preheating image .
 	req := &dragonflyCreateJobRequest{
 		Type: "preheat",
-		// TODO: Support set SchedulerClusterIDs, FilteredQueryParam, ConcurrentCount and Timeout.
+		// TODO: Support set FilteredQueryParam, ConcurrentCount and Timeout.
 		Args: dragonflyCreateJobRequestArgs{
-			Type:    preheatingImage.Type,
+			Type:    preheatTypeImage,
 			URL:     preheatingImage.URL,
 			Headers: headerToMapString(preheatingImage.Headers),
 		},

--- a/src/pkg/p2p/preheat/provider/preheat_image.go
+++ b/src/pkg/p2p/preheat/provider/preheat_image.go
@@ -17,13 +17,17 @@ package provider
 import (
 	"encoding/json"
 	"net/url"
+	"slices"
 
 	"github.com/pkg/errors"
 )
 
-const (
-	// SupportedType indicates the supported preheating type 'image'.
-	SupportedType = "image"
+var (
+	// SupportedTypes indicates the supported preheating types.
+	SupportedTypes = []string{
+		"image",
+		"cnai",
+	}
 )
 
 // PreheatImage contains related information which can help providers to get/pull the images.
@@ -75,7 +79,7 @@ func (img *PreheatImage) ToJSON() (string, error) {
 
 // Validate PreheatImage
 func (img *PreheatImage) Validate() error {
-	if img.Type != SupportedType {
+	if !slices.Contains(SupportedTypes, img.Type) {
 		return errors.Errorf("unsupported type '%s'", img.Type)
 	}
 


### PR DESCRIPTION
Preheat type should not only limit to image, cnai model artifact should be included as well in preheat target type.

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
