### PR TITLE
fix: check blob exist before copying layers samller than chunk size

### DIFF
--- a/src/controller/replication/transfer/image/transfer.go
+++ b/src/controller/replication/transfer/image/transfer.go
@@ -403,11 +403,6 @@ func (t *transfer) copyBlobByMonolithic(srcRepo, dstRepo, digest string, sizeFro
 // copyBlobByChunk copy blob by chunk with specified start and end range.
 // The <range> refers to the byte range of the chunk, and MUST be inclusive on both ends. The first chunk's range MUST begin with 0.
 func (t *transfer) copyBlobByChunk(srcRepo, dstRepo, digest string, sizeFromDescriptor int64, start, end *int64, location *string, speed int32) error {
-	// fallback to copy by monolithic if the blob size is equal or less than chunk size.
-	if sizeFromDescriptor <= replicationChunkSize {
-		return t.copyBlobByMonolithic(srcRepo, dstRepo, digest, sizeFromDescriptor, speed)
-	}
-
 	mounted, err := t.tryMountBlob(srcRepo, dstRepo, digest)
 	if err != nil {
 		return err
@@ -415,6 +410,11 @@ func (t *transfer) copyBlobByChunk(srcRepo, dstRepo, digest string, sizeFromDesc
 	// return earlier if it is mounted.
 	if mounted {
 		return nil
+	}
+
+	// fallback to copy by monolithic if the blob size is equal or less than chunk size.
+	if sizeFromDescriptor <= replicationChunkSize {
+		return t.copyBlobByMonolithic(srcRepo, dstRepo, digest, sizeFromDescriptor, speed)
 	}
 
 	// end range should equal (blobSize - 1)


### PR DESCRIPTION
`copyBlobByChunk()` should like `copyBlob()`, first try to mount an exists layer, if not mounted or exist, then copy the layer monolithic or by chunks.

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
