### PR TITLE
chore: bump golangci-lint to v2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -471,7 +471,7 @@ misspell:
 	@find . -type d \( -path ./tests \) -prune -o -name '*.go' -print | xargs misspell -error
 
 # golangci-lint binary installation or refer to https://golangci-lint.run/usage/install/#local-installation
-# curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.55.2
+# curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.1.2
 GOLANGCI_LINT := $(shell go env GOPATH)/bin/golangci-lint
 lint:
 	@echo checking lint

--- a/src/.golangci.yaml
+++ b/src/.golangci.yaml
@@ -1,76 +1,56 @@
-linters-settings:
-  gofmt:
-    # Simplify code: gofmt with `-s` option.
-    # Default: true
-    simplify: false
-  misspell:
-    locale: US,UK
-  goimports:
-    local-prefixes: github.com/goharbor/harbor
-  stylecheck:
-    checks: [
-      "ST1019",  # Importing the same package multiple times.
-    ]
-  goheader:
-    template-path: copyright.tmpl
-
+version: "2"
 linters:
-  disable-all: true
+  default: none
   enable:
-    - gofmt
-    - goheader
-    - misspell
-    - typecheck
-    # - dogsled
-    # - dupl
-    # - depguard
-    # - funlen
-    # - goconst
-    # - gocritic
-    # - gocyclo
-    # - goimports
-    # - goprintffuncname
-    - ineffassign
-    # - nakedret
-    # - nolintlint
-    - revive
-    - whitespace
     - bodyclose
     - errcheck
-    # - gosec
-    - gosimple
-    - goimports
+    - goheader
     - govet
-    # - noctx
-    # - rowserrcheck
+    - ineffassign
+    - misspell
+    - revive
     - staticcheck
-    - stylecheck
-    # - unconvert
-    # - unparam
-    # - unused  // disabled due to too many false positive check and limited support golang 1.19 https://github.com/dominikh/go-tools/issues/1282
- 
-run:
-  skip-files:
-    - ".*_test.go"
-    - ".*test.go"
-  skip-dirs:
-    - "testing"
-  timeout: 20m
-
-issue:
-  max-same-issues: 0
-  max-per-linter: 0
-
-issues:
-  # Excluding configuration per-path, per-linter, per-text and per-source
-  exclude-rules:
-    # Exclude some linters from running on tests files.
-    - path: _test\.go
-      linters:
-        - goimports
-    - path: src/testing/*.go
-      linters:
-        - goimports
-    - path: src/jobservice/mgt/mock_manager.go
-      linters:
-        - goimports
+    - whitespace
+  settings:
+    goheader:
+      template-path: copyright.tmpl
+    misspell:
+      locale: US,UK
+    staticcheck:
+      checks:
+        - ST1019
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+      - _test\.go
+      - .*test\.go
+      - testing
+      - src/jobservice/mgt/mock_manager.go
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  settings:
+    gofmt:
+      simplify: false
+    goimports:
+      local-prefixes:
+        - github.com/goharbor/harbor
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+      - _test\.go
+      - .*test\.go
+      - testing
+      - src/jobservice/mgt/mock_manager.go

--- a/src/common/utils/utils.go
+++ b/src/common/utils/utils.go
@@ -237,14 +237,14 @@ func GetStrValueOfAnyType(value interface{}) string {
 }
 
 // IsIllegalLength ...
-func IsIllegalLength(s string, min int, max int) bool {
-	if min == -1 {
-		return (len(s) > max)
+func IsIllegalLength(s string, minVal int, maxVal int) bool {
+	if minVal == -1 {
+		return (len(s) > maxVal)
 	}
-	if max == -1 {
-		return (len(s) <= min)
+	if maxVal == -1 {
+		return (len(s) <= minVal)
 	}
-	return (len(s) < min || len(s) > max)
+	return (len(s) < minVal || len(s) > maxVal)
 }
 
 // ParseJSONInt ...

--- a/src/jobservice/mgt/manager.go
+++ b/src/jobservice/mgt/manager.go
@@ -226,8 +226,8 @@ func (bm *basicManager) GetPeriodicExecution(pID string, q *query.Parameter) (re
 			return results, total, nil
 		}
 
-		min, max := (pageNumber-1)*pageSize, pageNumber*pageSize-1
-		args := []interface{}{key, min, max}
+		minVal, maxVal := (pageNumber-1)*pageSize, pageNumber*pageSize-1
+		args := []interface{}{key, minVal, maxVal}
 		list, err := redis.Values(conn.Do("ZREVRANGE", args...))
 		if err != nil {
 			return nil, 0, err

--- a/src/lib/q/builder.go
+++ b/src/lib/q/builder.go
@@ -132,17 +132,17 @@ func parseRange(value string) (*Range, error) {
 		return nil, fmt.Errorf(`range must start with "[", end with "]" and contains only one "~"`)
 	}
 	strs := strings.SplitN(value[1:length-1], "~", 2)
-	min := strings.TrimSpace(strs[0])
-	max := strings.TrimSpace(strs[1])
-	if len(min) == 0 && len(max) == 0 {
+	minVal := strings.TrimSpace(strs[0])
+	maxVal := strings.TrimSpace(strs[1])
+	if len(minVal) == 0 && len(maxVal) == 0 {
 		return nil, fmt.Errorf(`min and max at least one should be set in range'`)
 	}
 	r := &Range{}
-	if len(min) > 0 {
-		r.Min = parseValue(min)
+	if len(minVal) > 0 {
+		r.Min = parseValue(minVal)
 	}
-	if len(max) > 0 {
-		r.Max = parseValue(max)
+	if len(maxVal) > 0 {
+		r.Max = parseValue(maxVal)
 	}
 	return r, nil
 }

--- a/src/lib/q/query.go
+++ b/src/lib/q/query.go
@@ -105,10 +105,10 @@ func NewSort(key string, desc bool) *Sort {
 }
 
 // NewRange creates a new range
-func NewRange(min, max interface{}) *Range {
+func NewRange(minVal, maxVal interface{}) *Range {
 	return &Range{
-		Min: min,
-		Max: max,
+		Min: minVal,
+		Max: maxVal,
 	}
 }
 

--- a/src/lib/retry/retry.go
+++ b/src/lib/retry/retry.go
@@ -70,9 +70,9 @@ func InitialInterval(initial time.Duration) Option {
 }
 
 // MaxInterval set max interval
-func MaxInterval(max time.Duration) Option {
+func MaxInterval(maxInterval time.Duration) Option {
 	return func(opts *Options) {
-		opts.MaxInterval = max
+		opts.MaxInterval = maxInterval
 	}
 }
 

--- a/tests/ci/ut_install.sh
+++ b/tests/ci/ut_install.sh
@@ -18,11 +18,11 @@ set -e
 # cd ../
 # binary will be $(go env GOPATH)/bin/golangci-lint
 # go get installation aren't guaranteed to work. We recommend using binary installation.
-curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.61.0
+curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.1.2
 sudo service postgresql stop || echo no postgresql need to be stopped
 sleep 2
 
-sudo rm -rf /data/* 
+sudo rm -rf /data/*
 sudo -E env "PATH=$PATH" make go_check
 sudo ./tests/hostcfg.sh
 sudo ./tests/generateCerts.sh


### PR DESCRIPTION
This pull request includes updates to the `golangci-lint` version and significant changes to the `golangci-lint` configuration file. These changes aim to improve the linting process and ensure the codebase adheres to the latest standards.

### Updates to `golangci-lint` version:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L474-R474): Updated the `golangci-lint` installation command to use version `v2.1.2` instead of `v1.55.2`.
* [`tests/ci/ut_install.sh`](diffhunk://#diff-64312a020b777f5b0b4b2895a61fd049b6d7ef81b6b229980400e9e52e7914cdL21-R21): Updated the `golangci-lint` installation command to use version `v2.1.2` instead of `v1.61.0`.

### Changes to `golangci-lint` configuration:

* `src/.golangci.yaml`: 
  - Removed specific linter settings and simplified the configuration.
  - Enabled and disabled specific linters to optimize the linting process.
  - Added settings for `goheader`, `misspell`, and `staticcheck`.
  - Included exclusion rules for generated files and specific paths.Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
