### PR TITLE
refactor: replace interface{} to any

### DIFF
--- a/src/.golangci.yaml
+++ b/src/.golangci.yaml
@@ -30,7 +30,7 @@ linters:
       - third_party$
       - builtin$
       - examples$
-      - _test\.go
+      - .*_test\.go
       - .*test\.go
       - testing
       - src/jobservice/mgt/mock_manager.go
@@ -50,7 +50,7 @@ formatters:
       - third_party$
       - builtin$
       - examples$
-      - _test\.go
+      - .*_test\.go
       - .*test\.go
       - testing
       - src/jobservice/mgt/mock_manager.go

--- a/src/common/api/base.go
+++ b/src/common/api/base.go
@@ -78,7 +78,7 @@ func (b *BaseAPI) RenderError(code int, text string) {
 }
 
 // DecodeJSONReq decodes a json request
-func (b *BaseAPI) DecodeJSONReq(v interface{}) error {
+func (b *BaseAPI) DecodeJSONReq(v any) error {
 	err := json.Unmarshal(b.Ctx.Input.CopyBody(1<<35), v)
 	if err != nil {
 		log.Errorf("Error while decoding the json request, error: %v, %v",
@@ -89,7 +89,7 @@ func (b *BaseAPI) DecodeJSONReq(v interface{}) error {
 }
 
 // Validate validates v if it implements interface validation.ValidFormer
-func (b *BaseAPI) Validate(v interface{}) (bool, error) {
+func (b *BaseAPI) Validate(v any) (bool, error) {
 	validator := validation.Validation{}
 	isValid, err := validator.Valid(v)
 	if err != nil {
@@ -108,7 +108,7 @@ func (b *BaseAPI) Validate(v interface{}) (bool, error) {
 }
 
 // DecodeJSONReqAndValidate does both decoding and validation
-func (b *BaseAPI) DecodeJSONReqAndValidate(v interface{}) (bool, error) {
+func (b *BaseAPI) DecodeJSONReqAndValidate(v any) (bool, error) {
 	if err := b.DecodeJSONReq(v); err != nil {
 		return false, err
 	}

--- a/src/common/dao/base.go
+++ b/src/common/dao/base.go
@@ -144,6 +144,6 @@ func (l *mLogger) Verbose() bool {
 }
 
 // Printf ...
-func (l *mLogger) Printf(format string, v ...interface{}) {
+func (l *mLogger) Printf(format string, v ...any) {
 	l.logger.Infof(format, v...)
 }

--- a/src/common/dao/dao_test.go
+++ b/src/common/dao/dao_test.go
@@ -29,7 +29,7 @@ import (
 
 var testCtx context.Context
 
-func execUpdate(o orm.TxOrmer, sql string, params ...interface{}) error {
+func execUpdate(o orm.TxOrmer, sql string, params ...any) error {
 	p, err := o.Raw(sql).Prepare()
 	if err != nil {
 		return err

--- a/src/common/http/client.go
+++ b/src/common/http/client.go
@@ -69,7 +69,7 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 }
 
 // Get ...
-func (c *Client) Get(url string, v ...interface{}) error {
+func (c *Client) Get(url string, v ...any) error {
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return err
@@ -98,7 +98,7 @@ func (c *Client) Head(url string) error {
 }
 
 // Post ...
-func (c *Client) Post(url string, v ...interface{}) error {
+func (c *Client) Post(url string, v ...any) error {
 	var reader io.Reader
 	if len(v) > 0 {
 		if r, ok := v[0].(io.Reader); ok {
@@ -123,7 +123,7 @@ func (c *Client) Post(url string, v ...interface{}) error {
 }
 
 // Put ...
-func (c *Client) Put(url string, v ...interface{}) error {
+func (c *Client) Put(url string, v ...any) error {
 	var reader io.Reader
 	if len(v) > 0 {
 		data, err := json.Marshal(v[0])
@@ -176,7 +176,7 @@ func (c *Client) do(req *http.Request) ([]byte, error) {
 
 // GetAndIteratePagination iterates the pagination header and returns all resources
 // The parameter "v" must be a pointer to a slice
-func (c *Client) GetAndIteratePagination(endpoint string, v interface{}) error {
+func (c *Client) GetAndIteratePagination(endpoint string, v any) error {
 	url, err := url.Parse(endpoint)
 	if err != nil {
 		return err

--- a/src/common/job/models/models.go
+++ b/src/common/job/models/models.go
@@ -15,7 +15,7 @@
 package models
 
 // Parameters for job execution.
-type Parameters map[string]interface{}
+type Parameters map[string]any
 
 // JobRequest is the request of launching a job.
 type JobRequest struct {
@@ -96,5 +96,5 @@ type JobStatusChange struct {
 // Message is designed for sub/pub messages
 type Message struct {
 	Event string
-	Data  interface{} // generic format
+	Data  any // generic format
 }

--- a/src/common/rbac/project/namespace.go
+++ b/src/common/rbac/project/namespace.go
@@ -43,7 +43,7 @@ func (ns *projectNamespace) Resource(subresources ...types.Resource) types.Resou
 	return types.Resource(fmt.Sprintf("/project/%d", ns.projectID)).Subresource(subresources...)
 }
 
-func (ns *projectNamespace) Identity() interface{} {
+func (ns *projectNamespace) Identity() any {
 	return ns.projectID
 }
 

--- a/src/common/rbac/system/namespace.go
+++ b/src/common/rbac/system/namespace.go
@@ -38,7 +38,7 @@ func (ns *systemNamespace) Resource(subresources ...types.Resource) types.Resour
 	return types.Resource("/system/").Subresource(subresources...)
 }
 
-func (ns *systemNamespace) Identity() interface{} {
+func (ns *systemNamespace) Identity() any {
 	return nil
 }
 

--- a/src/common/security/v2token/context.go
+++ b/src/common/security/v2token/context.go
@@ -63,7 +63,7 @@ func (t *tokenSecurityCtx) GetMyProjects() ([]*models.Project, error) {
 	return []*models.Project{}, nil
 }
 
-func (t *tokenSecurityCtx) GetProjectRoles(_ interface{}) []int {
+func (t *tokenSecurityCtx) GetProjectRoles(_ any) []int {
 	return []int{}
 }
 

--- a/src/common/utils/test/config.go
+++ b/src/common/utils/test/config.go
@@ -18,7 +18,7 @@ import (
 	"github.com/goharbor/harbor/src/common"
 )
 
-var defaultConfig = map[string]interface{}{
+var defaultConfig = map[string]any{
 	common.ExtEndpoint:                "https://host01.com",
 	common.AUTHMode:                   common.DBAuth,
 	common.DatabaseType:               "postgresql",
@@ -66,6 +66,6 @@ var defaultConfig = map[string]interface{}{
 }
 
 // GetDefaultConfigMap returns the default config map for easier modification.
-func GetDefaultConfigMap() map[string]interface{} {
+func GetDefaultConfigMap() map[string]any {
 	return defaultConfig
 }

--- a/src/common/utils/test/registryctl.go
+++ b/src/common/utils/test/registryctl.go
@@ -30,7 +30,7 @@ type GCResult struct {
 }
 
 // NewRegistryCtl returns a mock registry server
-func NewRegistryCtl(_ map[string]interface{}) (*httptest.Server, error) {
+func NewRegistryCtl(_ map[string]any) (*httptest.Server, error) {
 	m := []*RequestHandlerMapping{}
 
 	gcr := GCResult{true, "hello-world", time.Now(), time.Now()}

--- a/src/common/utils/test/test.go
+++ b/src/common/utils/test/test.go
@@ -94,9 +94,9 @@ func NewServer(mappings ...*RequestHandlerMapping) *httptest.Server {
 }
 
 // GetUnitTestConfig ...
-func GetUnitTestConfig() map[string]interface{} {
+func GetUnitTestConfig() map[string]any {
 	ipAddress := os.Getenv("IP")
-	return map[string]interface{}{
+	return map[string]any{
 		common.ExtEndpoint:            fmt.Sprintf("https://%s", ipAddress),
 		common.AUTHMode:               "db_auth",
 		common.DatabaseType:           "postgresql",
@@ -130,7 +130,7 @@ func GetUnitTestConfig() map[string]interface{} {
 }
 
 // TraceCfgMap ...
-func TraceCfgMap(cfgs map[string]interface{}) {
+func TraceCfgMap(cfgs map[string]any) {
 	var keys []string
 	for k := range cfgs {
 		keys = append(keys, k)

--- a/src/common/utils/uaa/client.go
+++ b/src/common/utils/uaa/client.go
@@ -89,7 +89,7 @@ type SearchUserEntry struct {
 	ExtID    string                 `json:"externalId"`
 	UserName string                 `json:"userName"`
 	Emails   []SearchUserEmailEntry `json:"emails"`
-	Groups   []interface{}
+	Groups   []any
 }
 
 // SearchUserRes is the struct to parse the result of search user API of UAA

--- a/src/common/utils/utils.go
+++ b/src/common/utils/utils.go
@@ -140,7 +140,7 @@ func ParseTimeStamp(timestamp string) (*time.Time, error) {
 }
 
 // ConvertMapToStruct is used to fill the specified struct with map.
-func ConvertMapToStruct(object interface{}, values interface{}) error {
+func ConvertMapToStruct(object any, values any) error {
 	if object == nil {
 		return errors.New("nil struct is not supported")
 	}
@@ -158,7 +158,7 @@ func ConvertMapToStruct(object interface{}, values interface{}) error {
 }
 
 // ParseProjectIDOrName parses value to ID(int64) or name(string)
-func ParseProjectIDOrName(value interface{}) (int64, string, error) {
+func ParseProjectIDOrName(value any) (int64, string, error) {
 	if value == nil {
 		return 0, "", errors.New("harborIDOrName is nil")
 	}
@@ -177,7 +177,7 @@ func ParseProjectIDOrName(value interface{}) (int64, string, error) {
 }
 
 // SafeCastString -- cast an object to string safely
-func SafeCastString(value interface{}) string {
+func SafeCastString(value any) string {
 	if result, ok := value.(string); ok {
 		return result
 	}
@@ -185,7 +185,7 @@ func SafeCastString(value interface{}) string {
 }
 
 // SafeCastInt --
-func SafeCastInt(value interface{}) int {
+func SafeCastInt(value any) int {
 	if result, ok := value.(int); ok {
 		return result
 	}
@@ -193,7 +193,7 @@ func SafeCastInt(value interface{}) int {
 }
 
 // SafeCastBool --
-func SafeCastBool(value interface{}) bool {
+func SafeCastBool(value any) bool {
 	if result, ok := value.(bool); ok {
 		return result
 	}
@@ -201,7 +201,7 @@ func SafeCastBool(value interface{}) bool {
 }
 
 // SafeCastFloat64 --
-func SafeCastFloat64(value interface{}) float64 {
+func SafeCastFloat64(value any) float64 {
 	if result, ok := value.(float64); ok {
 		return result
 	}
@@ -214,9 +214,9 @@ func TrimLower(str string) string {
 }
 
 // GetStrValueOfAnyType return string format of any value, for map, need to convert to json
-func GetStrValueOfAnyType(value interface{}) string {
+func GetStrValueOfAnyType(value any) string {
 	var strVal string
-	if _, ok := value.(map[string]interface{}); ok {
+	if _, ok := value.(map[string]any); ok {
 		b, err := json.Marshal(value)
 		if err != nil {
 			log.Errorf("can not marshal json object, error %v", err)
@@ -248,7 +248,7 @@ func IsIllegalLength(s string, minVal int, maxVal int) bool {
 }
 
 // ParseJSONInt ...
-func ParseJSONInt(value interface{}) (int, bool) {
+func ParseJSONInt(value any) (int, bool) {
 	switch v := value.(type) {
 	case float64:
 		return int(v), true

--- a/src/common/utils/utils_test.go
+++ b/src/common/utils/utils_test.go
@@ -216,7 +216,7 @@ type testingStruct struct {
 }
 
 func TestConvertMapToStruct(t *testing.T) {
-	dataMap := make(map[string]interface{})
+	dataMap := make(map[string]any)
 	dataMap["Name"] = "testing"
 	dataMap["Count"] = 100
 
@@ -232,7 +232,7 @@ func TestConvertMapToStruct(t *testing.T) {
 
 func TestSafeCastString(t *testing.T) {
 	type args struct {
-		value interface{}
+		value any
 	}
 	tests := []struct {
 		name string
@@ -254,7 +254,7 @@ func TestSafeCastString(t *testing.T) {
 
 func TestSafeCastBool(t *testing.T) {
 	type args struct {
-		value interface{}
+		value any
 	}
 	tests := []struct {
 		name string
@@ -276,7 +276,7 @@ func TestSafeCastBool(t *testing.T) {
 
 func TestSafeCastInt(t *testing.T) {
 	type args struct {
-		value interface{}
+		value any
 	}
 	tests := []struct {
 		name string
@@ -298,7 +298,7 @@ func TestSafeCastInt(t *testing.T) {
 
 func TestSafeCastFloat64(t *testing.T) {
 	type args struct {
-		value interface{}
+		value any
 	}
 	tests := []struct {
 		name string
@@ -342,7 +342,7 @@ func TestTrimLower(t *testing.T) {
 
 func TestGetStrValueOfAnyType(t *testing.T) {
 	type args struct {
-		value interface{}
+		value any
 	}
 	tests := []struct {
 		name string
@@ -357,7 +357,7 @@ func TestGetStrValueOfAnyType(t *testing.T) {
 		{"string", args{"hello world"}, "hello world"},
 		{"bool", args{true}, "true"},
 		{"bool", args{false}, "false"},
-		{"map", args{map[string]interface{}{"key1": "value1"}}, "{\"key1\":\"value1\"}"},
+		{"map", args{map[string]any{"key1": "value1"}}, "{\"key1\":\"value1\"}"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/src/controller/artifact/annotation/v1alpha1_test.go
+++ b/src/controller/artifact/annotation/v1alpha1_test.go
@@ -231,7 +231,7 @@ func (p *v1alpha1TestSuite) TestParse() {
 	manifestMediaType, content, err := manifest.Payload()
 	p.Require().Nil(err)
 
-	metadata := map[string]interface{}{}
+	metadata := map[string]any{}
 	configBlob := io.NopCloser(strings.NewReader(ormbConfig))
 	err = json.NewDecoder(configBlob).Decode(&metadata)
 	p.Require().Nil(err)
@@ -244,7 +244,7 @@ func (p *v1alpha1TestSuite) TestParse() {
 	p.Len(art.ExtraAttrs, 12)
 	p.Equal("CNN Model", art.ExtraAttrs["description"])
 	p.Equal("TensorFlow", art.ExtraAttrs["framework"])
-	p.Equal([]interface{}{map[string]interface{}{"name": "batch_size", "value": "32"}}, art.ExtraAttrs["hyperparameters"])
+	p.Equal([]any{map[string]any{"name": "batch_size", "value": "32"}}, art.ExtraAttrs["hyperparameters"])
 	p.Equal("sha256:d923b93eadde0af5c639a972710a4d919066aba5d0dfbf4b9385099f70272da0", art.Icon)
 
 	// ormbManifestWithoutSkipList
@@ -255,7 +255,7 @@ func (p *v1alpha1TestSuite) TestParse() {
 	manifestMediaType, content, err = manifest.Payload()
 	p.Require().Nil(err)
 
-	metadata = map[string]interface{}{}
+	metadata = map[string]any{}
 	configBlob = io.NopCloser(strings.NewReader(ormbConfig))
 	err = json.NewDecoder(configBlob).Decode(&metadata)
 	p.Require().Nil(err)
@@ -268,7 +268,7 @@ func (p *v1alpha1TestSuite) TestParse() {
 	p.Len(art.ExtraAttrs, 13)
 	p.Equal("CNN Model", art.ExtraAttrs["description"])
 	p.Equal("TensorFlow", art.ExtraAttrs["framework"])
-	p.Equal([]interface{}{map[string]interface{}{"name": "batch_size", "value": "32"}}, art.ExtraAttrs["hyperparameters"])
+	p.Equal([]any{map[string]any{"name": "batch_size", "value": "32"}}, art.ExtraAttrs["hyperparameters"])
 	p.Equal("sha256:d923b93eadde0af5c639a972710a4d919066aba5d0dfbf4b9385099f70272da0", art.Icon)
 
 	// ormbManifestWithoutIcon
@@ -279,7 +279,7 @@ func (p *v1alpha1TestSuite) TestParse() {
 	manifestMediaType, content, err = manifest.Payload()
 	p.Require().Nil(err)
 
-	metadata = map[string]interface{}{}
+	metadata = map[string]any{}
 	configBlob = io.NopCloser(strings.NewReader(ormbConfig))
 	err = json.NewDecoder(configBlob).Decode(&metadata)
 	p.Require().Nil(err)
@@ -290,7 +290,7 @@ func (p *v1alpha1TestSuite) TestParse() {
 	p.Len(art.ExtraAttrs, 12)
 	p.Equal("CNN Model", art.ExtraAttrs["description"])
 	p.Equal("TensorFlow", art.ExtraAttrs["framework"])
-	p.Equal([]interface{}{map[string]interface{}{"name": "batch_size", "value": "32"}}, art.ExtraAttrs["hyperparameters"])
+	p.Equal([]any{map[string]any{"name": "batch_size", "value": "32"}}, art.ExtraAttrs["hyperparameters"])
 	p.Equal("", art.Icon)
 }
 

--- a/src/controller/artifact/controller.go
+++ b/src/controller/artifact/controller.go
@@ -313,7 +313,7 @@ func (c *controller) getByTag(ctx context.Context, repository, tag string, optio
 		return nil, err
 	}
 	tags, err := c.tagCtl.List(ctx, &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"RepositoryID": repo.RepositoryID,
 			"Name":         tag,
 		},
@@ -356,7 +356,7 @@ func (c *controller) deleteDeeply(ctx context.Context, id int64, isRoot, isAcces
 		return nil
 	}
 	parents, err := c.artMgr.ListReferences(ctx, &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"ChildID": id,
 		},
 	})
@@ -385,7 +385,7 @@ func (c *controller) deleteDeeply(ctx context.Context, id int64, isRoot, isAcces
 		if acc.IsHard() {
 			// if this acc artifact has parent(is child), set isRoot to false
 			parents, err := c.artMgr.ListReferences(ctx, &q.Query{
-				Keywords: map[string]interface{}{
+				Keywords: map[string]any{
 					"ChildID": acc.GetData().ArtifactID,
 				},
 			})
@@ -752,7 +752,7 @@ func (c *controller) populateIcon(art *Artifact) {
 
 func (c *controller) populateTags(ctx context.Context, art *Artifact, option *tag.Option) {
 	tags, err := c.tagCtl.List(ctx, &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"artifact_id": art.ID,
 		},
 	}, option)

--- a/src/controller/artifact/helper_test.go
+++ b/src/controller/artifact/helper_test.go
@@ -56,7 +56,7 @@ func (suite *IteratorTestSuite) TeardownSuite() {
 
 func (suite *IteratorTestSuite) TestIterator() {
 	suite.accMgr.On("List", mock.Anything, mock.Anything).Return([]accessorymodel.Accessory{}, nil)
-	q1 := &q.Query{PageNumber: 1, PageSize: 5, Keywords: map[string]interface{}{}}
+	q1 := &q.Query{PageNumber: 1, PageSize: 5, Keywords: map[string]any{}}
 	suite.artMgr.On("List", mock.Anything, q1).Return([]*artifact.Artifact{
 		{ID: 1},
 		{ID: 2},
@@ -65,7 +65,7 @@ func (suite *IteratorTestSuite) TestIterator() {
 		{ID: 5},
 	}, nil)
 
-	q2 := &q.Query{PageNumber: 2, PageSize: 5, Keywords: map[string]interface{}{}}
+	q2 := &q.Query{PageNumber: 2, PageSize: 5, Keywords: map[string]any{}}
 	suite.artMgr.On("List", mock.Anything, q2).Return([]*artifact.Artifact{
 		{ID: 6},
 		{ID: 7},

--- a/src/controller/artifact/model.go
+++ b/src/controller/artifact/model.go
@@ -40,7 +40,7 @@ func (artifact *Artifact) UnmarshalJSON(data []byte) error {
 	type Alias Artifact
 	ali := &struct {
 		*Alias
-		AccessoryItems []interface{} `json:"accessories,omitempty"`
+		AccessoryItems []any `json:"accessories,omitempty"`
 	}{
 		Alias: (*Alias)(artifact),
 	}

--- a/src/controller/artifact/processor/base/manifest.go
+++ b/src/controller/artifact/processor/base/manifest.go
@@ -44,7 +44,7 @@ type ManifestProcessor struct {
 // AbstractMetadata abstracts metadata of artifact
 func (m *ManifestProcessor) AbstractMetadata(ctx context.Context, artifact *artifact.Artifact, content []byte) error {
 	// parse metadata from config layer
-	metadata := map[string]interface{}{}
+	metadata := map[string]any{}
 	if err := m.UnmarshalConfig(ctx, artifact.RepositoryName, content, &metadata); err != nil {
 		return err
 	}
@@ -55,7 +55,7 @@ func (m *ManifestProcessor) AbstractMetadata(ctx context.Context, artifact *arti
 	}
 
 	if artifact.ExtraAttrs == nil {
-		artifact.ExtraAttrs = map[string]interface{}{}
+		artifact.ExtraAttrs = map[string]any{}
 	}
 	for _, property := range m.properties {
 		artifact.ExtraAttrs[property] = metadata[property]
@@ -80,7 +80,7 @@ func (m *ManifestProcessor) ListAdditionTypes(_ context.Context, _ *artifact.Art
 }
 
 // UnmarshalConfig unmarshal the config blob of the artifact into the specified object "v"
-func (m *ManifestProcessor) UnmarshalConfig(_ context.Context, repository string, manifest []byte, v interface{}) error {
+func (m *ManifestProcessor) UnmarshalConfig(_ context.Context, repository string, manifest []byte, v any) error {
 	// unmarshal manifest
 	mani := &v1.Manifest{}
 	if err := json.Unmarshal(manifest, mani); err != nil {

--- a/src/controller/artifact/processor/chart/chart_test.go
+++ b/src/controller/artifact/processor/chart/chart_test.go
@@ -89,7 +89,7 @@ func (p *processorTestSuite) TestAbstractAddition() {
 				Repository: "github.com/goharbor",
 			},
 		},
-		Values: map[string]interface{}{
+		Values: map[string]any{
 			"cluster.enable":                   true,
 			"cluster.slaveCount":               1,
 			"image.pullPolicy":                 "Always",

--- a/src/controller/artifact/processor/default.go
+++ b/src/controller/artifact/processor/default.go
@@ -110,7 +110,7 @@ func (d *defaultProcessor) AbstractMetadata(ctx context.Context, artifact *artif
 		}
 		defer blob.Close()
 		// parse metadata from config layer
-		metadata := map[string]interface{}{}
+		metadata := map[string]any{}
 		if err = json.NewDecoder(blob).Decode(&metadata); err != nil {
 			return err
 		}

--- a/src/controller/artifact/processor/default_test.go
+++ b/src/controller/artifact/processor/default_test.go
@@ -268,7 +268,7 @@ func (d *defaultProcessorTestSuite) TestAbstractMetadata() {
 	manifestMediaType, content, err := manifest.Payload()
 	d.Require().Nil(err)
 
-	metadata := map[string]interface{}{}
+	metadata := map[string]any{}
 	configBlob := io.NopCloser(strings.NewReader(ormbConfig))
 	err = json.NewDecoder(configBlob).Decode(&metadata)
 	d.Require().Nil(err)
@@ -289,7 +289,7 @@ func (d *defaultProcessorTestSuite) TestAbstractMetadataOfOCIManifesttWithUnknow
 	d.Require().Nil(err)
 
 	configBlob := io.NopCloser(strings.NewReader(UnknownJsonConfig))
-	metadata := map[string]interface{}{}
+	metadata := map[string]any{}
 	err = json.NewDecoder(configBlob).Decode(&metadata)
 	d.Require().Nil(err)
 

--- a/src/controller/artifact/processor/image/manifest_v1.go
+++ b/src/controller/artifact/processor/image/manifest_v1.go
@@ -44,7 +44,7 @@ func (m *manifestV1Processor) AbstractMetadata(_ context.Context, artifact *arti
 		return err
 	}
 	if artifact.ExtraAttrs == nil {
-		artifact.ExtraAttrs = map[string]interface{}{}
+		artifact.ExtraAttrs = map[string]any{}
 	}
 	artifact.ExtraAttrs["architecture"] = mani.Architecture
 	return nil

--- a/src/controller/artifact/processor/image/manifest_v2.go
+++ b/src/controller/artifact/processor/image/manifest_v2.go
@@ -59,7 +59,7 @@ func (m *manifestV2Processor) AbstractMetadata(ctx context.Context, artifact *ar
 		return err
 	}
 	if artifact.ExtraAttrs == nil {
-		artifact.ExtraAttrs = map[string]interface{}{}
+		artifact.ExtraAttrs = map[string]any{}
 	}
 	artifact.ExtraAttrs["created"] = config.Created
 	artifact.ExtraAttrs["architecture"] = config.Architecture

--- a/src/controller/artifact/processor/wasm/wasm.go
+++ b/src/controller/artifact/processor/wasm/wasm.go
@@ -62,14 +62,14 @@ type Processor struct {
 }
 
 func (m *Processor) AbstractMetadata(ctx context.Context, art *artifact.Artifact, manifestBody []byte) error {
-	art.ExtraAttrs = map[string]interface{}{}
+	art.ExtraAttrs = map[string]any{}
 	manifest := &v1.Manifest{}
 	if err := json.Unmarshal(manifestBody, manifest); err != nil {
 		return err
 	}
 
 	if art.ExtraAttrs == nil {
-		art.ExtraAttrs = map[string]interface{}{}
+		art.ExtraAttrs = map[string]any{}
 	}
 	if manifest.Annotations[AnnotationVariantKey] == AnnotationVariantValue || manifest.Annotations[AnnotationHandlerKey] == AnnotationHandlerValue {
 		// for annotation way

--- a/src/controller/blob/controller.go
+++ b/src/controller/blob/controller.go
@@ -225,10 +225,10 @@ func (c *controller) Get(ctx context.Context, digest string, options ...Option) 
 
 	opts := newOptions(options...)
 
-	keywords := make(map[string]interface{})
+	keywords := make(map[string]any)
 	if digest != "" {
 		ol := q.OrList{
-			Values: []interface{}{
+			Values: []any{
 				digest,
 			},
 		}

--- a/src/controller/config/controller.go
+++ b/src/controller/config/controller.go
@@ -46,11 +46,11 @@ type Controller interface {
 	// UserConfigs get the user scope configurations
 	UserConfigs(ctx context.Context) (map[string]*models.Value, error)
 	// UpdateUserConfigs update the user scope configurations
-	UpdateUserConfigs(ctx context.Context, conf map[string]interface{}) error
+	UpdateUserConfigs(ctx context.Context, conf map[string]any) error
 	// AllConfigs get all configurations, used by internal, should include the system config items
-	AllConfigs(ctx context.Context) (map[string]interface{}, error)
+	AllConfigs(ctx context.Context) (map[string]any, error)
 	// ConvertForGet - delete sensitive attrs and add editable field to every attr
-	ConvertForGet(ctx context.Context, cfg map[string]interface{}, internal bool) (map[string]*models.Value, error)
+	ConvertForGet(ctx context.Context, cfg map[string]any, internal bool) (map[string]*models.Value, error)
 	// OverwriteConfig overwrite config in the database and set all configure read only when CONFIG_OVERWRITE_JSON is provided
 	OverwriteConfig(ctx context.Context) error
 }
@@ -70,13 +70,13 @@ func (c *controller) UserConfigs(ctx context.Context) (map[string]*models.Value,
 	return c.ConvertForGet(ctx, configs, false)
 }
 
-func (c *controller) AllConfigs(ctx context.Context) (map[string]interface{}, error) {
+func (c *controller) AllConfigs(ctx context.Context) (map[string]any, error) {
 	mgr := config.GetCfgManager(ctx)
 	configs := mgr.GetAll(ctx)
 	return configs, nil
 }
 
-func (c *controller) UpdateUserConfigs(ctx context.Context, conf map[string]interface{}) error {
+func (c *controller) UpdateUserConfigs(ctx context.Context, conf map[string]any) error {
 	if readOnlyForAll {
 		return errors.ForbiddenError(nil).WithMessage("current config is init by env variable: CONFIG_OVERWRITE_JSON, it cannot be updated")
 	}
@@ -97,7 +97,7 @@ func (c *controller) UpdateUserConfigs(ctx context.Context, conf map[string]inte
 	return c.updateLogEndpoint(ctx, conf)
 }
 
-func (c *controller) updateLogEndpoint(ctx context.Context, cfgs map[string]interface{}) error {
+func (c *controller) updateLogEndpoint(ctx context.Context, cfgs map[string]any) error {
 	// check if the audit log forward endpoint updated
 	if _, ok := cfgs[common.AuditLogForwardEndpoint]; ok {
 		auditEP := config.AuditLogForwardEndpoint(ctx)
@@ -112,7 +112,7 @@ func (c *controller) updateLogEndpoint(ctx context.Context, cfgs map[string]inte
 	return nil
 }
 
-func (c *controller) validateCfg(ctx context.Context, cfgs map[string]interface{}) error {
+func (c *controller) validateCfg(ctx context.Context, cfgs map[string]any) error {
 	mgr := config.GetCfgManager(ctx)
 
 	// check if auth can be modified
@@ -146,7 +146,7 @@ func (c *controller) validateCfg(ctx context.Context, cfgs map[string]interface{
 	return nil
 }
 
-func verifySkipAuditLogCfg(ctx context.Context, cfgs map[string]interface{}, mgr config.Manager) error {
+func verifySkipAuditLogCfg(ctx context.Context, cfgs map[string]any, mgr config.Manager) error {
 	updated := false
 	endPoint := mgr.Get(ctx, common.AuditLogForwardEndpoint).GetString()
 	skipAuditDB := mgr.Get(ctx, common.SkipAuditLogDatabase).GetBool()
@@ -169,7 +169,7 @@ func verifySkipAuditLogCfg(ctx context.Context, cfgs map[string]interface{}, mgr
 }
 
 // verifyValueLengthCfg verifies the cfgs which need to check the value max length to align with frontend.
-func verifyValueLengthCfg(_ context.Context, cfgs map[string]interface{}) error {
+func verifyValueLengthCfg(_ context.Context, cfgs map[string]any) error {
 	maxValue := maxValueLimitedByLength(common.UIMaxLengthLimitedOfNumber)
 	validateCfgs := []string{
 		common.TokenExpiration,
@@ -217,11 +217,11 @@ func maxValueLimitedByLength(length int) int64 {
 // ScanAllPolicy is represent the json request and object for scan all policy
 // Only for migrating from the legacy schedule.
 type ScanAllPolicy struct {
-	Type  string                 `json:"type"`
-	Param map[string]interface{} `json:"parameter,omitempty"`
+	Type  string         `json:"type"`
+	Param map[string]any `json:"parameter,omitempty"`
 }
 
-func (c *controller) ConvertForGet(ctx context.Context, cfg map[string]interface{}, internal bool) (map[string]*models.Value, error) {
+func (c *controller) ConvertForGet(ctx context.Context, cfg map[string]any, internal bool) (map[string]*models.Value, error) {
 	result := map[string]*models.Value{}
 
 	mList := metadata.Instance().GetAll()
@@ -270,7 +270,7 @@ func (c *controller) ConvertForGet(ctx context.Context, cfg map[string]interface
 }
 
 func (c *controller) OverwriteConfig(ctx context.Context) error {
-	cfgMap := map[string]interface{}{}
+	cfgMap := map[string]any{}
 	if v, ok := os.LookupEnv(configOverwriteJSON); ok {
 		err := json.Unmarshal([]byte(v), &cfgMap)
 		if err != nil {

--- a/src/controller/config/controller_test.go
+++ b/src/controller/config/controller_test.go
@@ -33,7 +33,7 @@ func Test_verifySkipAuditLogCfg(t *testing.T) {
 		Return(&metadata.ConfigureValue{Name: common.SkipAuditLogDatabase, Value: "true"})
 	type args struct {
 		ctx  context.Context
-		cfgs map[string]interface{}
+		cfgs map[string]any
 		mgr  config.Manager
 	}
 	tests := []struct {
@@ -42,17 +42,17 @@ func Test_verifySkipAuditLogCfg(t *testing.T) {
 		wantErr bool
 	}{
 		{name: "both configured", args: args{ctx: context.TODO(),
-			cfgs: map[string]interface{}{common.AuditLogForwardEndpoint: "harbor-log:15041",
+			cfgs: map[string]any{common.AuditLogForwardEndpoint: "harbor-log:15041",
 				common.SkipAuditLogDatabase: true},
 			mgr: cfgManager}, wantErr: false},
 		{name: "no forward endpoint config", args: args{ctx: context.TODO(),
-			cfgs: map[string]interface{}{common.SkipAuditLogDatabase: true},
+			cfgs: map[string]any{common.SkipAuditLogDatabase: true},
 			mgr:  cfgManager}, wantErr: true},
 		{name: "none configured", args: args{ctx: context.TODO(),
-			cfgs: map[string]interface{}{},
+			cfgs: map[string]any{},
 			mgr:  cfgManager}, wantErr: false},
 		{name: "enabled skip audit log database, but change log forward endpoint to empty", args: args{ctx: context.TODO(),
-			cfgs: map[string]interface{}{common.AuditLogForwardEndpoint: ""},
+			cfgs: map[string]any{common.AuditLogForwardEndpoint: ""},
 			mgr:  cfgManager}, wantErr: true},
 	}
 	for _, tt := range tests {
@@ -89,24 +89,24 @@ func Test_maxValueLimitedByLength(t *testing.T) {
 func Test_verifyValueLengthCfg(t *testing.T) {
 	type args struct {
 		ctx  context.Context
-		cfgs map[string]interface{}
+		cfgs map[string]any
 	}
 	tests := []struct {
 		name    string
 		args    args
 		wantErr bool
 	}{
-		{name: "valid config", args: args{context.TODO(), map[string]interface{}{
+		{name: "valid config", args: args{context.TODO(), map[string]any{
 			common.TokenExpiration:    float64(100),
 			common.RobotTokenDuration: float64(100),
 			common.SessionTimeout:     float64(100),
 		}}, wantErr: false},
-		{name: "invalid config with negative value", args: args{context.TODO(), map[string]interface{}{
+		{name: "invalid config with negative value", args: args{context.TODO(), map[string]any{
 			common.TokenExpiration:    float64(-1),
 			common.RobotTokenDuration: float64(100),
 			common.SessionTimeout:     float64(100),
 		}}, wantErr: true},
-		{name: "invalid config with value over length limit", args: args{context.TODO(), map[string]interface{}{
+		{name: "invalid config with value over length limit", args: args{context.TODO(), map[string]any{
 			common.TokenExpiration:    float64(100),
 			common.RobotTokenDuration: float64(100000000000000000),
 			common.SessionTimeout:     float64(100),

--- a/src/controller/config/test/controller_test.go
+++ b/src/controller/config/test/controller_test.go
@@ -28,12 +28,12 @@ import (
 	htesting "github.com/goharbor/harbor/src/testing"
 )
 
-var TestDBConfig = map[string]interface{}{
+var TestDBConfig = map[string]any{
 	common.LDAPBaseDN: "dc=example,dc=com",
 	common.LDAPURL:    "ldap.example.com",
 }
 
-var TestConfigWithScanAll = map[string]interface{}{
+var TestConfigWithScanAll = map[string]any{
 	"postgresql_host":     "localhost",
 	"postgresql_database": "registry",
 	"postgresql_password": "root123",
@@ -67,7 +67,7 @@ func (c *controllerTestSuite) TestGetUserCfg() {
 }
 
 func (c *controllerTestSuite) TestConvertForGet() {
-	conf := map[string]interface{}{
+	conf := map[string]any{
 		"ldap_url":             "ldaps.myexample,com",
 		"ldap_base_dn":         "dc=myexample,dc=com",
 		"auth_mode":            "ldap_auth",
@@ -83,7 +83,7 @@ func (c *controllerTestSuite) TestConvertForGet() {
 	c.False(exist)
 
 	// password type should be sent to internal api call
-	conf2 := map[string]interface{}{
+	conf2 := map[string]any{
 		"ldap_url":             "ldaps.myexample,com",
 		"ldap_base_dn":         "dc=myexample,dc=com",
 		"auth_mode":            "ldap_auth",
@@ -109,7 +109,7 @@ func (c *controllerTestSuite) TestGetAll() {
 
 func (c *controllerTestSuite) TestUpdateUserCfg() {
 
-	userConf := map[string]interface{}{
+	userConf := map[string]any{
 		common.LDAPURL:    "ldaps.myexample,com",
 		common.LDAPBaseDN: "dc=myexample,dc=com",
 	}
@@ -121,7 +121,7 @@ func (c *controllerTestSuite) TestUpdateUserCfg() {
 	}
 	c.Equal("dc=myexample,dc=com", cfgResp["ldap_base_dn"].Val)
 	c.Equal("ldaps.myexample,com", cfgResp["ldap_url"].Val)
-	badCfg := map[string]interface{}{
+	badCfg := map[string]any{
 		common.LDAPScope: 5,
 	}
 	err2 := c.controller.UpdateUserConfigs(ctx, badCfg)
@@ -130,7 +130,7 @@ func (c *controllerTestSuite) TestUpdateUserCfg() {
 }
 
 /*func (c *controllerTestSuite) TestCheckUnmodifiable() {
-	conf := map[string]interface{}{
+	conf := map[string]any{
 		"ldap_url":     "ldaps.myexample,com",
 		"ldap_base_dn": "dc=myexample,dc=com",
 		"auth_mode":    "ldap_auth",

--- a/src/controller/event/handler/auditlog/auditlog.go
+++ b/src/controller/event/handler/auditlog/auditlog.go
@@ -41,7 +41,7 @@ func (h *Handler) Name() string {
 }
 
 // Handle ...
-func (h *Handler) Handle(ctx context.Context, value interface{}) error {
+func (h *Handler) Handle(ctx context.Context, value any) error {
 	var addAuditLog bool
 	switch v := value.(type) {
 	case *event.PushArtifactEvent, *event.DeleteArtifactEvent,

--- a/src/controller/event/handler/internal/artifact.go
+++ b/src/controller/event/handler/internal/artifact.go
@@ -99,7 +99,7 @@ func (a *ArtifactEventHandler) Name() string {
 }
 
 // Handle ...
-func (a *ArtifactEventHandler) Handle(ctx context.Context, value interface{}) error {
+func (a *ArtifactEventHandler) Handle(ctx context.Context, value any) error {
 	switch v := value.(type) {
 	case *event.PullArtifactEvent:
 		return a.onPull(ctx, v.ArtifactEvent)
@@ -190,7 +190,7 @@ func (a *ArtifactEventHandler) syncFlushPullTime(ctx context.Context, artifactID
 
 	if tagName != "" {
 		tags, err := tag.Ctl.List(ctx, q.New(
-			map[string]interface{}{
+			map[string]any{
 				"ArtifactID": artifactID,
 				"Name":       tagName,
 			}), nil)

--- a/src/controller/event/handler/internal/project.go
+++ b/src/controller/event/handler/internal/project.go
@@ -53,7 +53,7 @@ func (a *ProjectEventHandler) onProjectDelete(ctx context.Context, event *event.
 }
 
 // Handle handle project event
-func (a *ProjectEventHandler) Handle(ctx context.Context, value interface{}) error {
+func (a *ProjectEventHandler) Handle(ctx context.Context, value any) error {
 	switch v := value.(type) {
 	case *event.DeleteProjectEvent:
 		return a.onProjectDelete(ctx, v)

--- a/src/controller/event/handler/p2p/preheat.go
+++ b/src/controller/event/handler/p2p/preheat.go
@@ -36,7 +36,7 @@ func (p *Handler) Name() string {
 }
 
 // Handle ...
-func (p *Handler) Handle(ctx context.Context, value interface{}) error {
+func (p *Handler) Handle(ctx context.Context, value any) error {
 	switch v := value.(type) {
 	case *event.PushArtifactEvent:
 		return p.handlePushArtifact(ctx, v)

--- a/src/controller/event/handler/p2p/preheat_test.go
+++ b/src/controller/event/handler/p2p/preheat_test.go
@@ -82,7 +82,7 @@ func (suite *PreheatTestSuite) TestName() {
 // TestHandle ...
 func (suite *PreheatTestSuite) TestHandle() {
 	type args struct {
-		data interface{}
+		data any
 	}
 	tests := []struct {
 		name    string

--- a/src/controller/event/handler/replication/replication.go
+++ b/src/controller/event/handler/replication/replication.go
@@ -36,7 +36,7 @@ func (r *Handler) Name() string {
 }
 
 // Handle ...
-func (r *Handler) Handle(ctx context.Context, value interface{}) error {
+func (r *Handler) Handle(ctx context.Context, value any) error {
 	pushArtEvent, ok := value.(*event.PushArtifactEvent)
 	if ok {
 		return r.handlePushArtifact(ctx, pushArtEvent)
@@ -78,7 +78,7 @@ func (r *Handler) handlePushArtifact(ctx context.Context, event *event.PushArtif
 			Metadata: &model.ResourceMetadata{
 				Repository: &model.Repository{
 					Name: event.Repository,
-					Metadata: map[string]interface{}{
+					Metadata: map[string]any{
 						"public": strconv.FormatBool(public),
 					},
 				},
@@ -138,7 +138,7 @@ func (r *Handler) handleCreateTag(ctx context.Context, event *event.CreateTagEve
 			Metadata: &model.ResourceMetadata{
 				Repository: &model.Repository{
 					Name: event.Repository,
-					Metadata: map[string]interface{}{
+					Metadata: map[string]any{
 						"public": strconv.FormatBool(public),
 					},
 				},

--- a/src/controller/event/handler/util/util_test.go
+++ b/src/controller/event/handler/util/util_test.go
@@ -17,7 +17,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestBuildImageResourceURL(t *testing.T) {
-	cfg := map[string]interface{}{
+	cfg := map[string]any{
 		common.ExtEndpoint: "https://demo.goharbor.io",
 	}
 	config.InitWithSettings(cfg)

--- a/src/controller/event/handler/webhook/artifact/artifact.go
+++ b/src/controller/event/handler/webhook/artifact/artifact.go
@@ -39,7 +39,7 @@ func (a *Handler) Name() string {
 }
 
 // Handle preprocess artifact event data and then publish hook event
-func (a *Handler) Handle(ctx context.Context, value interface{}) error {
+func (a *Handler) Handle(ctx context.Context, value any) error {
 	if !config.NotificationEnable(ctx) {
 		log.Debug("notification feature is not enabled")
 		return nil

--- a/src/controller/event/handler/webhook/artifact/replication.go
+++ b/src/controller/event/handler/webhook/artifact/replication.go
@@ -45,7 +45,7 @@ func (r *ReplicationHandler) Name() string {
 }
 
 // Handle ...
-func (r *ReplicationHandler) Handle(ctx context.Context, value interface{}) error {
+func (r *ReplicationHandler) Handle(ctx context.Context, value any) error {
 	if !config.NotificationEnable(ctx) {
 		log.Debug("notification feature is not enabled")
 		return nil

--- a/src/controller/event/handler/webhook/artifact/replication_test.go
+++ b/src/controller/event/handler/webhook/artifact/replication_test.go
@@ -73,7 +73,7 @@ func TestReplicationHandler_Handle(t *testing.T) {
 	handler := &ReplicationHandler{}
 
 	type args struct {
-		data interface{}
+		data any
 	}
 	tests := []struct {
 		name    string

--- a/src/controller/event/handler/webhook/artifact/retention.go
+++ b/src/controller/event/handler/webhook/artifact/retention.go
@@ -40,7 +40,7 @@ func (r *RetentionHandler) Name() string {
 }
 
 // Handle ...
-func (r *RetentionHandler) Handle(ctx context.Context, value interface{}) error {
+func (r *RetentionHandler) Handle(ctx context.Context, value any) error {
 	if !config.NotificationEnable(ctx) {
 		log.Debug("notification feature is not enabled")
 		return nil

--- a/src/controller/event/handler/webhook/artifact/retention_test.go
+++ b/src/controller/event/handler/webhook/artifact/retention_test.go
@@ -61,7 +61,7 @@ func TestRetentionHandler_Handle(t *testing.T) {
 	}, nil)
 
 	type args struct {
-		data interface{}
+		data any
 	}
 	tests := []struct {
 		name    string

--- a/src/controller/event/handler/webhook/quota/quota.go
+++ b/src/controller/event/handler/webhook/quota/quota.go
@@ -38,7 +38,7 @@ func (qp *Handler) Name() string {
 }
 
 // Handle ...
-func (qp *Handler) Handle(ctx context.Context, value interface{}) error {
+func (qp *Handler) Handle(ctx context.Context, value any) error {
 	quotaEvent, ok := value.(*event.QuotaEvent)
 	if !ok {
 		return errors.New("invalid quota event type")

--- a/src/controller/event/handler/webhook/quota/quota_test.go
+++ b/src/controller/event/handler/webhook/quota/quota_test.go
@@ -53,7 +53,7 @@ func TestQuotaPreprocessHandler(t *testing.T) {
 // SetupSuite prepares env for test suite.
 func (suite *QuotaPreprocessHandlerSuite) SetupSuite() {
 	common_dao.PrepareTestForPostgresSQL()
-	cfg := map[string]interface{}{
+	cfg := map[string]any{
 		common.NotificationEnable: true,
 	}
 	config.InitWithSettings(cfg)
@@ -110,7 +110,7 @@ func (m *MockHandler) Name() string {
 }
 
 // Handle ...
-func (m *MockHandler) Handle(ctx context.Context, value interface{}) error {
+func (m *MockHandler) Handle(ctx context.Context, value any) error {
 	return nil
 }
 

--- a/src/controller/event/handler/webhook/scan/scan.go
+++ b/src/controller/event/handler/webhook/scan/scan.go
@@ -42,7 +42,7 @@ func (si *Handler) Name() string {
 }
 
 // Handle preprocess chart event data and then publish hook event
-func (si *Handler) Handle(ctx context.Context, value interface{}) error {
+func (si *Handler) Handle(ctx context.Context, value any) error {
 	if value == nil {
 		return errors.New("empty scan artifact event")
 	}
@@ -142,7 +142,7 @@ func constructScanImagePayload(ctx context.Context, event *event.ScanImageEvent,
 		time.Sleep(500 * time.Millisecond)
 	}
 
-	scanSummaries := map[string]interface{}{}
+	scanSummaries := map[string]any{}
 	if event.ScanType == v1.ScanTypeVulnerability {
 		scanSummaries, err = scan.DefaultController.GetSummary(ctx, art, event.ScanType, []string{v1.MimeTypeNativeReport, v1.MimeTypeGenericVulnerabilityReport})
 		if err != nil {
@@ -150,7 +150,7 @@ func constructScanImagePayload(ctx context.Context, event *event.ScanImageEvent,
 		}
 	}
 
-	sbomOverview := map[string]interface{}{}
+	sbomOverview := map[string]any{}
 	if event.ScanType == v1.ScanTypeSbom {
 		sbomOverview, err = scan.DefaultController.GetSummary(ctx, art, event.ScanType, []string{v1.MimeTypeSBOMReport})
 		if err != nil {

--- a/src/controller/event/handler/webhook/scan/scan_test.go
+++ b/src/controller/event/handler/webhook/scan/scan_test.go
@@ -63,7 +63,7 @@ func TestScanImagePreprocessHandler(t *testing.T) {
 // SetupSuite prepares env for test suite.
 func (suite *ScanImagePreprocessHandlerSuite) SetupSuite() {
 	common_dao.PrepareTestForPostgresSQL()
-	cfg := map[string]interface{}{
+	cfg := map[string]any{
 		common.NotificationEnable: true,
 	}
 	config.InitWithSettings(cfg)
@@ -92,7 +92,7 @@ func (suite *ScanImagePreprocessHandlerSuite) SetupSuite() {
 	mc := &scantesting.Controller{}
 
 	var options []report.Option
-	s := make(map[string]interface{})
+	s := make(map[string]any)
 	mc.On("GetSummary", a, []string{v1.MimeTypeNativeReport}, options).Return(s, nil)
 	mock.OnAnything(mc, "GetSummary").Return(s, nil)
 	mock.OnAnything(mc, "GetReport").Return(reports, nil)
@@ -153,7 +153,7 @@ func (m *MockHTTPHandler) Name() string {
 }
 
 // Handle ...
-func (m *MockHTTPHandler) Handle(ctx context.Context, value interface{}) error {
+func (m *MockHTTPHandler) Handle(ctx context.Context, value any) error {
 	return nil
 }
 

--- a/src/controller/event/metadata/robot_test.go
+++ b/src/controller/event/metadata/robot_test.go
@@ -33,7 +33,7 @@ type robotEventTestSuite struct {
 }
 
 func (t *tagEventTestSuite) TestResolveOfCreateRobotEventMetadata() {
-	cfg := map[string]interface{}{
+	cfg := map[string]any{
 		common.RobotPrefix: "robot$",
 	}
 	config.InitWithSettings(cfg)
@@ -57,7 +57,7 @@ func (t *tagEventTestSuite) TestResolveOfCreateRobotEventMetadata() {
 }
 
 func (t *tagEventTestSuite) TestResolveOfDeleteRobotEventMetadata() {
-	cfg := map[string]interface{}{
+	cfg := map[string]any{
 		common.RobotPrefix: "robot$",
 	}
 	config.InitWithSettings(cfg)

--- a/src/controller/gc/controller.go
+++ b/src/controller/gc/controller.go
@@ -75,7 +75,7 @@ type controller struct {
 
 // Start starts the manual GC
 func (c *controller) Start(ctx context.Context, policy Policy, trigger string) (int64, error) {
-	para := make(map[string]interface{})
+	para := make(map[string]any)
 	para["delete_untagged"] = policy.DeleteUntagged
 	para["dry_run"] = policy.DryRun
 	para["workers"] = policy.Workers
@@ -129,7 +129,7 @@ func (c *controller) ListExecutions(ctx context.Context, query *q.Query) ([]*Exe
 // GetExecution ...
 func (c *controller) GetExecution(ctx context.Context, id int64) (*Execution, error) {
 	execs, err := c.exeMgr.List(ctx, &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"ID":         id,
 			"VendorType": job.GarbageCollectionVendorType,
 		},
@@ -147,7 +147,7 @@ func (c *controller) GetExecution(ctx context.Context, id int64) (*Execution, er
 // GetTask ...
 func (c *controller) GetTask(ctx context.Context, id int64) (*Task, error) {
 	tasks, err := c.taskMgr.List(ctx, &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"ID":         id,
 			"VendorType": job.GarbageCollectionVendorType,
 		},
@@ -203,7 +203,7 @@ func (c *controller) GetSchedule(ctx context.Context) (*scheduler.Schedule, erro
 
 // CreateSchedule ...
 func (c *controller) CreateSchedule(ctx context.Context, cronType, cron string, policy Policy) (int64, error) {
-	extras := make(map[string]interface{})
+	extras := make(map[string]any)
 	extras["delete_untagged"] = policy.DeleteUntagged
 	extras["workers"] = policy.Workers
 	return c.schedulerMgr.Schedule(ctx, job.GarbageCollectionVendorType, -1, cronType, cron, job.GarbageCollectionVendorType, policy, extras)

--- a/src/controller/gc/controller_test.go
+++ b/src/controller/gc/controller_test.go
@@ -38,7 +38,7 @@ func (g *gcCtrTestSuite) TestStart() {
 	g.taskMgr.On("Create", mock.Anything, mock.Anything, mock.Anything).Return(int64(1), nil)
 	g.taskMgr.On("Stop", mock.Anything, mock.Anything).Return(nil)
 
-	dataMap := make(map[string]interface{})
+	dataMap := make(map[string]any)
 	p := Policy{
 		DeleteUntagged: true,
 		ExtraAttrs:     dataMap,
@@ -146,7 +146,7 @@ func (g *gcCtrTestSuite) TestCreateSchedule() {
 	g.scheduler.On("Schedule", mock.Anything, mock.Anything, mock.Anything, mock.Anything,
 		mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(int64(1), nil)
 
-	dataMap := make(map[string]interface{})
+	dataMap := make(map[string]any)
 	p := Policy{
 		DeleteUntagged: true,
 		ExtraAttrs:     dataMap,

--- a/src/controller/gc/model.go
+++ b/src/controller/gc/model.go
@@ -20,11 +20,11 @@ import (
 
 // Policy ...
 type Policy struct {
-	Trigger        *Trigger               `json:"trigger"`
-	DeleteUntagged bool                   `json:"deleteuntagged"`
-	DryRun         bool                   `json:"dryrun"`
-	Workers        int                    `json:"workers"`
-	ExtraAttrs     map[string]interface{} `json:"extra_attrs"`
+	Trigger        *Trigger       `json:"trigger"`
+	DeleteUntagged bool           `json:"deleteuntagged"`
+	DryRun         bool           `json:"dryrun"`
+	Workers        int            `json:"workers"`
+	ExtraAttrs     map[string]any `json:"extra_attrs"`
 }
 
 // TriggerType represents the type of trigger.
@@ -47,7 +47,7 @@ type Execution struct {
 	Status        string
 	StatusMessage string
 	Trigger       string
-	ExtraAttrs    map[string]interface{}
+	ExtraAttrs    map[string]any
 	StartTime     time.Time
 	UpdateTime    time.Time
 }

--- a/src/controller/icon/controller.go
+++ b/src/controller/icon/controller.go
@@ -138,7 +138,7 @@ func (c *controller) Get(ctx context.Context, digest string) (*Icon, error) {
 	} else {
 		// read icon from blob
 		artifacts, err := c.artMgr.List(ctx, &q.Query{
-			Keywords: map[string]interface{}{
+			Keywords: map[string]any{
 				"Icon": digest,
 			},
 		})

--- a/src/controller/jobservice/model.go
+++ b/src/controller/jobservice/model.go
@@ -22,7 +22,7 @@ type Execution struct {
 	Status        string
 	StatusMessage string
 	Trigger       string
-	ExtraAttrs    map[string]interface{}
+	ExtraAttrs    map[string]any
 	StartTime     time.Time
 	EndTime       time.Time
 }

--- a/src/controller/jobservice/schedule.go
+++ b/src/controller/jobservice/schedule.go
@@ -35,7 +35,7 @@ type SchedulerController interface {
 	// Get the schedule
 	Get(ctx context.Context, vendorType string) (*scheduler.Schedule, error)
 	// Create with cron type & string
-	Create(ctx context.Context, vendorType, cronType, cron, callbackFuncName string, policy interface{}, extrasParam map[string]interface{}) (int64, error)
+	Create(ctx context.Context, vendorType, cronType, cron, callbackFuncName string, policy any, extrasParam map[string]any) (int64, error)
 	// Delete the schedule
 	Delete(ctx context.Context, vendorType string) error
 	// List lists schedules
@@ -76,7 +76,7 @@ func (s *schedulerController) Get(ctx context.Context, vendorType string) (*sche
 }
 
 func (s *schedulerController) Create(ctx context.Context, vendorType, cronType, cron, callbackFuncName string,
-	policy interface{}, extrasParam map[string]interface{}) (int64, error) {
+	policy any, extrasParam map[string]any) (int64, error) {
 	return s.schedulerMgr.Schedule(ctx, vendorType, -1, cronType, cron, callbackFuncName, policy, extrasParam)
 }
 

--- a/src/controller/jobservice/schedule_test.go
+++ b/src/controller/jobservice/schedule_test.go
@@ -49,7 +49,7 @@ func (s *ScheduleTestSuite) TestCreateSchedule() {
 	s.scheduler.On("Schedule", mock.Anything, mock.Anything, mock.Anything, mock.Anything,
 		mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(int64(1), nil)
 
-	dataMap := make(map[string]interface{})
+	dataMap := make(map[string]any)
 	p := purge.JobPolicy{}
 	id, err := s.ctl.Create(nil, job.PurgeAuditVendorType, "Daily", "* * * * * *", purge.SchedulerCallback, p, dataMap)
 	s.Nil(err)
@@ -76,7 +76,7 @@ func (s *ScheduleTestSuite) TestGetSchedule() {
 
 func (s *ScheduleTestSuite) TestListSchedule() {
 	mock.OnAnything(s.scheduler, "ListSchedules").Return([]*scheduler.Schedule{
-		{ID: 1, VendorType: "GARBAGE_COLLECTION", CRON: "0 0 0 * * *", ExtraAttrs: map[string]interface{}{"args": "sample args"}}}, nil).Once()
+		{ID: 1, VendorType: "GARBAGE_COLLECTION", CRON: "0 0 0 * * *", ExtraAttrs: map[string]any{"args": "sample args"}}}, nil).Once()
 	schedules, err := s.scheduler.ListSchedules(nil, nil)
 	s.Assert().Nil(err)
 	s.Assert().Equal(1, len(schedules))

--- a/src/controller/ldap/controller_test.go
+++ b/src/controller/ldap/controller_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/goharbor/harbor/src/testing/pkg/ldap"
 )
 
-var defaultConfigWithVerifyCert = map[string]interface{}{
+var defaultConfigWithVerifyCert = map[string]any{
 	common.ExtEndpoint:                "https://host01.com",
 	common.AUTHMode:                   common.LDAPAuth,
 	common.DatabaseType:               "postgresql",

--- a/src/controller/member/controller.go
+++ b/src/controller/member/controller.go
@@ -34,17 +34,17 @@ import (
 // Controller defines the operation related to project member
 type Controller interface {
 	// Get gets the project member with ID
-	Get(ctx context.Context, projectNameOrID interface{}, memberID int) (*models.Member, error)
+	Get(ctx context.Context, projectNameOrID any, memberID int) (*models.Member, error)
 	// Create add project member to project
-	Create(ctx context.Context, projectNameOrID interface{}, req Request) (int, error)
+	Create(ctx context.Context, projectNameOrID any, req Request) (int, error)
 	// Delete member from project
-	Delete(ctx context.Context, projectNameOrID interface{}, memberID int) error
+	Delete(ctx context.Context, projectNameOrID any, memberID int) error
 	// List lists all project members with condition
-	List(ctx context.Context, projectNameOrID interface{}, entityName string, query *q.Query) ([]*models.Member, error)
+	List(ctx context.Context, projectNameOrID any, entityName string, query *q.Query) ([]*models.Member, error)
 	// UpdateRole update the project member role
-	UpdateRole(ctx context.Context, projectNameOrID interface{}, memberID int, role int) error
+	UpdateRole(ctx context.Context, projectNameOrID any, memberID int, role int) error
 	// Count get the total amount of project members
-	Count(ctx context.Context, projectNameOrID interface{}, query *q.Query) (int, error)
+	Count(ctx context.Context, projectNameOrID any, query *q.Query) (int, error)
 	// IsProjectAdmin judges if the user is a project admin of any project
 	IsProjectAdmin(ctx context.Context, member commonmodels.User) (bool, error)
 }
@@ -89,7 +89,7 @@ func NewController() Controller {
 	return &controller{mgr: member.Mgr, projectMgr: pkg.ProjectMgr, userManager: user.New(), groupManager: usergroup.Mgr}
 }
 
-func (c *controller) Count(ctx context.Context, projectNameOrID interface{}, query *q.Query) (int, error) {
+func (c *controller) Count(ctx context.Context, projectNameOrID any, query *q.Query) (int, error) {
 	p, err := c.projectMgr.Get(ctx, projectNameOrID)
 	if err != nil {
 		return 0, err
@@ -97,7 +97,7 @@ func (c *controller) Count(ctx context.Context, projectNameOrID interface{}, que
 	return c.mgr.GetTotalOfProjectMembers(ctx, p.ProjectID, query)
 }
 
-func (c *controller) UpdateRole(ctx context.Context, projectNameOrID interface{}, memberID int, role int) error {
+func (c *controller) UpdateRole(ctx context.Context, projectNameOrID any, memberID int, role int) error {
 	p, err := c.projectMgr.Get(ctx, projectNameOrID)
 	if err != nil {
 		return err
@@ -108,7 +108,7 @@ func (c *controller) UpdateRole(ctx context.Context, projectNameOrID interface{}
 	return c.mgr.UpdateRole(ctx, p.ProjectID, memberID, role)
 }
 
-func (c *controller) Get(ctx context.Context, projectNameOrID interface{}, memberID int) (*models.Member, error) {
+func (c *controller) Get(ctx context.Context, projectNameOrID any, memberID int) (*models.Member, error) {
 	p, err := c.projectMgr.Get(ctx, projectNameOrID)
 	if err != nil {
 		return nil, err
@@ -119,7 +119,7 @@ func (c *controller) Get(ctx context.Context, projectNameOrID interface{}, membe
 	return c.mgr.Get(ctx, p.ProjectID, memberID)
 }
 
-func (c *controller) Create(ctx context.Context, projectNameOrID interface{}, req Request) (int, error) {
+func (c *controller) Create(ctx context.Context, projectNameOrID any, req Request) (int, error) {
 	p, err := c.projectMgr.Get(ctx, projectNameOrID)
 	if err != nil {
 		return 0, err
@@ -239,7 +239,7 @@ func isValidRole(role int) bool {
 	}
 }
 
-func (c *controller) List(ctx context.Context, projectNameOrID interface{}, entityName string, query *q.Query) ([]*models.Member, error) {
+func (c *controller) List(ctx context.Context, projectNameOrID any, entityName string, query *q.Query) ([]*models.Member, error) {
 	p, err := c.projectMgr.Get(ctx, projectNameOrID)
 	if err != nil {
 		return nil, err
@@ -254,7 +254,7 @@ func (c *controller) List(ctx context.Context, projectNameOrID interface{}, enti
 	return c.mgr.List(ctx, pm, query)
 }
 
-func (c *controller) Delete(ctx context.Context, projectNameOrID interface{}, memberID int) error {
+func (c *controller) Delete(ctx context.Context, projectNameOrID any, memberID int) error {
 	p, err := c.projectMgr.Get(ctx, projectNameOrID)
 	if err != nil {
 		return err

--- a/src/controller/p2p/preheat/controller.go
+++ b/src/controller/p2p/preheat/controller.go
@@ -180,7 +180,7 @@ func (c *controller) CreateInstance(ctx context.Context, instance *providerModel
 
 	// Avoid duplicated endpoint
 	var query = &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"endpoint": instance.Endpoint,
 		},
 	}
@@ -208,7 +208,7 @@ func (c *controller) DeleteInstance(ctx context.Context, id int64) error {
 	}
 	// delete instance should check the instance whether be used by policies
 	policies, err := c.ListPolicies(ctx, &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"provider_id": id,
 		},
 	})
@@ -235,7 +235,7 @@ func (c *controller) UpdateInstance(ctx context.Context, instance *providerModel
 	if !instance.Enabled {
 		// update instance should check the instance whether be used by policies
 		policies, err := c.ListPolicies(ctx, &q.Query{
-			Keywords: map[string]interface{}{
+			Keywords: map[string]any{
 				"provider_id": instance.ID,
 			},
 		})
@@ -311,7 +311,7 @@ func (c *controller) CreatePolicy(ctx context.Context, schema *policyModels.Sche
 		schema.Trigger.Type == policyModels.TriggerTypeScheduled &&
 		len(schema.Trigger.Settings.Cron) > 0 {
 		// schedule and update policy
-		extras := make(map[string]interface{})
+		extras := make(map[string]any)
 		if _, err = c.scheduler.Schedule(ctx, job.P2PPreheatVendorType, id, "", schema.Trigger.Settings.Cron,
 			SchedulerCallback, TriggerParam{PolicyID: id}, extras); err != nil {
 			return 0, err
@@ -409,7 +409,7 @@ func (c *controller) UpdatePolicy(ctx context.Context, schema *policyModels.Sche
 
 	// schedule new
 	if needSch {
-		extras := make(map[string]interface{})
+		extras := make(map[string]any)
 		if _, err := c.scheduler.Schedule(ctx, job.P2PPreheatVendorType, schema.ID, "", cron, SchedulerCallback,
 			TriggerParam{PolicyID: schema.ID}, extras); err != nil {
 			return err
@@ -465,7 +465,7 @@ func (c *controller) DeletePoliciesOfProject(ctx context.Context, project int64)
 // deleteExecs delete executions
 func (c *controller) deleteExecs(ctx context.Context, vendorID int64) error {
 	executions, err := c.executionMgr.List(ctx, &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"VendorType": job.P2PPreheatVendorType,
 			"VendorID":   vendorID,
 		},

--- a/src/controller/p2p/preheat/controllor_test.go
+++ b/src/controller/p2p/preheat/controllor_test.go
@@ -82,7 +82,7 @@ func (s *preheatSuite) SetupSuite() {
 		},
 	}, nil)
 	s.fakeInstanceMgr.On("Save", mock.Anything, mock.Anything).Return(int64(1), nil)
-	s.fakeInstanceMgr.On("Count", mock.Anything, &q.Query{Keywords: map[string]interface{}{
+	s.fakeInstanceMgr.On("Count", mock.Anything, &q.Query{Keywords: map[string]any{
 		"endpoint": "http://localhost",
 	}}).Return(int64(1), nil)
 	s.fakeInstanceMgr.On("Count", mock.Anything, mock.Anything).Return(int64(0), nil)
@@ -117,7 +117,7 @@ func (s *preheatSuite) TearDownSuite() {
 func (s *preheatSuite) TestGetAvailableProviders() {
 	providers, err := s.controller.GetAvailableProviders()
 	s.Equal(2, len(providers))
-	expectProviders := map[string]interface{}{}
+	expectProviders := map[string]any{}
 	expectProviders["dragonfly"] = nil
 	expectProviders["kraken"] = nil
 	_, ok := expectProviders[providers[0].ID]
@@ -177,7 +177,7 @@ func (s *preheatSuite) TestCreateInstance() {
 func (s *preheatSuite) TestDeleteInstance() {
 	// instance be used should not be deleted
 	s.fakeInstanceMgr.On("Get", s.ctx, int64(1)).Return(&providerModel.Instance{ID: 1}, nil)
-	s.fakePolicyMgr.On("ListPolicies", s.ctx, &q.Query{Keywords: map[string]interface{}{"provider_id": int64(1)}}).Return([]*policy.Schema{
+	s.fakePolicyMgr.On("ListPolicies", s.ctx, &q.Query{Keywords: map[string]any{"provider_id": int64(1)}}).Return([]*policy.Schema{
 		{
 			ProviderID: 1,
 		},
@@ -186,7 +186,7 @@ func (s *preheatSuite) TestDeleteInstance() {
 	s.Error(err, "instance should not be deleted")
 
 	s.fakeInstanceMgr.On("Get", s.ctx, int64(2)).Return(&providerModel.Instance{ID: 2}, nil)
-	s.fakePolicyMgr.On("ListPolicies", s.ctx, &q.Query{Keywords: map[string]interface{}{"provider_id": int64(2)}}).Return([]*policy.Schema{}, nil)
+	s.fakePolicyMgr.On("ListPolicies", s.ctx, &q.Query{Keywords: map[string]any{"provider_id": int64(2)}}).Return([]*policy.Schema{}, nil)
 	s.fakeInstanceMgr.On("Delete", s.ctx, int64(2)).Return(nil)
 	err = s.controller.DeleteInstance(s.ctx, int64(2))
 	s.NoError(err, "instance can be deleted")
@@ -202,7 +202,7 @@ func (s *preheatSuite) TestUpdateInstance() {
 	// disable instance should error due to with policy used
 	s.fakeInstanceMgr.On("Get", s.ctx, int64(1001)).Return(&providerModel.Instance{ID: 1001}, nil)
 	s.fakeInstanceMgr.On("Update", s.ctx, &providerModel.Instance{ID: 1001}).Return(nil)
-	s.fakePolicyMgr.On("ListPolicies", s.ctx, &q.Query{Keywords: map[string]interface{}{"provider_id": int64(1001)}}).Return([]*policy.Schema{
+	s.fakePolicyMgr.On("ListPolicies", s.ctx, &q.Query{Keywords: map[string]any{"provider_id": int64(1001)}}).Return([]*policy.Schema{
 		{ProviderID: 1001},
 	}, nil)
 	err = s.controller.UpdateInstance(s.ctx, &providerModel.Instance{ID: 1001})
@@ -211,14 +211,14 @@ func (s *preheatSuite) TestUpdateInstance() {
 	// disable instance can be deleted if no policy used
 	s.fakeInstanceMgr.On("Get", s.ctx, int64(1002)).Return(&providerModel.Instance{ID: 1002}, nil)
 	s.fakeInstanceMgr.On("Update", s.ctx, &providerModel.Instance{ID: 1002}).Return(nil)
-	s.fakePolicyMgr.On("ListPolicies", s.ctx, &q.Query{Keywords: map[string]interface{}{"provider_id": int64(1002)}}).Return([]*policy.Schema{}, nil)
+	s.fakePolicyMgr.On("ListPolicies", s.ctx, &q.Query{Keywords: map[string]any{"provider_id": int64(1002)}}).Return([]*policy.Schema{}, nil)
 	err = s.controller.UpdateInstance(s.ctx, &providerModel.Instance{ID: 1002})
 	s.NoError(err, "instance can be disabled")
 
 	// not support change vendor type
 	s.fakeInstanceMgr.On("Get", s.ctx, int64(1003)).Return(&providerModel.Instance{ID: 1003, Vendor: "dragonfly"}, nil)
 	s.fakeInstanceMgr.On("Update", s.ctx, &providerModel.Instance{ID: 1003, Vendor: "kraken"}).Return(nil)
-	s.fakePolicyMgr.On("ListPolicies", s.ctx, &q.Query{Keywords: map[string]interface{}{"provider_id": int64(1003)}}).Return([]*policy.Schema{}, nil)
+	s.fakePolicyMgr.On("ListPolicies", s.ctx, &q.Query{Keywords: map[string]any{"provider_id": int64(1003)}}).Return([]*policy.Schema{}, nil)
 	err = s.controller.UpdateInstance(s.ctx, &providerModel.Instance{ID: 1003, Vendor: "kraken"})
 	s.Error(err, "provider vendor cannot be changed")
 }
@@ -347,7 +347,7 @@ func (s *preheatSuite) TestDeletePoliciesOfProject() {
 	for _, p := range fakePolicies {
 		s.fakePolicyMgr.On("Get", s.ctx, p.ID).Return(p, nil)
 		s.fakePolicyMgr.On("Delete", s.ctx, p.ID).Return(nil)
-		s.fakeExecutionMgr.On("List", s.ctx, &q.Query{Keywords: map[string]interface{}{"VendorID": p.ID, "VendorType": "P2P_PREHEAT"}}).Return([]*taskModel.Execution{}, nil)
+		s.fakeExecutionMgr.On("List", s.ctx, &q.Query{Keywords: map[string]any{"VendorID": p.ID, "VendorType": "P2P_PREHEAT"}}).Return([]*taskModel.Execution{}, nil)
 	}
 
 	err := s.controller.DeletePoliciesOfProject(s.ctx, 10)

--- a/src/controller/p2p/preheat/enforcer.go
+++ b/src/controller/p2p/preheat/enforcer.go
@@ -351,7 +351,7 @@ func (de *defaultEnforcer) getCandidates(ctx context.Context, ps *pol.Schema, p 
 	// Here we have a hidden filter, the artifact type filter.
 	// Only get the image type at this moment.
 	arts, err := de.artCtl.List(ctx, &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"ProjectID": ps.ProjectID,
 			"Type":      q.NewOrList(supportedTypes),
 		},
@@ -371,7 +371,7 @@ func (de *defaultEnforcer) getCandidates(ctx context.Context, ps *pol.Schema, p 
 // launchExecutions create execution record and launch tasks to preheat the filtered artifacts.
 func (de *defaultEnforcer) launchExecutions(ctx context.Context, candidates []*selector.Candidate, pl *pol.Schema, inst *provider.Instance) (int64, error) {
 	// Create execution first anyway
-	attrs := map[string]interface{}{
+	attrs := map[string]any{
 		extraAttrTotal:          len(candidates),
 		extraAttrTrigger:        pl.Trigger.Type,
 		extraAttrTriggerSetting: pl.Trigger.Settings.Cron,
@@ -427,7 +427,7 @@ func (de *defaultEnforcer) launchExecutions(ctx context.Context, candidates []*s
 }
 
 // startTask starts the preheat task(job) for the given candidate
-func (de *defaultEnforcer) startTask(ctx context.Context, executionID int64, candidate *selector.Candidate, instance string, extraAttrs map[string]interface{}) (int64, error) {
+func (de *defaultEnforcer) startTask(ctx context.Context, executionID int64, candidate *selector.Candidate, instance string, extraAttrs map[string]any) (int64, error) {
 	u, err := de.fullURLGetter(candidate)
 	if err != nil {
 		return -1, err
@@ -441,7 +441,7 @@ func (de *defaultEnforcer) startTask(ctx context.Context, executionID int64, can
 	pi := &pr.PreheatImage{
 		Type: candidate.Kind,
 		URL:  u,
-		Headers: map[string]interface{}{
+		Headers: map[string]any{
 			accessCredHeaderKey: cred,
 		},
 		ImageName:  fmt.Sprintf("%s/%s", candidate.Namespace, candidate.Repository),
@@ -467,7 +467,7 @@ func (de *defaultEnforcer) startTask(ctx context.Context, executionID int64, can
 		},
 	}
 
-	tid, err := de.taskMgr.Create(ctx, executionID, j, map[string]interface{}{
+	tid, err := de.taskMgr.Create(ctx, executionID, j, map[string]any{
 		extraAttrArtifact: fmt.Sprintf("%s:%s", pi.ImageName, pi.Tag),
 		extraAttrDigest:   candidate.Digest,
 		extraAttrKind:     pi.Type,
@@ -596,12 +596,12 @@ func checkProviderHealthy(inst *provider.Instance) error {
 // Check the project security settings and override the related settings in the policy if necessary.
 // NOTES: if the security settings (relevant with signature and vulnerability) are set at the project configuration,
 // the corresponding filters of P2P preheat policy will be set using the relevant settings of project configurations.
-func overrideSecuritySettings(p *pol.Schema, pro *proModels.Project) [][]interface{} {
+func overrideSecuritySettings(p *pol.Schema, pro *proModels.Project) [][]any {
 	if p == nil || pro == nil {
 		return nil
 	}
 
-	override := make([][]interface{}, 0)
+	override := make([][]any, 0)
 	filters := make([]*pol.Filter, 0)
 	for _, fl := range p.Filters {
 		if fl.Type != pol.FilterTypeSignature && fl.Type != pol.FilterTypeVulnerability {
@@ -617,7 +617,7 @@ func overrideSecuritySettings(p *pol.Schema, pro *proModels.Project) [][]interfa
 		})
 
 		// Record this is a override case
-		r1 := []interface{}{pro.Name, p.Name, pol.FilterTypeSignature, fmt.Sprintf("%v", true)}
+		r1 := []any{pro.Name, p.Name, pol.FilterTypeSignature, fmt.Sprintf("%v", true)}
 		override = append(override, r1)
 	}
 	// Append vulnerability filter if vulnerability severity config is set at project configurations
@@ -632,7 +632,7 @@ func overrideSecuritySettings(p *pol.Schema, pro *proModels.Project) [][]interfa
 			})
 
 			// Record this is a override case
-			r2 := []interface{}{pro.Name, p.Name, pol.FilterTypeVulnerability, fmt.Sprintf("%v:%d", se, code)}
+			r2 := []any{pro.Name, p.Name, pol.FilterTypeVulnerability, fmt.Sprintf("%v:%d", se, code)}
 			override = append(override, r2)
 		}
 	}

--- a/src/controller/project/controller.go
+++ b/src/controller/project/controller.go
@@ -53,9 +53,9 @@ type Controller interface {
 	// Delete delete the project by project id
 	Delete(ctx context.Context, id int64) error
 	// Exists returns true when the specific project exists
-	Exists(ctx context.Context, projectIDOrName interface{}) (bool, error)
+	Exists(ctx context.Context, projectIDOrName any) (bool, error)
 	// Get get the project by project id or name
-	Get(ctx context.Context, projectIDOrName interface{}, options ...Option) (*models.Project, error)
+	Get(ctx context.Context, projectIDOrName any, options ...Option) (*models.Project, error)
 	// GetByName get the project by project name
 	GetByName(ctx context.Context, projectName string, options ...Option) (*models.Project, error)
 	// List list projects
@@ -144,7 +144,7 @@ func (c *controller) Delete(ctx context.Context, id int64) error {
 	return nil
 }
 
-func (c *controller) Exists(ctx context.Context, projectIDOrName interface{}) (bool, error) {
+func (c *controller) Exists(ctx context.Context, projectIDOrName any) (bool, error) {
 	_, err := c.projectMgr.Get(ctx, projectIDOrName)
 	if err == nil {
 		return true, nil
@@ -155,7 +155,7 @@ func (c *controller) Exists(ctx context.Context, projectIDOrName interface{}) (b
 	return false, err
 }
 
-func (c *controller) Get(ctx context.Context, projectIDOrName interface{}, options ...Option) (*models.Project, error) {
+func (c *controller) Get(ctx context.Context, projectIDOrName any, options ...Option) (*models.Project, error) {
 	p, err := c.projectMgr.Get(ctx, projectIDOrName)
 	if err != nil {
 		return nil, err

--- a/src/controller/proxy/inflight.go
+++ b/src/controller/proxy/inflight.go
@@ -18,11 +18,11 @@ import "sync"
 
 type inflightRequest struct {
 	mu     sync.Mutex
-	reqMap map[string]interface{}
+	reqMap map[string]any
 }
 
 var inflightChecker = &inflightRequest{
-	reqMap: make(map[string]interface{}),
+	reqMap: make(map[string]any),
 }
 
 // addRequest if the artifact already exist in the inflightRequest, return false

--- a/src/controller/purge/controller.go
+++ b/src/controller/purge/controller.go
@@ -68,7 +68,7 @@ func (c *controller) Stop(ctx context.Context, id int64) error {
 }
 
 func (c *controller) Start(ctx context.Context, policy JobPolicy, trigger string) (int64, error) {
-	para := make(map[string]interface{})
+	para := make(map[string]any)
 
 	para[common.PurgeAuditDryRun] = policy.DryRun
 	para[common.PurgeAuditRetentionHour] = policy.RetentionHour

--- a/src/controller/purge/model.go
+++ b/src/controller/purge/model.go
@@ -22,11 +22,11 @@ import (
 
 // JobPolicy defines the purge job policy
 type JobPolicy struct {
-	Trigger           *Trigger               `json:"trigger"`
-	DryRun            bool                   `json:"dryrun"`
-	RetentionHour     int                    `json:"retention_hour"`
-	IncludeEventTypes string                 `json:"include_event_types"`
-	ExtraAttrs        map[string]interface{} `json:"extra_attrs"`
+	Trigger           *Trigger       `json:"trigger"`
+	DryRun            bool           `json:"dryrun"`
+	RetentionHour     int            `json:"retention_hour"`
+	IncludeEventTypes string         `json:"include_event_types"`
+	ExtraAttrs        map[string]any `json:"extra_attrs"`
 }
 
 // TriggerType represents the type of trigger.
@@ -44,7 +44,7 @@ type TriggerSettings struct {
 }
 
 // String convert map to json string
-func String(extras map[string]interface{}) string {
+func String(extras map[string]any) string {
 	result, err := json.Marshal(extras)
 	if err != nil {
 		log.Errorf("failed to convert to json string, value %+v", extras)

--- a/src/controller/purge/model_test.go
+++ b/src/controller/purge/model_test.go
@@ -18,15 +18,15 @@ import "testing"
 
 func TestString(t *testing.T) {
 	type args struct {
-		extras map[string]interface{}
+		extras map[string]any
 	}
 	tests := []struct {
 		name string
 		args args
 		want string
 	}{
-		{"normal", args{map[string]interface{}{"dry_run": true, "audit_log_retention_hour": 168}}, "{\"audit_log_retention_hour\":168,\"dry_run\":true}"},
-		{"empty", args{map[string]interface{}{}}, "{}"},
+		{"normal", args{map[string]any{"dry_run": true, "audit_log_retention_hour": 168}}, "{\"audit_log_retention_hour\":168,\"dry_run\":true}"},
+		{"empty", args{map[string]any{}}, "{}"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/src/controller/quota/controller.go
+++ b/src/controller/quota/controller.go
@@ -280,7 +280,7 @@ func (c *controller) updateUsageByRedis(ctx context.Context, reference, referenc
 		// calc the quota usage in real time if no key found
 		if err == redis.Nil {
 			// use singleflight to prevent cache penetration and cause pressure on the database.
-			realQuota, err, _ := c.g.Do(key, func() (interface{}, error) {
+			realQuota, err, _ := c.g.Do(key, func() (any, error) {
 				return c.calcQuota(ctx, reference, referenceID)
 			})
 			if err != nil {

--- a/src/controller/quota/controller_test.go
+++ b/src/controller/quota/controller_test.go
@@ -56,7 +56,7 @@ func (suite *ControllerTestSuite) SetupTest() {
 	suite.quota = &quota.Quota{Hard: hardLimits.String(), Used: types.Zero(hardLimits).String()}
 }
 
-func (suite *ControllerTestSuite) PrepareForUpdate(q *quota.Quota, newUsage interface{}) {
+func (suite *ControllerTestSuite) PrepareForUpdate(q *quota.Quota, newUsage any) {
 	mock.OnAnything(suite.quotaMgr, "GetByRef").Return(q, nil)
 
 	mock.OnAnything(suite.driver, "CalculateUsage").Return(newUsage, nil)

--- a/src/controller/quota/driver/project/util.go
+++ b/src/controller/quota/driver/project/util.go
@@ -51,7 +51,7 @@ func getProjectsBatchFn(ctx context.Context, keys dataloader.Keys) []*dataloader
 		return handleError(err)
 	}
 
-	var ownerIDs []interface{}
+	var ownerIDs []any
 	var projectsMap = make(map[int64]*proModels.Project, len(projectIDs))
 	for _, project := range projects {
 		ownerIDs = append(ownerIDs, project.OwnerID)

--- a/src/controller/quota/util.go
+++ b/src/controller/quota/util.go
@@ -30,7 +30,7 @@ const (
 )
 
 // ReferenceID returns reference id for the interface
-func ReferenceID(i interface{}) string {
+func ReferenceID(i any) string {
 	switch s := i.(type) {
 	case string:
 		return s

--- a/src/controller/registry/controller.go
+++ b/src/controller/registry/controller.go
@@ -128,7 +128,7 @@ func (c *controller) Update(ctx context.Context, registry *model.Registry, props
 func (c *controller) Delete(ctx context.Context, id int64) error {
 	// referenced by replication policy as source registry
 	count, err := c.repMgr.Count(ctx, &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"src_registry_id": id,
 		},
 	})
@@ -140,7 +140,7 @@ func (c *controller) Delete(ctx context.Context, id int64) error {
 	}
 	// referenced by replication policy as destination registry
 	count, err = c.repMgr.Count(ctx, &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"dest_registry_id": id,
 		},
 	})
@@ -152,7 +152,7 @@ func (c *controller) Delete(ctx context.Context, id int64) error {
 	}
 	// referenced by proxy cache project
 	count, err = c.proMgr.Count(ctx, &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"registry_id": id,
 		},
 	})

--- a/src/controller/replication/execution.go
+++ b/src/controller/replication/execution.go
@@ -105,7 +105,7 @@ func (c *controller) Start(ctx context.Context, policy *replicationmodel.Policy,
 			WithMessagef("the policy %d is disabled", policy.ID)
 	}
 	// create an execution record
-	extra := make(map[string]interface{})
+	extra := make(map[string]any)
 	if op := operator.FromContext(ctx); op != "" {
 		extra["operator"] = op
 	}
@@ -203,7 +203,7 @@ func (c *controller) buildExecutionQuery(query *q.Query) *q.Query {
 
 func (c *controller) GetExecution(ctx context.Context, id int64) (*Execution, error) {
 	execs, err := c.execMgr.List(ctx, &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"ID":         id,
 			"VendorType": job.ReplicationVendorType,
 		},
@@ -240,7 +240,7 @@ func (c *controller) ListTasks(ctx context.Context, query *q.Query) ([]*Task, er
 
 func (c *controller) GetTask(ctx context.Context, id int64) (*Task, error) {
 	tasks, err := c.taskMgr.List(ctx, &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"ID":         id,
 			"VendorType": job.ReplicationVendorType,
 		},

--- a/src/controller/replication/execution_test.go
+++ b/src/controller/replication/execution_test.go
@@ -194,7 +194,7 @@ func (r *replicationTestSuite) TestListTasks() {
 			ID:          1,
 			ExecutionID: 1,
 			Status:      job.RunningStatus.String(),
-			ExtraAttrs: map[string]interface{}{
+			ExtraAttrs: map[string]any{
 				"resource_type":        "artifact",
 				"source_resource":      "library/hello-world",
 				"destination_resource": "library/hello-world",
@@ -222,7 +222,7 @@ func (r *replicationTestSuite) TestGetTask() {
 			ID:          1,
 			ExecutionID: 1,
 			Status:      job.RunningStatus.String(),
-			ExtraAttrs: map[string]interface{}{
+			ExtraAttrs: map[string]any{
 				"resource_type":        "artifact",
 				"source_resource":      "library/hello-world",
 				"destination_resource": "library/hello-world",

--- a/src/controller/replication/flow/copy.go
+++ b/src/controller/replication/flow/copy.go
@@ -136,7 +136,7 @@ func (c *copyFlow) createTasks(ctx context.Context, srcResources, dstResources [
 			Metadata: &job.Metadata{
 				JobKind: job.KindGeneric,
 			},
-			Parameters: map[string]interface{}{
+			Parameters: map[string]any{
 				"src_resource":  string(src),
 				"dst_resource":  string(dest),
 				"speed":         speed,
@@ -144,7 +144,7 @@ func (c *copyFlow) createTasks(ctx context.Context, srcResources, dstResources [
 			},
 		}
 
-		if _, err = c.taskMgr.Create(ctx, c.executionID, job, map[string]interface{}{
+		if _, err = c.taskMgr.Create(ctx, c.executionID, job, map[string]any{
 			"operation":            "copy",
 			"resource_type":        string(srcResource.Type),
 			"source_resource":      getResourceName(srcResource),

--- a/src/controller/replication/flow/deletion.go
+++ b/src/controller/replication/flow/deletion.go
@@ -78,7 +78,7 @@ func (d *deletionFlow) createTasks(ctx context.Context, srcResources, dstResourc
 			Metadata: &job.Metadata{
 				JobKind: job.KindGeneric,
 			},
-			Parameters: map[string]interface{}{
+			Parameters: map[string]any{
 				"src_resource": string(src),
 				"dst_resource": string(dest),
 			},
@@ -89,7 +89,7 @@ func (d *deletionFlow) createTasks(ctx context.Context, srcResources, dstResourc
 			operation = "tag deletion"
 		}
 
-		if _, err = d.taskMgr.Create(ctx, d.executionID, job, map[string]interface{}{
+		if _, err = d.taskMgr.Create(ctx, d.executionID, job, map[string]any{
 			"operation":            operation,
 			"resource_type":        string(resource.Type),
 			"source_resource":      getResourceName(resource),

--- a/src/controller/replication/model/model.go
+++ b/src/controller/replication/model/model.go
@@ -214,11 +214,11 @@ func (p *Policy) To() (*replicationmodel.Policy, error) {
 }
 
 type filter struct {
-	Type       string      `json:"type"`
-	Value      interface{} `json:"value"`
-	Decoration string      `json:"decoration"`
-	Kind       string      `json:"kind"`
-	Pattern    string      `json:"pattern"`
+	Type       string `json:"type"`
+	Value      any    `json:"value"`
+	Decoration string `json:"decoration"`
+	Kind       string `json:"kind"`
+	Pattern    string `json:"pattern"`
 }
 
 type trigger struct {
@@ -290,7 +290,7 @@ func parseFilters(str string) ([]*model.Filter, error) {
 		}
 		if filter.Type == model.FilterTypeLabel {
 			labels := []string{}
-			for _, label := range filter.Value.([]interface{}) {
+			for _, label := range filter.Value.([]any) {
 				labels = append(labels, label.(string))
 			}
 			filter.Value = labels

--- a/src/controller/replication/policy.go
+++ b/src/controller/replication/policy.go
@@ -33,7 +33,7 @@ const callbackFuncName = "REPLICATION_CALLBACK"
 
 func init() {
 	callbackFunc := func(ctx context.Context, param string) error {
-		params := make(map[string]interface{})
+		params := make(map[string]any)
 		if err := json.Unmarshal([]byte(param), &params); err != nil {
 			return err
 		}
@@ -133,13 +133,13 @@ func (c *controller) CreatePolicy(ctx context.Context, policy *model.Policy) (in
 	}
 	// create schedule if needed
 	if policy.IsScheduledTrigger() {
-		cbParams := map[string]interface{}{
+		cbParams := map[string]any{
 			"policy_id": id,
 			// the operator of schedule job is harbor-jobservice
 			"operator": secret.JobserviceUser,
 		}
 		if _, err = c.scheduler.Schedule(ctx, job.ReplicationVendorType, id, "", policy.Trigger.Settings.Cron,
-			callbackFuncName, cbParams, map[string]interface{}{}); err != nil {
+			callbackFuncName, cbParams, map[string]any{}); err != nil {
 			return 0, err
 		}
 	}
@@ -165,13 +165,13 @@ func (c *controller) UpdatePolicy(ctx context.Context, policy *model.Policy, pro
 	}
 	// create schedule if needed
 	if policy.IsScheduledTrigger() {
-		cbParams := map[string]interface{}{
+		cbParams := map[string]any{
 			"policy_id": policy.ID,
 			// the operator of schedule job is harbor-jobservice
 			"operator": secret.JobserviceUser,
 		}
 		if _, err := c.scheduler.Schedule(ctx, job.ReplicationVendorType, policy.ID, "", policy.Trigger.Settings.Cron,
-			callbackFuncName, cbParams, map[string]interface{}{}); err != nil {
+			callbackFuncName, cbParams, map[string]any{}); err != nil {
 			return err
 		}
 	}

--- a/src/controller/replication/transfer/transfer.go
+++ b/src/controller/replication/transfer/transfer.go
@@ -40,21 +40,21 @@ type Transfer interface {
 // Logger defines an interface for logging
 type Logger interface {
 	// For debuging
-	Debug(v ...interface{})
+	Debug(v ...any)
 	// For debuging with format
-	Debugf(format string, v ...interface{})
+	Debugf(format string, v ...any)
 	// For logging info
-	Info(v ...interface{})
+	Info(v ...any)
 	// For logging info with format
-	Infof(format string, v ...interface{})
+	Infof(format string, v ...any)
 	// For warning
-	Warning(v ...interface{})
+	Warning(v ...any)
 	// For warning with format
-	Warningf(format string, v ...interface{})
+	Warningf(format string, v ...any)
 	// For logging error
-	Error(v ...interface{})
+	Error(v ...any)
 	// For logging error with format
-	Errorf(format string, v ...interface{})
+	Errorf(format string, v ...any)
 }
 
 // StopFunc is a function used to check whether the transfer

--- a/src/controller/repository/controller.go
+++ b/src/controller/repository/controller.go
@@ -143,7 +143,7 @@ func (c *controller) GetByName(ctx context.Context, name string) (*model.RepoRec
 
 func (c *controller) Delete(ctx context.Context, id int64) error {
 	candidates, err := c.artCtl.List(ctx, &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"RepositoryID": id,
 		},
 	}, nil)
@@ -155,7 +155,7 @@ func (c *controller) Delete(ctx context.Context, id int64) error {
 		candidates = nil
 		for _, artifact := range artifacts {
 			parents, err := c.artMgr.ListReferences(ctx, &q.Query{
-				Keywords: map[string]interface{}{
+				Keywords: map[string]any{
 					"ChildID": artifact.ID,
 				},
 			})

--- a/src/controller/retention/controller.go
+++ b/src/controller/retention/controller.go
@@ -116,7 +116,7 @@ func (r *defaultController) CreateRetention(ctx context.Context, p *policy.Metad
 	if p.Trigger.Kind == policy.TriggerKindSchedule {
 		cron, ok := p.Trigger.Settings[policy.TriggerSettingsCron]
 		if ok && len(cron.(string)) > 0 {
-			extras := make(map[string]interface{})
+			extras := make(map[string]any)
 			if _, err = r.scheduler.Schedule(ctx, schedulerVendorType, id, "", cron.(string), SchedulerCallback, TriggerParam{
 				PolicyID: id,
 				Trigger:  retention.ExecutionTriggerSchedule,
@@ -182,7 +182,7 @@ func (r *defaultController) UpdateRetention(ctx context.Context, p *policy.Metad
 		}
 	}
 	if needSch {
-		extras := make(map[string]interface{})
+		extras := make(map[string]any)
 		_, err := r.scheduler.Schedule(ctx, schedulerVendorType, p.ID, "", p.Trigger.Settings[policy.TriggerSettingsCron].(string), SchedulerCallback, TriggerParam{
 			PolicyID: p.ID,
 			Trigger:  retention.ExecutionTriggerSchedule,
@@ -220,7 +220,7 @@ func (r *defaultController) DeleteRetention(ctx context.Context, id int64) error
 // deleteExecs delete executions
 func (r *defaultController) deleteExecs(ctx context.Context, vendorID int64) error {
 	executions, err := r.execMgr.List(ctx, &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"VendorType": job.RetentionVendorType,
 			"VendorID":   vendorID,
 		},
@@ -246,7 +246,7 @@ func (r *defaultController) TriggerRetentionExec(ctx context.Context, policyID i
 		return 0, err
 	}
 
-	extra := map[string]interface{}{
+	extra := map[string]any{
 		"dry_run":  dryRun,
 		"operator": operator.FromContext(ctx),
 	}
@@ -357,7 +357,7 @@ func convertExecution(exec *task.Execution) *retention.Execution {
 // GetTotalOfRetentionExecs Count Retention Executions
 func (r *defaultController) GetTotalOfRetentionExecs(ctx context.Context, policyID int64) (int64, error) {
 	return r.execMgr.Count(ctx, &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"VendorType": job.RetentionVendorType,
 			"VendorID":   policyID,
 		},
@@ -398,7 +398,7 @@ func convertTask(t *task.Task) *retention.Task {
 // GetTotalOfRetentionExecTasks Count Retention Execution Histories
 func (r *defaultController) GetTotalOfRetentionExecTasks(ctx context.Context, executionID int64) (int64, error) {
 	return r.taskMgr.Count(ctx, &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"VendorType":  job.RetentionVendorType,
 			"ExecutionID": executionID,
 		},

--- a/src/controller/retention/controller_test.go
+++ b/src/controller/retention/controller_test.go
@@ -73,21 +73,21 @@ func (s *ControllerTestSuite) TestPolicy() {
 	execMgr.On("Get", mock.Anything, mock.Anything).Return(&task.Execution{
 		ID:     1,
 		Status: job.RunningStatus.String(),
-		ExtraAttrs: map[string]interface{}{
+		ExtraAttrs: map[string]any{
 			"dry_run": true,
 		},
 	}, nil)
 	execMgr.On("List", mock.Anything, mock.Anything).Return([]*task.Execution{{
 		ID:     1,
 		Status: job.RunningStatus.String(),
-		ExtraAttrs: map[string]interface{}{
+		ExtraAttrs: map[string]any{
 			"dry_run": true,
 		},
 	}}, nil)
 	taskMgr.On("List", mock.Anything, mock.Anything).Return([]*task.Task{{
 		ID:     1,
 		Status: job.RunningStatus.String(),
-		ExtraAttrs: map[string]interface{}{
+		ExtraAttrs: map[string]any{
 			"total":    1,
 			"retained": 1,
 		},
@@ -160,7 +160,7 @@ func (s *ControllerTestSuite) TestPolicy() {
 		},
 		Trigger: &policy.Trigger{
 			Kind: "Schedule",
-			Settings: map[string]interface{}{
+			Settings: map[string]any{
 				"cron": "0 22 11 * * *",
 			},
 		},
@@ -208,7 +208,7 @@ func (s *ControllerTestSuite) TestExecution() {
 	execMgr.On("Get", mock.Anything, mock.Anything).Return(&task.Execution{
 		ID:     1,
 		Status: job.RunningStatus.String(),
-		ExtraAttrs: map[string]interface{}{
+		ExtraAttrs: map[string]any{
 			"dry_run": true,
 		},
 	}, nil)
@@ -216,14 +216,14 @@ func (s *ControllerTestSuite) TestExecution() {
 	execMgr.On("List", mock.Anything, mock.Anything).Return([]*task.Execution{{
 		ID:     1,
 		Status: job.RunningStatus.String(),
-		ExtraAttrs: map[string]interface{}{
+		ExtraAttrs: map[string]any{
 			"dry_run": true,
 		},
 	}}, nil)
 	taskMgr.On("List", mock.Anything, mock.Anything).Return([]*task.Task{{
 		ID:     1,
 		Status: job.RunningStatus.String(),
-		ExtraAttrs: map[string]interface{}{
+		ExtraAttrs: map[string]any{
 			"total":    1,
 			"retained": 1,
 		},
@@ -272,7 +272,7 @@ func (s *ControllerTestSuite) TestExecution() {
 		},
 		Trigger: &policy.Trigger{
 			Kind: "Schedule",
-			Settings: map[string]interface{}{
+			Settings: map[string]any{
 				"cron": "0 22 11 * * *",
 			},
 		},
@@ -316,7 +316,7 @@ func (f *fakeRetentionScheduler) CountSchedules(ctx context.Context, query *q.Qu
 	panic("implement me")
 }
 
-func (f *fakeRetentionScheduler) Schedule(ctx context.Context, vendorType string, vendorID int64, cronType string, cron string, callbackFuncName string, params interface{}, extras map[string]interface{}) (int64, error) {
+func (f *fakeRetentionScheduler) Schedule(ctx context.Context, vendorType string, vendorID int64, cronType string, cron string, callbackFuncName string, params any, extras map[string]any) (int64, error) {
 	return 111, nil
 }
 

--- a/src/controller/robot/controller_test.go
+++ b/src/controller/robot/controller_test.go
@@ -94,7 +94,7 @@ func (suite *ControllerTestSuite) TestCreate() {
 	defer os.Remove(secretKeyPath)
 	suite.T().Setenv("KEY_PATH", secretKeyPath)
 
-	conf := map[string]interface{}{
+	conf := map[string]any{
 		common.RobotTokenDuration: "30",
 	}
 	config.InitWithSettings(conf)
@@ -170,7 +170,7 @@ func (suite *ControllerTestSuite) TestUpdate() {
 	c := controller{robotMgr: robotMgr, rbacMgr: rbacMgr, proMgr: projectMgr}
 	ctx := context.TODO()
 
-	conf := map[string]interface{}{
+	conf := map[string]any{
 		common.RobotPrefix: "robot$",
 	}
 	config.InitWithSettings(conf)
@@ -247,7 +247,7 @@ func (suite *ControllerTestSuite) TestList() {
 	}, nil)
 	projectMgr.On("Get", mock.Anything, mock.Anything).Return(&proModels.Project{ProjectID: 1, Name: "library"}, nil)
 	rs, err := c.List(ctx, &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"name": "test3",
 		},
 	}, &Option{

--- a/src/controller/robot/model.go
+++ b/src/controller/robot/model.go
@@ -40,7 +40,7 @@ const (
 type Robot struct {
 	model.Robot
 	ProjectName     string
-	ProjectNameOrID interface{}
+	ProjectNameOrID any
 	Level           string
 	Editable        bool          `json:"editable"`
 	Permissions     []*Permission `json:"permissions"`

--- a/src/controller/scan/base_controller.go
+++ b/src/controller/scan/base_controller.go
@@ -315,18 +315,18 @@ func (bc *basicController) Scan(ctx context.Context, artifact *ar.Artifact, opti
 	}
 
 	if opts.ExecutionID == 0 {
-		extraAttrs := map[string]interface{}{
-			artfiactKey: map[string]interface{}{
+		extraAttrs := map[string]any{
+			artfiactKey: map[string]any{
 				"id":              artifact.ID,
 				"project_id":      artifact.ProjectID,
 				"repository_name": artifact.RepositoryName,
 				"digest":          artifact.Digest,
 			},
-			registrationKey: map[string]interface{}{
+			registrationKey: map[string]any{
 				"id":   r.ID,
 				"name": r.Name,
 			},
-			enabledCapabilities: map[string]interface{}{
+			enabledCapabilities: map[string]any{
 				"type": opts.GetScanType(),
 			},
 		}
@@ -383,7 +383,7 @@ func (bc *basicController) Stop(ctx context.Context, artifact *ar.Artifact, capT
 }
 
 func (bc *basicController) ScanAll(ctx context.Context, trigger string, async bool) (int64, error) {
-	extra := make(map[string]interface{})
+	extra := make(map[string]any)
 	if op := operator.FromContext(ctx); op != "" {
 		extra["operator"] = op
 	}
@@ -511,7 +511,7 @@ func (bc *basicController) startScanAll(ctx context.Context, executionID int64) 
 
 	extraAttrs := exec.ExtraAttrs
 	if extraAttrs == nil {
-		extraAttrs = map[string]interface{}{"summary": summary}
+		extraAttrs = map[string]any{"summary": summary}
 	} else {
 		extraAttrs["summary"] = summary
 	}
@@ -644,7 +644,7 @@ func (bc *basicController) GetReport(ctx context.Context, artifact *ar.Artifact,
 }
 
 // GetSummary ...
-func (bc *basicController) GetSummary(ctx context.Context, artifact *ar.Artifact, scanType string, mimeTypes []string) (map[string]interface{}, error) {
+func (bc *basicController) GetSummary(ctx context.Context, artifact *ar.Artifact, scanType string, mimeTypes []string) (map[string]any, error) {
 	handler := sca.GetScanHandler(scanType)
 	return handler.GetSummary(ctx, artifact, mimeTypes)
 }
@@ -663,7 +663,7 @@ func (bc *basicController) GetScanLog(ctx context.Context, artifact *ar.Artifact
 	if err != nil {
 		return nil, err
 	}
-	artifactMap := map[int64]interface{}{}
+	artifactMap := map[int64]any{}
 	for _, a := range artifacts {
 		artifactMap[a.ID] = struct{}{}
 	}
@@ -751,7 +751,7 @@ func (bc *basicController) GetScanLog(ctx context.Context, artifact *ar.Artifact
 	return b.Bytes(), nil
 }
 
-func scanTaskForArtifacts(task *task.Task, artifactMap map[int64]interface{}) bool {
+func scanTaskForArtifacts(task *task.Task, artifactMap map[int64]any) bool {
 	if task == nil {
 		return false
 	}
@@ -961,7 +961,7 @@ func (bc *basicController) launchScanJob(ctx context.Context, param *launchScanJ
 		reportUUIDs[i] = report.UUID
 	}
 
-	params := make(map[string]interface{})
+	params := make(map[string]any)
 	params[sca.JobParamRegistration] = rJSON
 	params[sca.JobParameterAuthType] = param.Registration.GetRegistryAuthorizationType()
 	params[sca.JobParameterRequest] = sJSON
@@ -979,7 +979,7 @@ func (bc *basicController) launchScanJob(ctx context.Context, param *launchScanJ
 
 	// keep the report uuids in array so that when ?| operator support by the FilterRaw method of beego's orm
 	// we can list the tasks of the scan reports by one SQL
-	extraAttrs := map[string]interface{}{
+	extraAttrs := map[string]any{
 		artifactIDKey:  param.Artifact.ID,
 		artifactTagKey: param.Tag,
 		robotIDKey:     robot.ID,
@@ -1110,7 +1110,7 @@ func (bc *basicController) isAccessory(ctx context.Context, art *ar.Artifact) (b
 	return false, nil
 }
 
-func getArtifactID(extraAttrs map[string]interface{}) int64 {
+func getArtifactID(extraAttrs map[string]any) int64 {
 	var artifactID float64
 	if extraAttrs != nil {
 		if v, ok := extraAttrs[artifactIDKey]; ok {
@@ -1121,7 +1121,7 @@ func getArtifactID(extraAttrs map[string]interface{}) int64 {
 	return int64(artifactID)
 }
 
-func getArtifactTag(extraAttrs map[string]interface{}) string {
+func getArtifactTag(extraAttrs map[string]any) string {
 	var tag string
 	if extraAttrs != nil {
 		if v, ok := extraAttrs[artifactTagKey]; ok {
@@ -1133,13 +1133,13 @@ func getArtifactTag(extraAttrs map[string]interface{}) string {
 }
 
 // GetReportUUIDs returns the report UUIDs from the extra attributes
-func GetReportUUIDs(extraAttrs map[string]interface{}) []string {
+func GetReportUUIDs(extraAttrs map[string]any) []string {
 	var reportUUIDs []string
 
 	if extraAttrs != nil {
 		value, ok := extraAttrs[reportUUIDsKey]
 		if ok {
-			arr, _ := value.([]interface{})
+			arr, _ := value.([]any)
 			for _, el := range arr {
 				if s, ok := el.(string); ok {
 					reportUUIDs = append(reportUUIDs, s)
@@ -1151,7 +1151,7 @@ func GetReportUUIDs(extraAttrs map[string]interface{}) []string {
 	return reportUUIDs
 }
 
-func getRobotID(extraAttrs map[string]interface{}) int64 {
+func getRobotID(extraAttrs map[string]any) int64 {
 	var trackID float64
 	if extraAttrs != nil {
 		if v, ok := extraAttrs[robotIDKey]; ok {

--- a/src/controller/scan/base_controller_test.go
+++ b/src/controller/scan/base_controller_test.go
@@ -224,7 +224,7 @@ func (suite *ControllerTestSuite) SetupSuite() {
 
 	rname := fmt.Sprintf("%s-%s-%s", config.ScannerRobotPrefix(context.TODO()), suite.registration.Name, "the-uuid-123")
 
-	conf := map[string]interface{}{
+	conf := map[string]any{
 		common.RobotTokenDuration: "30",
 	}
 	config.InitWithSettings(conf)
@@ -299,7 +299,7 @@ func (suite *ControllerTestSuite) SetupSuite() {
 	robotJSON, err := rb.ToJSON()
 	require.NoError(suite.T(), err)
 
-	params := make(map[string]interface{})
+	params := make(map[string]any)
 	params[sca.JobParamRegistration] = regJSON
 	params[sca.JobParameterRequest] = rJSON
 	params[sca.JobParameterMimes] = []string{v1.MimeTypeNativeReport}
@@ -672,10 +672,10 @@ func (suite *ControllerTestSuite) TestStopScanAll() {
 	suite.NoError(err)
 }
 
-func (suite *ControllerTestSuite) makeExtraAttrs(artifactID int64, reportUUIDs ...string) map[string]interface{} {
-	b, _ := json.Marshal(map[string]interface{}{reportUUIDsKey: reportUUIDs})
+func (suite *ControllerTestSuite) makeExtraAttrs(artifactID int64, reportUUIDs ...string) map[string]any {
+	b, _ := json.Marshal(map[string]any{reportUUIDsKey: reportUUIDs})
 
-	extraAttrs := map[string]interface{}{}
+	extraAttrs := map[string]any{}
 	json.Unmarshal(b, &extraAttrs)
 	extraAttrs[artifactIDKey] = float64(artifactID)
 

--- a/src/controller/scan/callback.go
+++ b/src/controller/scan/callback.go
@@ -64,7 +64,7 @@ func init() {
 
 func scanAllCallback(ctx context.Context, param string) error {
 	if param != "" {
-		params := make(map[string]interface{})
+		params := make(map[string]any)
 		if err := json.Unmarshal([]byte(param), &params); err != nil {
 			return err
 		}
@@ -126,7 +126,7 @@ func scanTaskStatusChange(ctx context.Context, taskID int64, status string) (err
 				}
 
 				// extract ScanType if exist in ExtraAttrs
-				if c, ok := exec.ExtraAttrs["enabled_capabilities"].(map[string]interface{}); ok {
+				if c, ok := exec.ExtraAttrs["enabled_capabilities"].(map[string]any); ok {
 					if Type, ok := c["type"].(string); ok {
 						e.ScanType = Type
 					}

--- a/src/controller/scan/callback_test.go
+++ b/src/controller/scan/callback_test.go
@@ -168,10 +168,10 @@ func (suite *CallbackTestSuite) TestScanAllCallback() {
 	}
 }
 
-func (suite *CallbackTestSuite) makeExtraAttrs(artifactID, robotID int64) map[string]interface{} {
-	b, _ := json.Marshal(map[string]interface{}{artifactIDKey: artifactID, robotIDKey: robotID})
+func (suite *CallbackTestSuite) makeExtraAttrs(artifactID, robotID int64) map[string]any {
+	b, _ := json.Marshal(map[string]any{artifactIDKey: artifactID, robotIDKey: robotID})
 
-	extraAttrs := map[string]interface{}{}
+	extraAttrs := map[string]any{}
 	json.Unmarshal(b, &extraAttrs)
 
 	return extraAttrs

--- a/src/controller/scan/controller.go
+++ b/src/controller/scan/controller.go
@@ -81,9 +81,9 @@ type Controller interface {
 	//     mimeTypes []string       : the mime types of the reports
 	//
 	//   Returns:
-	//     map[string]interface{} : report summaries indexed by mime types
+	//     map[string]any : report summaries indexed by mime types
 	//     error                  : non nil error if any errors occurred
-	GetSummary(ctx context.Context, artifact *artifact.Artifact, scanType string, mimeTypes []string) (map[string]interface{}, error)
+	GetSummary(ctx context.Context, artifact *artifact.Artifact, scanType string, mimeTypes []string) (map[string]any, error)
 
 	// Get the scan log for the specified artifact with the given digest
 	//

--- a/src/controller/scandataexport/execution.go
+++ b/src/controller/scandataexport/execution.go
@@ -57,7 +57,7 @@ type controller struct {
 }
 
 func (c *controller) ListExecutions(ctx context.Context, userName string) ([]*export.Execution, error) {
-	keywords := make(map[string]interface{})
+	keywords := make(map[string]any)
 	keywords["VendorType"] = job.ScanDataExportVendorType
 	keywords[fmt.Sprintf("ExtraAttrs.%s", export.UserNameAttribute)] = userName
 
@@ -78,7 +78,7 @@ func (c *controller) GetTask(ctx context.Context, executionID int64) (*task.Task
 	logger := log.GetLogger(ctx)
 	query := q2.New(q2.KeyWords{})
 
-	keywords := make(map[string]interface{})
+	keywords := make(map[string]any)
 	keywords["VendorType"] = job.ScanDataExportVendorType
 	keywords["ExecutionID"] = executionID
 	query.Keywords = keywords
@@ -125,7 +125,7 @@ func (c *controller) DeleteExecution(ctx context.Context, executionID int64) err
 func (c *controller) Start(ctx context.Context, request export.Request) (executionID int64, err error) {
 	logger := log.GetLogger(ctx)
 	vendorID := int64(ctx.Value(export.CsvJobVendorIDKey).(int))
-	extraAttrs := make(map[string]interface{})
+	extraAttrs := make(map[string]any)
 	extraAttrs[export.ProjectIDsAttribute] = request.Projects
 	extraAttrs[export.JobNameAttribute] = request.JobName
 	extraAttrs[export.UserNameAttribute] = request.UserName
@@ -137,7 +137,7 @@ func (c *controller) Start(ctx context.Context, request export.Request) (executi
 	}
 
 	// create a job object and fill with metadata and parameters
-	params := make(map[string]interface{})
+	params := make(map[string]any)
 	params[export.JobID] = fmt.Sprintf("%d", id)
 	params[export.JobRequest] = request
 	params[export.JobModeKey] = export.JobModeExport
@@ -184,7 +184,7 @@ func (c *controller) convertToExportExecStatus(ctx context.Context, exec *task.E
 		EndTime:       exec.EndTime,
 	}
 	if pids, ok := exec.ExtraAttrs[export.ProjectIDsAttribute]; ok {
-		for _, pid := range pids.([]interface{}) {
+		for _, pid := range pids.([]any) {
 			execStatus.ProjectIDs = append(execStatus.ProjectIDs, int64(pid.(float64)))
 		}
 	}

--- a/src/controller/scandataexport/execution_test.go
+++ b/src/controller/scandataexport/execution_test.go
@@ -94,7 +94,7 @@ func (suite *ScanDataExportExecutionTestSuite) TestGetExecution() {
 		sysArtifactMgr: suite.sysArtifactMgr,
 	}
 	// get execution succeeds
-	attrs := make(map[string]interface{})
+	attrs := make(map[string]any)
 	attrs[export.JobNameAttribute] = "test-job"
 	attrs[export.UserNameAttribute] = "test-user"
 	attrs[export.DigestKey] = "sha256:d04b98f48e8f8bcc15c6ae5ac050801cd6dcfd428fb5f9e65c4e16e7807340fa"
@@ -154,7 +154,7 @@ func (suite *ScanDataExportExecutionTestSuite) TestGetExecutionSysArtifactExistF
 		sysArtifactMgr: suite.sysArtifactMgr,
 	}
 	// get execution succeeds
-	attrs := make(map[string]interface{})
+	attrs := make(map[string]any)
 	attrs[export.JobNameAttribute] = "test-job"
 	attrs[export.UserNameAttribute] = "test-user"
 	{
@@ -194,7 +194,7 @@ func (suite *ScanDataExportExecutionTestSuite) TestGetExecutionList() {
 		sysArtifactMgr: suite.sysArtifactMgr,
 	}
 	// get execution succeeds
-	attrs := make(map[string]interface{})
+	attrs := make(map[string]any)
 	attrs[export.JobNameAttribute] = "test-job"
 	attrs[export.UserNameAttribute] = "test-user"
 	{
@@ -243,7 +243,7 @@ func (suite *ScanDataExportExecutionTestSuite) TestStart() {
 	// execution manager and task manager return successfully
 	{
 		// get execution succeeds
-		attrs := make(map[string]interface{})
+		attrs := make(map[string]any)
 		attrs[export.ProjectIDsAttribute] = []int64{1}
 		attrs[export.JobNameAttribute] = "test-job"
 		attrs[export.UserNameAttribute] = "test-user"
@@ -307,7 +307,7 @@ func (suite *ScanDataExportExecutionTestSuite) TestStartWithTaskManagerError() {
 	{
 		ctx := context.Background()
 		ctx = context.WithValue(ctx, export.CsvJobVendorIDKey, int(-1))
-		attrs := make(map[string]interface{})
+		attrs := make(map[string]any)
 		attrs[export.ProjectIDsAttribute] = []int64{1}
 		attrs[export.JobNameAttribute] = "test-job"
 		attrs[export.UserNameAttribute] = "test-user"
@@ -327,7 +327,7 @@ func (suite *ScanDataExportExecutionTestSuite) TearDownSuite() {
 
 func (suite *ScanDataExportExecutionTestSuite) validateExecutionManagerInvocation(ctx context.Context) {
 	// validate that execution manager has been called with the specified
-	extraAttsMatcher := testifymock.MatchedBy(func(m map[string]interface{}) bool {
+	extraAttsMatcher := testifymock.MatchedBy(func(m map[string]any) bool {
 		jobName, jobNamePresent := m[export.JobNameAttribute]
 		userName, userNamePresent := m[export.UserNameAttribute]
 		return jobNamePresent && userNamePresent && jobName == "test-job" && userName == "test-user"

--- a/src/controller/scanner/base_controller.go
+++ b/src/controller/scanner/base_controller.go
@@ -362,7 +362,7 @@ func (bc *basicController) getScannerAdapterMetadataWithCache(ctx context.Contex
 	key := fmt.Sprintf("reg:%d:metadata", registration.ID)
 
 	var result MetadataResult
-	err := cache.FetchOrSave(ctx, bc.Cache(), key, &result, func() (interface{}, error) {
+	err := cache.FetchOrSave(ctx, bc.Cache(), key, &result, func() (any, error) {
 		meta, err := bc.getScannerAdapterMetadata(registration)
 		if err != nil {
 			return &MetadataResult{Error: err.Error()}, nil

--- a/src/controller/securityhub/controller.go
+++ b/src/controller/securityhub/controller.go
@@ -147,7 +147,7 @@ func (c *controller) attachTags(ctx context.Context, vuls []*secHubModel.Vulnera
 	}
 
 	// get tags in the artifact list
-	var artifactIDs []interface{}
+	var artifactIDs []any
 	for k := range artifactTagMap {
 		artifactIDs = append(artifactIDs, k)
 	}

--- a/src/controller/systemartifact/execution.go
+++ b/src/controller/systemartifact/execution.go
@@ -148,7 +148,7 @@ func scheduleSystemArtifactCleanJob(ctx context.Context) error {
 }
 
 func getSystemArtifactCleanupSchedule(ctx context.Context) (*scheduler.Schedule, error) {
-	query := q.New(map[string]interface{}{"vendor_type": job.SystemArtifactCleanupVendorType})
+	query := q.New(map[string]any{"vendor_type": job.SystemArtifactCleanupVendorType})
 	schedules, err := sched.ListSchedules(ctx, query)
 	if err != nil {
 		log.Errorf("Unable to check if export data cleanup job is already scheduled : %v", err)

--- a/src/controller/systemartifact/execution_test.go
+++ b/src/controller/systemartifact/execution_test.go
@@ -137,7 +137,7 @@ func (suite *SystemArtifactCleanupTestSuite) TestScheduleCleanupJobNoPreviousSch
 		makeCtx:           func() context.Context { return orm.NewContext(nil, &ormtesting.FakeOrmer{}) },
 	}
 
-	var extraAttrs map[string]interface{}
+	var extraAttrs map[string]any
 	suite.sched.On("Schedule", mock.Anything,
 		job.SystemArtifactCleanupVendorType, int64(0), cronTypeDaily, cronSpec, SystemArtifactCleanupCallback, nil, extraAttrs).Return(int64(1), nil)
 	suite.sched.On("ListSchedules", mock.Anything, mock.Anything).Return(make([]*scheduler2.Schedule, 0), nil)
@@ -163,7 +163,7 @@ func (suite *SystemArtifactCleanupTestSuite) TestScheduleCleanupJobPreviousSched
 		makeCtx:           func() context.Context { return orm.NewContext(nil, &ormtesting.FakeOrmer{}) },
 	}
 
-	var extraAttrs map[string]interface{}
+	var extraAttrs map[string]any
 	suite.sched.On("Schedule", mock.Anything,
 		job.SystemArtifactCleanupVendorType, int64(0), cronTypeDaily, cronSpec, SystemArtifactCleanupCallback, nil, extraAttrs).Return(int64(1), nil)
 
@@ -200,7 +200,7 @@ func (suite *SystemArtifactCleanupTestSuite) TestScheduleCleanupJobPreviousSched
 
 	ScheduleCleanupTask(ctx)
 
-	extraAttributesMatcher := testifymock.MatchedBy(func(attrs map[string]interface{}) bool {
+	extraAttributesMatcher := testifymock.MatchedBy(func(attrs map[string]any) bool {
 		return len(attrs) == 0
 	})
 	suite.sched.AssertNotCalled(suite.T(), "Schedule", mock.Anything,

--- a/src/controller/systeminfo/controller.go
+++ b/src/controller/systeminfo/controller.go
@@ -139,7 +139,7 @@ func (c *controller) GetInfo(ctx context.Context, opt Options) (*Data, error) {
 	return res, nil
 }
 
-func OIDCProviderName(cfg map[string]interface{}) string {
+func OIDCProviderName(cfg map[string]any) string {
 	authMode := utils.SafeCastString(cfg[common.AUTHMode])
 	if authMode != common.OIDCAuth {
 		return ""

--- a/src/controller/systeminfo/controller_test.go
+++ b/src/controller/systeminfo/controller_test.go
@@ -23,7 +23,7 @@ func (s *sysInfoCtlTestSuite) SetupTest() {
 	version.ReleaseVersion = "test"
 	version.GitCommit = "fakeid"
 
-	conf := map[string]interface{}{
+	conf := map[string]any{
 		common.AUTHMode:                    "db_auth",
 		common.SelfRegistration:            true,
 		common.ExtEndpoint:                 "https://test.goharbor.io",
@@ -107,16 +107,16 @@ func TestControllerSuite(t *testing.T) {
 
 func TestOIDCProviderName(t *testing.T) {
 	type args struct {
-		cfg map[string]interface{}
+		cfg map[string]any
 	}
 	tests := []struct {
 		name string
 		args args
 		want string
 	}{
-		{"normal testing", args{map[string]interface{}{common.AUTHMode: common.OIDCAuth, common.OIDCName: "test"}}, "test"},
-		{"not oidc", args{map[string]interface{}{common.AUTHMode: common.DBAuth, common.OIDCName: "test"}}, ""},
-		{"empty provider", args{map[string]interface{}{common.AUTHMode: common.OIDCAuth, common.OIDCName: ""}}, ""},
+		{"normal testing", args{map[string]any{common.AUTHMode: common.OIDCAuth, common.OIDCName: "test"}}, "test"},
+		{"not oidc", args{map[string]any{common.AUTHMode: common.DBAuth, common.OIDCName: "test"}}, ""},
+		{"empty provider", args{map[string]any{common.AUTHMode: common.OIDCAuth, common.OIDCName: ""}}, ""},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/src/controller/tag/controller.go
+++ b/src/controller/tag/controller.go
@@ -76,7 +76,7 @@ type controller struct {
 // Ensure ...
 func (c *controller) Ensure(ctx context.Context, repositoryID, artifactID int64, name string) (int64, error) {
 	query := &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"repository_id": repositoryID,
 			"name":          name,
 		},

--- a/src/controller/task/sweep.go
+++ b/src/controller/task/sweep.go
@@ -67,7 +67,7 @@ type sweepController struct {
 }
 
 func (sc *sweepController) Start(ctx context.Context, params *SweepParams, trigger string) error {
-	jobParams := make(map[string]interface{})
+	jobParams := make(map[string]any)
 	jobParams[task.ExecRetainCounts] = params.ExecRetainCounts
 
 	execID, err := sc.execMgr.Create(ctx, job.ExecSweepVendorType, systemVendorID, trigger, jobParams)
@@ -129,7 +129,7 @@ func ScheduleSweepJob(ctx context.Context) error {
 
 // getScheduledSweepJob gets sweep job which already scheduled.
 func getScheduledSweepJob(ctx context.Context) (*scheduler.Schedule, error) {
-	query := q.New(map[string]interface{}{"vendor_type": job.ExecSweepVendorType})
+	query := q.New(map[string]any{"vendor_type": job.ExecSweepVendorType})
 	schedules, err := scheduler.Sched.ListSchedules(ctx, query)
 	if err != nil {
 		return nil, err

--- a/src/controller/user/controller.go
+++ b/src/controller/user/controller.go
@@ -196,7 +196,7 @@ func (c *controller) Delete(ctx context.Context, id int) error {
 		if err != nil {
 			return errors.Wrap(err, "unable to get user information")
 		}
-		params := map[string]interface{}{
+		params := map[string]any{
 			gdpr.UserNameParam: userDb.Username,
 		}
 		execID, err := c.exeMgr.Create(ctx, job.AuditLogsGDPRCompliantVendorType, -1, task.ExecutionTriggerEvent, params)

--- a/src/controller/usergroup/test/controller_test.go
+++ b/src/controller/usergroup/test/controller_test.go
@@ -38,7 +38,7 @@ func (c *controllerTestSuite) SetupTest() {
 	c.Suite.ClearTables = []string{"user_group"}
 }
 
-var defaultConfigWithVerifyCert = map[string]interface{}{
+var defaultConfigWithVerifyCert = map[string]any{
 	common.ExtEndpoint:                "https://host01.com",
 	common.AUTHMode:                   common.LDAPAuth,
 	common.DatabaseType:               "postgresql",

--- a/src/controller/webhook/controller.go
+++ b/src/controller/webhook/controller.go
@@ -31,7 +31,7 @@ var (
 	Ctl = NewController()
 
 	// webhookJobVendors represents webhook(http) or slack.
-	webhookJobVendors = q.NewOrList([]interface{}{job.WebhookJobVendorType, job.SlackJobVendorType})
+	webhookJobVendors = q.NewOrList([]any{job.WebhookJobVendorType, job.SlackJobVendorType})
 )
 
 type Controller interface {

--- a/src/core/api/api_test.go
+++ b/src/core/api/api_test.go
@@ -73,8 +73,8 @@ type testingRequest struct {
 	method      string
 	url         string
 	header      http.Header
-	queryStruct interface{}
-	bodyJSON    interface{}
+	queryStruct any
+	bodyJSON    any
 	credential  *usrInfo
 }
 
@@ -139,7 +139,7 @@ func handle(r *testingRequest) (*httptest.ResponseRecorder, error) {
 	return resp, nil
 }
 
-func handleAndParse(r *testingRequest, v interface{}) error {
+func handleAndParse(r *testingRequest, v any) error {
 	resp, err := handle(r)
 	if err != nil {
 		return err

--- a/src/core/api/base.go
+++ b/src/core/api/base.go
@@ -74,7 +74,7 @@ func (b *BaseController) RequireAuthenticated() bool {
 }
 
 // HasProjectPermission returns true when the request has action permission on project subresource
-func (b *BaseController) HasProjectPermission(projectIDOrName interface{}, action rbac.Action, subresource ...rbac.Resource) (bool, error) {
+func (b *BaseController) HasProjectPermission(projectIDOrName any, action rbac.Action, subresource ...rbac.Resource) (bool, error) {
 	_, _, err := utils.ParseProjectIDOrName(projectIDOrName)
 	if err != nil {
 		return false, err
@@ -95,7 +95,7 @@ func (b *BaseController) HasProjectPermission(projectIDOrName interface{}, actio
 
 // RequireProjectAccess returns true when the request has action access on project subresource
 // otherwise send UnAuthorized or Forbidden response and returns false
-func (b *BaseController) RequireProjectAccess(projectIDOrName interface{}, action rbac.Action, subresource ...rbac.Resource) bool {
+func (b *BaseController) RequireProjectAccess(projectIDOrName any, action rbac.Action, subresource ...rbac.Resource) bool {
 	hasPermission, err := b.HasProjectPermission(projectIDOrName, action, subresource...)
 	if err != nil {
 		if errors.IsNotFoundErr(err) {
@@ -116,7 +116,7 @@ func (b *BaseController) RequireProjectAccess(projectIDOrName interface{}, actio
 
 // This should be called when a project is not found, if the caller is a system admin it returns 404.
 // If it's regular user, it will render permission error
-func (b *BaseController) handleProjectNotFound(projectIDOrName interface{}) {
+func (b *BaseController) handleProjectNotFound(projectIDOrName any) {
 	if b.SecurityCtx.IsSysAdmin() {
 		b.SendNotFoundError(fmt.Errorf("project %v not found", projectIDOrName))
 	} else {
@@ -134,7 +134,7 @@ func (b *BaseController) SendPermissionError() {
 }
 
 // WriteJSONData writes the JSON data to the client.
-func (b *BaseController) WriteJSONData(object interface{}) {
+func (b *BaseController) WriteJSONData(object any) {
 	b.Data["json"] = object
 	if err := b.ServeJSON(); err != nil {
 		log.Errorf("failed to serve json, %v", err)
@@ -144,7 +144,7 @@ func (b *BaseController) WriteJSONData(object interface{}) {
 }
 
 // WriteYamlData writes the yaml data to the client.
-func (b *BaseController) WriteYamlData(object interface{}) {
+func (b *BaseController) WriteYamlData(object any) {
 	yData, err := yaml.Marshal(object)
 	if err != nil {
 		b.SendInternalServerError(err)

--- a/src/core/auth/authproxy/auth_test.go
+++ b/src/core/auth/authproxy/auth_test.go
@@ -54,7 +54,7 @@ func TestMain(m *testing.M) {
 		userMgr:             user.New(),
 	}
 	cfgMap := cut.GetUnitTestConfig()
-	conf := map[string]interface{}{
+	conf := map[string]any{
 		common.HTTPAuthProxyEndpoint:            a.Endpoint,
 		common.HTTPAuthProxyTokenReviewEndpoint: a.TokenReviewEndpoint,
 		common.HTTPAuthProxyVerifyCert:          false,

--- a/src/core/auth/ldap/ldap_test.go
+++ b/src/core/auth/ldap/ldap_test.go
@@ -38,7 +38,7 @@ import (
 	ugModel "github.com/goharbor/harbor/src/pkg/usergroup/model"
 )
 
-var ldapTestConfig = map[string]interface{}{
+var ldapTestConfig = map[string]any{
 	common.ExtEndpoint:        "host01.com",
 	common.AUTHMode:           "ldap_auth",
 	common.DatabaseType:       "postgresql",

--- a/src/core/controllers/oidc.go
+++ b/src/core/controllers/oidc.go
@@ -430,7 +430,7 @@ func getSessionType(refreshToken string) (string, error) {
 	if err != nil {
 		return "", errors.Errorf("failed to decode refresh token: %v", err)
 	}
-	var claims map[string]interface{}
+	var claims map[string]any
 	if err := json.Unmarshal(payload, &claims); err != nil {
 		return "", errors.Errorf("failed to unmarshal refresh token: %v", err)
 	}

--- a/src/core/service/token/token_test.go
+++ b/src/core/service/token/token_test.go
@@ -148,7 +148,7 @@ func TestMakeToken(t *testing.T) {
 	if err != nil {
 		t.Errorf("Error while getting public key from cert: %s", crt)
 	}
-	tok, err := jwt.ParseWithClaims(tokenString, &harborClaims{}, func(t *jwt.Token) (interface{}, error) {
+	tok, err := jwt.ParseWithClaims(tokenString, &harborClaims{}, func(t *jwt.Token) (any, error) {
 		if _, ok := t.Method.(*jwt.SigningMethodRSA); !ok {
 			return nil, fmt.Errorf("unexpected signing method: %v", t.Header["alg"])
 		}
@@ -251,7 +251,7 @@ func (f *fakeSecurityContext) Can(ctx context.Context, action rbac.Action, resou
 func (f *fakeSecurityContext) GetMyProjects() ([]*proModels.Project, error) {
 	return nil, nil
 }
-func (f *fakeSecurityContext) GetProjectRoles(interface{}) []int {
+func (f *fakeSecurityContext) GetProjectRoles(any) []int {
 	return nil
 }
 

--- a/src/core/session/codec.go
+++ b/src/core/session/codec.go
@@ -35,26 +35,26 @@ var (
 
 type gobCodec struct{}
 
-func (*gobCodec) Encode(v interface{}) ([]byte, error) {
-	if vm, ok := v.(map[interface{}]interface{}); ok {
+func (*gobCodec) Encode(v any) ([]byte, error) {
+	if vm, ok := v.(map[any]any); ok {
 		return session.EncodeGob(vm)
 	}
 
 	return nil, errors.Errorf("object type invalid, %#v", v)
 }
 
-func (*gobCodec) Decode(data []byte, v interface{}) error {
+func (*gobCodec) Decode(data []byte, v any) error {
 	vm, err := session.DecodeGob(data)
 	if err != nil {
 		return err
 	}
 
 	switch in := v.(type) {
-	case map[interface{}]interface{}:
+	case map[any]any:
 		for k, v := range vm {
 			in[k] = v
 		}
-	case *map[interface{}]interface{}:
+	case *map[any]any:
 		m := *in
 		for k, v := range vm {
 			m[k] = v

--- a/src/core/session/codec_test.go
+++ b/src/core/session/codec_test.go
@@ -26,12 +26,12 @@ type User struct {
 
 func TestCodec(t *testing.T) {
 	u := &User{User: "admin", Pass: "123456"}
-	m := make(map[interface{}]interface{})
+	m := make(map[any]any)
 	m["user"] = u
 	c, err := codec.Encode(m)
 	assert.NoError(t, err, "encode should not error")
 
-	v := make(map[interface{}]interface{})
+	v := make(map[any]any)
 	err = codec.Decode(c, &v)
 	assert.NoError(t, err, "decode should not error")
 

--- a/src/core/session/session.go
+++ b/src/core/session/session.go
@@ -41,12 +41,12 @@ type Store struct {
 	c           cache.Cache
 	sid         string
 	lock        sync.RWMutex
-	values      map[interface{}]interface{}
+	values      map[any]any
 	maxlifetime int64
 }
 
 // Set value in redis session
-func (rs *Store) Set(_ context.Context, key, value interface{}) error {
+func (rs *Store) Set(_ context.Context, key, value any) error {
 	rs.lock.Lock()
 	defer rs.lock.Unlock()
 	rs.values[key] = value
@@ -54,7 +54,7 @@ func (rs *Store) Set(_ context.Context, key, value interface{}) error {
 }
 
 // Get value in redis session
-func (rs *Store) Get(_ context.Context, key interface{}) interface{} {
+func (rs *Store) Get(_ context.Context, key any) any {
 	rs.lock.RLock()
 	defer rs.lock.RUnlock()
 	if v, ok := rs.values[key]; ok {
@@ -64,7 +64,7 @@ func (rs *Store) Get(_ context.Context, key interface{}) interface{} {
 }
 
 // Delete value in redis session
-func (rs *Store) Delete(_ context.Context, key interface{}) error {
+func (rs *Store) Delete(_ context.Context, key any) error {
 	rs.lock.Lock()
 	defer rs.lock.Unlock()
 	delete(rs.values, key)
@@ -75,7 +75,7 @@ func (rs *Store) Delete(_ context.Context, key interface{}) error {
 func (rs *Store) Flush(_ context.Context) error {
 	rs.lock.Lock()
 	defer rs.lock.Unlock()
-	rs.values = make(map[interface{}]interface{})
+	rs.values = make(map[any]any)
 	return nil
 }
 
@@ -144,7 +144,7 @@ func (rp *Provider) SessionInit(ctx context.Context, maxlifetime int64, url stri
 
 // SessionRead read redis session by sid
 func (rp *Provider) SessionRead(ctx context.Context, sid string) (session.Store, error) {
-	kv := make(map[interface{}]interface{})
+	kv := make(map[any]any)
 	if ctx == nil {
 		ctx = context.TODO()
 	}
@@ -182,7 +182,7 @@ func (rp *Provider) SessionRegenerate(ctx context.Context, oldsid, sid string) (
 			rdb.Rename(ctx, oldsid, sid)
 			rdb.Expire(ctx, sid, maxlifetime)
 		} else {
-			kv := make(map[interface{}]interface{})
+			kv := make(map[any]any)
 			err := rp.c.Fetch(ctx, sid, &kv)
 			if err != nil && !errors.Is(err, cache.ErrNotFound) {
 				return nil, err

--- a/src/jobservice/README.md
+++ b/src/jobservice/README.md
@@ -100,7 +100,7 @@ type Interface interface {
 	// The related arguments will be injected by the workerpool.
 	//
 	// ctx Context                   : Job execution context.
-	// params map[string]interface{} : parameters with key-pair style for the job execution.
+	// params map[string]any : parameters with key-pair style for the job execution.
 	//
 	// Returns:
 	//  error if failed to run. NOTES: If job is stopped or cancelled, a specified error should be returned

--- a/src/jobservice/api/handler.go
+++ b/src/jobservice/api/handler.go
@@ -271,7 +271,7 @@ func (dh *DefaultHandler) HandleGetJobsReq(w http.ResponseWriter, req *http.Requ
 	dh.handleJSONData(w, req, http.StatusOK, jobs)
 }
 
-func (dh *DefaultHandler) handleJSONData(w http.ResponseWriter, req *http.Request, code int, object interface{}) {
+func (dh *DefaultHandler) handleJSONData(w http.ResponseWriter, req *http.Request, code int, object any) {
 	data, err := json.Marshal(object)
 	if err != nil {
 		dh.handleError(w, req, http.StatusInternalServerError, errs.HandleJSONDataError(err))

--- a/src/jobservice/common/list/list.go
+++ b/src/jobservice/common/list/list.go
@@ -36,7 +36,7 @@ func New() *SyncList {
 }
 
 // Iterate the list
-func (l *SyncList) Iterate(f func(ele interface{}) bool) {
+func (l *SyncList) Iterate(f func(ele any) bool) {
 	l.lock.RLock()
 	defer l.lock.RUnlock()
 
@@ -54,7 +54,7 @@ func (l *SyncList) Iterate(f func(ele interface{}) bool) {
 }
 
 // Push the element to the back of the list
-func (l *SyncList) Push(ele interface{}) {
+func (l *SyncList) Push(ele any) {
 	if ele != nil {
 		l.lock.Lock()
 		defer l.lock.Unlock()

--- a/src/jobservice/common/list/list_test.go
+++ b/src/jobservice/common/list/list_test.go
@@ -43,7 +43,7 @@ func (suite *ListSuite) SetupSuite() {
 }
 
 func (suite *ListSuite) TestIterate() {
-	suite.l.Iterate(func(ele interface{}) bool {
+	suite.l.Iterate(func(ele any) bool {
 		if s, ok := ele.(string); ok {
 			if strings.HasPrefix(s, "b") {
 				return true

--- a/src/jobservice/common/query/q.go
+++ b/src/jobservice/common/query/q.go
@@ -38,17 +38,17 @@ const (
 )
 
 // ExtraParameters to keep non pagination query parameters
-type ExtraParameters map[string]interface{}
+type ExtraParameters map[string]any
 
 // Set extra parameters
-func (ep ExtraParameters) Set(key string, v interface{}) {
+func (ep ExtraParameters) Set(key string, v any) {
 	if len(key) > 0 {
 		ep[key] = v
 	}
 }
 
 // Get the extra parameter by key
-func (ep ExtraParameters) Get(key string) (interface{}, bool) {
+func (ep ExtraParameters) Get(key string) (any, bool) {
 	v, ok := ep[key]
 
 	return v, ok

--- a/src/jobservice/common/rds/utils.go
+++ b/src/jobservice/common/rds/utils.go
@@ -29,7 +29,7 @@ import (
 var ErrNoElements = errors.New("no elements got from the backend")
 
 // HmSet sets the properties of hash map
-func HmSet(conn redis.Conn, key string, fieldAndValues ...interface{}) error {
+func HmSet(conn redis.Conn, key string, fieldAndValues ...any) error {
 	if conn == nil {
 		return errors.New("nil redis connection")
 	}
@@ -42,7 +42,7 @@ func HmSet(conn redis.Conn, key string, fieldAndValues ...interface{}) error {
 		return errors.New("no properties specified to do HMSET")
 	}
 
-	args := make([]interface{}, 0, len(fieldAndValues)+2)
+	args := make([]any, 0, len(fieldAndValues)+2)
 
 	args = append(args, key)
 	args = append(args, fieldAndValues...)
@@ -55,7 +55,7 @@ func HmSet(conn redis.Conn, key string, fieldAndValues ...interface{}) error {
 
 // HmGet gets values of multiple fields
 // Values have same order with the provided fields
-func HmGet(conn redis.Conn, key string, fields ...interface{}) ([]interface{}, error) {
+func HmGet(conn redis.Conn, key string, fields ...any) ([]any, error) {
 	if conn == nil {
 		return nil, errors.New("nil redis connection")
 	}
@@ -68,7 +68,7 @@ func HmGet(conn redis.Conn, key string, fields ...interface{}) ([]interface{}, e
 		return nil, errors.New("no fields specified to do HMGET")
 	}
 
-	args := make([]interface{}, 0, len(fields)+1)
+	args := make([]any, 0, len(fields)+1)
 	args = append(args, key)
 	args = append(args, fields...)
 
@@ -111,7 +111,7 @@ func GetZsetByScore(conn redis.Conn, key string, scores []int64) ([]JobScore, er
 
 // AcquireLock acquires a redis lock with specified expired time
 func AcquireLock(conn redis.Conn, lockerKey string, lockerID string, expireTime int64) error {
-	args := []interface{}{lockerKey, lockerID, "NX", "EX", expireTime}
+	args := []any{lockerKey, lockerID, "NX", "EX", expireTime}
 	res, err := conn.Do("SET", args...)
 	if err != nil {
 		return err

--- a/src/jobservice/common/utils/utils_test.go
+++ b/src/jobservice/common/utils/utils_test.go
@@ -92,7 +92,7 @@ func (suite *UtilsTestSuite) TestJobSerializeAndDeSerialize() {
 		Name:       "test",
 		ID:         "123",
 		EnqueuedAt: 123,
-		Args: map[string]interface{}{
+		Args: map[string]any{
 			"test": "test",
 		},
 		Unique:   true,

--- a/src/jobservice/config/config.go
+++ b/src/jobservice/config/config.go
@@ -123,7 +123,7 @@ type MetricConfig struct {
 }
 
 // CustomizedSettings keeps the customized settings of logger
-type CustomizedSettings map[string]interface{}
+type CustomizedSettings map[string]any
 
 // LogSweeperConfig keeps settings of log sweeper
 type LogSweeperConfig struct {

--- a/src/jobservice/core/controller_test.go
+++ b/src/jobservice/core/controller_test.go
@@ -235,7 +235,7 @@ func (suite *ControllerTestSuite) GetPoolID() string {
 	return suite.worker.GetPoolID()
 }
 
-func (suite *ControllerTestSuite) RegisterJobs(jobs map[string]interface{}) error {
+func (suite *ControllerTestSuite) RegisterJobs(jobs map[string]any) error {
 	return suite.worker.RegisterJobs(jobs)
 }
 
@@ -255,11 +255,11 @@ func (suite *ControllerTestSuite) Stats() (*worker.Stats, error) {
 	return suite.worker.Stats()
 }
 
-func (suite *ControllerTestSuite) IsKnownJob(name string) (interface{}, bool) {
+func (suite *ControllerTestSuite) IsKnownJob(name string) (any, bool) {
 	return suite.worker.IsKnownJob(name)
 }
 
-func (suite *ControllerTestSuite) ValidateJobParameters(jobType interface{}, params job.Parameters) error {
+func (suite *ControllerTestSuite) ValidateJobParameters(jobType any, params job.Parameters) error {
 	return suite.worker.ValidateJobParameters(jobType, params)
 }
 
@@ -305,7 +305,7 @@ func (f *fakeWorker) GetPoolID() string {
 	return f.Called().String()
 }
 
-func (f *fakeWorker) RegisterJobs(jobs map[string]interface{}) error {
+func (f *fakeWorker) RegisterJobs(jobs map[string]any) error {
 	return f.Called(jobs).Error(0)
 }
 
@@ -345,7 +345,7 @@ func (f *fakeWorker) Stats() (*worker.Stats, error) {
 	return args.Get(0).(*worker.Stats), nil
 }
 
-func (f *fakeWorker) IsKnownJob(name string) (interface{}, bool) {
+func (f *fakeWorker) IsKnownJob(name string) (any, bool) {
 	args := f.Called(name)
 	if !args.Bool(1) {
 		return nil, args.Bool(1)
@@ -354,7 +354,7 @@ func (f *fakeWorker) IsKnownJob(name string) (interface{}, bool) {
 	return args.Get(0), args.Bool(1)
 }
 
-func (f *fakeWorker) ValidateJobParameters(jobType interface{}, params job.Parameters) error {
+func (f *fakeWorker) ValidateJobParameters(jobType any, params job.Parameters) error {
 	return f.Called(jobType, params).Error(0)
 }
 

--- a/src/jobservice/errs/errors.go
+++ b/src/jobservice/errs/errors.go
@@ -191,7 +191,7 @@ type badRequestError struct {
 }
 
 // BadRequestError returns the error of handing bad request case
-func BadRequestError(object interface{}) error {
+func BadRequestError(object any) error {
 	return badRequestError{
 		baseError{
 			Code:        BadRequestErrorCode,

--- a/src/jobservice/job/context.go
+++ b/src/jobservice/job/context.go
@@ -40,7 +40,7 @@ type Context interface {
 	// Returns:
 	//  The data of the specified context property if have
 	//  bool to indicate if the property existing
-	Get(prop string) (interface{}, bool)
+	Get(prop string) (any, bool)
 
 	// SystemContext returns the system context
 	//

--- a/src/jobservice/job/impl/context.go
+++ b/src/jobservice/job/impl/context.go
@@ -44,7 +44,7 @@ type Context struct {
 	// Logger for job
 	logger logger.Interface
 	// other required information
-	properties map[string]interface{}
+	properties map[string]any
 	// admin server client
 	cfgMgr libCfg.Manager
 	// job life cycle tracker
@@ -58,7 +58,7 @@ func NewContext(sysCtx context.Context, cfgMgr libCfg.Manager) *Context {
 	return &Context{
 		sysContext: libCfg.NewContext(sysCtx, cfgMgr),
 		cfgMgr:     cfgMgr,
-		properties: make(map[string]interface{}),
+		properties: make(map[string]any),
 	}
 }
 
@@ -110,7 +110,7 @@ func (c *Context) Build(tracker job.Tracker) (job.Context, error) {
 	jContext := &Context{
 		sysContext: orm.NewContext(c.sysContext, o.NewOrm()),
 		cfgMgr:     c.cfgMgr,
-		properties: make(map[string]interface{}),
+		properties: make(map[string]any),
 		tracker:    tracker,
 	}
 
@@ -145,7 +145,7 @@ func (c *Context) Build(tracker job.Tracker) (job.Context, error) {
 }
 
 // Get implements the same method in env.JobContext interface
-func (c *Context) Get(prop string) (interface{}, bool) {
+func (c *Context) Get(prop string) (any, bool) {
 	v, ok := c.properties[prop]
 	return v, ok
 }
@@ -192,13 +192,13 @@ func createLoggers(jobID string) (logger.Interface, error) {
 		// For running job, the depth should be 5
 		if lc.Name == logger.NameFile || lc.Name == logger.NameStdOutput || lc.Name == logger.NameDB {
 			if lc.Settings == nil {
-				lc.Settings = map[string]interface{}{}
+				lc.Settings = map[string]any{}
 			}
 			lc.Settings["depth"] = 5
 		}
 		if lc.Name == logger.NameFile || lc.Name == logger.NameDB {
 			// Need extra param
-			fSettings := map[string]interface{}{}
+			fSettings := map[string]any{}
 			for k, v := range lc.Settings {
 				// Copy settings
 				fSettings[k] = v

--- a/src/jobservice/job/impl/context_test.go
+++ b/src/jobservice/job/impl/context_test.go
@@ -62,12 +62,12 @@ func (suite *ContextImplTestSuite) SetupSuite() {
 		{
 			Name:  "FILE",
 			Level: "INFO",
-			Settings: map[string]interface{}{
+			Settings: map[string]any{
 				"base_dir": os.TempDir(),
 			},
 			Sweeper: &config.LogSweeperConfig{
 				Duration: 1,
-				Settings: map[string]interface{}{
+				Settings: map[string]any{
 					"work_dir": os.TempDir(),
 				},
 			},

--- a/src/jobservice/job/impl/default_context.go
+++ b/src/jobservice/job/impl/default_context.go
@@ -32,7 +32,7 @@ type DefaultContext struct {
 	// Logger for job
 	logger logger.Interface
 	// Other required information
-	properties map[string]interface{}
+	properties map[string]any
 	// Track the job attached with the context
 	tracker job.Tracker
 }
@@ -41,7 +41,7 @@ type DefaultContext struct {
 func NewDefaultContext(sysCtx context.Context) job.Context {
 	return &DefaultContext{
 		sysContext: sysCtx,
-		properties: make(map[string]interface{}),
+		properties: make(map[string]any),
 	}
 }
 
@@ -56,7 +56,7 @@ func (dc *DefaultContext) Build(t job.Tracker) (job.Context, error) {
 		// TODO support DB transaction
 		sysContext: orm.NewContext(dc.sysContext, o.NewOrm()),
 		tracker:    t,
-		properties: make(map[string]interface{}),
+		properties: make(map[string]any),
 	}
 
 	// Copy properties
@@ -78,7 +78,7 @@ func (dc *DefaultContext) Build(t job.Tracker) (job.Context, error) {
 }
 
 // Get implements the same method in env.Context interface
-func (dc *DefaultContext) Get(prop string) (interface{}, bool) {
+func (dc *DefaultContext) Get(prop string) (any, bool) {
 	v, ok := dc.properties[prop]
 	return v, ok
 }

--- a/src/jobservice/job/impl/gc/garbage_collection.go
+++ b/src/jobservice/job/impl/gc/garbage_collection.go
@@ -536,7 +536,7 @@ func (gc *GarbageCollector) deletedArt(ctx job.Context) (map[string][]model.Arti
 	// handle the optional ones, and the artifact controller will move them into trash.
 	if gc.deleteUntagged {
 		untaggedArts, err := gc.artCtl.List(ctx.SystemContext(), &q.Query{
-			Keywords: map[string]interface{}{
+			Keywords: map[string]any{
 				"Tags": "nil",
 			},
 		}, &artifact.Option{WithAccessory: true})
@@ -639,7 +639,7 @@ func (gc *GarbageCollector) markOrSweepUntaggedBlobs(ctx job.Context) ([]*blobMo
 				Min: lastBlobID,
 			}
 			query := &q.Query{
-				Keywords: map[string]interface{}{
+				Keywords: map[string]any{
 					"update_time": &timeRG,
 					"projectID":   p.ProjectID,
 					"id":          &blobRG,

--- a/src/jobservice/job/impl/gc/garbage_collection_test.go
+++ b/src/jobservice/job/impl/gc/garbage_collection_test.go
@@ -157,7 +157,7 @@ func (suite *gcTestSuite) TestInit() {
 	gc := &GarbageCollector{
 		registryCtlClient: suite.registryCtlClient,
 	}
-	params := map[string]interface{}{
+	params := map[string]any{
 		"delete_untagged": true,
 		"redis_url_reg":   "redis url",
 		"time_window":     1,
@@ -169,21 +169,21 @@ func (suite *gcTestSuite) TestInit() {
 	suite.True(gc.deleteUntagged)
 	suite.Equal(3, gc.workers)
 
-	params = map[string]interface{}{
+	params = map[string]any{
 		"delete_untagged": "unsupported",
 		"redis_url_reg":   "redis url",
 	}
 	suite.Nil(gc.init(ctx, params))
 	suite.True(gc.deleteUntagged)
 
-	params = map[string]interface{}{
+	params = map[string]any{
 		"delete_untagged": false,
 		"redis_url_reg":   "redis url",
 	}
 	suite.Nil(gc.init(ctx, params))
 	suite.False(gc.deleteUntagged)
 
-	params = map[string]interface{}{
+	params = map[string]any{
 		"redis_url_reg": "redis url",
 	}
 	suite.Nil(gc.init(ctx, params))
@@ -281,7 +281,7 @@ func (suite *gcTestSuite) TestRun() {
 		blobMgr:           suite.blobMgr,
 		registryCtlClient: suite.registryCtlClient,
 	}
-	params := map[string]interface{}{
+	params := map[string]any{
 		"delete_untagged": false,
 		"redis_url_reg":   tests.GetRedisURL(),
 		"time_window":     1,

--- a/src/jobservice/job/impl/notification/slack_job.go
+++ b/src/jobservice/job/impl/notification/slack_job.go
@@ -106,7 +106,7 @@ func (sj *SlackJob) Run(ctx job.Context, params job.Parameters) error {
 }
 
 // init slack job
-func (sj *SlackJob) init(ctx job.Context, params map[string]interface{}) error {
+func (sj *SlackJob) init(ctx job.Context, params map[string]any) error {
 	sj.logger = ctx.GetLogger()
 
 	// default use secure transport
@@ -121,7 +121,7 @@ func (sj *SlackJob) init(ctx job.Context, params map[string]interface{}) error {
 }
 
 // execute slack job
-func (sj *SlackJob) execute(params map[string]interface{}) error {
+func (sj *SlackJob) execute(params map[string]any) error {
 	payload := params["payload"].(string)
 	address := params["address"].(string)
 

--- a/src/jobservice/job/impl/notification/slack_job_test.go
+++ b/src/jobservice/job/impl/notification/slack_job_test.go
@@ -64,7 +64,7 @@ func TestSlackJobRun(t *testing.T) {
 			assert.Equal(t, string(body), `{"key": "value"}`)
 		}))
 	defer ts.Close()
-	params := map[string]interface{}{
+	params := map[string]any{
 		"skip_cert_verify": true,
 		"payload":          `{"key": "value"}`,
 		"address":          ts.URL,
@@ -77,7 +77,7 @@ func TestSlackJobRun(t *testing.T) {
 			w.WriteHeader(http.StatusUnauthorized)
 		}))
 	defer tsWrong.Close()
-	paramsWrong := map[string]interface{}{
+	paramsWrong := map[string]any{
 		"skip_cert_verify": true,
 		"payload":          `{"key": "value"}`,
 		"address":          tsWrong.URL,

--- a/src/jobservice/job/impl/notification/webhook_job.go
+++ b/src/jobservice/job/impl/notification/webhook_job.go
@@ -82,7 +82,7 @@ func (wj *WebhookJob) Run(ctx job.Context, params job.Parameters) error {
 }
 
 // init webhook job
-func (wj *WebhookJob) init(ctx job.Context, params map[string]interface{}) error {
+func (wj *WebhookJob) init(ctx job.Context, params map[string]any) error {
 	wj.logger = ctx.GetLogger()
 	wj.ctx = ctx
 
@@ -98,7 +98,7 @@ func (wj *WebhookJob) init(ctx job.Context, params map[string]interface{}) error
 }
 
 // execute webhook job
-func (wj *WebhookJob) execute(_ job.Context, params map[string]interface{}) error {
+func (wj *WebhookJob) execute(_ job.Context, params map[string]any) error {
 	payload := params["payload"].(string)
 	address := params["address"].(string)
 

--- a/src/jobservice/job/impl/notification/webhook_job_test.go
+++ b/src/jobservice/job/impl/notification/webhook_job_test.go
@@ -59,7 +59,7 @@ func TestRun(t *testing.T) {
 			assert.Equal(t, string(body), `{"key": "value"}`)
 		}))
 	defer ts.Close()
-	params := map[string]interface{}{
+	params := map[string]any{
 		"skip_cert_verify": true,
 		"payload":          `{"key": "value"}`,
 		"address":          ts.URL,
@@ -73,7 +73,7 @@ func TestRun(t *testing.T) {
 			w.WriteHeader(http.StatusUnauthorized)
 		}))
 	defer tsWrong.Close()
-	paramsWrong := map[string]interface{}{
+	paramsWrong := map[string]any{
 		"skip_cert_verify": true,
 		"payload":          `{"key": "value"}`,
 		"address":          tsWrong.URL,

--- a/src/jobservice/job/impl/replication/replication.go
+++ b/src/jobservice/job/impl/replication/replication.go
@@ -112,7 +112,7 @@ func (r *Replication) Run(ctx job.Context, params job.Parameters) error {
 	return trans.Transfer(src, dst, opts)
 }
 
-func parseParams(params map[string]interface{}) (*model.Resource, *model.Resource, *transfer.Options, error) {
+func parseParams(params map[string]any) (*model.Resource, *model.Resource, *transfer.Options, error) {
 	src := &model.Resource{}
 	if err := parseParam(params, "src_resource", src); err != nil {
 		return nil, nil, nil, err
@@ -158,7 +158,7 @@ func parseParams(params map[string]interface{}) (*model.Resource, *model.Resourc
 	return src, dst, opts, nil
 }
 
-func parseParam(params map[string]interface{}, name string, v interface{}) error {
+func parseParam(params map[string]any, name string, v any) error {
 	value, exist := params[name]
 	if !exist {
 		return fmt.Errorf("param %s not found", name)

--- a/src/jobservice/job/impl/replication/replication_test.go
+++ b/src/jobservice/job/impl/replication/replication_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestParseParam(t *testing.T) {
-	params := map[string]interface{}{}
+	params := map[string]any{}
 	// not exist param
 	err := parseParam(params, "not_exist_param", nil)
 	assert.NotNil(t, err)
@@ -80,7 +80,7 @@ func (f *fakedTransfer) Transfer(src *model.Resource, dst *model.Resource, opts 
 func TestRun(t *testing.T) {
 	err := transfer.RegisterFactory("art", fakedTransferFactory)
 	require.Nil(t, err)
-	params := map[string]interface{}{
+	params := map[string]any{
 		"src_resource": `{"type":"art"}`,
 		"dst_resource": `{}`,
 	}

--- a/src/jobservice/job/impl/scandataexport/scan_data_export.go
+++ b/src/jobservice/job/impl/scandataexport/scan_data_export.go
@@ -79,7 +79,7 @@ func (sde *ScanDataExport) Validate(_ job.Parameters) error {
 // The related arguments will be injected by the workerpool.
 //
 // ctx Context                   : Job execution context.
-// params map[string]interface{} : parameters with key-pair style for the job execution.
+// params map[string]any : parameters with key-pair style for the job execution.
 //
 // Returns:
 //
@@ -127,7 +127,7 @@ func (sde *ScanDataExport) Run(ctx job.Context, params job.Parameters) error {
 	logger.Infof("Export Job Id = %s. CSV file size: %d", params[export.JobID], stat.Size())
 	// earlier return and update status message if the file size is 0, unnecessary to push a empty system artifact.
 	if stat.Size() == 0 {
-		extra := map[string]interface{}{
+		extra := map[string]any{
 			export.StatusMessageAttribute: "No vulnerabilities found or matched",
 		}
 		updateErr := sde.updateExecAttributes(ctx, params, extra)
@@ -148,7 +148,7 @@ func (sde *ScanDataExport) Run(ctx job.Context, params job.Parameters) error {
 	}
 
 	logger.Infof("Export Job Id = %s. Created system artifact: %v for report file %s to persistent storage: %v", params[export.JobID], artID, fileName, err)
-	err = sde.updateExecAttributes(ctx, params, map[string]interface{}{export.DigestKey: hash.String()})
+	err = sde.updateExecAttributes(ctx, params, map[string]any{export.DigestKey: hash.String()})
 	if err != nil {
 		logger.Errorf("Export Job Id = %s. Error when updating execution record : %v", params[export.JobID], err)
 		return err
@@ -158,7 +158,7 @@ func (sde *ScanDataExport) Run(ctx job.Context, params job.Parameters) error {
 	return nil
 }
 
-func (sde *ScanDataExport) updateExecAttributes(ctx job.Context, params job.Parameters, attrs map[string]interface{}) error {
+func (sde *ScanDataExport) updateExecAttributes(ctx job.Context, params job.Parameters, attrs map[string]any) error {
 	logger := ctx.GetLogger()
 	execID, err := strconv.ParseInt(params[export.JobID].(string), 10, 64)
 	if err != nil {
@@ -295,7 +295,7 @@ func (sde *ScanDataExport) writeCsvFile(ctx job.Context, params job.Parameters, 
 }
 
 func (sde *ScanDataExport) extractCriteria(params job.Parameters) (*export.Request, error) {
-	filterMap, ok := params[export.JobRequest].(map[string]interface{})
+	filterMap, ok := params[export.JobRequest].(map[string]any)
 	if !ok {
 		return nil, errors.Errorf("malformed criteria '%v'", params[export.JobRequest])
 	}

--- a/src/jobservice/job/interface.go
+++ b/src/jobservice/job/interface.go
@@ -45,7 +45,7 @@ type Interface interface {
 	// The related arguments will be injected by the workerpool.
 	//
 	// ctx Context                   : Job execution context.
-	// params map[string]interface{} : parameters with key-pair style for the job execution.
+	// params map[string]any : parameters with key-pair style for the job execution.
 	//
 	// Returns:
 	//  error if failed to run. NOTES: If job is stopped or cancelled, a specified error should be returned

--- a/src/jobservice/job/models.go
+++ b/src/jobservice/job/models.go
@@ -24,7 +24,7 @@ import (
 )
 
 // Parameters for job execution.
-type Parameters map[string]interface{}
+type Parameters map[string]any
 
 // Request is the request of launching a job.
 type Request struct {

--- a/src/jobservice/job/status_test.go
+++ b/src/jobservice/job/status_test.go
@@ -291,14 +291,14 @@ func TestStatus_Validate(t *testing.T) {
 		{
 			name: "Error status checksum failure",
 			s:    Status("error"),
-			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+			wantErr: func(t assert.TestingT, err error, i ...any) bool {
 				return false
 			},
 		},
 		{
 			name: "SuccessStatus check success",
 			s:    SuccessStatus,
-			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+			wantErr: func(t assert.TestingT, err error, i ...any) bool {
 				return true
 			},
 		},

--- a/src/jobservice/job/tracker.go
+++ b/src/jobservice/job/tracker.go
@@ -61,11 +61,11 @@ type Tracker interface {
 
 	// Update the properties of the job stats
 	//
-	// fieldAndValues ...interface{} : One or more properties being updated
+	// fieldAndValues ...any : One or more properties being updated
 	//
 	// Returns:
 	//  error if update failed
-	Update(fieldAndValues ...interface{}) error
+	Update(fieldAndValues ...any) error
 
 	// NumericID returns the numeric ID of periodic job.
 	// Please pay attention, this only for periodic job.
@@ -164,7 +164,7 @@ func (bt *basicTracker) Job() *Stats {
 }
 
 // Update the properties of the job stats
-func (bt *basicTracker) Update(fieldAndValues ...interface{}) error {
+func (bt *basicTracker) Update(fieldAndValues ...any) error {
 	if len(fieldAndValues) == 0 {
 		return errors.New("no properties specified to update")
 	}
@@ -175,7 +175,7 @@ func (bt *basicTracker) Update(fieldAndValues ...interface{}) error {
 	}()
 
 	key := rds.KeyJobStats(bt.namespace, bt.jobID)
-	args := []interface{}{"update_time", time.Now().Unix()} // update timestamp
+	args := []any{"update_time", time.Now().Unix()} // update timestamp
 	args = append(args, fieldAndValues...)
 
 	return rds.HmSet(conn, key, args...)
@@ -215,7 +215,7 @@ func (bt *basicTracker) PeriodicExecutionDone() error {
 		_ = conn.Close()
 	}()
 
-	args := []interface{}{key, "XX", -1, bt.jobID}
+	args := []any{key, "XX", -1, bt.jobID}
 	_, err := conn.Do("ZADD", args...)
 
 	return err
@@ -302,7 +302,7 @@ func (bt *basicTracker) Save() (err error) {
 	stats := bt.jobStats
 
 	key := rds.KeyJobStats(bt.namespace, stats.Info.JobID)
-	args := make([]interface{}, 0)
+	args := make([]any, 0)
 	args = append(args, key)
 	args = append(args,
 		"id", stats.Info.JobID,
@@ -362,7 +362,7 @@ func (bt *basicTracker) Save() (err error) {
 	// Link with its upstream job if upstream job ID exists for future querying
 	if !utils.IsEmptyStr(stats.Info.UpstreamJobID) {
 		k := rds.KeyUpstreamJobAndExecutions(bt.namespace, stats.Info.UpstreamJobID)
-		zargs := []interface{}{k, "NX", stats.Info.RunAt, stats.Info.JobID}
+		zargs := []any{k, "NX", stats.Info.RunAt, stats.Info.JobID}
 		err = conn.Send("ZADD", zargs...)
 	}
 

--- a/src/jobservice/lcm/controller.go
+++ b/src/jobservice/lcm/controller.go
@@ -154,7 +154,7 @@ func (bc *basicController) retryLoop() {
 	}()
 
 	// Check the list
-	bc.retryList.Iterate(func(ele interface{}) bool {
+	bc.retryList.Iterate(func(ele any) bool {
 		if change, ok := ele.(job.SimpleStatusChange); ok {
 			err := retry(conn, bc.namespace, change)
 			if err != nil {

--- a/src/jobservice/logger/backend/db_logger.go
+++ b/src/jobservice/logger/backend/db_logger.go
@@ -71,51 +71,51 @@ func (dbl *DBLogger) Close() error {
 }
 
 // Debug ...
-func (dbl *DBLogger) Debug(v ...interface{}) {
+func (dbl *DBLogger) Debug(v ...any) {
 	dbl.backendLogger.Debug(v...)
 }
 
 // Debugf with format
-func (dbl *DBLogger) Debugf(format string, v ...interface{}) {
+func (dbl *DBLogger) Debugf(format string, v ...any) {
 	dbl.backendLogger.Debugf(format, v...)
 }
 
 // Info ...
-func (dbl *DBLogger) Info(v ...interface{}) {
+func (dbl *DBLogger) Info(v ...any) {
 	dbl.backendLogger.Info(v...)
 }
 
 // Infof with format
-func (dbl *DBLogger) Infof(format string, v ...interface{}) {
+func (dbl *DBLogger) Infof(format string, v ...any) {
 	dbl.backendLogger.Infof(format, v...)
 }
 
 // Warning ...
-func (dbl *DBLogger) Warning(v ...interface{}) {
+func (dbl *DBLogger) Warning(v ...any) {
 	dbl.backendLogger.Warning(v...)
 }
 
 // Warningf with format
-func (dbl *DBLogger) Warningf(format string, v ...interface{}) {
+func (dbl *DBLogger) Warningf(format string, v ...any) {
 	dbl.backendLogger.Warningf(format, v...)
 }
 
 // Error ...
-func (dbl *DBLogger) Error(v ...interface{}) {
+func (dbl *DBLogger) Error(v ...any) {
 	dbl.backendLogger.Error(v...)
 }
 
 // Errorf with format
-func (dbl *DBLogger) Errorf(format string, v ...interface{}) {
+func (dbl *DBLogger) Errorf(format string, v ...any) {
 	dbl.backendLogger.Errorf(format, v...)
 }
 
 // Fatal error
-func (dbl *DBLogger) Fatal(v ...interface{}) {
+func (dbl *DBLogger) Fatal(v ...any) {
 	dbl.backendLogger.Fatal(v...)
 }
 
 // Fatalf error
-func (dbl *DBLogger) Fatalf(format string, v ...interface{}) {
+func (dbl *DBLogger) Fatalf(format string, v ...any) {
 	dbl.backendLogger.Fatalf(format, v...)
 }

--- a/src/jobservice/logger/backend/file_logger.go
+++ b/src/jobservice/logger/backend/file_logger.go
@@ -54,51 +54,51 @@ func (fl *FileLogger) Close() error {
 }
 
 // Debug ...
-func (fl *FileLogger) Debug(v ...interface{}) {
+func (fl *FileLogger) Debug(v ...any) {
 	fl.backendLogger.Debug(v...)
 }
 
 // Debugf with format
-func (fl *FileLogger) Debugf(format string, v ...interface{}) {
+func (fl *FileLogger) Debugf(format string, v ...any) {
 	fl.backendLogger.Debugf(format, v...)
 }
 
 // Info ...
-func (fl *FileLogger) Info(v ...interface{}) {
+func (fl *FileLogger) Info(v ...any) {
 	fl.backendLogger.Info(v...)
 }
 
 // Infof with format
-func (fl *FileLogger) Infof(format string, v ...interface{}) {
+func (fl *FileLogger) Infof(format string, v ...any) {
 	fl.backendLogger.Infof(format, v...)
 }
 
 // Warning ...
-func (fl *FileLogger) Warning(v ...interface{}) {
+func (fl *FileLogger) Warning(v ...any) {
 	fl.backendLogger.Warning(v...)
 }
 
 // Warningf with format
-func (fl *FileLogger) Warningf(format string, v ...interface{}) {
+func (fl *FileLogger) Warningf(format string, v ...any) {
 	fl.backendLogger.Warningf(format, v...)
 }
 
 // Error ...
-func (fl *FileLogger) Error(v ...interface{}) {
+func (fl *FileLogger) Error(v ...any) {
 	fl.backendLogger.Error(v...)
 }
 
 // Errorf with format
-func (fl *FileLogger) Errorf(format string, v ...interface{}) {
+func (fl *FileLogger) Errorf(format string, v ...any) {
 	fl.backendLogger.Errorf(format, v...)
 }
 
 // Fatal error
-func (fl *FileLogger) Fatal(v ...interface{}) {
+func (fl *FileLogger) Fatal(v ...any) {
 	fl.backendLogger.Fatal(v...)
 }
 
 // Fatalf error
-func (fl *FileLogger) Fatalf(format string, v ...interface{}) {
+func (fl *FileLogger) Fatalf(format string, v ...any) {
 	fl.backendLogger.Fatalf(format, v...)
 }

--- a/src/jobservice/logger/backend/std_logger.go
+++ b/src/jobservice/logger/backend/std_logger.go
@@ -48,51 +48,51 @@ func NewStdOutputLogger(level string, output string, depth int) *StdOutputLogger
 }
 
 // Debug ...
-func (sl *StdOutputLogger) Debug(v ...interface{}) {
+func (sl *StdOutputLogger) Debug(v ...any) {
 	sl.backendLogger.Debug(v...)
 }
 
 // Debugf with format
-func (sl *StdOutputLogger) Debugf(format string, v ...interface{}) {
+func (sl *StdOutputLogger) Debugf(format string, v ...any) {
 	sl.backendLogger.Debugf(format, v...)
 }
 
 // Info ...
-func (sl *StdOutputLogger) Info(v ...interface{}) {
+func (sl *StdOutputLogger) Info(v ...any) {
 	sl.backendLogger.Info(v...)
 }
 
 // Infof with format
-func (sl *StdOutputLogger) Infof(format string, v ...interface{}) {
+func (sl *StdOutputLogger) Infof(format string, v ...any) {
 	sl.backendLogger.Infof(format, v...)
 }
 
 // Warning ...
-func (sl *StdOutputLogger) Warning(v ...interface{}) {
+func (sl *StdOutputLogger) Warning(v ...any) {
 	sl.backendLogger.Warning(v...)
 }
 
 // Warningf with format
-func (sl *StdOutputLogger) Warningf(format string, v ...interface{}) {
+func (sl *StdOutputLogger) Warningf(format string, v ...any) {
 	sl.backendLogger.Warningf(format, v...)
 }
 
 // Error ...
-func (sl *StdOutputLogger) Error(v ...interface{}) {
+func (sl *StdOutputLogger) Error(v ...any) {
 	sl.backendLogger.Error(v...)
 }
 
 // Errorf with format
-func (sl *StdOutputLogger) Errorf(format string, v ...interface{}) {
+func (sl *StdOutputLogger) Errorf(format string, v ...any) {
 	sl.backendLogger.Errorf(format, v...)
 }
 
 // Fatal error
-func (sl *StdOutputLogger) Fatal(v ...interface{}) {
+func (sl *StdOutputLogger) Fatal(v ...any) {
 	sl.backendLogger.Fatal(v...)
 }
 
 // Fatalf error
-func (sl *StdOutputLogger) Fatalf(format string, v ...interface{}) {
+func (sl *StdOutputLogger) Fatalf(format string, v ...any) {
 	sl.backendLogger.Fatalf(format, v...)
 }

--- a/src/jobservice/logger/base.go
+++ b/src/jobservice/logger/base.go
@@ -71,7 +71,7 @@ func GetLogger(loggerOptions ...Option) (Interface, error) {
 
 		// Singleton
 		if d.Singleton {
-			var li interface{}
+			var li any
 			li, ok = singletons.Load(name)
 			if ok {
 				l = li.(Interface)
@@ -200,7 +200,7 @@ func Init(ctx context.Context) error {
 		// For logger of job service itself, the depth should be 6
 		if lc.Name == NameFile || lc.Name == NameStdOutput {
 			if lc.Settings == nil {
-				lc.Settings = map[string]interface{}{}
+				lc.Settings = map[string]any{}
 			}
 			lc.Settings["depth"] = 6
 		}

--- a/src/jobservice/logger/base_test.go
+++ b/src/jobservice/logger/base_test.go
@@ -27,7 +27,7 @@ func TestGetLoggerSingleStd(t *testing.T) {
 
 	l.Debugf("Verify logger testing: %s", "case_1")
 
-	lSettings := map[string]interface{}{}
+	lSettings := map[string]any{}
 	lSettings["output"] = backend.StdErr
 	l, err = GetLogger(BackendOption("STD_OUTPUT", "ERROR", lSettings))
 	if err != nil {
@@ -52,7 +52,7 @@ func TestGetLoggerSingleFile(t *testing.T) {
 		t.Fatalf("expect non nil error when creating file logger with empty settings but got nil error: %s", "case_4")
 	}
 
-	lSettings := map[string]interface{}{}
+	lSettings := map[string]any{}
 	lSettings["base_dir"] = os.TempDir()
 	lSettings["filename"] = fmt.Sprintf("%s.log", fakeJobID)
 	defer func() {
@@ -71,7 +71,7 @@ func TestGetLoggerSingleFile(t *testing.T) {
 
 // Test getting multi loggers
 func TestGetLoggersMulti(t *testing.T) {
-	lSettings := map[string]interface{}{}
+	lSettings := map[string]any{}
 	lSettings["base_dir"] = os.TempDir()
 	lSettings["filename"] = fmt.Sprintf("%s.log", fakeJobID2)
 	defer func() {
@@ -110,7 +110,7 @@ func TestGetSweeper(t *testing.T) {
 		t.Fatalf("expect non nil error but got nil error when getting sweeper with name 'STD_OUTPUT': %s", "case_8")
 	}
 
-	sSettings := map[string]interface{}{}
+	sSettings := map[string]any{}
 	sSettings["work_dir"] = os.TempDir()
 	s, err := GetSweeper(ctx, SweeperOption("FILE", 5, sSettings))
 	if err != nil {
@@ -136,7 +136,7 @@ func TestGetGetter(t *testing.T) {
 		t.Fatalf("nil interface with nil error should be returned if no log data getter configured: %s", "case_11")
 	}
 
-	lSettings := map[string]interface{}{}
+	lSettings := map[string]any{}
 	_, err = GetLogDataGetter(GetterOption("FILE", lSettings))
 	if err == nil {
 		t.Fatalf("expect non nil error but got nil one: %s", "case_12")
@@ -184,19 +184,19 @@ func TestLoggerInit(t *testing.T) {
 		{
 			Name:  "STD_OUTPUT",
 			Level: "DEBUG",
-			Settings: map[string]interface{}{
+			Settings: map[string]any{
 				"output": backend.StdErr,
 			},
 		},
 		{
 			Name:  "FILE",
 			Level: "ERROR",
-			Settings: map[string]interface{}{
+			Settings: map[string]any{
 				"base_dir": os.TempDir(),
 			},
 			Sweeper: &config.LogSweeperConfig{
 				Duration: 5,
-				Settings: map[string]interface{}{
+				Settings: map[string]any{
 					"work_dir": os.TempDir(),
 				},
 			},

--- a/src/jobservice/logger/entry.go
+++ b/src/jobservice/logger/entry.go
@@ -33,70 +33,70 @@ func NewEntry(loggers []Interface) *Entry {
 }
 
 // Debug ...
-func (e *Entry) Debug(v ...interface{}) {
+func (e *Entry) Debug(v ...any) {
 	for _, l := range e.loggers {
 		l.Debug(v...)
 	}
 }
 
 // Debugf with format
-func (e *Entry) Debugf(format string, v ...interface{}) {
+func (e *Entry) Debugf(format string, v ...any) {
 	for _, l := range e.loggers {
 		l.Debugf(format, v...)
 	}
 }
 
 // Info ...
-func (e *Entry) Info(v ...interface{}) {
+func (e *Entry) Info(v ...any) {
 	for _, l := range e.loggers {
 		l.Info(v...)
 	}
 }
 
 // Infof with format
-func (e *Entry) Infof(format string, v ...interface{}) {
+func (e *Entry) Infof(format string, v ...any) {
 	for _, l := range e.loggers {
 		l.Infof(format, v...)
 	}
 }
 
 // Warning ...
-func (e *Entry) Warning(v ...interface{}) {
+func (e *Entry) Warning(v ...any) {
 	for _, l := range e.loggers {
 		l.Warning(v...)
 	}
 }
 
 // Warningf with format
-func (e *Entry) Warningf(format string, v ...interface{}) {
+func (e *Entry) Warningf(format string, v ...any) {
 	for _, l := range e.loggers {
 		l.Warningf(format, v...)
 	}
 }
 
 // Error ...
-func (e *Entry) Error(v ...interface{}) {
+func (e *Entry) Error(v ...any) {
 	for _, l := range e.loggers {
 		l.Error(v...)
 	}
 }
 
 // Errorf with format
-func (e *Entry) Errorf(format string, v ...interface{}) {
+func (e *Entry) Errorf(format string, v ...any) {
 	for _, l := range e.loggers {
 		l.Errorf(format, v...)
 	}
 }
 
 // Fatal error
-func (e *Entry) Fatal(v ...interface{}) {
+func (e *Entry) Fatal(v ...any) {
 	for _, l := range e.loggers {
 		l.Fatal(v...)
 	}
 }
 
 // Fatalf error
-func (e *Entry) Fatalf(format string, v ...interface{}) {
+func (e *Entry) Fatalf(format string, v ...any) {
 	for _, l := range e.loggers {
 		l.Fatalf(format, v...)
 	}

--- a/src/jobservice/logger/interface.go
+++ b/src/jobservice/logger/interface.go
@@ -17,32 +17,32 @@ package logger
 // Interface for logger.
 type Interface interface {
 	// For debuging
-	Debug(v ...interface{})
+	Debug(v ...any)
 
 	// For debuging with format
-	Debugf(format string, v ...interface{})
+	Debugf(format string, v ...any)
 
 	// For logging info
-	Info(v ...interface{})
+	Info(v ...any)
 
 	// For logging info with format
-	Infof(format string, v ...interface{})
+	Infof(format string, v ...any)
 
 	// For warning
-	Warning(v ...interface{})
+	Warning(v ...any)
 
 	// For warning with format
-	Warningf(format string, v ...interface{})
+	Warningf(format string, v ...any)
 
 	// For logging error
-	Error(v ...interface{})
+	Error(v ...any)
 
 	// For logging error with format
-	Errorf(format string, v ...interface{})
+	Errorf(format string, v ...any)
 
 	// For fatal error
-	Fatal(v ...interface{})
+	Fatal(v ...any)
 
 	// For fatal error with error
-	Fatalf(format string, v ...interface{})
+	Fatalf(format string, v ...any)
 }

--- a/src/jobservice/logger/log_data_handler_test.go
+++ b/src/jobservice/logger/log_data_handler_test.go
@@ -33,12 +33,12 @@ func TestRetrieve(t *testing.T) {
 		{
 			Name:  "FILE",
 			Level: "INFO",
-			Settings: map[string]interface{}{
+			Settings: map[string]any{
 				"base_dir": os.TempDir(),
 			},
 			Sweeper: &config.LogSweeperConfig{
 				Duration: 1,
-				Settings: map[string]interface{}{
+				Settings: map[string]any{
 					"work_dir": os.TempDir(),
 				},
 			},

--- a/src/jobservice/logger/options.go
+++ b/src/jobservice/logger/options.go
@@ -27,7 +27,7 @@ type Option struct {
 }
 
 // BackendOption creates option for the specified backend.
-func BackendOption(name string, level string, settings map[string]interface{}) Option {
+func BackendOption(name string, level string, settings map[string]any) Option {
 	return Option{func(op *options) {
 		vals := make([]OptionItem, 0)
 		vals = append(vals, OptionItem{"level", level})
@@ -45,7 +45,7 @@ func BackendOption(name string, level string, settings map[string]interface{}) O
 }
 
 // SweeperOption creates option for the sweeper.
-func SweeperOption(name string, duration int, settings map[string]interface{}) Option {
+func SweeperOption(name string, duration int, settings map[string]any) Option {
 	return Option{func(op *options) {
 		vals := make([]OptionItem, 0)
 		vals = append(vals, OptionItem{"duration", duration})
@@ -63,7 +63,7 @@ func SweeperOption(name string, duration int, settings map[string]interface{}) O
 }
 
 // GetterOption creates option for the getter.
-func GetterOption(name string, settings map[string]interface{}) Option {
+func GetterOption(name string, settings map[string]any) Option {
 	return Option{func(op *options) {
 		vals := make([]OptionItem, 0)
 		// Append settings if existing
@@ -81,7 +81,7 @@ func GetterOption(name string, settings map[string]interface{}) Option {
 // OptionItem is a simple wrapper of property and value
 type OptionItem struct {
 	field string
-	val   interface{}
+	val   any
 }
 
 // Field returns name of the option
@@ -108,6 +108,6 @@ func (o *OptionItem) String() string {
 }
 
 // Raw returns the raw value
-func (o *OptionItem) Raw() interface{} {
+func (o *OptionItem) Raw() any {
 	return o.val
 }

--- a/src/jobservice/logger/service.go
+++ b/src/jobservice/logger/service.go
@@ -29,7 +29,7 @@ func jobServiceLogger() (Interface, bool) {
 }
 
 // Debug ...
-func Debug(v ...interface{}) {
+func Debug(v ...any) {
 	if jLogger, ok := jobServiceLogger(); ok {
 		jLogger.Debug(v...)
 	} else {
@@ -38,7 +38,7 @@ func Debug(v ...interface{}) {
 }
 
 // Debugf for debuging with format
-func Debugf(format string, v ...interface{}) {
+func Debugf(format string, v ...any) {
 	if jLogger, ok := jobServiceLogger(); ok {
 		jLogger.Debugf(format, v...)
 	} else {
@@ -47,7 +47,7 @@ func Debugf(format string, v ...interface{}) {
 }
 
 // Info ...
-func Info(v ...interface{}) {
+func Info(v ...any) {
 	if jLogger, ok := jobServiceLogger(); ok {
 		jLogger.Info(v...)
 	} else {
@@ -56,7 +56,7 @@ func Info(v ...interface{}) {
 }
 
 // Infof for logging info with format
-func Infof(format string, v ...interface{}) {
+func Infof(format string, v ...any) {
 	if jLogger, ok := jobServiceLogger(); ok {
 		jLogger.Infof(format, v...)
 	} else {
@@ -65,7 +65,7 @@ func Infof(format string, v ...interface{}) {
 }
 
 // Warning ...
-func Warning(v ...interface{}) {
+func Warning(v ...any) {
 	if jLogger, ok := jobServiceLogger(); ok {
 		jLogger.Warning(v...)
 	} else {
@@ -74,7 +74,7 @@ func Warning(v ...interface{}) {
 }
 
 // Warningf for warning with format
-func Warningf(format string, v ...interface{}) {
+func Warningf(format string, v ...any) {
 	if jLogger, ok := jobServiceLogger(); ok {
 		jLogger.Warningf(format, v...)
 	} else {
@@ -83,7 +83,7 @@ func Warningf(format string, v ...interface{}) {
 }
 
 // Error for logging error
-func Error(v ...interface{}) {
+func Error(v ...any) {
 	if jLogger, ok := jobServiceLogger(); ok {
 		jLogger.Error(v...)
 	} else {
@@ -92,7 +92,7 @@ func Error(v ...interface{}) {
 }
 
 // Errorf for logging error with format
-func Errorf(format string, v ...interface{}) {
+func Errorf(format string, v ...any) {
 	if jLogger, ok := jobServiceLogger(); ok {
 		jLogger.Errorf(format, v...)
 	} else {
@@ -101,7 +101,7 @@ func Errorf(format string, v ...interface{}) {
 }
 
 // Fatal ...
-func Fatal(v ...interface{}) {
+func Fatal(v ...any) {
 	if jLogger, ok := jobServiceLogger(); ok {
 		jLogger.Fatal(v...)
 	} else {
@@ -110,7 +110,7 @@ func Fatal(v ...interface{}) {
 }
 
 // Fatalf for fatal error with error
-func Fatalf(format string, v ...interface{}) {
+func Fatalf(format string, v ...any) {
 	if jLogger, ok := jobServiceLogger(); ok {
 		jLogger.Fatalf(format, v...)
 	} else {

--- a/src/jobservice/mgt/manager.go
+++ b/src/jobservice/mgt/manager.go
@@ -129,7 +129,7 @@ func (bm *basicManager) GetJobs(q *query.Parameter) ([]*job.Stats, int64, error)
 	}
 
 	pattern := rds.KeyJobStats(bm.namespace, "*")
-	args := []interface{}{cursor, "MATCH", pattern, "COUNT", count}
+	args := []any{cursor, "MATCH", pattern, "COUNT", count}
 
 	conn := bm.pool.Get()
 	defer func() {
@@ -148,7 +148,7 @@ func (bm *basicManager) GetJobs(q *query.Parameter) ([]*job.Stats, int64, error)
 	if err != nil {
 		return nil, 0, err
 	}
-	list := values[1].([]interface{})
+	list := values[1].([]any)
 
 	results := make([]*job.Stats, 0)
 	for _, v := range list {
@@ -227,7 +227,7 @@ func (bm *basicManager) GetPeriodicExecution(pID string, q *query.Parameter) (re
 		}
 
 		minVal, maxVal := (pageNumber-1)*pageSize, pageNumber*pageSize-1
-		args := []interface{}{key, minVal, maxVal}
+		args := []any{key, minVal, maxVal}
 		list, err := redis.Values(conn.Do("ZREVRANGE", args...))
 		if err != nil {
 			return nil, 0, err
@@ -334,7 +334,7 @@ func queryExecutions(conn redis.Conn, dataKey string, q *query.Parameter) ([]str
 	}
 
 	offset := (pageNumber - 1) * pageSize
-	args := []interface{}{dataKey, "+inf", 0, "LIMIT", offset, pageSize}
+	args := []any{dataKey, "+inf", 0, "LIMIT", offset, pageSize}
 
 	eIDs, err := redis.Values(conn.Do("ZREVRANGEBYSCORE", args...))
 	if err != nil {

--- a/src/jobservice/mgt/manager_test.go
+++ b/src/jobservice/mgt/manager_test.go
@@ -138,7 +138,7 @@ func (suite *BasicManagerTestSuite) TestGetPeriodicExecutions() {
 // TestGetScheduledJobs tests get scheduled jobs
 func (suite *BasicManagerTestSuite) TestGetScheduledJobs() {
 	enqueuer := work.NewEnqueuer(suite.namespace, suite.pool)
-	scheduledJob, err := enqueuer.EnqueueIn(job.SampleJob, 1000, make(map[string]interface{}))
+	scheduledJob, err := enqueuer.EnqueueIn(job.SampleJob, 1000, make(map[string]any))
 	require.NoError(suite.T(), err)
 	stats := &job.Stats{
 		Info: &job.StatsInfo{

--- a/src/jobservice/migration/manager_test.go
+++ b/src/jobservice/migration/manager_test.go
@@ -69,7 +69,7 @@ func (suite *ManagerTestSuite) SetupTest() {
 	id := utils.MakeIdentifier()
 	suite.jobID = id
 	// Mock stats of periodic job
-	args := []interface{}{
+	args := []any{
 		rds.KeyJobStats(suite.namespace, id),
 		"status_hook",
 		"http://core:8080/hook",
@@ -101,10 +101,10 @@ func (suite *ManagerTestSuite) SetupTest() {
 	require.Equal(suite.T(), "ok", strings.ToLower(reply), "ok expected")
 
 	// Mock periodic job policy object
-	params := make(map[string]interface{})
+	params := make(map[string]any)
 	params["redis_url_reg"] = "redis://redis:6379/1"
 
-	policy := make(map[string]interface{})
+	policy := make(map[string]any)
 	policy["job_name"] = jobNameGarbageCollection
 	policy["job_params"] = params
 	policy["cron_spec"] = "0 0 17 * * *"
@@ -118,7 +118,7 @@ func (suite *ManagerTestSuite) SetupTest() {
 
 	score := time.Now().Unix()
 	suite.numbericID = score
-	zaddArgs := []interface{}{
+	zaddArgs := []any{
 		rds.KeyPeriodicPolicy(suite.namespace),
 		score,
 		rawJSON,
@@ -130,7 +130,7 @@ func (suite *ManagerTestSuite) SetupTest() {
 	require.Equal(suite.T(), 2, count)
 
 	// Mock key score mapping
-	keyScoreArgs := []interface{}{
+	keyScoreArgs := []any{
 		fmt.Sprintf("%s%s", rds.KeyNamespacePrefix(suite.namespace), "period:key_score"),
 		score,
 		id,
@@ -181,7 +181,7 @@ func (suite *ManagerTestSuite) TestManager() {
 	assert.NoError(suite.T(), err, "check existence of key score mapping error")
 	assert.Equal(suite.T(), 0, count)
 
-	hmGetArgs := []interface{}{
+	hmGetArgs := []any{
 		rds.KeyJobStats(suite.namespace, suite.jobID),
 		"id",
 		"status",

--- a/src/jobservice/migration/migrator_v180.go
+++ b/src/jobservice/migration/migrator_v180.go
@@ -84,7 +84,7 @@ func (pm *PolicyMigrator) Migrate() error {
 		return errors.Wrap(err, "get job stats list error")
 	}
 
-	args := []interface{}{
+	args := []any{
 		"id_placeholder",
 		"id",
 		"kind",
@@ -126,7 +126,7 @@ func (pm *PolicyMigrator) Migrate() error {
 					logger.Errorf("send command MULTI failed with error: %s", err)
 					continue
 				}
-				setArgs := []interface{}{
+				setArgs := []any{
 					fullID,
 					"status",
 					job.ScheduledStatus.String(), // make sure the status of periodic job is "Scheduled"
@@ -146,7 +146,7 @@ func (pm *PolicyMigrator) Migrate() error {
 				}
 
 				// Remove useless fields
-				rmArgs := []interface{}{
+				rmArgs := []any{
 					fullID,
 					"status_hook",
 					"multiple_executions",
@@ -210,7 +210,7 @@ func (pm *PolicyMigrator) Migrate() error {
 // getAllJobStatsIDs get all the IDs of the existing jobs
 func getAllJobStatsIDs(conn redis.Conn, ns string) ([]string, error) {
 	pattern := rds.KeyJobStats(ns, "*")
-	args := []interface{}{
+	args := []any{
 		0,
 		"MATCH",
 		pattern,
@@ -218,7 +218,7 @@ func getAllJobStatsIDs(conn redis.Conn, ns string) ([]string, error) {
 		100,
 	}
 
-	allFullIDs := make([]interface{}, 0)
+	allFullIDs := make([]any, 0)
 
 	for {
 		// Use SCAN to iterate the IDs
@@ -232,7 +232,7 @@ func getAllJobStatsIDs(conn redis.Conn, ns string) ([]string, error) {
 			return nil, errors.Errorf("Invalid result returned for the SCAN command: %#v", values)
 		}
 
-		if fullIDs, ok := values[1].([]interface{}); ok {
+		if fullIDs, ok := values[1].([]any); ok {
 			allFullIDs = append(allFullIDs, fullIDs...)
 		}
 
@@ -301,7 +301,7 @@ func getPeriodicPolicy(numericID int64, conn redis.Conn, ns string) (*period.Pol
 
 // Clear the duplicated policy entries for the job "IMAGE_GC" and "IMAGE_SCAN_ALL"
 func clearDuplicatedPolicies(conn redis.Conn, ns string) error {
-	hash := make(map[string]interface{})
+	hash := make(map[string]any)
 
 	bytes, err := redis.Values(conn.Do("ZREVRANGE", rds.KeyPeriodicPolicy(ns), 0, -1, "WITHSCORES"))
 	if err != nil {
@@ -362,7 +362,7 @@ func delScoreZset(conn redis.Conn, ns string) {
 	}
 }
 
-func toString(v interface{}) string {
+func toString(v any) string {
 	if v == nil {
 		return ""
 	}
@@ -374,7 +374,7 @@ func toString(v interface{}) string {
 	return ""
 }
 
-func toInt(v interface{}) int64 {
+func toInt(v any) int64 {
 	if v == nil {
 		return -1
 	}

--- a/src/jobservice/period/basic_scheduler.go
+++ b/src/jobservice/period/basic_scheduler.go
@@ -241,7 +241,7 @@ func (bs *basicScheduler) clearDirtyJobs() {
 
 // Get relevant executions for the periodic job
 func getPeriodicExecutions(conn redis.Conn, key string) ([]string, error) {
-	args := []interface{}{key, 0, "+inf"}
+	args := []any{key, 0, "+inf"}
 
 	list, err := redis.Values(conn.Do("ZRANGEBYSCORE", args...))
 	if err != nil {

--- a/src/jobservice/period/basic_scheduler_test.go
+++ b/src/jobservice/period/basic_scheduler_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//    http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -154,7 +154,7 @@ func (suite *BasicSchedulerTestSuite) setupDirtyJobs() {
 		ID:   "jid",
 		// Already expired
 		EnqueuedAt: time.Now().Unix() - 86400,
-		Args:       map[string]interface{}{"image": "sample:latest"},
+		Args:       map[string]any{"image": "sample:latest"},
 	}
 
 	rawJSON, err := utils.SerializeJob(j)

--- a/src/jobservice/period/policy_store.go
+++ b/src/jobservice/period/policy_store.go
@@ -31,12 +31,12 @@ import (
 type Policy struct {
 	// Policy can be treated as job template of periodic job.
 	// The info of policy will be copied into the scheduled job executions for the periodic job.
-	ID            string                 `json:"id"`
-	JobName       string                 `json:"job_name"`
-	CronSpec      string                 `json:"cron_spec"`
-	JobParameters map[string]interface{} `json:"job_params,omitempty"`
-	WebHookURL    string                 `json:"web_hook_url,omitempty"`
-	NumericID     int64                  `json:"numeric_id,omitempty"`
+	ID            string         `json:"id"`
+	JobName       string         `json:"job_name"`
+	CronSpec      string         `json:"cron_spec"`
+	JobParameters map[string]any `json:"job_params,omitempty"`
+	WebHookURL    string         `json:"web_hook_url,omitempty"`
+	NumericID     int64          `json:"numeric_id,omitempty"`
 }
 
 // Serialize the policy to raw data.

--- a/src/jobservice/runner/redis.go
+++ b/src/jobservice/runner/redis.go
@@ -42,13 +42,13 @@ const (
 
 // RedisJob is a job wrapper to wrap the job.Interface to the style which can be recognized by the redis worker.
 type RedisJob struct {
-	job     interface{}    // the real job implementation
+	job     any            // the real job implementation
 	context *env.Context   // context
 	ctl     lcm.Controller // life cycle controller
 }
 
 // NewRedisJob is constructor of RedisJob
-func NewRedisJob(job interface{}, ctx *env.Context, ctl lcm.Controller) *RedisJob {
+func NewRedisJob(job any, ctx *env.Context, ctl lcm.Controller) *RedisJob {
 	return &RedisJob{
 		job:     job,
 		context: ctx,

--- a/src/jobservice/runner/redis_test.go
+++ b/src/jobservice/runner/redis_test.go
@@ -120,19 +120,19 @@ func (suite *RedisRunnerTestSuite) TestJobWrapper() {
 		{
 			Name:  "STD_OUTPUT",
 			Level: "DEBUG",
-			Settings: map[string]interface{}{
+			Settings: map[string]any{
 				"output": backend.StdErr,
 			},
 		},
 		{
 			Name:  "FILE",
 			Level: "ERROR",
-			Settings: map[string]interface{}{
+			Settings: map[string]any{
 				"base_dir": os.TempDir(),
 			},
 			Sweeper: &config.LogSweeperConfig{
 				Duration: 5,
-				Settings: map[string]interface{}{
+				Settings: map[string]any{
 					"work_dir": os.TempDir(),
 				},
 			},

--- a/src/jobservice/runner/wrapper.go
+++ b/src/jobservice/runner/wrapper.go
@@ -21,7 +21,7 @@ import (
 )
 
 // Wrap returns a new job.Interface based on the wrapped job handler reference.
-func Wrap(j interface{}) job.Interface {
+func Wrap(j any) job.Interface {
 	theType := reflect.TypeOf(j)
 
 	if theType.Kind() == reflect.Ptr {

--- a/src/jobservice/runtime/bootstrap.go
+++ b/src/jobservice/runtime/bootstrap.go
@@ -312,7 +312,7 @@ func (bs *Bootstrap) loadAndRunRedisWorkerPool(
 
 	// Register jobs here
 	if err := redisWorker.RegisterJobs(
-		map[string]interface{}{
+		map[string]any{
 			// Only for debugging and testing purpose
 			job.SampleJob: (*sample.Job)(nil),
 			// Functional jobs

--- a/src/jobservice/sync/schedule.go
+++ b/src/jobservice/sync/schedule.go
@@ -362,7 +362,7 @@ func (w *Worker) validate() error {
 func (w *Worker) getTask(ctx context.Context, schedule *scheduler.Schedule) (*task.Task, error) {
 	// Get associated execution first.
 	executions, err := w.coreExecutionManager.List(ctx, &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"vendor_type": scheduler.JobNameScheduler,
 			"vendor_id":   schedule.ID,
 		},
@@ -379,7 +379,7 @@ func (w *Worker) getTask(ctx context.Context, schedule *scheduler.Schedule) (*ta
 	theOne := executions[0]
 	// Now get the execution.
 	tasks, err := w.coreTaskManager.List(ctx, &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"execution_id": theOne.ID,
 		},
 	})

--- a/src/jobservice/sync/schedule_test.go
+++ b/src/jobservice/sync/schedule_test.go
@@ -81,7 +81,7 @@ func (suite *WorkerTestSuite) SetupSuite() {
 	// The missing schedule in database.
 	tte := &tt.ExecutionManager{}
 	tte.On("List", mock.Anything, &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"vendor_type": scheduler.JobNameScheduler,
 			"vendor_id":   (int64)(550),
 		},
@@ -93,7 +93,7 @@ func (suite *WorkerTestSuite) SetupSuite() {
 
 	ttm := &tt.Manager{}
 	ttm.On("List", mock.Anything, &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"execution_id": (int64)(1550),
 		},
 	}).Return([]*task.Task{

--- a/src/jobservice/worker/cworker/c_worker.go
+++ b/src/jobservice/worker/cworker/c_worker.go
@@ -154,7 +154,7 @@ func (w *basicWorker) Start() error {
 	logger.Infof("Basic worker is started")
 
 	// Start the reaper
-	w.knownJobs.Range(func(k interface{}, _ interface{}) bool {
+	w.knownJobs.Range(func(k any, _ any) bool {
 		w.reaper.jobTypes = append(w.reaper.jobTypes, k.(string))
 
 		return true
@@ -171,7 +171,7 @@ func (w *basicWorker) GetPoolID() string {
 }
 
 // RegisterJobs is used to register multiple jobs to worker.
-func (w *basicWorker) RegisterJobs(jobs map[string]interface{}) error {
+func (w *basicWorker) RegisterJobs(jobs map[string]any) error {
 	if len(jobs) == 0 {
 		// Do nothing
 		return nil
@@ -374,12 +374,12 @@ func (w *basicWorker) RetryJob(_ string) error {
 }
 
 // IsKnownJob ...
-func (w *basicWorker) IsKnownJob(name string) (interface{}, bool) {
+func (w *basicWorker) IsKnownJob(name string) (any, bool) {
 	return w.knownJobs.Load(name)
 }
 
 // ValidateJobParameters ...
-func (w *basicWorker) ValidateJobParameters(jobType interface{}, params job.Parameters) error {
+func (w *basicWorker) ValidateJobParameters(jobType any, params job.Parameters) error {
 	if jobType == nil {
 		return errors.New("nil job type")
 	}
@@ -390,7 +390,7 @@ func (w *basicWorker) ValidateJobParameters(jobType interface{}, params job.Para
 
 // RegisterJob is used to register the job to the worker.
 // j is the type of job
-func (w *basicWorker) registerJob(name string, j interface{}) (err error) {
+func (w *basicWorker) registerJob(name string, j any) (err error) {
 	if utils.IsEmptyStr(name) || j == nil {
 		return errors.New("job can not be registered with empty name or nil interface")
 	}
@@ -406,7 +406,7 @@ func (w *basicWorker) registerJob(name string, j interface{}) (err error) {
 	}
 
 	// Same job implementation can be only registered with one name
-	w.knownJobs.Range(func(jName interface{}, jInList interface{}) bool {
+	w.knownJobs.Range(func(jName any, jInList any) bool {
 		jobImpl := reflect.TypeOf(j).String()
 		if reflect.TypeOf(jInList).String() == jobImpl {
 			err = errors.Errorf("job %s has been already registered with name %s", jobImpl, jName)

--- a/src/jobservice/worker/cworker/c_worker_test.go
+++ b/src/jobservice/worker/cworker/c_worker_test.go
@@ -78,7 +78,7 @@ func (suite *CWorkerTestSuite) SetupSuite() {
 	)
 
 	suite.cWorker = NewWorker(envCtx, suite.namespace, 5, suite.pool, suite.lcmCtl)
-	err := suite.cWorker.RegisterJobs(map[string]interface{}{
+	err := suite.cWorker.RegisterJobs(map[string]any{
 		"fake_job":          (*fakeJob)(nil),
 		"fake_long_run_job": (*fakeLongRunJob)(nil),
 	})
@@ -110,7 +110,7 @@ func (suite *CWorkerTestSuite) TestRegisterJobs() {
 	_, ok := suite.cWorker.IsKnownJob("fake_job")
 	assert.EqualValues(suite.T(), true, ok, "expected known job but registering 'fake_job' appears to have failed")
 
-	params := make(map[string]interface{})
+	params := make(map[string]any)
 	params["name"] = "testing:v1"
 	err := suite.cWorker.ValidateJobParameters((*fakeJob)(nil), params)
 	assert.NoError(suite.T(), err, "validate parameters: nil error expected but got %s", err)
@@ -184,7 +184,7 @@ func (suite *CWorkerTestSuite) TestWorkerStats() {
 // TestStopJob test stop job
 func (suite *CWorkerTestSuite) TestStopJob() {
 	// Stop generic job
-	params := make(map[string]interface{})
+	params := make(map[string]any)
 	params["name"] = "testing:v1"
 
 	genericJob, err := suite.cWorker.Enqueue("fake_long_run_job", params, false, "")

--- a/src/jobservice/worker/cworker/de_duplicator.go
+++ b/src/jobservice/worker/cworker/de_duplicator.go
@@ -83,7 +83,7 @@ func (rdd *redisDeDuplicator) MustUnique(jobName string, params job.Parameters) 
 		_ = conn.Close()
 	}()
 
-	args := []interface{}{
+	args := []any{
 		uniqueKey,
 		1,
 		"NX",
@@ -127,7 +127,7 @@ func (rdd *redisDeDuplicator) DelUniqueSign(jobName string, params job.Parameter
 }
 
 // Same key with upstream framework
-func redisKeyUniqueJob(namespace, jobName string, args map[string]interface{}) (string, error) {
+func redisKeyUniqueJob(namespace, jobName string, args map[string]any) (string, error) {
 	var buf bytes.Buffer
 
 	buf.WriteString(rds.KeyNamespacePrefix(namespace))

--- a/src/jobservice/worker/cworker/de_duplicator_test.go
+++ b/src/jobservice/worker/cworker/de_duplicator_test.go
@@ -23,7 +23,7 @@ func TestDeDuplicatorTestSuite(t *testing.T) {
 // TestDeDuplicator ...
 func (suite *DeDuplicatorTestSuite) TestDeDuplicator() {
 	jobName := "fake_job"
-	jobParams := map[string]interface{}{
+	jobParams := map[string]any{
 		"image": "ubuntu:latest",
 	}
 

--- a/src/jobservice/worker/cworker/reaper.go
+++ b/src/jobservice/worker/cworker/reaper.go
@@ -250,7 +250,7 @@ func (r *reaper) scanLocks(key string, handler func(k string, v int64) error) er
 			return errors.Wrap(err, "scan locks")
 		}
 
-		if values, ok := reply[1].([]interface{}); ok {
+		if values, ok := reply[1].([]any); ok {
 			for i := 0; i < len(values); i += 2 {
 				k := string(values[i].([]uint8))
 				lc, err := strconv.ParseInt(string(values[i+1].([]uint8)), 10, 64)
@@ -317,7 +317,7 @@ func (r *reaper) getCurrentWorkerPools() (map[string]bool, error) {
 func (r *reaper) requeueInProgressJobs(poolID string, jobTypes []string) error {
 	numKeys := len(jobTypes)
 	redisRequeueScript := rds.RedisLuaReenqueueScript(numKeys)
-	var scriptArgs = make([]interface{}, 0, numKeys+1)
+	var scriptArgs = make([]any, 0, numKeys+1)
 
 	for _, jobType := range jobTypes {
 		// pops from in progress, push into job queue and decrement the queue lock

--- a/src/jobservice/worker/cworker/reaper_test.go
+++ b/src/jobservice/worker/cworker/reaper_test.go
@@ -163,11 +163,11 @@ func (suite *ReaperTestSuite) TestSyncOutdatedStats() {
 }
 
 func mockJobData() (string, error) {
-	j := make(map[string]interface{})
+	j := make(map[string]any)
 	j["name"] = job.SampleJob
 	j["id"] = utils.MakeIdentifier()
 	j["t"] = time.Now().Unix()
-	args := make(map[string]interface{})
+	args := make(map[string]any)
 	j["args"] = args
 	args["image"] = "test suite"
 
@@ -193,7 +193,7 @@ func mockJobStats(conn redis.Conn, ns string, jid string) error {
 		return err
 	}
 
-	args := []interface{}{
+	args := []any{
 		sk,
 		"id", jid,
 		"status", job.RunningStatus.String(),

--- a/src/jobservice/worker/interface.go
+++ b/src/jobservice/worker/interface.go
@@ -26,11 +26,11 @@ type Interface interface {
 
 	// Register multiple jobs.
 	//
-	// jobs	map[string]interface{}: job map, key is job name and value is job handler.
+	// jobs	map[string]any: job map, key is job name and value is job handler.
 	//
 	// Return:
 	//  error if failed to register
-	RegisterJobs(jobs map[string]interface{}) error
+	RegisterJobs(jobs map[string]any) error
 
 	// Get the worker pool ID
 	//
@@ -88,19 +88,19 @@ type Interface interface {
 	// name string : name of job
 	//
 	// Returns:
-	// interface{} : the job type of the known job if it's existing
+	// any : the job type of the known job if it's existing
 	// bool        : if the known job requires parameters
-	IsKnownJob(name string) (interface{}, bool)
+	IsKnownJob(name string) (any, bool)
 
 	// Validate the parameters of the known job
 	//
-	// jobType interface{}            : type of known job
-	// params map[string]interface{} : parameters of known job
+	// jobType any            : type of known job
+	// params map[string]any : parameters of known job
 	//
 	// Return:
 	//  error if parameters are not valid
 
-	ValidateJobParameters(jobType interface{}, params job.Parameters) error
+	ValidateJobParameters(jobType any, params job.Parameters) error
 
 	// Stop the job
 	//

--- a/src/lib/cache/cache.go
+++ b/src/lib/cache/cache.go
@@ -60,13 +60,13 @@ type Cache interface {
 	Delete(ctx context.Context, key string) error
 
 	// Fetch retrieve the cached key value
-	Fetch(ctx context.Context, key string, value interface{}) error
+	Fetch(ctx context.Context, key string, value any) error
 
 	// Ping ping the cache
 	Ping(ctx context.Context) error
 
 	// Save cache the value by key
-	Save(ctx context.Context, key string, value interface{}, expiration ...time.Duration) error
+	Save(ctx context.Context, key string, value any, expiration ...time.Duration) error
 
 	// Scan scans the keys matched by match string
 	// NOTICE: memory cache does not support use wildcard, compared by strings.Contains

--- a/src/lib/cache/codec.go
+++ b/src/lib/cache/codec.go
@@ -21,10 +21,10 @@ import (
 // Codec codec interface for cache
 type Codec interface {
 	// Encode returns the encoded byte array of v.
-	Encode(v interface{}) ([]byte, error)
+	Encode(v any) ([]byte, error)
 
 	// Decode analyzes the encoded data and stores the result into the v.
-	Decode(data []byte, v interface{}) error
+	Decode(data []byte, v any) error
 }
 
 var (
@@ -34,11 +34,11 @@ var (
 
 type msgpackCodec struct{}
 
-func (*msgpackCodec) Encode(v interface{}) ([]byte, error) {
+func (*msgpackCodec) Encode(v any) ([]byte, error) {
 	return msgpack.Marshal(v)
 }
 
-func (*msgpackCodec) Decode(data []byte, v interface{}) error {
+func (*msgpackCodec) Decode(data []byte, v any) error {
 	return msgpack.Unmarshal(data, v)
 }
 

--- a/src/lib/cache/helper.go
+++ b/src/lib/cache/helper.go
@@ -30,7 +30,7 @@ var (
 
 // FetchOrSave retrieves the value for the key if present in the cache.
 // Otherwise, it saves the value from the builder and retrieves the value for the key again.
-func FetchOrSave(ctx context.Context, c Cache, key string, value interface{}, builder func() (interface{}, error), expiration ...time.Duration) error {
+func FetchOrSave(ctx context.Context, c Cache, key string, value any, builder func() (any, error), expiration ...time.Duration) error {
 	err := c.Fetch(ctx, key, value)
 	// value found from the cache
 	if err == nil {

--- a/src/lib/cache/helper_test.go
+++ b/src/lib/cache/helper_test.go
@@ -46,7 +46,7 @@ func (suite *FetchOrSaveTestSuite) TestFetchInternalError() {
 	mock.OnAnything(c, "Fetch").Return(fmt.Errorf("oops"))
 
 	var str string
-	err := FetchOrSave(suite.ctx, c, "key", &str, func() (interface{}, error) {
+	err := FetchOrSave(suite.ctx, c, "key", &str, func() (any, error) {
 		return "str", nil
 	})
 
@@ -59,7 +59,7 @@ func (suite *FetchOrSaveTestSuite) TestBuildError() {
 	mock.OnAnything(c, "Fetch").Return(ErrNotFound)
 
 	var str string
-	err := FetchOrSave(suite.ctx, c, "key", &str, func() (interface{}, error) {
+	err := FetchOrSave(suite.ctx, c, "key", &str, func() (any, error) {
 		return nil, fmt.Errorf("oops")
 	})
 
@@ -73,7 +73,7 @@ func (suite *FetchOrSaveTestSuite) TestSaveError() {
 	mock.OnAnything(c, "Save").Return(fmt.Errorf("oops"))
 
 	var str string
-	err := FetchOrSave(suite.ctx, c, "key", &str, func() (interface{}, error) {
+	err := FetchOrSave(suite.ctx, c, "key", &str, func() (any, error) {
 		return "str", nil
 	})
 
@@ -86,7 +86,7 @@ func (suite *FetchOrSaveTestSuite) TestSaveCalledOnlyOneTime() {
 
 	var data sync.Map
 
-	mock.OnAnything(c, "Fetch").Return(func(ctx context.Context, key string, value interface{}) error {
+	mock.OnAnything(c, "Fetch").Return(func(ctx context.Context, key string, value any) error {
 		_, ok := data.Load(key)
 		if ok {
 			return nil
@@ -95,7 +95,7 @@ func (suite *FetchOrSaveTestSuite) TestSaveCalledOnlyOneTime() {
 		return ErrNotFound
 	})
 
-	mock.OnAnything(c, "Save").Return(func(ctx context.Context, key string, value interface{}, exp ...time.Duration) error {
+	mock.OnAnything(c, "Save").Return(func(ctx context.Context, key string, value any, exp ...time.Duration) error {
 		data.Store(key, value)
 
 		return nil
@@ -110,7 +110,7 @@ func (suite *FetchOrSaveTestSuite) TestSaveCalledOnlyOneTime() {
 			defer wg.Done()
 
 			var str string
-			FetchOrSave(suite.ctx, c, "key", &str, func() (interface{}, error) {
+			FetchOrSave(suite.ctx, c, "key", &str, func() (any, error) {
 				return "str", nil
 			})
 		}()

--- a/src/lib/cache/memory/memory.go
+++ b/src/lib/cache/memory/memory.go
@@ -66,7 +66,7 @@ func (c *Cache) Delete(_ context.Context, key string) error {
 }
 
 // Fetch retrieve the cached key value
-func (c *Cache) Fetch(ctx context.Context, key string, value interface{}) error {
+func (c *Cache) Fetch(ctx context.Context, key string, value any) error {
 	v, ok := c.storage.Load(c.opts.Key(key))
 	if !ok {
 		return cache.ErrNotFound
@@ -94,7 +94,7 @@ func (c *Cache) Ping(_ context.Context) error {
 }
 
 // Save cache the value by key
-func (c *Cache) Save(_ context.Context, key string, value interface{}, expiration ...time.Duration) error {
+func (c *Cache) Save(_ context.Context, key string, value any, expiration ...time.Duration) error {
 	data, err := c.opts.Codec.Encode(value)
 	if err != nil {
 		return fmt.Errorf("failed to encode value, key %s, error: %v", key, err)
@@ -120,7 +120,7 @@ func (c *Cache) Save(_ context.Context, key string, value interface{}, expiratio
 // Scan scans the keys matched by match string
 func (c *Cache) Scan(_ context.Context, match string) (cache.Iterator, error) {
 	var keys []string
-	c.storage.Range(func(k, v interface{}) bool {
+	c.storage.Range(func(k, v any) bool {
 		matched := true
 		if match != "" {
 			matched = strings.Contains(k.(string), match)

--- a/src/lib/cache/memory/memory_test.go
+++ b/src/lib/cache/memory/memory_test.go
@@ -66,9 +66,9 @@ func (suite *CacheTestSuite) TestDelete() {
 func (suite *CacheTestSuite) TestFetch() {
 	key := "fetch"
 
-	suite.cache.Save(suite.ctx, key, map[string]interface{}{"name": "harbor", "version": "1.10"})
+	suite.cache.Save(suite.ctx, key, map[string]any{"name": "harbor", "version": "1.10"})
 
-	mp := map[string]interface{}{}
+	mp := map[string]any{}
 	suite.cache.Fetch(suite.ctx, key, &mp)
 	suite.Len(mp, 2)
 	suite.Equal("harbor", mp["name"])

--- a/src/lib/cache/redis/redis.go
+++ b/src/lib/cache/redis/redis.go
@@ -52,7 +52,7 @@ func (c *Cache) Delete(ctx context.Context, key string) error {
 }
 
 // Fetch retrieve the cached key value
-func (c *Cache) Fetch(ctx context.Context, key string, value interface{}) error {
+func (c *Cache) Fetch(ctx context.Context, key string, value any) error {
 	data, err := c.Client.Get(ctx, c.opts.Key(key)).Bytes()
 	if err != nil {
 		// convert internal or Timeout error to be ErrNotFound
@@ -78,7 +78,7 @@ func (c *Cache) Ping(ctx context.Context) error {
 }
 
 // Save cache the value by key
-func (c *Cache) Save(ctx context.Context, key string, value interface{}, expiration ...time.Duration) error {
+func (c *Cache) Save(ctx context.Context, key string, value any, expiration ...time.Duration) error {
 	data, err := c.opts.Codec.Encode(value)
 	if err != nil {
 		return errors.Errorf("failed to encode value, key %s, error: %v", key, err)

--- a/src/lib/cache/redis/redis_test.go
+++ b/src/lib/cache/redis/redis_test.go
@@ -66,9 +66,9 @@ func (suite *CacheTestSuite) TestDelete() {
 func (suite *CacheTestSuite) TestFetch() {
 	key := "fetch"
 
-	suite.cache.Save(suite.ctx, key, map[string]interface{}{"name": "harbor", "version": "1.10"})
+	suite.cache.Save(suite.ctx, key, map[string]any{"name": "harbor", "version": "1.10"})
 
-	mp := map[string]interface{}{}
+	mp := map[string]any{}
 	suite.cache.Fetch(suite.ctx, key, &mp)
 	suite.Len(mp, 2)
 	suite.Equal("harbor", mp["name"])

--- a/src/lib/cache/util.go
+++ b/src/lib/cache/util.go
@@ -22,7 +22,7 @@ type keyMutex struct {
 	m *sync.Map
 }
 
-func (km keyMutex) Lock(key interface{}) {
+func (km keyMutex) Lock(key any) {
 	m := sync.Mutex{}
 	act, _ := km.m.LoadOrStore(key, &m)
 
@@ -34,7 +34,7 @@ func (km keyMutex) Lock(key interface{}) {
 	}
 }
 
-func (km keyMutex) Unlock(key interface{}) {
+func (km keyMutex) Unlock(key any) {
 	act, exist := km.m.Load(key)
 	if !exist {
 		panic("unlock of unlocked mutex")

--- a/src/lib/config/config.go
+++ b/src/lib/config/config.go
@@ -45,13 +45,13 @@ var (
 // Manager defines the operation for config
 type Manager interface {
 	Load(ctx context.Context) error
-	Set(ctx context.Context, key string, value interface{})
+	Set(ctx context.Context, key string, value any)
 	Save(ctx context.Context) error
 	Get(ctx context.Context, key string) *metadata.ConfigureValue
-	UpdateConfig(ctx context.Context, cfgs map[string]interface{}) error
-	GetUserCfgs(ctx context.Context) map[string]interface{}
-	ValidateCfg(ctx context.Context, cfgs map[string]interface{}) error
-	GetAll(ctx context.Context) map[string]interface{}
+	UpdateConfig(ctx context.Context, cfgs map[string]any) error
+	GetUserCfgs(ctx context.Context) map[string]any
+	ValidateCfg(ctx context.Context, cfgs map[string]any) error
+	GetAll(ctx context.Context) map[string]any
 	GetDatabaseCfg() *comModels.Database
 }
 
@@ -98,7 +98,7 @@ func Init() {
 // InitWithSettings init config with predefined configs, and optionally overwrite the keyprovider
 // need to import following package before calling it
 // _ "github.com/goharbor/harbor/src/pkg/config/inmemory"
-func InitWithSettings(cfgs map[string]interface{}, kp ...encrypt.KeyProvider) {
+func InitWithSettings(cfgs map[string]any, kp ...encrypt.KeyProvider) {
 	Init()
 	DefaultCfgManager = common.InMemoryCfgManager
 	mgr := DefaultMgr()
@@ -122,6 +122,6 @@ func Load(ctx context.Context) error {
 }
 
 // Upload save all configurations, used by testing
-func Upload(cfg map[string]interface{}) error {
+func Upload(cfg map[string]any) error {
 	return DefaultMgr().UpdateConfig(orm.Context(), cfg)
 }

--- a/src/lib/config/metadata/type.go
+++ b/src/lib/config/metadata/type.go
@@ -31,7 +31,7 @@ type Type interface {
 	// validate the configure value
 	validate(str string) error
 	// get the real type of current value, if it is int, return int, if it is string return string etc.
-	get(str string) (interface{}, error)
+	get(str string) (any, error)
 }
 
 // StringType ...
@@ -42,7 +42,7 @@ func (t *StringType) validate(_ string) error {
 	return nil
 }
 
-func (t *StringType) get(str string) (interface{}, error) {
+func (t *StringType) get(str string) (any, error) {
 	return str, nil
 }
 
@@ -95,7 +95,7 @@ func (t *IntType) validate(str string) error {
 	return err
 }
 
-func (t *IntType) get(str string) (interface{}, error) {
+func (t *IntType) get(str string) (any, error) {
 	return parseInt(str)
 }
 
@@ -145,7 +145,7 @@ func (t *Int64Type) validate(str string) error {
 	return err
 }
 
-func (t *Int64Type) get(str string) (interface{}, error) {
+func (t *Int64Type) get(str string) (any, error) {
 	return parseInt64(str)
 }
 
@@ -156,7 +156,7 @@ func (f *Float64Type) validate(str string) error {
 	return err
 }
 
-func (f *Float64Type) get(str string) (interface{}, error) {
+func (f *Float64Type) get(str string) (any, error) {
 	return parseFloat64(str)
 }
 
@@ -169,7 +169,7 @@ func (t *BoolType) validate(str string) error {
 	return err
 }
 
-func (t *BoolType) get(str string) (interface{}, error) {
+func (t *BoolType) get(str string) (any, error) {
 	return strconv.ParseBool(str)
 }
 
@@ -181,7 +181,7 @@ func (t *PasswordType) validate(_ string) error {
 	return nil
 }
 
-func (t *PasswordType) get(str string) (interface{}, error) {
+func (t *PasswordType) get(str string) (any, error) {
 	return str, nil
 }
 
@@ -190,13 +190,13 @@ type MapType struct {
 }
 
 func (t *MapType) validate(str string) error {
-	result := map[string]interface{}{}
+	result := map[string]any{}
 	err := json.Unmarshal([]byte(str), &result)
 	return err
 }
 
-func (t *MapType) get(str string) (interface{}, error) {
-	result := map[string]interface{}{}
+func (t *MapType) get(str string) (any, error) {
+	result := map[string]any{}
 	err := json.Unmarshal([]byte(str), &result)
 	return result, err
 }
@@ -211,7 +211,7 @@ func (t *StringToStringMapType) validate(str string) error {
 	return err
 }
 
-func (t *StringToStringMapType) get(str string) (interface{}, error) {
+func (t *StringToStringMapType) get(str string) (any, error) {
 	result := map[string]string{}
 	err := json.Unmarshal([]byte(str), &result)
 	return result, err
@@ -244,7 +244,7 @@ func (t *DurationType) validate(str string) error {
 	return err
 }
 
-func (t *DurationType) get(str string) (interface{}, error) {
+func (t *DurationType) get(str string) (any, error) {
 	// should not parse the duration to avoid duplicate parse.
 	return str, nil
 }

--- a/src/lib/config/metadata/type_test.go
+++ b/src/lib/config/metadata/type_test.go
@@ -95,7 +95,7 @@ func TestMapType_validate(t *testing.T) {
 func TestMapType_get(t *testing.T) {
 	test := &MapType{}
 	result, _ := test.get(`{"sample":"abc", "another":"welcome"}`)
-	assert.Equal(t, map[string]interface{}{"sample": "abc", "another": "welcome"}, result)
+	assert.Equal(t, map[string]any{"sample": "abc", "another": "welcome"}, result)
 }
 
 func TestStringToStringMapType_validate(t *testing.T) {

--- a/src/lib/config/metadata/value.go
+++ b/src/lib/config/metadata/value.go
@@ -169,8 +169,8 @@ func (c *ConfigureValue) GetDuration() time.Duration {
 	return 0
 }
 
-// GetAnyType get the interface{} of current value
-func (c *ConfigureValue) GetAnyType() (interface{}, error) {
+// GetAnyType get the any of current value
+func (c *ConfigureValue) GetAnyType() (any, error) {
 	if item, ok := Instance().GetByName(c.Name); ok {
 		return item.ItemType.get(c.Value)
 	}

--- a/src/lib/config/metadata/value_test.go
+++ b/src/lib/config/metadata/value_test.go
@@ -58,7 +58,7 @@ func TestConfigureValue_GetStringToStringMap(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	assert.Equal(t, val, map[string]interface{}{"sample": "abc"})
+	assert.Equal(t, val, map[string]any{"sample": "abc"})
 	Instance().init()
 }
 

--- a/src/lib/config/models/model.go
+++ b/src/lib/config/models/model.go
@@ -70,8 +70,8 @@ func (ce *ConfigEntry) TableName() string {
 
 // Value ...
 type Value struct {
-	Val      interface{} `json:"value"`
-	Editable bool        `json:"editable"`
+	Val      any  `json:"value"`
+	Editable bool `json:"editable"`
 }
 
 // LdapConf holds information about ldap configuration

--- a/src/lib/config/test/userconfig_test.go
+++ b/src/lib/config/test/userconfig_test.go
@@ -41,7 +41,7 @@ func TestConfig(t *testing.T) {
 	test.InitDatabaseFromEnv()
 	dao.PrepareTestData([]string{"delete from properties where k='scan_all_policy'"}, []string{})
 	defaultCACertPath = path.Join(currPath(), "test", "ca.crt")
-	c := map[string]interface{}{
+	c := map[string]any{
 		common.WithTrivy: false,
 	}
 	Init()
@@ -68,7 +68,7 @@ func TestConfig(t *testing.T) {
 		t.Fatalf("failed to load configurations: %v", err)
 	}
 
-	if err := Upload(map[string]interface{}{}); err != nil {
+	if err := Upload(map[string]any{}); err != nil {
 		t.Fatalf("failed to upload configurations: %v", err)
 	}
 
@@ -225,7 +225,7 @@ pkgODrJUf0p5dhcnLyA2nZolRV1rtwlgJstnEV4JpG1MwtmAZYZUilLvnfpVxTtA
 y1bQusZMygQezfCuEzsewF+OpANFovCTUEs6s5vyoVNP8lk=
 -----END CERTIFICATE-----
 `
-	m := map[string]interface{}{
+	m := map[string]any{
 		common.HTTPAuthProxySkipSearch:        "true",
 		common.HTTPAuthProxyVerifyCert:        "true",
 		common.HTTPAuthProxyAdminGroups:       "group1, group2",
@@ -246,7 +246,7 @@ y1bQusZMygQezfCuEzsewF+OpANFovCTUEs6s5vyoVNP8lk=
 }
 
 func TestOIDCSetting(t *testing.T) {
-	m := map[string]interface{}{
+	m := map[string]any{
 		common.OIDCName:         "test",
 		common.OIDCEndpoint:     "https://oidc.test",
 		common.OIDCVerifyCert:   "true",

--- a/src/lib/config/userconfig.go
+++ b/src/lib/config/userconfig.go
@@ -28,7 +28,7 @@ import (
 // It contains all user related configurations, each of user related settings requires a context provided
 
 // GetSystemCfg returns the all configurations
-func GetSystemCfg(ctx context.Context) (map[string]interface{}, error) {
+func GetSystemCfg(ctx context.Context) (map[string]any, error) {
 	sysCfg := DefaultMgr().GetAll(ctx)
 	if len(sysCfg) == 0 {
 		return nil, errors.New("can not load system config, the database might be down")

--- a/src/lib/context.go
+++ b/src/lib/context.go
@@ -41,14 +41,14 @@ type ArtifactInfo struct {
 	BlobMountDigest      string
 }
 
-func setToContext(ctx context.Context, key contextKey, value interface{}) context.Context {
+func setToContext(ctx context.Context, key contextKey, value any) context.Context {
 	if ctx == nil {
 		ctx = context.Background()
 	}
 	return context.WithValue(ctx, key, value)
 }
 
-func getFromContext(ctx context.Context, key contextKey) interface{} {
+func getFromContext(ctx context.Context, key contextKey) any {
 	if ctx == nil {
 		return nil
 	}

--- a/src/lib/convert_types.go
+++ b/src/lib/convert_types.go
@@ -43,7 +43,7 @@ func StringValue(v *string) string {
 }
 
 // ToBool convert interface to bool
-func ToBool(v interface{}) bool {
+func ToBool(v any) bool {
 	switch b := v.(type) {
 	case bool:
 		return b

--- a/src/lib/convert_types_test.go
+++ b/src/lib/convert_types_test.go
@@ -20,7 +20,7 @@ import (
 
 func TestToBool(t *testing.T) {
 	type args struct {
-		v interface{}
+		v any
 	}
 	tests := []struct {
 		name string

--- a/src/lib/encrypt/encrypt.go
+++ b/src/lib/encrypt/encrypt.go
@@ -37,7 +37,7 @@ type Encryptor interface {
 // AESEncryptor uses AES to encrypt or decrypt string
 type AESEncryptor struct {
 	keyProvider KeyProvider
-	keyParams   map[string]interface{}
+	keyParams   map[string]any
 }
 
 // NewAESEncryptor returns an instance of an AESEncryptor

--- a/src/lib/encrypt/keyprovider.go
+++ b/src/lib/encrypt/keyprovider.go
@@ -20,7 +20,7 @@ import "os"
 type KeyProvider interface {
 	// Get returns the key
 	// params can be used to pass parameters in different implements
-	Get(params map[string]interface{}) (string, error)
+	Get(params map[string]any) (string, error)
 }
 
 // FileKeyProvider reads key from file
@@ -37,7 +37,7 @@ func NewFileKeyProvider(path string) KeyProvider {
 }
 
 // Get returns the key read from file
-func (f *FileKeyProvider) Get(_ map[string]interface{}) (string, error) {
+func (f *FileKeyProvider) Get(_ map[string]any) (string, error) {
 	b, err := os.ReadFile(f.path)
 	if err != nil {
 		return "", err
@@ -51,6 +51,6 @@ type PresetKeyProvider struct {
 }
 
 // Get ...
-func (p *PresetKeyProvider) Get(_ map[string]interface{}) (string, error) {
+func (p *PresetKeyProvider) Get(_ map[string]any) (string, error) {
 	return p.Key, nil
 }

--- a/src/lib/errors/errors.go
+++ b/src/lib/errors/errors.go
@@ -64,7 +64,7 @@ func (e *Error) MarshalJSON() ([]byte, error) {
 }
 
 // WithMessagef ...
-func (e *Error) WithMessagef(format string, v ...interface{}) *Error {
+func (e *Error) WithMessagef(format string, v ...any) *Error {
 	e.Message = fmt.Sprintf(format, v...)
 	return e
 }
@@ -132,7 +132,7 @@ func NewErrs(err error) Errors {
 }
 
 // New ...
-func New(in interface{}) *Error {
+func New(in any) *Error {
 	var err error
 	switch in := in.(type) {
 	case error:
@@ -161,7 +161,7 @@ func Wrap(err error, message string) *Error {
 }
 
 // Wrapf ...
-func Wrapf(err error, format string, args ...interface{}) *Error {
+func Wrapf(err error, format string, args ...any) *Error {
 	if err == nil {
 		return nil
 	}
@@ -174,7 +174,7 @@ func Wrapf(err error, format string, args ...interface{}) *Error {
 }
 
 // Errorf ...
-func Errorf(format string, args ...interface{}) *Error {
+func Errorf(format string, args ...any) *Error {
 	return &Error{
 		Message: fmt.Sprintf(format, args...),
 		Stack:   newStack(),

--- a/src/lib/json_copy.go
+++ b/src/lib/json_copy.go
@@ -21,7 +21,7 @@ import (
 // JSONCopy copy from src to dst with json marshal and unmarshal.
 // NOTE: copy from one struct to another struct may miss some values depend on
 // the json tag in the fields, you should know what will happened when call this function.
-func JSONCopy(dst, src interface{}) error {
+func JSONCopy(dst, src any) error {
 	data, err := json.Marshal(src)
 	if err != nil {
 		return err

--- a/src/lib/json_copy_test.go
+++ b/src/lib/json_copy_test.go
@@ -29,7 +29,7 @@ func TestJSONCopy(t *testing.T) {
 	assert := assert.New(t)
 
 	{
-		var m map[string]interface{}
+		var m map[string]any
 		foo := &jsonCopyFoo{
 			Name: "foo",
 			Age:  1,
@@ -42,7 +42,7 @@ func TestJSONCopy(t *testing.T) {
 	}
 
 	{
-		var m map[string]interface{}
+		var m map[string]any
 		var foo *jsonCopyFoo
 
 		assert.Nil(m)
@@ -51,7 +51,7 @@ func TestJSONCopy(t *testing.T) {
 	}
 
 	{
-		m := map[string]interface{}{
+		m := map[string]any{
 			"name": "foo",
 			"age":  1,
 		}

--- a/src/lib/log/logger.go
+++ b/src/lib/log/logger.go
@@ -46,8 +46,8 @@ func init() {
 	logger.setLevel(level)
 }
 
-// Fields type alias to map[string]interface{}
-type Fields = map[string]interface{}
+// Fields type alias to map[string]any
+type Fields = map[string]any
 
 // Logger provides a struct with fields that describe the details of logger.
 type Logger struct {
@@ -56,14 +56,14 @@ type Logger struct {
 	lvl       Level
 	callDepth int
 	skipLine  bool
-	fields    map[string]interface{}
+	fields    map[string]any
 	fieldsStr string
 	mu        *sync.Mutex // ptr here to share one sync.Mutex for clone method
 	fallback  *Logger     // fallback logger when current out fail
 }
 
 // New returns a customized Logger
-func New(out io.Writer, fmtter Formatter, lvl Level, options ...interface{}) *Logger {
+func New(out io.Writer, fmtter Formatter, lvl Level, options ...any) *Logger {
 	// Default set to be 3
 	depth := 3
 	// If passed in as option, then reset depth
@@ -80,7 +80,7 @@ func New(out io.Writer, fmtter Formatter, lvl Level, options ...interface{}) *Lo
 		fmtter:    fmtter,
 		lvl:       lvl,
 		callDepth: depth,
-		fields:    map[string]interface{}{},
+		fields:    map[string]any{},
 		mu:        &sync.Mutex{},
 	}
 }
@@ -121,7 +121,7 @@ func (l *Logger) WithFields(fields Fields) *Logger {
 	r := l.clone()
 
 	if len(fields) > 0 {
-		copyFields := make(map[string]interface{}, len(l.fields)+len(fields))
+		copyFields := make(map[string]any, len(l.fields)+len(fields))
 		for key, value := range l.fields {
 			copyFields[key] = value
 		}
@@ -148,7 +148,7 @@ func (l *Logger) WithFields(fields Fields) *Logger {
 }
 
 // WithField returns cloned logger which fields merged with field key=value
-func (l *Logger) WithField(key string, value interface{}) *Logger {
+func (l *Logger) WithField(key string, value any) *Logger {
 	return l.WithFields(Fields{key: value})
 }
 
@@ -196,7 +196,7 @@ func (l *Logger) output(record *Record) (err error) {
 }
 
 // Debug ...
-func (l *Logger) Debug(v ...interface{}) {
+func (l *Logger) Debug(v ...any) {
 	if l.lvl <= DebugLevel {
 		record := NewRecord(time.Now(), fmt.Sprint(v...), l.getLine(), DebugLevel)
 		_ = l.output(record)
@@ -204,7 +204,7 @@ func (l *Logger) Debug(v ...interface{}) {
 }
 
 // Debugf ...
-func (l *Logger) Debugf(format string, v ...interface{}) {
+func (l *Logger) Debugf(format string, v ...any) {
 	if l.lvl <= DebugLevel {
 		record := NewRecord(time.Now(), fmt.Sprintf(format, v...), l.getLine(), DebugLevel)
 		_ = l.output(record)
@@ -212,7 +212,7 @@ func (l *Logger) Debugf(format string, v ...interface{}) {
 }
 
 // Info ...
-func (l *Logger) Info(v ...interface{}) {
+func (l *Logger) Info(v ...any) {
 	if l.lvl <= InfoLevel {
 		record := NewRecord(time.Now(), fmt.Sprint(v...), l.getLine(), InfoLevel)
 		_ = l.output(record)
@@ -220,7 +220,7 @@ func (l *Logger) Info(v ...interface{}) {
 }
 
 // Infof ...
-func (l *Logger) Infof(format string, v ...interface{}) {
+func (l *Logger) Infof(format string, v ...any) {
 	if l.lvl <= InfoLevel {
 		record := NewRecord(time.Now(), fmt.Sprintf(format, v...), l.getLine(), InfoLevel)
 		_ = l.output(record)
@@ -228,7 +228,7 @@ func (l *Logger) Infof(format string, v ...interface{}) {
 }
 
 // Warning ...
-func (l *Logger) Warning(v ...interface{}) {
+func (l *Logger) Warning(v ...any) {
 	if l.lvl <= WarningLevel {
 		record := NewRecord(time.Now(), fmt.Sprint(v...), l.getLine(), WarningLevel)
 		_ = l.output(record)
@@ -236,7 +236,7 @@ func (l *Logger) Warning(v ...interface{}) {
 }
 
 // Warningf ...
-func (l *Logger) Warningf(format string, v ...interface{}) {
+func (l *Logger) Warningf(format string, v ...any) {
 	if l.lvl <= WarningLevel {
 		record := NewRecord(time.Now(), fmt.Sprintf(format, v...), l.getLine(), WarningLevel)
 		_ = l.output(record)
@@ -244,7 +244,7 @@ func (l *Logger) Warningf(format string, v ...interface{}) {
 }
 
 // Error ...
-func (l *Logger) Error(v ...interface{}) {
+func (l *Logger) Error(v ...any) {
 	if l.lvl <= ErrorLevel {
 		record := NewRecord(time.Now(), fmt.Sprint(v...), l.getLine(), ErrorLevel)
 		_ = l.output(record)
@@ -252,7 +252,7 @@ func (l *Logger) Error(v ...interface{}) {
 }
 
 // Errorf ...
-func (l *Logger) Errorf(format string, v ...interface{}) {
+func (l *Logger) Errorf(format string, v ...any) {
 	if l.lvl <= ErrorLevel {
 		record := NewRecord(time.Now(), fmt.Sprintf(format, v...), l.getLine(), ErrorLevel)
 		_ = l.output(record)
@@ -260,7 +260,7 @@ func (l *Logger) Errorf(format string, v ...interface{}) {
 }
 
 // Fatal ...
-func (l *Logger) Fatal(v ...interface{}) {
+func (l *Logger) Fatal(v ...any) {
 	if l.lvl <= FatalLevel {
 		record := NewRecord(time.Now(), fmt.Sprint(v...), l.getLine(), FatalLevel)
 		_ = l.output(record)
@@ -269,7 +269,7 @@ func (l *Logger) Fatal(v ...interface{}) {
 }
 
 // Fatalf ...
-func (l *Logger) Fatalf(format string, v ...interface{}) {
+func (l *Logger) Fatalf(format string, v ...any) {
 	if l.lvl <= FatalLevel {
 		record := NewRecord(time.Now(), fmt.Sprintf(format, v...), l.getLine(), FatalLevel)
 		_ = l.output(record)
@@ -298,52 +298,52 @@ func (l *Logger) getLine() string {
 }
 
 // Debug ...
-func Debug(v ...interface{}) {
+func Debug(v ...any) {
 	logger.WithDepth(4).Debug(v...)
 }
 
 // Debugf ...
-func Debugf(format string, v ...interface{}) {
+func Debugf(format string, v ...any) {
 	logger.WithDepth(4).Debugf(format, v...)
 }
 
 // Info ...
-func Info(v ...interface{}) {
+func Info(v ...any) {
 	logger.WithDepth(4).Info(v...)
 }
 
 // Infof ...
-func Infof(format string, v ...interface{}) {
+func Infof(format string, v ...any) {
 	logger.WithDepth(4).Infof(format, v...)
 }
 
 // Warning  ...
-func Warning(v ...interface{}) {
+func Warning(v ...any) {
 	logger.WithDepth(4).Warning(v...)
 }
 
 // Warningf ...
-func Warningf(format string, v ...interface{}) {
+func Warningf(format string, v ...any) {
 	logger.WithDepth(4).Warningf(format, v...)
 }
 
 // Error ...
-func Error(v ...interface{}) {
+func Error(v ...any) {
 	logger.WithDepth(4).Error(v...)
 }
 
 // Errorf ...
-func Errorf(format string, v ...interface{}) {
+func Errorf(format string, v ...any) {
 	logger.WithDepth(4).Errorf(format, v...)
 }
 
 // Fatal ...
-func Fatal(v ...interface{}) {
+func Fatal(v ...any) {
 	logger.WithDepth(4).Fatal(v...)
 }
 
 // Fatalf ...
-func Fatalf(format string, v ...interface{}) {
+func Fatalf(format string, v ...any) {
 	logger.WithDepth(4).Fatalf(format, v...)
 }
 

--- a/src/lib/orm/error.go
+++ b/src/lib/orm/error.go
@@ -30,7 +30,7 @@ var (
 )
 
 // WrapNotFoundError wrap error as NotFoundError when it is orm.ErrNoRows otherwise return err
-func WrapNotFoundError(err error, format string, args ...interface{}) error {
+func WrapNotFoundError(err error, format string, args ...any) error {
 	if e := AsNotFoundError(err, format, args...); e != nil {
 		return e
 	}
@@ -39,7 +39,7 @@ func WrapNotFoundError(err error, format string, args ...interface{}) error {
 }
 
 // WrapConflictError wrap error as ConflictError when it is duplicate key error otherwise return err
-func WrapConflictError(err error, format string, args ...interface{}) error {
+func WrapConflictError(err error, format string, args ...any) error {
 	if e := AsConflictError(err, format, args...); e != nil {
 		return e
 	}
@@ -49,7 +49,7 @@ func WrapConflictError(err error, format string, args ...interface{}) error {
 
 // AsNotFoundError checks whether the err is orm.ErrNoRows. If it it, wrap it
 // as a src/internal/error.Error with not found error code, else return nil
-func AsNotFoundError(err error, messageFormat string, args ...interface{}) *errors.Error {
+func AsNotFoundError(err error, messageFormat string, args ...any) *errors.Error {
 	if errors.Is(err, orm.ErrNoRows) {
 		e := errors.NotFoundError(nil)
 		if len(messageFormat) > 0 {
@@ -62,7 +62,7 @@ func AsNotFoundError(err error, messageFormat string, args ...interface{}) *erro
 
 // AsConflictError checks whether the err is duplicate key error. If it is, wrap it
 // as a src/internal/error.Error with conflict error code, else return nil
-func AsConflictError(err error, messageFormat string, args ...interface{}) *errors.Error {
+func AsConflictError(err error, messageFormat string, args ...any) *errors.Error {
 	if IsDuplicateKeyError(err) {
 		e := errors.New(err).
 			WithCode(errors.ConflictCode).
@@ -74,7 +74,7 @@ func AsConflictError(err error, messageFormat string, args ...interface{}) *erro
 
 // AsForeignKeyError checks whether the err is violating foreign key constraint error. If it it, wrap it
 // as a src/internal/error.Error with violating foreign key constraint error code, else return nil
-func AsForeignKeyError(err error, messageFormat string, args ...interface{}) *errors.Error {
+func AsForeignKeyError(err error, messageFormat string, args ...any) *errors.Error {
 	if isViolatingForeignKeyConstraintError(err) {
 		e := errors.New(err).
 			WithCode(errors.ViolateForeignKeyConstraintCode).

--- a/src/lib/orm/metadata.go
+++ b/src/lib/orm/metadata.go
@@ -34,7 +34,7 @@ var (
 type key struct {
 	Name       string
 	Filterable bool
-	FilterFunc func(context.Context, orm.QuerySeter, string, interface{}) orm.QuerySeter
+	FilterFunc func(context.Context, orm.QuerySeter, string, any) orm.QuerySeter
 	Sortable   bool
 }
 
@@ -60,7 +60,7 @@ func (m *metadata) Sortable(key string) bool {
 }
 
 // parse the definition of the provided model(fields/methods/annotations) and return the parsed metadata
-func parseModel(model interface{}) *metadata {
+func parseModel(model any) *metadata {
 	// pointer type
 	ptr := reflect.TypeOf(model)
 	// struct type
@@ -116,7 +116,7 @@ func parseModel(model interface{}) *metadata {
 		if !methodValue.IsValid() {
 			continue
 		}
-		filterFunc, ok := methodValue.Interface().(func(context.Context, orm.QuerySeter, string, interface{}) orm.QuerySeter)
+		filterFunc, ok := methodValue.Interface().(func(context.Context, orm.QuerySeter, string, any) orm.QuerySeter)
 		if !ok {
 			continue
 		}

--- a/src/lib/orm/metadata_test.go
+++ b/src/lib/orm/metadata_test.go
@@ -32,7 +32,7 @@ type foo struct {
 	Field4 string `sort:"default:desc"`
 }
 
-func (f *foo) FilterByField5(context.Context, orm.QuerySeter, string, interface{}) orm.QuerySeter {
+func (f *foo) FilterByField5(context.Context, orm.QuerySeter, string, any) orm.QuerySeter {
 	return nil
 }
 

--- a/src/lib/orm/orm.go
+++ b/src/lib/orm/orm.go
@@ -45,7 +45,7 @@ type ParamsList = orm.ParamsList
 type QuerySeter = orm.QuerySeter
 
 // RegisterModel ...
-func RegisterModel(models ...interface{}) {
+func RegisterModel(models ...any) {
 	orm.RegisterModel(models...)
 }
 
@@ -176,7 +176,7 @@ func WithTransaction(f func(ctx context.Context) error) func(ctx context.Context
 }
 
 // ReadOrCreate read or create instance to database, retry to read when met a duplicate key error after the creating
-func ReadOrCreate(ctx context.Context, md interface{}, col1 string, cols ...string) (created bool, id int64, err error) {
+func ReadOrCreate(ctx context.Context, md any, col1 string, cols ...string) (created bool, id int64, err error) {
 	getter, ok := md.(interface {
 		GetID() int64
 	})
@@ -237,7 +237,7 @@ func ReadOrCreate(ctx context.Context, md interface{}, col1 string, cols ...stri
 // The sql should return the ID list with the specific condition(e.g. select id from table1 where column1=?)
 // The sql runs as a prepare statement with the "?" be populated rather than concat string directly
 // The returning in clause is a string like "IN (id1, id2, id3, ...)"
-func CreateInClause(ctx context.Context, sql string, args ...interface{}) (string, error) {
+func CreateInClause(ctx context.Context, sql string, args ...any) (string, error) {
 	ormer, err := FromContext(ctx)
 	if err != nil {
 		return "", err

--- a/src/lib/orm/query.go
+++ b/src/lib/orm/query.go
@@ -39,7 +39,7 @@ import (
 //
 // // support filter by "Field6", "field6"
 //
-//	func (f *Foo) FilterByField6(ctx context.Context, qs orm.QuerySetter, key string, value interface{}) orm.QuerySetter {
+//	func (f *Foo) FilterByField6(ctx context.Context, qs orm.QuerySetter, key string, value any) orm.QuerySetter {
 //	  ...
 //		 return qs
 //	}
@@ -72,7 +72,7 @@ type Config struct {
 
 type Option func(*Config)
 
-func QuerySetter(ctx context.Context, model interface{}, query *q.Query, options ...Option) (orm.QuerySeter, error) {
+func QuerySetter(ctx context.Context, model any, query *q.Query, options ...Option) (orm.QuerySeter, error) {
 	t := reflect.TypeOf(model)
 	if t.Kind() != reflect.Ptr {
 		return nil, fmt.Errorf("<orm.QuerySetter> cannot use non-ptr model struct `%s`", getFullName(t.Elem()))
@@ -128,7 +128,7 @@ func newConfig(opts ...Option) *Config {
 // select a, b, c from mytable order by a limit ? offset ?
 // it appends the " limit ? offset ? " to sql,
 // and appends the limit value and offset value to the params of this query
-func PaginationOnRawSQL(query *q.Query, sql string, params []interface{}) (string, []interface{}) {
+func PaginationOnRawSQL(query *q.Query, sql string, params []any) (string, []any) {
 	if query != nil && query.PageSize > 0 {
 		sql += ` limit ?`
 		params = append(params, query.PageSize)
@@ -142,7 +142,7 @@ func PaginationOnRawSQL(query *q.Query, sql string, params []interface{}) (strin
 }
 
 // QuerySetterForCount creates the query setter used for count with the sort and pagination information ignored
-func QuerySetterForCount(ctx context.Context, model interface{}, query *q.Query, _ ...string) (orm.QuerySeter, error) {
+func QuerySetterForCount(ctx context.Context, model any, query *q.Query, _ ...string) (orm.QuerySeter, error) {
 	query = q.MustClone(query)
 	query.Sorts = nil
 	query.PageSize = 0

--- a/src/lib/orm/test/orm_test.go
+++ b/src/lib/orm/test/orm_test.go
@@ -418,7 +418,7 @@ func (suite *OrmSuite) TestPaginationOnRawSQL() {
 		PageSize:   10,
 	}
 	sql := "select * from harbor_user where user_id > ? order by user_name "
-	params := []interface{}{2}
+	params := []any{2}
 	sql, params = PaginationOnRawSQL(query, sql, params)
 	suite.Equal("select * from harbor_user where user_id > ? order by user_name  limit ? offset ?", sql)
 	suite.Equal(int64(10), params[1])

--- a/src/lib/q/builder.go
+++ b/src/lib/q/builder.go
@@ -47,8 +47,8 @@ func Build(q, sort string, pageNumber, pageSize int64) (*Query, error) {
 	}, nil
 }
 
-func parseKeywords(q string) (map[string]interface{}, error) {
-	keywords := map[string]interface{}{}
+func parseKeywords(q string) (map[string]any, error) {
+	keywords := map[string]any{}
 	if len(q) == 0 {
 		return keywords, nil
 	}
@@ -97,7 +97,7 @@ func ParseSorting(sort string) []*Sort {
 	return sorts
 }
 
-func parsePattern(value string) (interface{}, error) {
+func parsePattern(value string) (any, error) {
 	// empty string
 	if len(value) == 0 {
 		return value, nil
@@ -167,7 +167,7 @@ func parseAndList(value string) (*AndList, error) {
 	return al, nil
 }
 
-func parseList(value string, c rune) ([]interface{}, error) {
+func parseList(value string, c rune) ([]any, error) {
 	length := len(value)
 	if c == '{' && value[length-1] != '}' {
 		return nil, fmt.Errorf(`or list must start with "{" and end with "}"`)
@@ -175,7 +175,7 @@ func parseList(value string, c rune) ([]interface{}, error) {
 	if c == '(' && value[length-1] != ')' {
 		return nil, fmt.Errorf(`and list must start with "(" and end with ")"`)
 	}
-	var vs []interface{}
+	var vs []any
 	strs := strings.Split(value[1:length-1], " ")
 	for _, str := range strs {
 		v := parseValue(str)
@@ -188,7 +188,7 @@ func parseList(value string, c rune) ([]interface{}, error) {
 }
 
 // try to parse value as time first, then integer, and last string
-func parseValue(value string) interface{} {
+func parseValue(value string) any {
 	value = strings.TrimSpace(value)
 	// try to parse time
 	time, err := time.Parse("2006-01-02T15:04:05", value)

--- a/src/lib/q/query.go
+++ b/src/lib/q/query.go
@@ -15,7 +15,7 @@
 package q
 
 // KeyWords ...
-type KeyWords = map[string]interface{}
+type KeyWords = map[string]any
 
 // Query parameters
 type Query struct {
@@ -51,7 +51,7 @@ func New(kw KeyWords) *Query {
 // or returns a new Query instance
 func MustClone(query *Query) *Query {
 	q := &Query{
-		Keywords: map[string]interface{}{},
+		Keywords: map[string]any{},
 	}
 	if query != nil {
 		q.PageNumber = query.PageNumber
@@ -77,18 +77,18 @@ type Sort struct {
 
 // Range query
 type Range struct {
-	Min interface{}
-	Max interface{}
+	Min any
+	Max any
 }
 
 // AndList query
 type AndList struct {
-	Values []interface{}
+	Values []any
 }
 
 // OrList query
 type OrList struct {
-	Values []interface{}
+	Values []any
 }
 
 // FuzzyMatchValue query
@@ -105,7 +105,7 @@ func NewSort(key string, desc bool) *Sort {
 }
 
 // NewRange creates a new range
-func NewRange(minVal, maxVal interface{}) *Range {
+func NewRange(minVal, maxVal any) *Range {
 	return &Range{
 		Min: minVal,
 		Max: maxVal,
@@ -113,14 +113,14 @@ func NewRange(minVal, maxVal interface{}) *Range {
 }
 
 // NewAndList creates a new and list
-func NewAndList(values []interface{}) *AndList {
+func NewAndList(values []any) *AndList {
 	return &AndList{
 		Values: values,
 	}
 }
 
 // NewOrList creates a new or list
-func NewOrList(values []interface{}) *OrList {
+func NewOrList(values []any) *OrList {
 	return &OrList{
 		Values: values,
 	}

--- a/src/lib/selector/selector.go
+++ b/src/lib/selector/selector.go
@@ -28,5 +28,5 @@ type Selector interface {
 
 // Factory is factory method to return a selector implementation
 // Pattern can be any type of data.
-// TODO: 'extras' can also be an optional interface{} to accept more complicated data.
-type Factory func(decoration string, pattern interface{}, extras string) Selector
+// TODO: 'extras' can also be an optional any to accept more complicated data.
+type Factory func(decoration string, pattern any, extras string) Selector

--- a/src/lib/selector/selectors/doublestar/selector.go
+++ b/src/lib/selector/selectors/doublestar/selector.go
@@ -134,7 +134,7 @@ func (s *selector) tagSelectExclude(artifact *iselector.Candidate) (selected boo
 }
 
 // New is factory method for doublestar selector
-func New(decoration string, pattern interface{}, extras string) iselector.Selector {
+func New(decoration string, pattern any, extras string) iselector.Selector {
 	untagged := true // default behavior for upgrade, active keep the untagged images
 	if decoration == Excludes {
 		untagged = false

--- a/src/lib/selector/selectors/index/index.go
+++ b/src/lib/selector/selectors/index/index.go
@@ -94,7 +94,7 @@ func Get(kind, decoration, pattern, extras string) (selector.Selector, error) {
 func Index() []*IndexedMeta {
 	all := make([]*IndexedMeta, 0)
 
-	index.Range(func(_, v interface{}) bool {
+	index.Range(func(_, v any) bool {
 		if item, ok := v.(*indexedItem); ok {
 			all = append(all, item.Meta)
 			return true

--- a/src/lib/selector/selectors/label/selector.go
+++ b/src/lib/selector/selectors/label/selector.go
@@ -50,7 +50,7 @@ func (s *selector) Select(artifacts []*iselector.Candidate) (selected []*iselect
 }
 
 // New is factory method for label selector
-func New(decoration string, pattern interface{}, _ string) iselector.Selector {
+func New(decoration string, pattern any, _ string) iselector.Selector {
 	labels := make([]string, 0)
 
 	if pattern != nil {

--- a/src/lib/selector/selectors/severity/selector.go
+++ b/src/lib/selector/selectors/severity/selector.go
@@ -82,7 +82,7 @@ func (s *selector) Select(artifacts []*sl.Candidate) (selected []*sl.Candidate, 
 }
 
 // New is factory method for vulnerability severity selector
-func New(decoration string, pattern interface{}, _ string) sl.Selector {
+func New(decoration string, pattern any, _ string) sl.Selector {
 	var sev int
 	if pattern != nil {
 		sev, _ = pattern.(int)

--- a/src/lib/selector/selectors/signature/selector.go
+++ b/src/lib/selector/selectors/signature/selector.go
@@ -64,7 +64,7 @@ func (s *selector) Select(artifacts []*sl.Candidate) (selected []*sl.Candidate, 
 }
 
 // New is factory method for signature selector
-func New(decoration string, pattern interface{}, _ string) sl.Selector {
+func New(decoration string, pattern any, _ string) sl.Selector {
 	var e bool
 	if pattern != nil {
 		e, _ = pattern.(bool)

--- a/src/lib/set.go
+++ b/src/lib/set.go
@@ -17,23 +17,23 @@ package lib
 type void = struct{}
 
 // Set a simple set
-type Set map[interface{}]void
+type Set map[any]void
 
 // Add add item to set
-func (s Set) Add(item interface{}) {
+func (s Set) Add(item any) {
 	s[item] = void{}
 }
 
 // Exists returns true when item in the set
-func (s Set) Exists(item interface{}) bool {
+func (s Set) Exists(item any) bool {
 	_, ok := s[item]
 
 	return ok
 }
 
 // Items returns the items in the set
-func (s Set) Items() []interface{} {
-	var items []interface{}
+func (s Set) Items() []any {
+	var items []any
 	for item := range s {
 		items = append(items, item)
 	}

--- a/src/pkg/accessory/dao/dao_test.go
+++ b/src/pkg/accessory/dao/dao_test.go
@@ -110,7 +110,7 @@ func (d *daoTestSuite) TestCount() {
 	d.Require().Nil(err)
 	d.True(total > 0)
 	total, err = d.dao.Count(d.ctx, &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"SubjectArtifactDigest": d.subArtifactDigest,
 		},
 	})
@@ -132,7 +132,7 @@ func (d *daoTestSuite) TestList() {
 	d.True(found)
 
 	accs, err = d.dao.List(d.ctx, &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"SubjectArtifactDigest": d.subArtifactDigest,
 		},
 	})
@@ -254,7 +254,7 @@ func (d *daoTestSuite) TestDeleteOfArtifact() {
 	d.Require().Nil(err)
 
 	accs, err := d.dao.List(d.ctx, &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"SubjectArtifactDigest": art.Digest,
 		},
 	})
@@ -265,14 +265,14 @@ func (d *daoTestSuite) TestDeleteOfArtifact() {
 	d.Require().Len(accs, 2)
 
 	_, err = d.dao.DeleteAccessories(d.ctx, &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"SubjectArtifactDigest": art.Digest, "SubjectArtifactRepo": art.RepositoryName,
 		},
 	})
 	d.Require().Nil(err)
 
 	accs, err = d.dao.List(d.ctx, &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"SubjectArtifactDigest": art.Digest, "SubjectArtifactRepo": art.RepositoryName,
 		},
 	})

--- a/src/pkg/artifact/dao/dao.go
+++ b/src/pkg/artifact/dao/dao.go
@@ -132,7 +132,7 @@ func (d *dao) Get(ctx context.Context, id int64) (*Artifact, error) {
 
 func (d *dao) GetByDigest(ctx context.Context, repository, digest string) (*Artifact, error) {
 	qs, err := orm.QuerySetter(ctx, &Artifact{}, &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"RepositoryName": repository,
 			"Digest":         digest,
 		},
@@ -212,7 +212,7 @@ func (d *dao) UpdatePullTime(ctx context.Context, id int64, pullTime time.Time) 
 	formatPullTime := pullTime.Format("2006-01-02 15:04:05.999999")
 	// update db only if pull_time is null or pull_time < (in-coming)pullTime
 	sql := "UPDATE artifact SET pull_time = ? WHERE id = ? AND (pull_time IS NULL OR pull_time < ?)"
-	args := []interface{}{formatPullTime, id, formatPullTime}
+	args := []any{formatPullTime, id, formatPullTime}
 
 	_, err = ormer.Raw(sql, args...).Exec()
 	if err != nil {
@@ -273,7 +273,7 @@ func (d *dao) DeleteReferences(ctx context.Context, parentID int64) error {
 		return err
 	}
 	qs, err := orm.QuerySetter(ctx, &ArtifactReference{}, &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"parent_id": parentID,
 		},
 	})
@@ -299,16 +299,16 @@ func (d *dao) ListWithLatest(ctx context.Context, query *q.Query) (artifacts []*
 	GROUP BY repository_name
 	) latest ON a.repository_name = latest.repository_name AND a.push_time = latest.latest_push_time`
 
-	queryParam := make([]interface{}, 0)
+	queryParam := make([]any, 0)
 	var ok bool
-	var pid interface{}
+	var pid any
 	if pid, ok = query.Keywords["ProjectID"]; !ok {
 		return nil, errors.New(nil).WithCode(errors.BadRequestCode).
 			WithMessage(`the value of "ProjectID" must be set`)
 	}
 	queryParam = append(queryParam, pid)
 
-	var attributionValue interface{}
+	var attributionValue any
 	if attributionValue, ok = query.Keywords["media_type"]; ok {
 		sql = fmt.Sprintf(sql, "media_type")
 	} else if attributionValue, ok = query.Keywords["artifact_type"]; ok {

--- a/src/pkg/artifact/dao/dao_test.go
+++ b/src/pkg/artifact/dao/dao_test.go
@@ -144,7 +144,7 @@ func (d *daoTestSuite) TearDownTest() {
 func (d *daoTestSuite) TestCount() {
 	// query by repository ID: both tagged and untagged artifacts
 	totalOfAll, err := d.dao.Count(d.ctx, &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"RepositoryID": 1,
 		},
 	})
@@ -153,7 +153,7 @@ func (d *daoTestSuite) TestCount() {
 
 	// only query tagged artifacts
 	totalOfTagged, err := d.dao.Count(d.ctx, &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"RepositoryID": 1,
 			"Tags":         "*",
 		},
@@ -163,7 +163,7 @@ func (d *daoTestSuite) TestCount() {
 
 	// only query untagged artifacts
 	totalOfUnTagged, err := d.dao.Count(d.ctx, &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"RepositoryID": 1,
 			"Tags":         "nil",
 		},
@@ -173,7 +173,7 @@ func (d *daoTestSuite) TestCount() {
 
 	// specific tag value
 	total, err := d.dao.Count(d.ctx, &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"RepositoryID": 1,
 			"Tags":         "latest",
 		},
@@ -183,7 +183,7 @@ func (d *daoTestSuite) TestCount() {
 
 	// query by repository ID and digest
 	total, err = d.dao.Count(d.ctx, &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"RepositoryID": 1,
 			"Digest":       "parent_digest",
 		},
@@ -193,7 +193,7 @@ func (d *daoTestSuite) TestCount() {
 
 	// set pagination in query
 	total, err = d.dao.Count(d.ctx, &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"RepositoryID": 1,
 		},
 		PageNumber: 1,
@@ -206,7 +206,7 @@ func (d *daoTestSuite) TestCount() {
 func (d *daoTestSuite) TestList() {
 	// query by repository ID: both tagged and untagged artifacts
 	artifacts, err := d.dao.List(d.ctx, &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"RepositoryID": 1,
 		},
 	})
@@ -235,7 +235,7 @@ func (d *daoTestSuite) TestList() {
 
 	// only query tagged artifacts
 	artifacts, err = d.dao.List(d.ctx, &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"RepositoryID": 1,
 			"Tags":         "*",
 		},
@@ -264,7 +264,7 @@ func (d *daoTestSuite) TestList() {
 
 	// only query untagged artifacts
 	artifacts, err = d.dao.List(d.ctx, &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"RepositoryID": 1,
 			"Tags":         "nil",
 		},
@@ -293,7 +293,7 @@ func (d *daoTestSuite) TestList() {
 
 	// query by repository ID and digest
 	artifacts, err = d.dao.List(d.ctx, &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"RepositoryID": 1,
 			"Digest":       "parent_digest",
 		},
@@ -304,7 +304,7 @@ func (d *daoTestSuite) TestList() {
 
 	// set pagination in query
 	artifacts, err = d.dao.List(d.ctx, &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"RepositoryID": 1,
 		},
 		PageNumber: 1,
@@ -446,7 +446,7 @@ func (d *daoTestSuite) TestCreateReference() {
 
 func (d *daoTestSuite) TestListReferences() {
 	references, err := d.dao.ListReferences(d.ctx, &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"ParentID": d.parentArtID,
 			"ChildID":  d.childArt01ID,
 		},
@@ -526,7 +526,7 @@ func (d *daoTestSuite) TestListWithLatest() {
 	d.Require().Nil(err)
 
 	latest, err := d.dao.ListWithLatest(d.ctx, &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"ProjectID":  1234,
 			"media_type": v1.MediaTypeImageConfig,
 		},

--- a/src/pkg/artifact/model.go
+++ b/src/pkg/artifact/model.go
@@ -30,22 +30,22 @@ import (
 // underlying concrete detail and provides an unified artifact view
 // for all users.
 type Artifact struct {
-	ID                int64                  `json:"id"`
-	Type              string                 `json:"type"`                // image, chart or other OCI compatible
-	MediaType         string                 `json:"media_type"`          // the media type of artifact. Mostly, it's the value of `manifest.config.mediatype`
-	ManifestMediaType string                 `json:"manifest_media_type"` // the media type of manifest/index
-	ArtifactType      string                 `json:"artifact_type"`       // the artifactType of manifest/index
-	ProjectID         int64                  `json:"project_id"`
-	RepositoryID      int64                  `json:"repository_id"`
-	RepositoryName    string                 `json:"repository_name"`
-	Digest            string                 `json:"digest"`
-	Size              int64                  `json:"size"`
-	Icon              string                 `json:"icon"`
-	PushTime          time.Time              `json:"push_time"`
-	PullTime          time.Time              `json:"pull_time"`
-	ExtraAttrs        map[string]interface{} `json:"extra_attrs"` // only contains the simple attributes specific for the different artifact type, most of them should come from the config layer
-	Annotations       map[string]string      `json:"annotations"`
-	References        []*Reference           `json:"references"` // child artifacts referenced by the parent artifact if the artifact is an index
+	ID                int64             `json:"id"`
+	Type              string            `json:"type"`                // image, chart or other OCI compatible
+	MediaType         string            `json:"media_type"`          // the media type of artifact. Mostly, it's the value of `manifest.config.mediatype`
+	ManifestMediaType string            `json:"manifest_media_type"` // the media type of manifest/index
+	ArtifactType      string            `json:"artifact_type"`       // the artifactType of manifest/index
+	ProjectID         int64             `json:"project_id"`
+	RepositoryID      int64             `json:"repository_id"`
+	RepositoryName    string            `json:"repository_name"`
+	Digest            string            `json:"digest"`
+	Size              int64             `json:"size"`
+	Icon              string            `json:"icon"`
+	PushTime          time.Time         `json:"push_time"`
+	PullTime          time.Time         `json:"pull_time"`
+	ExtraAttrs        map[string]any    `json:"extra_attrs"` // only contains the simple attributes specific for the different artifact type, most of them should come from the config layer
+	Annotations       map[string]string `json:"annotations"`
+	References        []*Reference      `json:"references"` // child artifacts referenced by the parent artifact if the artifact is an index
 }
 
 // ResolveArtifactType returns the artifact type of the artifact, prefer ArtifactType, use MediaType if ArtifactType is empty.
@@ -82,7 +82,7 @@ func (a *Artifact) From(art *dao.Artifact) {
 	a.Icon = art.Icon
 	a.PushTime = art.PushTime
 	a.PullTime = art.PullTime
-	a.ExtraAttrs = map[string]interface{}{}
+	a.ExtraAttrs = map[string]any{}
 	a.Annotations = map[string]string{}
 	if len(art.ExtraAttrs) > 0 {
 		if err := json.Unmarshal([]byte(art.ExtraAttrs), &a.ExtraAttrs); err != nil {

--- a/src/pkg/artifact/model_test.go
+++ b/src/pkg/artifact/model_test.go
@@ -78,7 +78,7 @@ func (m *modelTestSuite) TestArtifactTo() {
 		Size:              1024,
 		PushTime:          time.Now(),
 		PullTime:          time.Now(),
-		ExtraAttrs: map[string]interface{}{
+		ExtraAttrs: map[string]any{
 			"attr1": "value1",
 		},
 		Annotations: map[string]string{

--- a/src/pkg/audit/dao/dao.go
+++ b/src/pkg/audit/dao/dao.go
@@ -51,7 +51,7 @@ func New() DAO {
 	return &dao{}
 }
 
-var allowedMaps = map[string]interface{}{
+var allowedMaps = map[string]any{
 	strings.ToLower(rbac.ActionPull.String()):   struct{}{},
 	strings.ToLower(rbac.ActionCreate.String()): struct{}{},
 	strings.ToLower(rbac.ActionDelete.String()): struct{}{},

--- a/src/pkg/audit/dao/dao_test.go
+++ b/src/pkg/audit/dao/dao_test.go
@@ -65,7 +65,7 @@ func (d *daoTestSuite) TestCount() {
 	d.Require().Nil(err)
 	d.True(total > 0)
 	total, err = d.dao.Count(d.ctx, &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"Resource": "library/test-audit",
 		},
 	})
@@ -80,7 +80,7 @@ func (d *daoTestSuite) TestList() {
 
 	// query by repository ID and name
 	audits, err = d.dao.List(d.ctx, &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"Resource": "library/test-audit",
 		},
 	})
@@ -134,7 +134,7 @@ func (d *daoTestSuite) TestListPIDs() {
 		ol.Values = append(ol.Values, item)
 	}
 	audits, err := d.dao.List(d.ctx, &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"ProjectID": ol,
 		},
 	})

--- a/src/pkg/auditext/dao/dao_test.go
+++ b/src/pkg/auditext/dao/dao_test.go
@@ -68,7 +68,7 @@ func (d *daoTestSuite) TestList() {
 
 	// query by repository ID and name
 	audits, err = d.dao.List(d.ctx, &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"Resource": "user01",
 		},
 	})
@@ -94,7 +94,7 @@ func (d *daoTestSuite) TestCount() {
 	d.Require().Nil(err)
 	d.True(total > 0)
 	total, err = d.dao.Count(d.ctx, &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"Resource": "user01",
 		},
 	})
@@ -135,7 +135,7 @@ func (d *daoTestSuite) TestListPIDs() {
 		ol.Values = append(ol.Values, item)
 	}
 	audits, err := d.dao.List(d.ctx, &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"ProjectID": ol,
 		},
 	})

--- a/src/pkg/auditext/event/utils.go
+++ b/src/pkg/auditext/event/utils.go
@@ -26,7 +26,7 @@ func Redact(payload string, sensitiveAttributes []string) string {
 	if len(payload) == 0 {
 		return ""
 	}
-	var jsonData map[string]interface{}
+	var jsonData map[string]any
 	if err := json.Unmarshal([]byte(payload), &jsonData); err != nil {
 		log.Fatalf("Error parsing JSON: %v", err)
 		return ""
@@ -42,15 +42,15 @@ func Redact(payload string, sensitiveAttributes []string) string {
 }
 
 // replacePassword recursively replaces attribute in maskAttributes's value with "***"
-func replacePassword(data map[string]interface{}, maskAttributes []string) {
+func replacePassword(data map[string]any, maskAttributes []string) {
 	for key, value := range data {
 		if slices.Contains(maskAttributes, key) {
 			data[key] = "***"
-		} else if nestedMap, ok := value.(map[string]interface{}); ok {
+		} else if nestedMap, ok := value.(map[string]any); ok {
 			replacePassword(nestedMap, maskAttributes)
-		} else if nestedArray, ok := value.([]interface{}); ok {
+		} else if nestedArray, ok := value.([]any); ok {
 			for _, item := range nestedArray {
-				if itemMap, ok := item.(map[string]interface{}); ok {
+				if itemMap, ok := item.(map[string]any); ok {
 					replacePassword(itemMap, maskAttributes)
 				}
 			}

--- a/src/pkg/auditext/event/utils_test.go
+++ b/src/pkg/auditext/event/utils_test.go
@@ -44,15 +44,15 @@ func TestRedact(t *testing.T) {
 
 func Test_replacePassword(t *testing.T) {
 	type args struct {
-		data           map[string]interface{}
+		data           map[string]any
 		maskAttributes []string
 	}
 	tests := []struct {
 		name string
 		args args
 	}{
-		{"normal case", args{map[string]interface{}{"password": "123456"}, []string{"password"}}},
-		{"nested case", args{map[string]interface{}{"master": map[string]interface{}{"password": "123456"}}, []string{"password"}}},
+		{"normal case", args{map[string]any{"password": "123456"}, []string{"password"}}},
+		{"nested case", args{map[string]any{"master": map[string]any{"password": "123456"}}, []string{"password"}}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -60,8 +60,8 @@ func Test_replacePassword(t *testing.T) {
 			if val, ok := tt.args.data["password"]; ok && val != nil && tt.args.data["password"] != "***" {
 				t.Errorf("replacePassword() = %v, want %v", tt.args.data["password"], "***")
 			}
-			if val, ok := tt.args.data["master"]; ok && val != nil && tt.args.data["master"].(map[string]interface{})["password"] != "***" {
-				t.Errorf("replacePassword() = %v, want %v", tt.args.data["master"].(map[string]interface{})["password"], "***")
+			if val, ok := tt.args.data["master"]; ok && val != nil && tt.args.data["master"].(map[string]any)["password"] != "***" {
+				t.Errorf("replacePassword() = %v, want %v", tt.args.data["master"].(map[string]any)["password"], "***")
 			}
 		})
 	}

--- a/src/pkg/blob/dao/dao.go
+++ b/src/pkg/blob/dao/dao.go
@@ -195,7 +195,7 @@ func (d *dao) UpdateBlobStatus(ctx context.Context, blob *models.Blob) (int64, e
 	}
 
 	var newVersion int64
-	params := []interface{}{time.Now(), blob.Status, blob.ID, blob.Version}
+	params := []any{time.Now(), blob.Status, blob.ID, blob.Version}
 	stats := models.StatusMap[blob.Status]
 	for _, stat := range stats {
 		params = append(params, stat)
@@ -247,7 +247,7 @@ func (d *dao) FindBlobsShouldUnassociatedWithProject(ctx context.Context, projec
 	}
 
 	sql := `SELECT b.digest_blob FROM artifact a, artifact_blob b WHERE a.digest = b.digest_af AND a.project_id = ? AND b.digest_blob IN (%s)`
-	params := []interface{}{projectID}
+	params := []any{projectID}
 	for _, blob := range blobs {
 		params = append(params, blob.Digest)
 	}
@@ -279,10 +279,10 @@ func (d *dao) SumBlobsSizeByProject(ctx context.Context, projectID int64, exclud
 		return 0, err
 	}
 
-	params := []interface{}{projectID}
+	params := []any{projectID}
 	sql := `SELECT SUM(size) FROM blob JOIN project_blob ON blob.id = project_blob.blob_id AND project_id = ?`
 	if excludeForeignLayer {
-		foreignLayerTypes := []interface{}{
+		foreignLayerTypes := []any{
 			schema2.MediaTypeForeignLayer,
 		}
 
@@ -305,10 +305,10 @@ func (d *dao) SumBlobsSize(ctx context.Context, excludeForeignLayer bool) (int64
 		return 0, err
 	}
 
-	params := []interface{}{}
+	params := []any{}
 	sql := `SELECT SUM(size) FROM blob`
 	if excludeForeignLayer {
-		foreignLayerTypes := []interface{}{
+		foreignLayerTypes := []any{
 			schema2.MediaTypeForeignLayer,
 		}
 		sql = fmt.Sprintf(`%s Where content_type NOT IN (%s)`, sql, orm.ParamPlaceholderForIn(len(foreignLayerTypes)))

--- a/src/pkg/blob/dao/dao_test.go
+++ b/src/pkg/blob/dao/dao_test.go
@@ -206,7 +206,7 @@ func (suite *DaoTestSuite) TestListBlobs() {
 	suite.dao.CreateBlob(ctx, &models.Blob{Digest: digest2})
 
 	ol := q.OrList{
-		Values: []interface{}{
+		Values: []any{
 			digest1,
 		},
 	}
@@ -216,7 +216,7 @@ func (suite *DaoTestSuite) TestListBlobs() {
 	}
 
 	ol = q.OrList{
-		Values: []interface{}{
+		Values: []any{
 			digest1,
 			digest2,
 		},

--- a/src/pkg/blob/manager_test.go
+++ b/src/pkg/blob/manager_test.go
@@ -38,7 +38,7 @@ func (suite *ManagerTestSuite) SetupSuite() {
 
 func (suite *ManagerTestSuite) isAssociatedWithArtifact(ctx context.Context, blobDigest, artifactDigest string) (bool, error) {
 	ol := q.OrList{
-		Values: []interface{}{
+		Values: []any{
 			blobDigest,
 		},
 	}
@@ -52,7 +52,7 @@ func (suite *ManagerTestSuite) isAssociatedWithArtifact(ctx context.Context, blo
 
 func (suite *ManagerTestSuite) isAssociatedWithProject(ctx context.Context, blobDigest string, projectID int64) (bool, error) {
 	ol := q.OrList{
-		Values: []interface{}{
+		Values: []any{
 			blobDigest,
 		},
 	}
@@ -304,7 +304,7 @@ func (suite *ManagerTestSuite) TestList() {
 	digest2 := suite.DigestString()
 
 	ol := q.OrList{
-		Values: []interface{}{
+		Values: []any{
 			digest1,
 			digest2,
 		},
@@ -317,7 +317,7 @@ func (suite *ManagerTestSuite) TestList() {
 	Mgr.Create(ctx, digest2, "media type", 100)
 
 	ol = q.OrList{
-		Values: []interface{}{
+		Values: []any{
 			digest1,
 			digest2,
 		},

--- a/src/pkg/blob/models/blob.go
+++ b/src/pkg/blob/models/blob.go
@@ -123,7 +123,7 @@ func (b *Blob) IsManifest() bool {
 }
 
 // FilterByArtifactDigest returns orm.QuerySeter with artifact digest filter
-func (b *Blob) FilterByArtifactDigest(_ context.Context, qs orm.QuerySeter, _ string, value interface{}) orm.QuerySeter {
+func (b *Blob) FilterByArtifactDigest(_ context.Context, qs orm.QuerySeter, _ string, value any) orm.QuerySeter {
 	v, ok := value.(string)
 	if !ok {
 		return qs
@@ -133,7 +133,7 @@ func (b *Blob) FilterByArtifactDigest(_ context.Context, qs orm.QuerySeter, _ st
 }
 
 // FilterByArtifactDigests returns orm.QuerySeter with artifact digests filter
-func (b *Blob) FilterByArtifactDigests(_ context.Context, qs orm.QuerySeter, _ string, value interface{}) orm.QuerySeter {
+func (b *Blob) FilterByArtifactDigests(_ context.Context, qs orm.QuerySeter, _ string, value any) orm.QuerySeter {
 	artifactDigests, ok := value.([]string)
 	if !ok {
 		return qs
@@ -148,7 +148,7 @@ func (b *Blob) FilterByArtifactDigests(_ context.Context, qs orm.QuerySeter, _ s
 }
 
 // FilterByProjectID returns orm.QuerySeter with project id filter
-func (b *Blob) FilterByProjectID(_ context.Context, qs orm.QuerySeter, _ string, value interface{}) orm.QuerySeter {
+func (b *Blob) FilterByProjectID(_ context.Context, qs orm.QuerySeter, _ string, value any) orm.QuerySeter {
 	projectID, ok := value.(int64)
 	if !ok {
 		return qs

--- a/src/pkg/cached/base_manager.go
+++ b/src/pkg/cached/base_manager.go
@@ -39,7 +39,7 @@ func (*cacheClient) Delete(ctx context.Context, key string) error {
 	return cache.LayerCache().Delete(ctx, key)
 }
 
-func (*cacheClient) Fetch(ctx context.Context, key string, value interface{}) error {
+func (*cacheClient) Fetch(ctx context.Context, key string, value any) error {
 	return cache.LayerCache().Fetch(ctx, key, value)
 }
 
@@ -47,7 +47,7 @@ func (*cacheClient) Ping(ctx context.Context) error {
 	return cache.LayerCache().Ping(ctx)
 }
 
-func (*cacheClient) Save(ctx context.Context, key string, value interface{}, expiration ...time.Duration) error {
+func (*cacheClient) Save(ctx context.Context, key string, value any, expiration ...time.Duration) error {
 	// intercept here
 	// it should ignore save cache if this request is wrapped by orm.Transaction,
 	// because if tx rollback, we can not rollback cache,

--- a/src/pkg/cached/base_manager_test.go
+++ b/src/pkg/cached/base_manager_test.go
@@ -33,7 +33,7 @@ type testCache struct {
 	iterator *testcache.Iterator
 }
 
-func (tc *testCache) Save(ctx context.Context, key string, value interface{}, expiration ...time.Duration) error {
+func (tc *testCache) Save(ctx context.Context, key string, value any, expiration ...time.Duration) error {
 	if orm.HasCommittedKey(ctx) {
 		return nil
 	}

--- a/src/pkg/cached/manager.go
+++ b/src/pkg/cached/manager.go
@@ -68,7 +68,7 @@ func NewObjectKey(ns string) *ObjectKey {
 // Format formats fields to string.
 // eg. namespace: 'artifact'
 // Format("id", 100, "digest", "aaa"): "artifact:id:100:digest:aaa"
-func (ok *ObjectKey) Format(keysAndValues ...interface{}) (string, error) {
+func (ok *ObjectKey) Format(keysAndValues ...any) (string, error) {
 	// keysAndValues must be paired.
 	if len(keysAndValues)%2 != 0 {
 		return "", errors.Errorf("invalid keysAndValues: %v", keysAndValues...)

--- a/src/pkg/cached/project/redis/manager.go
+++ b/src/pkg/cached/project/redis/manager.go
@@ -95,7 +95,7 @@ func (m *Manager) Delete(ctx context.Context, id int64) error {
 	return nil
 }
 
-func (m *Manager) Get(ctx context.Context, idOrName interface{}) (*models.Project, error) {
+func (m *Manager) Get(ctx context.Context, idOrName any) (*models.Project, error) {
 	var (
 		key string
 		err error

--- a/src/pkg/chart/model.go
+++ b/src/pkg/chart/model.go
@@ -23,7 +23,7 @@ import (
 // VersionDetails keeps the detailed data info of the chart version
 type VersionDetails struct {
 	Dependencies []*helm_chart.Dependency `json:"dependencies"`
-	Values       map[string]interface{}   `json:"values"`
+	Values       map[string]any           `json:"values"`
 	Files        map[string]string        `json:"files"`
 	Security     *SecurityReport          `json:"security"`
 }

--- a/src/pkg/chart/operator.go
+++ b/src/pkg/chart/operator.go
@@ -70,7 +70,7 @@ func (cho *operator) GetDetails(content []byte) (*VersionDetails, error) {
 		depts = chartData.Metadata.Dependencies
 	}
 
-	var values map[string]interface{}
+	var values map[string]any
 	files := make(map[string]string)
 	// Parse values
 	if chartData.Values != nil {
@@ -130,14 +130,14 @@ func (cho *operator) GetData(content []byte) (*helm_chart.Chart, error) {
 }
 
 // Recursively read value
-func readValue(values map[string]interface{}, keyPrefix string, valueMap map[string]interface{}) {
+func readValue(values map[string]any, keyPrefix string, valueMap map[string]any) {
 	for key, value := range values {
 		longKey := key
 		if keyPrefix != "" {
 			longKey = fmt.Sprintf("%s.%s", keyPrefix, key)
 		}
 
-		if subValues, ok := value.(map[string]interface{}); ok {
+		if subValues, ok := value.(map[string]any); ok {
 			readValue(subValues, longKey, valueMap)
 		} else {
 			valueMap[longKey] = value

--- a/src/pkg/config/db/cache.go
+++ b/src/pkg/config/db/cache.go
@@ -32,12 +32,12 @@ type Cache struct {
 }
 
 // Load - load config from database, only user setting will be load from database.
-func (d *Cache) Load(ctx context.Context) (map[string]interface{}, error) {
-	f := func() (interface{}, error) {
+func (d *Cache) Load(ctx context.Context) (map[string]any, error) {
+	f := func() (any, error) {
 		return d.driver.Load(ctx)
 	}
 
-	result := map[string]interface{}{}
+	result := map[string]any{}
 
 	// let the cache expired after one minute
 	// because the there no way to rollback the config items been saved when invalidate the cache failed
@@ -49,7 +49,7 @@ func (d *Cache) Load(ctx context.Context) (map[string]interface{}, error) {
 }
 
 // Save - Only save user config items in the cfgs map
-func (d *Cache) Save(ctx context.Context, cfg map[string]interface{}) error {
+func (d *Cache) Save(ctx context.Context, cfg map[string]any) error {
 	if err := d.driver.Save(ctx, cfg); err != nil {
 		return err
 	}

--- a/src/pkg/config/db/cache_test.go
+++ b/src/pkg/config/db/cache_test.go
@@ -33,7 +33,7 @@ func TestCacheLoadAndSave(t *testing.T) {
 	cache, _ := cache.New("redis")
 	driver := NewCacheDriver(cache, &Database{cfgDAO: dao.New()})
 
-	cfgs := map[string]interface{}{
+	cfgs := map[string]any{
 		common.AUTHMode: "db_auth",
 		common.LDAPURL:  "ldap://ldap.vmware.com",
 	}
@@ -50,7 +50,7 @@ func TestCacheLoadAndSave(t *testing.T) {
 
 func BenchmarkCacheLoad(b *testing.B) {
 	ctx := orm.Context()
-	cfgs := map[string]interface{}{}
+	cfgs := map[string]any{}
 	for _, item := range metadata.Instance().GetAll() {
 		cfgs[item.Name] = item.DefaultValue
 	}

--- a/src/pkg/config/db/dao/dao.go
+++ b/src/pkg/config/db/dao/dao.go
@@ -47,7 +47,7 @@ func (d *dao) GetConfigEntries(ctx context.Context) ([]*models.ConfigEntry, erro
 	}
 	var p []*models.ConfigEntry
 	sql := "select * from properties"
-	n, err := o.Raw(sql, []interface{}{}).QueryRows(&p)
+	n, err := o.Raw(sql, []any{}).QueryRows(&p)
 
 	if err != nil {
 		return nil, err

--- a/src/pkg/config/db/db.go
+++ b/src/pkg/config/db/db.go
@@ -32,8 +32,8 @@ type Database struct {
 }
 
 // Load - load config from database, only user setting will be load from database.
-func (d *Database) Load(ctx context.Context) (map[string]interface{}, error) {
-	resultMap := map[string]interface{}{}
+func (d *Database) Load(ctx context.Context) (map[string]any, error) {
+	resultMap := map[string]any{}
 	configEntries, err := d.cfgDAO.GetConfigEntries(ctx)
 	if err != nil {
 		return resultMap, err
@@ -60,7 +60,7 @@ func (d *Database) Load(ctx context.Context) (map[string]interface{}, error) {
 }
 
 // Save - Only save user config items in the cfgs map
-func (d *Database) Save(ctx context.Context, cfgs map[string]interface{}) error {
+func (d *Database) Save(ctx context.Context, cfgs map[string]any) error {
 	var configEntries []models.ConfigEntry
 	for key, value := range cfgs {
 		if item, ok := metadata.Instance().GetByName(key); ok {

--- a/src/pkg/config/db/db_test.go
+++ b/src/pkg/config/db/db_test.go
@@ -26,7 +26,7 @@ import (
 
 func TestDatabase_Load(t *testing.T) {
 
-	cfgs := map[string]interface{}{
+	cfgs := map[string]any{
 		common.AUTHMode: "db_auth",
 		common.LDAPURL:  "ldap://ldap.vmware.com",
 	}
@@ -50,7 +50,7 @@ func TestDatabase_Save(t *testing.T) {
 	if err != nil {
 		t.Errorf("failed to load config %v", err)
 	}
-	cfgMap := map[string]interface{}{"ldap_url": ldapURL}
+	cfgMap := map[string]any{"ldap_url": ldapURL}
 	driver.Save(testCtx, cfgMap)
 	updatedMap, err := driver.Load(testCtx)
 	if err != nil {
@@ -62,7 +62,7 @@ func TestDatabase_Save(t *testing.T) {
 }
 
 func BenchmarkDatabaseLoad(b *testing.B) {
-	cfgs := map[string]interface{}{}
+	cfgs := map[string]any{}
 	for _, item := range metadata.Instance().GetAll() {
 		cfgs[item.Name] = item.DefaultValue
 	}

--- a/src/pkg/config/db/manager_test.go
+++ b/src/pkg/config/db/manager_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/goharbor/harbor/src/pkg/config/store"
 )
 
-var TestDBConfig = map[string]interface{}{
+var TestDBConfig = map[string]any{
 	"postgresql_host":     "localhost",
 	"postgresql_database": "registry",
 	"postgresql_password": "root123",
@@ -72,7 +72,7 @@ func TestSaveToDatabase(t *testing.T) {
 }
 
 func TestUpdateCfg(t *testing.T) {
-	testConfig := map[string]interface{}{
+	testConfig := map[string]any{
 		"ldap_url":             "ldaps://ldap.vmware.com",
 		"ldap_search_dn":       "cn=admin,dc=example,dc=com",
 		"ldap_timeout":         10,
@@ -99,7 +99,7 @@ func TestCfgManager_loadDefaultValues(t *testing.T) {
 func TestCfgManger_loadSystemValues(t *testing.T) {
 	configManager.LoadDefault()
 	configManager.LoadSystemConfigFromEnv()
-	configManager.UpdateConfig(testCtx, map[string]interface{}{
+	configManager.UpdateConfig(testCtx, map[string]any{
 		"postgresql_host": "127.0.0.1",
 	})
 	if configManager.Get(testCtx, "postgresql_host").GetString() != "127.0.0.1" {
@@ -107,7 +107,7 @@ func TestCfgManger_loadSystemValues(t *testing.T) {
 	}
 }
 func TestCfgManager_GetDatabaseCfg(t *testing.T) {
-	configManager.UpdateConfig(testCtx, map[string]interface{}{
+	configManager.UpdateConfig(testCtx, map[string]any{
 		"postgresql_host":     "localhost",
 		"postgresql_database": "registry",
 		"postgresql_password": "root123",
@@ -155,7 +155,7 @@ func TestConfigStore_Load(t *testing.T) {
 func TestToString(t *testing.T) {
 	cases := []struct {
 		name   string
-		value  interface{}
+		value  any
 		expect string
 	}{
 		{

--- a/src/pkg/config/inmemory/manager.go
+++ b/src/pkg/config/inmemory/manager.go
@@ -31,16 +31,16 @@ func init() {
 // Driver driver for unit testing
 type Driver struct {
 	sync.Mutex
-	cfgMap map[string]interface{}
+	cfgMap map[string]any
 }
 
 // Load load data from driver, for example load from database,
 // it should be invoked before get any user scope config
 // for system scope config, because it is immutable, no need to call this method
-func (d *Driver) Load(context.Context) (map[string]interface{}, error) {
+func (d *Driver) Load(context.Context) (map[string]any, error) {
 	d.Lock()
 	defer d.Unlock()
-	res := make(map[string]interface{})
+	res := make(map[string]any)
 	for k, v := range d.cfgMap {
 		res[k] = v
 	}
@@ -48,7 +48,7 @@ func (d *Driver) Load(context.Context) (map[string]interface{}, error) {
 }
 
 // Save only save user config setting to driver, for example: database, REST
-func (d *Driver) Save(_ context.Context, cfg map[string]interface{}) error {
+func (d *Driver) Save(_ context.Context, cfg map[string]any) error {
 	d.Lock()
 	defer d.Unlock()
 	for k, v := range cfg {
@@ -59,7 +59,7 @@ func (d *Driver) Save(_ context.Context, cfg map[string]interface{}) error {
 
 // NewInMemoryManager create a manager for unit testing, doesn't involve database or REST
 func NewInMemoryManager() *config.CfgManager {
-	manager := &config.CfgManager{Store: store.NewConfigStore(&Driver{cfgMap: map[string]interface{}{}})}
+	manager := &config.CfgManager{Store: store.NewConfigStore(&Driver{cfgMap: map[string]any{}})}
 	// load default Value
 	manager.LoadDefault()
 	// load system config from env

--- a/src/pkg/config/inmemory/manager_test.go
+++ b/src/pkg/config/inmemory/manager_test.go
@@ -24,7 +24,7 @@ import (
 func TestNewInMemoryManager(t *testing.T) {
 	ctx := context.Background()
 	inMemoryManager := NewInMemoryManager()
-	inMemoryManager.UpdateConfig(ctx, map[string]interface{}{
+	inMemoryManager.UpdateConfig(ctx, map[string]any{
 		"ldap_url":         "ldaps://ldap.vmware.com",
 		"ldap_timeout":     5,
 		"ldap_verify_cert": true,

--- a/src/pkg/config/manager.go
+++ b/src/pkg/config/manager.go
@@ -75,8 +75,8 @@ func (c *CfgManager) LoadSystemConfigFromEnv() {
 }
 
 // GetAll get all settings.
-func (c *CfgManager) GetAll(ctx context.Context) map[string]interface{} {
-	resultMap := map[string]interface{}{}
+func (c *CfgManager) GetAll(ctx context.Context) map[string]any {
+	resultMap := map[string]any{}
 	if err := c.Store.Load(ctx); err != nil {
 		log.Errorf("AllConfigs failed, error %v", err)
 		return resultMap
@@ -96,8 +96,8 @@ func (c *CfgManager) GetAll(ctx context.Context) map[string]interface{} {
 }
 
 // GetUserCfgs retrieve all user configs
-func (c *CfgManager) GetUserCfgs(ctx context.Context) map[string]interface{} {
-	resultMap := map[string]interface{}{}
+func (c *CfgManager) GetUserCfgs(ctx context.Context) map[string]any {
+	resultMap := map[string]any{}
 	if err := c.Store.Load(ctx); err != nil {
 		log.Errorf("UserConfigs failed, error %v", err)
 		return resultMap
@@ -146,7 +146,7 @@ func (c *CfgManager) Get(_ context.Context, key string) *metadata.ConfigureValue
 }
 
 // Set ...
-func (c *CfgManager) Set(_ context.Context, key string, value interface{}) {
+func (c *CfgManager) Set(_ context.Context, key string, value any) {
 	configValue, err := metadata.NewCfgValue(key, utils.GetStrValueOfAnyType(value))
 	if err != nil {
 		log.Errorf("error when setting key: %v,  error %v", key, err)
@@ -176,12 +176,12 @@ func (c *CfgManager) GetDatabaseCfg() *models.Database {
 }
 
 // UpdateConfig - Update config Store with a specified configuration and also save updated configure.
-func (c *CfgManager) UpdateConfig(ctx context.Context, cfgs map[string]interface{}) error {
+func (c *CfgManager) UpdateConfig(ctx context.Context, cfgs map[string]any) error {
 	return c.Store.Update(ctx, cfgs)
 }
 
 // ValidateCfg validate config by metadata. return the first error if exist.
-func (c *CfgManager) ValidateCfg(ctx context.Context, cfgs map[string]interface{}) error {
+func (c *CfgManager) ValidateCfg(ctx context.Context, cfgs map[string]any) error {
 	for key, value := range cfgs {
 		item, exist := metadata.Instance().GetByName(key)
 		if !exist {

--- a/src/pkg/config/rest/rest.go
+++ b/src/pkg/config/rest/rest.go
@@ -36,13 +36,13 @@ func NewRESTDriver(configRESTURL string, modifiers ...modifier.Modifier) *Driver
 
 // Value ...
 type Value struct {
-	Val      interface{} `json:"value"`
-	Editable bool        `json:"editable"`
+	Val      any  `json:"value"`
+	Editable bool `json:"editable"`
 }
 
 // Load - load config data from REST server
-func (h *Driver) Load(_ context.Context) (map[string]interface{}, error) {
-	cfgMap := map[string]interface{}{}
+func (h *Driver) Load(_ context.Context) (map[string]any, error) {
+	cfgMap := map[string]any{}
 	origMap := map[string]*Value{}
 	log.Infof("get configuration from url: %+v", h.configRESTURL)
 	err := h.client.Get(h.configRESTURL, &origMap)
@@ -59,6 +59,6 @@ func (h *Driver) Load(_ context.Context) (map[string]interface{}, error) {
 }
 
 // Save - Save config data to REST server by PUT method
-func (h *Driver) Save(_ context.Context, cfg map[string]interface{}) error {
+func (h *Driver) Save(_ context.Context, cfg map[string]any) error {
 	return h.client.Put(h.configRESTURL, cfg)
 }

--- a/src/pkg/config/rest/rest_test.go
+++ b/src/pkg/config/rest/rest_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 func ConfigGetHandler(w http.ResponseWriter, r *http.Request) {
-	cfgs := map[string]interface{}{
+	cfgs := map[string]any{
 		"ldap_url":         &Value{Val: "ldaps://ldap.vmware.com", Editable: true},
 		"ldap_scope":       &Value{Val: 5, Editable: true},
 		"ldap_verify_cert": &Value{Val: true, Editable: true},
@@ -54,10 +54,10 @@ func TestHTTPDriver_Load(t *testing.T) {
 	assert.Equal(t, true, configMap["ldap_verify_cert"])
 }
 
-var configMapForTest = map[string]interface{}{}
+var configMapForTest = map[string]any{}
 
 func ConfigPutHandler(w http.ResponseWriter, r *http.Request) {
-	cfgs := map[string]interface{}{}
+	cfgs := map[string]any{}
 	content, err := io.ReadAll(r.Body)
 	if err != nil {
 		log.Fatal(err)
@@ -75,7 +75,7 @@ func TestHTTPDriver_Save(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(ConfigPutHandler))
 	defer server.Close()
 	httpDriver := NewRESTDriver(server.URL)
-	configMap := map[string]interface{}{
+	configMap := map[string]any{
 		"ldap_url":         "ldap://www.example.com",
 		"ldap_timeout":     10,
 		"ldap_verify_cert": false,

--- a/src/pkg/config/store/driver.go
+++ b/src/pkg/config/store/driver.go
@@ -20,7 +20,7 @@ import "context"
 // Driver the interface to save/load config
 type Driver interface {
 	// Load - load config item from config driver
-	Load(ctx context.Context) (map[string]interface{}, error)
+	Load(ctx context.Context) (map[string]any, error)
 	// Save - save config item into config driver
-	Save(ctx context.Context, cfg map[string]interface{}) error
+	Save(ctx context.Context, cfg map[string]any) error
 }

--- a/src/pkg/config/store/store.go
+++ b/src/pkg/config/store/store.go
@@ -51,8 +51,8 @@ func (c *ConfigStore) Get(key string) (*metadata.ConfigureValue, error) {
 	return nil, metadata.ErrValueNotSet
 }
 
-// GetAnyType get interface{} type for config items
-func (c *ConfigStore) GetAnyType(key string) (interface{}, error) {
+// GetAnyType get any type for config items
+func (c *ConfigStore) GetAnyType(key string) (any, error) {
 	if value, ok := c.cfgValues.Load(key); ok {
 		if result, ok := value.(metadata.ConfigureValue); ok {
 			return result.GetAnyType()
@@ -96,8 +96,8 @@ func (c *ConfigStore) Load(ctx context.Context) error {
 
 // Save - Save all data in current store
 func (c *ConfigStore) Save(ctx context.Context) error {
-	cfgMap := map[string]interface{}{}
-	c.cfgValues.Range(func(key, value interface{}) bool {
+	cfgMap := map[string]any{}
+	c.cfgValues.Range(func(key, value any) bool {
 		keyStr := fmt.Sprintf("%v", key)
 		if configValue, ok := value.(metadata.ConfigureValue); ok {
 			valueStr := configValue.Value
@@ -118,7 +118,7 @@ func (c *ConfigStore) Save(ctx context.Context) error {
 }
 
 // Update - Only update specified settings in cfgMap in store and driver
-func (c *ConfigStore) Update(ctx context.Context, cfgMap map[string]interface{}) error {
+func (c *ConfigStore) Update(ctx context.Context, cfgMap map[string]any) error {
 	// Update to store
 	for key, value := range cfgMap {
 		configValue, err := metadata.NewCfgValue(key, utils.GetStrValueOfAnyType(value))
@@ -137,7 +137,7 @@ func (c *ConfigStore) Update(ctx context.Context, cfgMap map[string]interface{})
 }
 
 // ToString ...
-func ToString(value interface{}) (string, error) {
+func ToString(value any) (string, error) {
 	if value == nil {
 		return "nil", nil
 	}

--- a/src/pkg/config/validate/ldapgroup.go
+++ b/src/pkg/config/validate/ldapgroup.go
@@ -28,7 +28,7 @@ type LdapGroupValidateRule struct {
 }
 
 // Validate validate the ldap group config settings, cfgs is the config items need to be updated, the final config should be merged with the cfgMgr
-func (l LdapGroupValidateRule) Validate(ctx context.Context, cfgMgr config.Manager, cfgs map[string]interface{}) error {
+func (l LdapGroupValidateRule) Validate(ctx context.Context, cfgMgr config.Manager, cfgs map[string]any) error {
 	cfg := &cfgModels.GroupConf{
 		Filter:              cfgMgr.Get(ctx, common.LDAPGroupSearchFilter).GetString(),
 		NameAttribute:       cfgMgr.Get(ctx, common.LDAPGroupAttributeName).GetString(),

--- a/src/pkg/config/validate/test/ldapgroup_test.go
+++ b/src/pkg/config/validate/test/ldapgroup_test.go
@@ -30,7 +30,7 @@ import (
 
 func TestMain(m *testing.M) {
 	test.InitDatabaseFromEnv()
-	config.InitWithSettings(map[string]interface{}{
+	config.InitWithSettings(map[string]any{
 		"ldap_group_search_filter":        "objectClass=groupOfNames",
 		"ldap_group_attribute_name":       "",
 		"ldap_group_membership_attribute": "memberof",
@@ -47,7 +47,7 @@ func TestLdapGroupValidateRule_Validate(t *testing.T) {
 	type args struct {
 		ctx    context.Context
 		cfgMgr config.Manager
-		cfgs   map[string]interface{}
+		cfgs   map[string]any
 	}
 	cases := []struct {
 		name string
@@ -56,17 +56,17 @@ func TestLdapGroupValidateRule_Validate(t *testing.T) {
 	}{
 		{
 			name: `nothing updated, no error`,
-			in:   args{ctx: orm.Context(), cfgMgr: mgr, cfgs: map[string]interface{}{}},
+			in:   args{ctx: orm.Context(), cfgMgr: mgr, cfgs: map[string]any{}},
 			want: nil,
 		},
 		{
 			name: `empty ldap group membership attribute, update all`,
-			in:   args{ctx: orm.Context(), cfgMgr: mgr, cfgs: map[string]interface{}{"ldap_group_search_filter": "objectClass=groupOfNames", "ldap_group_attribute_name": "cn", "ldap_group_membership_attribute": ""}},
+			in:   args{ctx: orm.Context(), cfgMgr: mgr, cfgs: map[string]any{"ldap_group_search_filter": "objectClass=groupOfNames", "ldap_group_attribute_name": "cn", "ldap_group_membership_attribute": ""}},
 			want: errors.New("ldap group membership attribute can not be empty"),
 		},
 		{
 			name: `empty ldap group attribute name, update partially`,
-			in:   args{ctx: orm.Context(), cfgMgr: mgr, cfgs: map[string]interface{}{"ldap_group_search_filter": "objectClass=groupOfNames", "ldap_group_membership_attribute": "memberof"}},
+			in:   args{ctx: orm.Context(), cfgMgr: mgr, cfgs: map[string]any{"ldap_group_search_filter": "objectClass=groupOfNames", "ldap_group_membership_attribute": "memberof"}},
 			want: errors.New("ldap group name attribute can not be empty"),
 		},
 	}

--- a/src/pkg/config/validate/validate.go
+++ b/src/pkg/config/validate/validate.go
@@ -27,5 +27,5 @@ import (
 // 3. Add the rule to validateRules in pkg/config/manager.go
 type Rule interface {
 	// Validate validates a specific group of configuration items, cfgs contains the config need to be updated, the final config should merged with the cfgMgr
-	Validate(ctx context.Context, cfgMgr config.Manager, cfgs map[string]interface{}) error
+	Validate(ctx context.Context, cfgMgr config.Manager, cfgs map[string]any) error
 }

--- a/src/pkg/exporter/cache.go
+++ b/src/pkg/exporter/cache.go
@@ -24,7 +24,7 @@ var c *cache
 const defaultCacheCleanInterval = 10
 
 type cachedValue struct {
-	Value      interface{}
+	Value      any
 	Expiration int64
 }
 
@@ -35,7 +35,7 @@ type cache struct {
 }
 
 // CacheGet get a value from cache
-func CacheGet(key string) (value interface{}, ok bool) {
+func CacheGet(key string) (value any, ok bool) {
 	c.RLock()
 	v, ok := c.store[key]
 	c.RUnlock()
@@ -52,7 +52,7 @@ func CacheGet(key string) (value interface{}, ok bool) {
 }
 
 // CachePut put a value to cache with key
-func CachePut(key, value interface{}) {
+func CachePut(key, value any) {
 	c.Lock()
 	defer c.Unlock()
 	c.store[key.(string)] = cachedValue{

--- a/src/pkg/exporter/statistics_collector.go
+++ b/src/pkg/exporter/statistics_collector.go
@@ -119,12 +119,12 @@ func (g StatisticsCollector) getPublicProjectsAndRepositories(ctx context.Contex
 	if pubProjectsAmount == 0 {
 		return pubProjectsAmount, 0
 	}
-	var ids []interface{}
+	var ids []any
 	for _, p := range pubProjects {
 		ids = append(ids, p.ProjectID)
 	}
 	n, err := g.repoCtl.Count(ctx, &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"ProjectID": q.NewOrList(ids),
 		},
 	})

--- a/src/pkg/label/dao/dao_test.go
+++ b/src/pkg/label/dao/dao_test.go
@@ -164,7 +164,7 @@ func (l *labelDaoTestSuite) DeleteReference() {
 
 func (l *labelDaoTestSuite) DeleteReferences() {
 	n, err := l.dao.DeleteReferences(l.ctx, &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"LabelID": 1000,
 		},
 	})

--- a/src/pkg/label/manager.go
+++ b/src/pkg/label/manager.go
@@ -105,7 +105,7 @@ func (m *manager) AddTo(ctx context.Context, labelID int64, artifactID int64) er
 }
 func (m *manager) RemoveFrom(ctx context.Context, labelID int64, artifactID int64) error {
 	n, err := m.dao.DeleteReferences(ctx, &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"LabelID":    labelID,
 			"ArtifactID": artifactID,
 		},
@@ -121,7 +121,7 @@ func (m *manager) RemoveFrom(ctx context.Context, labelID int64, artifactID int6
 
 func (m *manager) RemoveAllFrom(ctx context.Context, artifactID int64) error {
 	_, err := m.dao.DeleteReferences(ctx, &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"ArtifactID": artifactID,
 		},
 	})
@@ -130,7 +130,7 @@ func (m *manager) RemoveAllFrom(ctx context.Context, artifactID int64) error {
 
 func (m *manager) RemoveFromAllArtifacts(ctx context.Context, labelID int64) error {
 	_, err := m.dao.DeleteReferences(ctx, &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"LabelID": labelID,
 		},
 	})

--- a/src/pkg/member/dao/dao.go
+++ b/src/pkg/member/dao/dao.go
@@ -79,7 +79,7 @@ func (d *dao) GetProjectMember(ctx context.Context, queryMember models.Member, q
 		on pm.project_id = ? and u.user_id = pm.entity_id
 		join role r on pm.role = r.role_id where pm.entity_type = 'u') as a where a.project_id = ? `
 
-	queryParam := make([]interface{}, 1)
+	queryParam := make([]any, 1)
 	// used ProjectID already
 	queryParam = append(queryParam, queryMember.ProjectID)
 	queryParam = append(queryParam, queryMember.ProjectID)
@@ -119,7 +119,7 @@ func (d *dao) GetTotalOfProjectMembers(ctx context.Context, projectID int64, _ *
 
 	sql := "SELECT COUNT(1) FROM project_member WHERE project_id = ?"
 
-	queryParam := []interface{}{projectID}
+	queryParam := []any{projectID}
 
 	if len(roles) > 0 {
 		sql += " AND role = ?"
@@ -223,7 +223,7 @@ func (d *dao) SearchMemberByName(ctx context.Context, projectID int64, entityNam
 	     left join role r on pm.role = r.role_id
 			 where pm.project_id = ? and ug.group_name like ?
 			 order by entity_name  `
-	queryParam := make([]interface{}, 4)
+	queryParam := make([]any, 4)
 	queryParam = append(queryParam, projectID)
 	queryParam = append(queryParam, "%"+orm.Escape(entityName)+"%")
 	queryParam = append(queryParam, projectID)
@@ -238,7 +238,7 @@ func (d *dao) ListRoles(ctx context.Context, user *models.User, projectID int64)
 	if user == nil {
 		return nil, nil
 	}
-	var params []interface{}
+	var params []any
 	sql := `
 		select role
 			from project_member

--- a/src/pkg/notification/hook/hook.go
+++ b/src/pkg/notification/hook/hook.go
@@ -58,7 +58,7 @@ func (hm *DefaultManager) StartHook(ctx context.Context, event *model.HookEvent,
 		return errors.Errorf("invalid event target type: %s", event.Target.Type)
 	}
 
-	extraAttrs := map[string]interface{}{
+	extraAttrs := map[string]any{
 		"event_type": event.EventType,
 		"payload":    data.Parameters["payload"],
 	}
@@ -73,7 +73,7 @@ func (hm *DefaultManager) StartHook(ctx context.Context, event *model.HookEvent,
 		Metadata: &job.Metadata{
 			JobKind: data.Metadata.JobKind,
 		},
-		Parameters: map[string]interface{}(data.Parameters),
+		Parameters: map[string]any(data.Parameters),
 	})
 	if err != nil {
 		return errors.Errorf("failed to create task for webhook based on policy %d: %v", event.PolicyID, err)

--- a/src/pkg/notification/policy/dao/dao_test.go
+++ b/src/pkg/notification/policy/dao/dao_test.go
@@ -99,7 +99,7 @@ func (suite *DaoTestSuite) TestDelete() {
 
 func (suite *DaoTestSuite) TestList() {
 	jobs, err := suite.dao.List(orm.Context(), &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"ProjectID": 333,
 		},
 	})
@@ -151,7 +151,7 @@ func (suite *DaoTestSuite) TestCount() {
 	suite.True(total > 0)
 
 	total, err = suite.dao.Count(orm.Context(), &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"ProjectID": 111,
 		},
 	})

--- a/src/pkg/notifier/event/event.go
+++ b/src/pkg/notifier/event/event.go
@@ -27,7 +27,7 @@ import (
 // Event to publish
 type Event struct {
 	Topic string
-	Data  interface{}
+	Data  any
 }
 
 // TopicEvent - Events that contains topic information

--- a/src/pkg/notifier/handler/notification/http_handler.go
+++ b/src/pkg/notifier/handler/notification/http_handler.go
@@ -36,7 +36,7 @@ func (h *HTTPHandler) Name() string {
 }
 
 // Handle handles http event
-func (h *HTTPHandler) Handle(ctx context.Context, value interface{}) error {
+func (h *HTTPHandler) Handle(ctx context.Context, value any) error {
 	if value == nil {
 		return errors.New("HTTPHandler cannot handle nil value")
 	}
@@ -84,7 +84,7 @@ func (h *HTTPHandler) process(ctx context.Context, event *model.HookEvent) error
 		return errors.Wrap(err, "error to marshal header")
 	}
 
-	j.Parameters = map[string]interface{}{
+	j.Parameters = map[string]any{
 		"payload":          string(payload),
 		"address":          event.Target.Address,
 		"header":           string(headerBytes),

--- a/src/pkg/notifier/handler/notification/slack_handler.go
+++ b/src/pkg/notifier/handler/notification/slack_handler.go
@@ -85,7 +85,7 @@ func (s *SlackHandler) Name() string {
 }
 
 // Handle handles event to slack
-func (s *SlackHandler) Handle(ctx context.Context, value interface{}) error {
+func (s *SlackHandler) Handle(ctx context.Context, value any) error {
 	if value == nil {
 		return errors.New("SlackHandler cannot handle nil value")
 	}
@@ -118,7 +118,7 @@ func (s *SlackHandler) process(ctx context.Context, event *model.HookEvent) erro
 		return fmt.Errorf("convert payload to slack body failed: %v", err)
 	}
 
-	j.Parameters = map[string]interface{}{
+	j.Parameters = map[string]any{
 		"payload":          payload,
 		"address":          event.Target.Address,
 		"skip_cert_verify": event.Target.SkipCertVerify,
@@ -127,7 +127,7 @@ func (s *SlackHandler) process(ctx context.Context, event *model.HookEvent) erro
 }
 
 func (s *SlackHandler) convert(payLoad *model.Payload) (string, error) {
-	data := make(map[string]interface{})
+	data := make(map[string]any)
 	data["Type"] = payLoad.Type
 	data["OccurAt"] = payLoad.OccurAt
 	data["Operator"] = payLoad.Operator

--- a/src/pkg/notifier/model/event.go
+++ b/src/pkg/notifier/model/event.go
@@ -48,11 +48,11 @@ type EventData struct {
 
 // Resource describe infos of resource triggered notification
 type Resource struct {
-	Digest       string                 `json:"digest,omitempty"`
-	Tag          string                 `json:"tag,omitempty"`
-	ResourceURL  string                 `json:"resource_url,omitempty"`
-	ScanOverview map[string]interface{} `json:"scan_overview,omitempty"`
-	SBOMOverview map[string]interface{} `json:"sbom_overview,omitempty"`
+	Digest       string         `json:"digest,omitempty"`
+	Tag          string         `json:"tag,omitempty"`
+	ResourceURL  string         `json:"resource_url,omitempty"`
+	ScanOverview map[string]any `json:"scan_overview,omitempty"`
+	SBOMOverview map[string]any `json:"sbom_overview,omitempty"`
 }
 
 // Repository info of notification event

--- a/src/pkg/notifier/notification_handler.go
+++ b/src/pkg/notifier/notification_handler.go
@@ -24,7 +24,7 @@ type NotificationHandler interface {
 
 	// Handle the event when it coming.
 	// value might be optional, it depends on usages.
-	Handle(ctx context.Context, value interface{}) error
+	Handle(ctx context.Context, value any) error
 
 	// IsStateful returns whether the handler is stateful or not.
 	// If handler is stateful, it will not be triggered in parallel.

--- a/src/pkg/notifier/notifier.go
+++ b/src/pkg/notifier/notifier.go
@@ -38,7 +38,7 @@ type Notification struct {
 
 	// Value of notification.
 	// Optional
-	Value interface{}
+	Value any
 }
 
 // HandlerChannel provides not only the chan itself but also the count of
@@ -237,7 +237,7 @@ func UnSubscribe(topic string, handler string) error {
 }
 
 // Publish is a wrapper utility method for NotificationWatcher.notify()
-func Publish(ctx context.Context, topic string, value interface{}) error {
+func Publish(ctx context.Context, topic string, value any) error {
 	return notificationWatcher.Notify(ctx, Notification{
 		Topic: topic,
 		Value: value,

--- a/src/pkg/notifier/notifier_test.go
+++ b/src/pkg/notifier/notifier_test.go
@@ -24,7 +24,7 @@ func (fsh *fakeStatefulHandler) IsStateful() bool {
 	return true
 }
 
-func (fsh *fakeStatefulHandler) Handle(ctx context.Context, v interface{}) error {
+func (fsh *fakeStatefulHandler) Handle(ctx context.Context, v any) error {
 	increment := 0
 	if v != nil && reflect.TypeOf(v).Kind() == reflect.Int {
 		increment = v.(int)
@@ -43,7 +43,7 @@ func (fsh *fakeStatelessHandler) Name() string {
 	return "fakeStateless"
 }
 
-func (fsh *fakeStatelessHandler) Handle(ctx context.Context, v interface{}) error {
+func (fsh *fakeStatelessHandler) Handle(ctx context.Context, v any) error {
 	return nil
 }
 

--- a/src/pkg/oidc/helper.go
+++ b/src/pkg/oidc/helper.go
@@ -48,7 +48,7 @@ const (
 )
 
 type claimsProvider interface {
-	Claims(v interface{}) error
+	Claims(v any) error
 }
 
 type providerHelper struct {
@@ -376,7 +376,7 @@ func userInfoFromClaims(c claimsProvider, setting cfgModels.OIDCSetting) (*UserI
 		return nil, err
 	}
 	if setting.UserClaim != "" {
-		allClaims := make(map[string]interface{})
+		allClaims := make(map[string]any)
 		if err := c.Claims(&allClaims); err != nil {
 			return nil, err
 		}
@@ -406,12 +406,12 @@ func userInfoFromClaims(c claimsProvider, setting cfgModels.OIDCSetting) (*UserI
 // If the claims does not have the claim defined as k, the second return value will be false, otherwise true
 func groupsFromClaims(gp claimsProvider, k string) ([]string, bool) {
 	res := make([]string, 0)
-	claimMap := make(map[string]interface{})
+	claimMap := make(map[string]any)
 	if err := gp.Claims(&claimMap); err != nil {
 		log.Errorf("failed to fetch claims, error: %v", err)
 		return res, false
 	}
-	g, ok := claimMap[k].([]interface{})
+	g, ok := claimMap[k].([]any)
 	if !ok {
 		if len(strings.TrimSpace(k)) > 0 {
 			log.Warningf("Unable to get groups from claims, claims: %+v, groups claims key: %s", claimMap, k)

--- a/src/pkg/oidc/helper_test.go
+++ b/src/pkg/oidc/helper_test.go
@@ -37,7 +37,7 @@ import (
 
 func TestMain(m *testing.M) {
 	test.InitDatabaseFromEnv()
-	conf := map[string]interface{}{
+	conf := map[string]any{
 		common.OIDCName:         "test",
 		common.OIDCEndpoint:     "https://accounts.google.com",
 		common.OIDCVerifyCert:   "true",
@@ -72,7 +72,7 @@ func TestHelperGet(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, "https://oauth2.googleapis.com/token", p.Endpoint().TokenURL)
 
-	update := map[string]interface{}{
+	update := map[string]any{
 		common.OIDCName:         "test",
 		common.OIDCEndpoint:     "https://accounts.google.com",
 		common.OIDCVerifyCert:   "true",
@@ -91,7 +91,7 @@ func TestHelperGet(t *testing.T) {
 }
 
 func TestAuthCodeURL(t *testing.T) {
-	conf := map[string]interface{}{
+	conf := map[string]any{
 		common.OIDCName:               "test",
 		common.OIDCEndpoint:           "https://accounts.google.com",
 		common.OIDCVerifyCert:         "true",
@@ -130,10 +130,10 @@ func TestTestEndpoint(t *testing.T) {
 }
 
 type fakeClaims struct {
-	claims map[string]interface{}
+	claims map[string]any
 }
 
-func (fc *fakeClaims) Claims(n interface{}) error {
+func (fc *fakeClaims) Claims(n any) error {
 	b, err := json.Marshal(fc.claims)
 	if err != nil {
 		return err
@@ -142,14 +142,14 @@ func (fc *fakeClaims) Claims(n interface{}) error {
 }
 
 func TestGroupsFromClaim(t *testing.T) {
-	in := map[string]interface{}{
+	in := map[string]any{
 		"user":     "user1",
-		"groups":   []interface{}{"group1", "group2"},
-		"groups_2": []interface{}{"group1", "group2", 2},
+		"groups":   []any{"group1", "group2"},
+		"groups_2": []any{"group1", "group2", 2},
 	}
 
 	m := []struct {
-		input  map[string]interface{}
+		input  map[string]any
 		key    string
 		expect []string
 		ok     bool
@@ -190,15 +190,15 @@ func TestGroupsFromClaim(t *testing.T) {
 
 func TestUserInfoFromClaims(t *testing.T) {
 	s := []struct {
-		input   map[string]interface{}
+		input   map[string]any
 		setting cfgModels.OIDCSetting
 		expect  *UserInfo
 	}{
 		{
-			input: map[string]interface{}{
+			input: map[string]any{
 				"name":   "Daniel",
 				"email":  "daniel@gmail.com",
-				"groups": []interface{}{"g1", "g2"},
+				"groups": []any{"g1", "g2"},
 			},
 			setting: cfgModels.OIDCSetting{
 				Name:        "t1",
@@ -217,10 +217,10 @@ func TestUserInfoFromClaims(t *testing.T) {
 			},
 		},
 		{
-			input: map[string]interface{}{
+			input: map[string]any{
 				"name":   "Daniel",
 				"email":  "daniel@gmail.com",
-				"groups": []interface{}{"g1", "g2"},
+				"groups": []any{"g1", "g2"},
 			},
 			setting: cfgModels.OIDCSetting{
 				Name:        "t2",
@@ -240,12 +240,12 @@ func TestUserInfoFromClaims(t *testing.T) {
 			},
 		},
 		{
-			input: map[string]interface{}{
+			input: map[string]any{
 				"iss":        "issuer",
 				"sub":        "subject000",
 				"name":       "jack",
 				"email":      "jack@gmail.com",
-				"groupclaim": []interface{}{},
+				"groupclaim": []any{},
 			},
 			setting: cfgModels.OIDCSetting{
 				Name:        "t3",
@@ -265,10 +265,10 @@ func TestUserInfoFromClaims(t *testing.T) {
 			},
 		},
 		{
-			input: map[string]interface{}{
+			input: map[string]any{
 				"name":   "Alvaro",
 				"email":  "airadier@gmail.com",
-				"groups": []interface{}{"g1", "g2"},
+				"groups": []any{"g1", "g2"},
 			},
 			setting: cfgModels.OIDCSetting{
 				Name:        "t4",

--- a/src/pkg/p2p/preheat/dao/instance/dao_test.go
+++ b/src/pkg/p2p/preheat/dao/instance/dao_test.go
@@ -149,7 +149,7 @@ func (is *instanceSuite) TestList() {
 	assert.Equal(t, defaultInstance.ID, instances[0].ID)
 
 	// keyword search
-	keywords := make(map[string]interface{})
+	keywords := make(map[string]any)
 	keywords["name"] = "kraken-us-1"
 	instances, err = is.dao.List(is.ctx, &q.Query{Keywords: keywords})
 	assert.Nil(t, err)

--- a/src/pkg/p2p/preheat/dao/policy/dao_test.go
+++ b/src/pkg/p2p/preheat/dao/policy/dao_test.go
@@ -182,7 +182,7 @@ func (d *daoTestSuite) TestList() {
 
 	// list policy filter by project
 	query := &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"project_id": 1,
 		},
 	}

--- a/src/pkg/p2p/preheat/job_test.go
+++ b/src/pkg/p2p/preheat/job_test.go
@@ -58,7 +58,7 @@ func (suite *JobTestSuite) SetupSuite() {
 		ImageName: "busybox",
 		Tag:       "latest",
 		URL:       "https://harbor.com",
-		Headers: map[string]interface{}{
+		Headers: map[string]any{
 			"robot$my": "jwt-token",
 		},
 	}

--- a/src/pkg/p2p/preheat/models/policy/policy.go
+++ b/src/pkg/p2p/preheat/models/policy/policy.go
@@ -73,10 +73,10 @@ type Schema struct {
 	TriggerStr string `orm:"column(trigger)" json:"-"`
 	Enabled    bool   `orm:"column(enabled)" json:"enabled"`
 	// ExtraAttrs is used to store extra attributes provided by vendor.
-	ExtraAttrsStr string                 `orm:"column(extra_attrs)" json:"-"`
-	ExtraAttrs    map[string]interface{} `orm:"-" json:"extra_attrs"`
-	CreatedAt     time.Time              `orm:"column(creation_time)" json:"creation_time"`
-	UpdatedTime   time.Time              `orm:"column(update_time)" json:"update_time"`
+	ExtraAttrsStr string         `orm:"column(extra_attrs)" json:"-"`
+	ExtraAttrs    map[string]any `orm:"-" json:"extra_attrs"`
+	CreatedAt     time.Time      `orm:"column(creation_time)" json:"creation_time"`
+	UpdatedTime   time.Time      `orm:"column(update_time)" json:"update_time"`
 }
 
 // TableName specifies the policy schema table name.
@@ -102,8 +102,8 @@ type FilterType = string
 
 // Filter holds the info of the filter
 type Filter struct {
-	Type  FilterType  `json:"type"`
-	Value interface{} `json:"value"`
+	Type  FilterType `json:"type"`
+	Value any        `json:"value"`
 }
 
 // TriggerType represents the type of trigger.
@@ -235,12 +235,12 @@ func decodeTrigger(triggerStr string) (*Trigger, error) {
 }
 
 // decodeExtraAttrs parse extraAttrsStr to extraAttrs.
-func decodeExtraAttrs(extraAttrsStr string) (map[string]interface{}, error) {
+func decodeExtraAttrs(extraAttrsStr string) (map[string]any, error) {
 	if len(extraAttrsStr) == 0 {
 		return nil, nil
 	}
 
-	extraAttrs := make(map[string]interface{})
+	extraAttrs := make(map[string]any)
 	if err := json.Unmarshal([]byte(extraAttrsStr), &extraAttrs); err != nil {
 		return nil, err
 	}

--- a/src/pkg/p2p/preheat/models/policy/policy_test.go
+++ b/src/pkg/p2p/preheat/models/policy/policy_test.go
@@ -85,7 +85,7 @@ func (p *PolicyTestSuite) TestDecode() {
 	p.Len(s.Filters, 3)
 	p.NotNil(s.Trigger)
 
-	p.Equal(map[string]interface{}{"key": "value"}, s.ExtraAttrs)
+	p.Equal(map[string]any{"key": "value"}, s.ExtraAttrs)
 
 	// invalid filter or trigger
 	s.FiltersStr = ""
@@ -125,7 +125,7 @@ func (p *PolicyTestSuite) TestEncode() {
 		},
 		TriggerStr: "",
 		Enabled:    false,
-		ExtraAttrs: map[string]interface{}{
+		ExtraAttrs: map[string]any{
 			"key": "value",
 		},
 	}

--- a/src/pkg/p2p/preheat/policy/manager.go
+++ b/src/pkg/p2p/preheat/policy/manager.go
@@ -125,7 +125,7 @@ func (m *manager) ListPoliciesByProject(ctx context.Context, project int64, quer
 	}
 
 	if query.Keywords == nil {
-		query.Keywords = make(map[string]interface{})
+		query.Keywords = make(map[string]any)
 	}
 	// set project filter
 	query.Keywords["project_id"] = project

--- a/src/pkg/p2p/preheat/provider/client/http_client.go
+++ b/src/pkg/p2p/preheat/provider/client/http_client.go
@@ -147,7 +147,7 @@ func (hc *HTTPClient) get(url string, cred *auth.Credential, parmas map[string]s
 }
 
 // Post content to the service specified by the url
-func (hc *HTTPClient) Post(url string, cred *auth.Credential, body interface{}, options map[string]string) ([]byte, error) {
+func (hc *HTTPClient) Post(url string, cred *auth.Credential, body any, options map[string]string) ([]byte, error) {
 	bytes, err := hc.post(url, cred, body, options)
 	logMsg := fmt.Sprintf("Post %s with cred=%v, options=%v", url, cred, options)
 	if err != nil {
@@ -159,7 +159,7 @@ func (hc *HTTPClient) Post(url string, cred *auth.Credential, body interface{}, 
 	return bytes, err
 }
 
-func (hc *HTTPClient) post(url string, cred *auth.Credential, body interface{}, options map[string]string) ([]byte, error) {
+func (hc *HTTPClient) post(url string, cred *auth.Credential, body any, options map[string]string) ([]byte, error) {
 	if len(url) == 0 {
 		return nil, errors.New("empty url")
 	}

--- a/src/pkg/p2p/preheat/provider/dragonfly.go
+++ b/src/pkg/p2p/preheat/provider/dragonfly.go
@@ -368,7 +368,7 @@ func (dd *DragonflyDriver) getCred() *auth.Credential {
 	}
 }
 
-func headerToMapString(header map[string]interface{}) map[string]string {
+func headerToMapString(header map[string]any) map[string]string {
 	m := make(map[string]string)
 	for k, v := range header {
 		if s, ok := v.(string); ok {

--- a/src/pkg/p2p/preheat/provider/dragonfly_test.go
+++ b/src/pkg/p2p/preheat/provider/dragonfly_test.go
@@ -85,7 +85,7 @@ func (suite *DragonflyTestSuite) TestPreheat() {
 		Tag:       "latest",
 		URL:       "https://harbor.com",
 		Digest:    "sha256:f3c97e3bd1e27393eb853a5c90b1132f2cda84336d5ba5d100c720dc98524c82",
-		ExtraAttrs: map[string]interface{}{
+		ExtraAttrs: map[string]any{
 			"scope":       "all_peers",
 			"cluster_ids": []uint{1, 2, 3},
 		},

--- a/src/pkg/p2p/preheat/provider/preheat_image.go
+++ b/src/pkg/p2p/preheat/provider/preheat_image.go
@@ -39,7 +39,7 @@ type PreheatImage struct {
 	URL string `json:"url"`
 
 	// The headers which will be sent to the above URL of preheating image
-	Headers map[string]interface{} `json:"headers"`
+	Headers map[string]any `json:"headers"`
 
 	// The image name
 	ImageName string `json:"image,omitempty"`
@@ -51,7 +51,7 @@ type PreheatImage struct {
 	Digest string `json:"digest"`
 
 	// ExtraAttrs contains extra attributes for the preheating image.
-	ExtraAttrs map[string]interface{} `json:"extra_attrs,omitempty"`
+	ExtraAttrs map[string]any `json:"extra_attrs,omitempty"`
 }
 
 // FromJSON build preheating image from the given data.

--- a/src/pkg/permission/evaluator/rbac/casbin_match.go
+++ b/src/pkg/permission/evaluator/rbac/casbin_match.go
@@ -39,8 +39,8 @@ func (s *regexpStore) Get(key string, build func(string) *regexp.Regexp) *regexp
 }
 
 func (s *regexpStore) Purge() {
-	var keys []interface{}
-	s.entries.Range(func(key, _ interface{}) bool {
+	var keys []any
+	s.entries.Range(func(key, _ any) bool {
 		keys = append(keys, key)
 		return true
 	})
@@ -94,7 +94,7 @@ func keyMatch2(key1 string, key2 string) bool {
 	return store.Get(key2, keyMatch2Build).MatchString(key1)
 }
 
-func keyMatch2Func(args ...interface{}) (interface{}, error) {
+func keyMatch2Func(args ...any) (any, error) {
 	name1 := args[0].(string)
 	name2 := args[1].(string)
 

--- a/src/pkg/permission/evaluator/rbac/casbin_match_test.go
+++ b/src/pkg/permission/evaluator/rbac/casbin_match_test.go
@@ -67,7 +67,7 @@ func TestRegexpStore(t *testing.T) {
 
 	sLen := func() int {
 		var l int
-		s.entries.Range(func(key, value interface{}) bool {
+		s.entries.Range(func(key, value any) bool {
 			l++
 
 			return true

--- a/src/pkg/permission/types/namespace.go
+++ b/src/pkg/permission/types/namespace.go
@@ -33,7 +33,7 @@ type Namespace interface {
 	// Resource returns new resource for subresources with the namespace
 	Resource(subresources ...Resource) Resource
 	// Identity returns identity attached with namespace
-	Identity() interface{}
+	Identity() any
 	// GetPolicies returns all policies of the namespace
 	GetPolicies() []*Policy
 }

--- a/src/pkg/project/dao/dao.go
+++ b/src/pkg/project/dao/dao.go
@@ -218,7 +218,7 @@ func (d *dao) ListAdminRolesOfUser(ctx context.Context, user commonmodels.User) 
 
 	var membersG []models.Member
 	if len(user.GroupIDs) > 0 {
-		var params []interface{}
+		var params []any
 		params = append(params, user.GroupIDs)
 		sqlG := fmt.Sprintf(`select b.* from project as a 
     		left join project_member as b on a.project_id = b.project_id 

--- a/src/pkg/project/manager.go
+++ b/src/pkg/project/manager.go
@@ -39,7 +39,7 @@ type Manager interface {
 	Delete(ctx context.Context, id int64) error
 
 	// Get the project specified by the ID or name
-	Get(ctx context.Context, idOrName interface{}) (*models.Project, error)
+	Get(ctx context.Context, idOrName any) (*models.Project, error)
 
 	// List projects according to the query
 	List(ctx context.Context, query *q.Query) ([]*models.Project, error)
@@ -98,7 +98,7 @@ func (m *manager) Delete(ctx context.Context, id int64) error {
 }
 
 // Get the project specified by the ID
-func (m *manager) Get(ctx context.Context, idOrName interface{}) (*models.Project, error) {
+func (m *manager) Get(ctx context.Context, idOrName any) (*models.Project, error) {
 	id, ok := idOrName.(int64)
 	if ok {
 		return m.dao.Get(ctx, id)

--- a/src/pkg/project/models/project.go
+++ b/src/pkg/project/models/project.go
@@ -170,7 +170,7 @@ func (p *Project) ProxyCacheSpeed() int32 {
 }
 
 // FilterByPublic returns orm.QuerySeter with public filter
-func (p *Project) FilterByPublic(_ context.Context, qs orm.QuerySeter, _ string, value interface{}) orm.QuerySeter {
+func (p *Project) FilterByPublic(_ context.Context, qs orm.QuerySeter, _ string, value any) orm.QuerySeter {
 	subQuery := `SELECT project_id FROM project_metadata WHERE name = 'public' AND value = '%s'`
 	if isTrue(value) {
 		subQuery = fmt.Sprintf(subQuery, "true")
@@ -181,7 +181,7 @@ func (p *Project) FilterByPublic(_ context.Context, qs orm.QuerySeter, _ string,
 }
 
 // FilterByOwner returns orm.QuerySeter with owner filter
-func (p *Project) FilterByOwner(_ context.Context, qs orm.QuerySeter, _ string, value interface{}) orm.QuerySeter {
+func (p *Project) FilterByOwner(_ context.Context, qs orm.QuerySeter, _ string, value any) orm.QuerySeter {
 	username, ok := value.(string)
 	if !ok {
 		return qs
@@ -191,7 +191,7 @@ func (p *Project) FilterByOwner(_ context.Context, qs orm.QuerySeter, _ string, 
 }
 
 // FilterByMember returns orm.QuerySeter with member filter
-func (p *Project) FilterByMember(_ context.Context, qs orm.QuerySeter, _ string, value interface{}) orm.QuerySeter {
+func (p *Project) FilterByMember(_ context.Context, qs orm.QuerySeter, _ string, value any) orm.QuerySeter {
 	query, ok := value.(*MemberQuery)
 	if !ok {
 		return qs
@@ -219,7 +219,7 @@ func (p *Project) FilterByMember(_ context.Context, qs orm.QuerySeter, _ string,
 }
 
 // FilterByNames returns orm.QuerySeter with name filter
-func (p *Project) FilterByNames(_ context.Context, qs orm.QuerySeter, _ string, value interface{}) orm.QuerySeter {
+func (p *Project) FilterByNames(_ context.Context, qs orm.QuerySeter, _ string, value any) orm.QuerySeter {
 	query, ok := value.(*NamesQuery)
 	if !ok {
 		return qs
@@ -242,7 +242,7 @@ func (p *Project) FilterByNames(_ context.Context, qs orm.QuerySeter, _ string, 
 	return qs.FilterRaw("project_id", fmt.Sprintf("IN (%s)", subQuery))
 }
 
-func isTrue(i interface{}) bool {
+func isTrue(i any) bool {
 	switch value := i.(type) {
 	case bool:
 		return value

--- a/src/pkg/proxy/secret/manager.go
+++ b/src/pkg/proxy/secret/manager.go
@@ -129,7 +129,7 @@ func (man *mgr) gc() {
 		return
 	}
 	log.Debugf("Running GC on secret map...")
-	man.m.Range(func(k, v interface{}) bool {
+	man.m.Range(func(k, v any) bool {
 		repoV, ok := v.(targetRepository)
 		if ok && repoV.expiresAt.Before(time.Now()) {
 			log.Debugf("Removed expire secret: %s, repo: %s", k, repoV.name)

--- a/src/pkg/quota/dao/dao.go
+++ b/src/pkg/quota/dao/dao.go
@@ -186,12 +186,12 @@ func (d *dao) Update(ctx context.Context, quota *models.Quota) error {
 
 	var (
 		sql    string
-		params []interface{}
+		params []any
 	)
 
 	if quota.UsedChanged {
 		sql = "UPDATE quota_usage SET used = ?, update_time = ?, version = ? WHERE id = ? AND version = ?"
-		params = []interface{}{
+		params = []any{
 			quota.Used,
 			time.Now(),
 			getVersion(quota.UsedVersion),
@@ -200,7 +200,7 @@ func (d *dao) Update(ctx context.Context, quota *models.Quota) error {
 		}
 	} else {
 		sql = "UPDATE quota SET hard = ?, update_time = ?, version = ? WHERE id = ? AND version = ?"
-		params = []interface{}{
+		params = []any{
 			quota.Hard,
 			time.Now(),
 			getVersion(quota.HardVersion),

--- a/src/pkg/quota/dao/util.go
+++ b/src/pkg/quota/dao/util.go
@@ -42,8 +42,8 @@ type listQuery struct {
 	ReferenceIDs []string `json:"reference_ids"`
 }
 
-func listConditions(query *q.Query) (string, []interface{}) {
-	params := []interface{}{}
+func listConditions(query *q.Query) (string, []any) {
+	params := []any{}
 	sql := ""
 	if query == nil {
 		return sql, params

--- a/src/pkg/quota/driver/driver.go
+++ b/src/pkg/quota/driver/driver.go
@@ -27,7 +27,7 @@ var (
 )
 
 // QuotaRefObject type for quota ref object
-type QuotaRefObject map[string]interface{}
+type QuotaRefObject map[string]any
 
 // Driver the driver for quota
 type Driver interface {

--- a/src/pkg/rbac/dao/dao.go
+++ b/src/pkg/rbac/dao/dao.go
@@ -93,7 +93,7 @@ func (d *dao) ListPermissions(ctx context.Context, query *q.Query) ([]*model.Rol
 
 func (d *dao) DeletePermissionsByRole(ctx context.Context, roleType string, roleID int64) error {
 	qs, err := orm.QuerySetter(ctx, &model.RolePermission{}, &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"role_type": roleType,
 			"role_id":   roleID,
 		},

--- a/src/pkg/rbac/dao/dao_test.go
+++ b/src/pkg/rbac/dao/dao_test.go
@@ -126,7 +126,7 @@ func (suite *DaoTestSuite) TestDeletePermission() {
 
 func (suite *DaoTestSuite) TestListPermissions() {
 	rps, err := suite.dao.ListPermissions(orm.Context(), &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"role_type":            "robot",
 			"role_id":              1,
 			"permission_policy_id": 4,
@@ -141,7 +141,7 @@ func (suite *DaoTestSuite) TestDeletePermissionsByRole() {
 	suite.Require().Nil(err)
 
 	rps, err := suite.dao.ListPermissions(orm.Context(), &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"role_type": "serviceaccount",
 			"role_id":   2,
 		},
@@ -172,7 +172,7 @@ func (suite *DaoTestSuite) TestDeleteRbacPolicy() {
 
 func (suite *DaoTestSuite) TestListRbacPolicies() {
 	rps, err := suite.dao.ListRbacPolicies(orm.Context(), &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"scope":    "/project/1",
 			"resource": "repository",
 			"action":   "pull",

--- a/src/pkg/reg/adapter/dtr/client.go
+++ b/src/pkg/reg/adapter/dtr/client.go
@@ -53,7 +53,7 @@ func NewClient(registry *model.Registry) *Client {
 }
 
 // getAndIteratePagination will iterator over a paginated response from DTR
-func (c *Client) getAndIteratePagination(endpoint string, v interface{}) error {
+func (c *Client) getAndIteratePagination(endpoint string, v any) error {
 	urlAPI, err := url.Parse(endpoint)
 	if err != nil {
 		return err

--- a/src/pkg/reg/adapter/gitlab/adapter.go
+++ b/src/pkg/reg/adapter/gitlab/adapter.go
@@ -165,7 +165,7 @@ func (a *adapter) FetchArtifacts(filters []*model.Filter) ([]*model.Resource, er
 				}
 				tags = append(tags, vTag.Name)
 			}
-			info := make(map[string]interface{})
+			info := make(map[string]any)
 			info["location"] = repository.Location
 			info["path"] = repository.Path
 

--- a/src/pkg/reg/adapter/gitlab/client.go
+++ b/src/pkg/reg/adapter/gitlab/client.go
@@ -111,7 +111,7 @@ func (c *Client) getTags(projectID int64, repositoryID int64) ([]*Tag, error) {
 
 // GetAndIteratePagination iterates the pagination header and returns all resources
 // The parameter "v" must be a pointer to a slice
-func (c *Client) GetAndIteratePagination(endpoint string, v interface{}) error {
+func (c *Client) GetAndIteratePagination(endpoint string, v any) error {
 	urlAPI, err := url.Parse(endpoint)
 	if err != nil {
 		return err

--- a/src/pkg/reg/adapter/harbor/base/adapter.go
+++ b/src/pkg/reg/adapter/harbor/base/adapter.go
@@ -256,7 +256,7 @@ func (a *Adapter) ListProjects(filters []*model.Filter) ([]*Project, error) {
 	return a.Client.ListProjects("")
 }
 
-func abstractPublicMetadata(metadata map[string]interface{}) map[string]interface{} {
+func abstractPublicMetadata(metadata map[string]any) map[string]any {
 	if metadata == nil {
 		return nil
 	}
@@ -264,20 +264,20 @@ func abstractPublicMetadata(metadata map[string]interface{}) map[string]interfac
 	if !exist {
 		return nil
 	}
-	return map[string]interface{}{
+	return map[string]any{
 		"public": public,
 	}
 }
 
 // currently, mergeMetadata only handles the public metadata
-func mergeMetadata(metadata1, metadata2 map[string]interface{}) map[string]interface{} {
+func mergeMetadata(metadata1, metadata2 map[string]any) map[string]any {
 	public := parsePublic(metadata1) && parsePublic(metadata2)
-	return map[string]interface{}{
+	return map[string]any{
 		"public": strconv.FormatBool(public),
 	}
 }
 
-func parsePublic(metadata map[string]interface{}) bool {
+func parsePublic(metadata map[string]any) bool {
 	if metadata == nil {
 		return false
 	}
@@ -303,10 +303,10 @@ func parsePublic(metadata map[string]interface{}) bool {
 
 // Project model
 type Project struct {
-	ID         int64                  `json:"project_id"`
-	Name       string                 `json:"name"`
-	Metadata   map[string]interface{} `json:"metadata"`
-	RegistryID int64                  `json:"registry_id"`
+	ID         int64          `json:"project_id"`
+	Name       string         `json:"name"`
+	Metadata   map[string]any `json:"metadata"`
+	RegistryID int64          `json:"registry_id"`
 }
 
 func isLocalHarbor(url string) bool {

--- a/src/pkg/reg/adapter/harbor/base/adapter_test.go
+++ b/src/pkg/reg/adapter/harbor/base/adapter_test.go
@@ -194,15 +194,15 @@ func TestPrepareForPush(t *testing.T) {
 
 func TestParsePublic(t *testing.T) {
 	cases := []struct {
-		metadata map[string]interface{}
+		metadata map[string]any
 		result   bool
 	}{
 		{nil, false},
-		{map[string]interface{}{}, false},
-		{map[string]interface{}{"public": true}, true},
-		{map[string]interface{}{"public": "not_bool"}, false},
-		{map[string]interface{}{"public": "true"}, true},
-		{map[string]interface{}{"public": struct{}{}}, false},
+		{map[string]any{}, false},
+		{map[string]any{"public": true}, true},
+		{map[string]any{"public": "not_bool"}, false},
+		{map[string]any{"public": "true"}, true},
+		{map[string]any{"public": struct{}{}}, false},
 	}
 	for _, c := range cases {
 		assert.Equal(t, c.result, parsePublic(c.metadata))
@@ -211,33 +211,33 @@ func TestParsePublic(t *testing.T) {
 
 func TestMergeMetadata(t *testing.T) {
 	cases := []struct {
-		m1     map[string]interface{}
-		m2     map[string]interface{}
+		m1     map[string]any
+		m2     map[string]any
 		public bool
 	}{
 		{
-			m1: map[string]interface{}{
+			m1: map[string]any{
 				"public": "true",
 			},
-			m2: map[string]interface{}{
+			m2: map[string]any{
 				"public": "true",
 			},
 			public: true,
 		},
 		{
-			m1: map[string]interface{}{
+			m1: map[string]any{
 				"public": "false",
 			},
-			m2: map[string]interface{}{
+			m2: map[string]any{
 				"public": "true",
 			},
 			public: false,
 		},
 		{
-			m1: map[string]interface{}{
+			m1: map[string]any{
 				"public": "false",
 			},
-			m2: map[string]interface{}{
+			m2: map[string]any{
 				"public": "false",
 			},
 			public: false,
@@ -255,14 +255,14 @@ func TestAbstractPublicMetadata(t *testing.T) {
 	assert.Nil(t, meta)
 
 	// contains no public metadata
-	metadata := map[string]interface{}{
+	metadata := map[string]any{
 		"other": "test",
 	}
 	meta = abstractPublicMetadata(metadata)
 	assert.Nil(t, meta)
 
 	// contains public metadata
-	metadata = map[string]interface{}{
+	metadata = map[string]any{
 		"other":  "test",
 		"public": "true",
 	}

--- a/src/pkg/reg/adapter/harbor/base/client.go
+++ b/src/pkg/reg/adapter/harbor/base/client.go
@@ -81,10 +81,10 @@ func (c *Client) ListLabels() ([]string, error) {
 }
 
 // CreateProject creates project
-func (c *Client) CreateProject(name string, metadata map[string]interface{}) error {
+func (c *Client) CreateProject(name string, metadata map[string]any) error {
 	project := struct {
-		Name     string                 `json:"project_name"`
-		Metadata map[string]interface{} `json:"metadata"`
+		Name     string         `json:"project_name"`
+		Metadata map[string]any `json:"metadata"`
 	}{
 		Name:     name,
 		Metadata: metadata,

--- a/src/pkg/reg/adapter/huawei/huawei_adapter.go
+++ b/src/pkg/reg/adapter/huawei/huawei_adapter.go
@@ -212,7 +212,7 @@ func (a *adapter) PrepareForPush(resources []*model.Resource) error {
 func (a *adapter) GetNamespace(namespaceStr string) (*model.Namespace, error) {
 	var namespace = &model.Namespace{
 		Name:     "",
-		Metadata: make(map[string]interface{}),
+		Metadata: make(map[string]any),
 	}
 
 	urls := fmt.Sprintf("%s/dockyard/v2/namespaces/%s", a.registry.URL, namespaceStr)
@@ -299,8 +299,8 @@ type hwNamespace struct {
 	ImageCount   int64  `json:"image_count"`
 }
 
-func (ns hwNamespace) metadata() map[string]interface{} {
-	var metadata = make(map[string]interface{})
+func (ns hwNamespace) metadata() map[string]any {
+	var metadata = make(map[string]any)
 	metadata["id"] = ns.ID
 	metadata["creator_name"] = ns.CreatorName
 	metadata["domain_public"] = ns.DomainPublic

--- a/src/pkg/reg/adapter/huawei/huawei_adapter_test.go
+++ b/src/pkg/reg/adapter/huawei/huawei_adapter_test.go
@@ -71,7 +71,7 @@ func TestAdapter_PrepareForPush(t *testing.T) {
 
 	repository := &model.Repository{
 		Name:     "domain_repo_new",
-		Metadata: make(map[string]interface{}),
+		Metadata: make(map[string]any),
 	}
 	resource := &model.Resource{}
 	metadata := &model.ResourceMetadata{

--- a/src/pkg/reg/adapter/huawei/image_registry.go
+++ b/src/pkg/reg/adapter/huawei/image_registry.go
@@ -149,7 +149,7 @@ func (a *adapter) DeleteManifest(repository, reference string) error {
 
 func parseRepoQueryResultToResource(repo hwRepoQueryResult) *model.Resource {
 	var resource model.Resource
-	info := make(map[string]interface{})
+	info := make(map[string]any)
 	info["category"] = repo.Category
 	info["description"] = repo.Description
 	info["size"] = repo.Size

--- a/src/pkg/reg/adapter/volcenginecr/consts.go
+++ b/src/pkg/reg/adapter/volcenginecr/consts.go
@@ -17,7 +17,7 @@ package volcenginecr
 import "errors"
 
 var (
-	regionRegs = map[string]interface{}{
+	regionRegs = map[string]any{
 		"(.*)-(cn-.*)": nil,
 	}
 	errListNamespaceResp    = errors.New("[VolcengineCR adapt] ListNamespaces resp nil")

--- a/src/pkg/reg/dao/dao_test.go
+++ b/src/pkg/reg/dao/dao_test.go
@@ -66,7 +66,7 @@ func (d *daoTestSuite) TestCount() {
 
 	// query by name
 	total, err = d.dao.Count(d.ctx, &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"Name": "harbor",
 		},
 	})
@@ -89,7 +89,7 @@ func (d *daoTestSuite) TestList() {
 
 	// query by name
 	registries, err = d.dao.List(d.ctx, &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"Name": "harbor",
 		},
 	})

--- a/src/pkg/reg/model/namespace.go
+++ b/src/pkg/reg/model/namespace.go
@@ -20,8 +20,8 @@ package model
 // if the namespace has hierarchical structure, e.g organization->team,
 // it should be converted to organization.team
 type Namespace struct {
-	Name     string                 `json:"name"`
-	Metadata map[string]interface{} `json:"metadata"`
+	Name     string         `json:"name"`
+	Metadata map[string]any `json:"metadata"`
 }
 
 // GetStringMetadata get a string value metadata from the namespace, if not found, return the default value.

--- a/src/pkg/reg/model/policy.go
+++ b/src/pkg/reg/model/policy.go
@@ -35,9 +35,9 @@ const (
 
 // Filter holds the info of the filter
 type Filter struct {
-	Type       string      `json:"type"`
-	Value      interface{} `json:"value"`
-	Decoration string      `json:"decoration,omitempty"`
+	Type       string `json:"type"`
+	Value      any    `json:"value"`
+	Decoration string `json:"decoration,omitempty"`
 }
 
 func (f *Filter) Validate() error {
@@ -62,7 +62,7 @@ func (f *Filter) Validate() error {
 			}
 		}
 	case FilterTypeLabel:
-		labels, ok := f.Value.([]interface{})
+		labels, ok := f.Value.([]any)
 		if !ok {
 			return errors.New(nil).WithCode(errors.BadRequestCode).
 				WithMessage("the type of label filter value isn't string slice")

--- a/src/pkg/reg/model/resource.go
+++ b/src/pkg/reg/model/resource.go
@@ -27,10 +27,10 @@ const (
 
 // Resource represents the general replicating content
 type Resource struct {
-	Type         string                 `json:"type"`
-	Metadata     *ResourceMetadata      `json:"metadata"`
-	Registry     *Registry              `json:"registry"`
-	ExtendedInfo map[string]interface{} `json:"extended_info"`
+	Type         string            `json:"type"`
+	Metadata     *ResourceMetadata `json:"metadata"`
+	Registry     *Registry         `json:"registry"`
+	ExtendedInfo map[string]any    `json:"extended_info"`
 	// Indicate if the resource is a deleted resource
 	Deleted bool `json:"deleted"`
 	// indicate the resource is a tag deletion
@@ -51,8 +51,8 @@ type ResourceMetadata struct {
 
 // Repository info of the resource
 type Repository struct {
-	Name     string                 `json:"name"`
-	Metadata map[string]interface{} `json:"metadata"`
+	Name     string         `json:"name"`
+	Metadata map[string]any `json:"metadata"`
 }
 
 // Artifact is the individual unit that can be replicated

--- a/src/pkg/registry/interceptor/readonly/interceptor_test.go
+++ b/src/pkg/registry/interceptor/readonly/interceptor_test.go
@@ -53,7 +53,7 @@ func TestIntercept(t *testing.T) {
 	// method: DELETE
 	// read only enable: true
 	req, _ = http.NewRequest(http.MethodDelete, "", nil)
-	err := config.DefaultMgr().UpdateConfig(context.Background(), map[string]interface{}{common.ReadOnly: true})
+	err := config.DefaultMgr().UpdateConfig(context.Background(), map[string]any{common.ReadOnly: true})
 	require.Nil(t, err)
 	time.Sleep(1 * time.Nanosecond) // make sure the cached key is expired
 	assert.Equal(t, Err, interceptor.Intercept(req))

--- a/src/pkg/replication/dao/dao_test.go
+++ b/src/pkg/replication/dao/dao_test.go
@@ -63,7 +63,7 @@ func (d *daoTestSuite) TestCount() {
 
 	// query by name
 	total, err = d.dao.Count(d.ctx, &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"Name": "test-rule",
 		},
 	})
@@ -86,7 +86,7 @@ func (d *daoTestSuite) TestList() {
 
 	// query by name
 	policies, err = d.dao.List(d.ctx, &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"Name": "test-rule",
 		},
 	})

--- a/src/pkg/repository/dao/dao_test.go
+++ b/src/pkg/repository/dao/dao_test.go
@@ -79,7 +79,7 @@ func (d *daoTestSuite) TestCount() {
 
 	// query by name
 	total, err = d.dao.Count(d.ctx, &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"name": repository,
 		},
 	})
@@ -102,7 +102,7 @@ func (d *daoTestSuite) TestList() {
 
 	// query by name
 	repositories, err = d.dao.List(d.ctx, &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"name": repository,
 		},
 	})

--- a/src/pkg/repository/manager.go
+++ b/src/pkg/repository/manager.go
@@ -74,7 +74,7 @@ func (m *manager) Get(ctx context.Context, id int64) (*model.RepoRecord, error) 
 
 func (m *manager) GetByName(ctx context.Context, name string) (repository *model.RepoRecord, err error) {
 	repositories, err := m.List(ctx, &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"Name": name,
 		},
 	})

--- a/src/pkg/repository/model/model.go
+++ b/src/pkg/repository/model/model.go
@@ -42,7 +42,7 @@ type RepoRecord struct {
 }
 
 // FilterByBlobDigest filters the repositories by the blob digest
-func (r *RepoRecord) FilterByBlobDigest(_ context.Context, qs orm.QuerySeter, _ string, value interface{}) orm.QuerySeter {
+func (r *RepoRecord) FilterByBlobDigest(_ context.Context, qs orm.QuerySeter, _ string, value any) orm.QuerySeter {
 	digest, ok := value.(string)
 	if !ok || len(digest) == 0 {
 		return qs

--- a/src/pkg/retention/dao/retention_test.go
+++ b/src/pkg/retention/dao/retention_test.go
@@ -54,7 +54,7 @@ func TestPolicy(t *testing.T) {
 		},
 		Trigger: &policy.Trigger{
 			Kind: "Schedule",
-			Settings: map[string]interface{}{
+			Settings: map[string]any{
 				"cron": "* 22 11 * * *",
 			},
 		},

--- a/src/pkg/retention/job_test.go
+++ b/src/pkg/retention/job_test.go
@@ -153,41 +153,41 @@ func (frc *fakeRetentionClient) DeleteRepository(repo *selector.Repository) erro
 type fakeLogger struct{}
 
 // For debuging
-func (l *fakeLogger) Debug(v ...interface{}) {}
+func (l *fakeLogger) Debug(v ...any) {}
 
 // For debuging with format
-func (l *fakeLogger) Debugf(format string, v ...interface{}) {}
+func (l *fakeLogger) Debugf(format string, v ...any) {}
 
 // For logging info
-func (l *fakeLogger) Info(v ...interface{}) {
+func (l *fakeLogger) Info(v ...any) {
 	fmt.Println(v...)
 }
 
 // For logging info with format
-func (l *fakeLogger) Infof(format string, v ...interface{}) {
+func (l *fakeLogger) Infof(format string, v ...any) {
 	fmt.Printf(format+"\n", v...)
 }
 
 // For warning
-func (l *fakeLogger) Warning(v ...interface{}) {}
+func (l *fakeLogger) Warning(v ...any) {}
 
 // For warning with format
-func (l *fakeLogger) Warningf(format string, v ...interface{}) {}
+func (l *fakeLogger) Warningf(format string, v ...any) {}
 
 // For logging error
-func (l *fakeLogger) Error(v ...interface{}) {
+func (l *fakeLogger) Error(v ...any) {
 	fmt.Println(v...)
 }
 
 // For logging error with format
-func (l *fakeLogger) Errorf(format string, v ...interface{}) {
+func (l *fakeLogger) Errorf(format string, v ...any) {
 }
 
 // For fatal error
-func (l *fakeLogger) Fatal(v ...interface{}) {}
+func (l *fakeLogger) Fatal(v ...any) {}
 
 // For fatal error with error
-func (l *fakeLogger) Fatalf(format string, v ...interface{}) {}
+func (l *fakeLogger) Fatalf(format string, v ...any) {}
 
 type fakeJobContext struct{}
 
@@ -195,7 +195,7 @@ func (c *fakeJobContext) Build(tracker job.Tracker) (job.Context, error) {
 	return nil, nil
 }
 
-func (c *fakeJobContext) Get(prop string) (interface{}, bool) {
+func (c *fakeJobContext) Get(prop string) (any, bool) {
 	return nil, false
 }
 

--- a/src/pkg/retention/launcher.go
+++ b/src/pkg/retention/launcher.go
@@ -83,7 +83,7 @@ type jobData struct {
 	TaskID     int64
 	Repository selector.Repository
 	JobName    string
-	JobParams  map[string]interface{}
+	JobParams  map[string]any
 }
 
 type launcher struct {
@@ -211,7 +211,7 @@ func createJobs(repositoryRules map[selector.Repository]*lwp.Metadata, isDryRun 
 		jobData := &jobData{
 			Repository: repository,
 			JobName:    job.RetentionVendorType,
-			JobParams:  make(map[string]interface{}, 3),
+			JobParams:  make(map[string]any, 3),
 		}
 		// set dry run
 		jobData.JobParams[ParamDryRun] = isDryRun
@@ -241,7 +241,7 @@ func (l *launcher) submitTasks(ctx context.Context, executionID int64, jobDatas 
 				JobKind: job.KindGeneric,
 			},
 		},
-			map[string]interface{}{
+			map[string]any{
 				"repository": jobData.Repository.Name,
 				"dry_run":    jobData.JobParams[ParamDryRun],
 			})
@@ -288,7 +288,7 @@ func getRepositories(ctx context.Context, _ project.Manager, repositoryMgr repos
 	*/
 	// get image repositories
 	imageRepositories, err := repositoryMgr.List(ctx, &pq.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"ProjectID": projectID,
 		},
 	})

--- a/src/pkg/retention/manager_test.go
+++ b/src/pkg/retention/manager_test.go
@@ -50,7 +50,7 @@ func TestPolicy(t *testing.T) {
 		},
 		Trigger: &policy.Trigger{
 			Kind: "Schedule",
-			Settings: map[string]interface{}{
+			Settings: map[string]any{
 				"cron": "* 22 11 * * *",
 			},
 		},
@@ -118,7 +118,7 @@ func TestExecution(t *testing.T) {
 		},
 		Trigger: &policy.Trigger{
 			Kind: "Schedule",
-			Settings: map[string]interface{}{
+			Settings: map[string]any{
 				"cron": "* 22 11 * * *",
 			},
 		},

--- a/src/pkg/retention/policy/action/index/index.go
+++ b/src/pkg/retention/policy/action/index/index.go
@@ -40,7 +40,7 @@ func Register(action string, factory action.PerformerFactory) {
 }
 
 // Get performer with the provided action
-func Get(act string, params interface{}, isDryRun bool) (action.Performer, error) {
+func Get(act string, params any, isDryRun bool) (action.Performer, error) {
 	if len(act) == 0 {
 		return nil, errors.New("empty action")
 	}

--- a/src/pkg/retention/policy/action/index/index_test.go
+++ b/src/pkg/retention/policy/action/index/index_test.go
@@ -74,7 +74,7 @@ func (suite *IndexTestSuite) TestGet() {
 }
 
 type fakePerformer struct {
-	parameters interface{}
+	parameters any
 	isDryRun   bool
 }
 
@@ -89,7 +89,7 @@ func (p *fakePerformer) Perform(ctx context.Context, candidates []*selector.Cand
 	return
 }
 
-func newFakePerformer(params interface{}, isDryRun bool) action.Performer {
+func newFakePerformer(params any, isDryRun bool) action.Performer {
 	return &fakePerformer{
 		parameters: params,
 		isDryRun:   isDryRun,

--- a/src/pkg/retention/policy/action/performer.go
+++ b/src/pkg/retention/policy/action/performer.go
@@ -43,7 +43,7 @@ type Performer interface {
 }
 
 // PerformerFactory is factory method for creating Performer
-type PerformerFactory func(params interface{}, isDryRun bool) Performer
+type PerformerFactory func(params any, isDryRun bool) Performer
 
 // retainAction make sure all the candidates will be retained and others will be cleared
 type retainAction struct {
@@ -110,7 +110,7 @@ func isImmutable(ctx context.Context, c *selector.Candidate) bool {
 }
 
 // NewRetainAction is factory method for RetainAction
-func NewRetainAction(params interface{}, isDryRun bool) Performer {
+func NewRetainAction(params any, isDryRun bool) Performer {
 	if params != nil {
 		if all, ok := params.([]*selector.Candidate); ok {
 			return &retainAction{

--- a/src/pkg/retention/policy/models.go
+++ b/src/pkg/retention/policy/models.go
@@ -117,7 +117,7 @@ type Trigger struct {
 
 	// Settings for the specified trigger
 	// '[cron]="* 22 11 * * *"' for the 'Schedule'
-	Settings map[string]interface{} `json:"settings" valid:"Required"`
+	Settings map[string]any `json:"settings" valid:"Required"`
 }
 
 // Scope definition
@@ -164,7 +164,7 @@ func WithNDaysSinceLastPull(projID int64, n int) *Metadata {
 		},
 		Trigger: &Trigger{
 			Kind: "Schedule",
-			Settings: map[string]interface{}{
+			Settings: map[string]any{
 				"cron": "0 0 0 * * *",
 			},
 		},

--- a/src/pkg/retention/policy/models_test.go
+++ b/src/pkg/retention/policy/models_test.go
@@ -65,15 +65,15 @@ func (p *PolicyTestSuite) TestValidateRetentionPolicy() {
 	p.NoError(p.policy.ValidateRetentionPolicy())
 
 	// cron value is an empty string
-	p.policy.Trigger.Settings = map[string]interface{}{"cron": ""}
+	p.policy.Trigger.Settings = map[string]any{"cron": ""}
 	p.NoError(p.policy.ValidateRetentionPolicy())
 
 	//  the 1st field of cron value is not 0
-	p.policy.Trigger.Settings = map[string]interface{}{"cron": "1 0 0 1 1 *"}
+	p.policy.Trigger.Settings = map[string]any{"cron": "1 0 0 1 1 *"}
 	p.Error(p.policy.ValidateRetentionPolicy())
 
 	// valid cron value
-	p.policy.Trigger.Settings = map[string]interface{}{"cron": "0 0 0 1 1 *"}
+	p.policy.Trigger.Settings = map[string]any{"cron": "0 0 0 1 1 *"}
 	p.NoError(p.policy.ValidateRetentionPolicy())
 }
 
@@ -109,7 +109,7 @@ func TestRule(t *testing.T) {
 		},
 		Trigger: &Trigger{
 			Kind: "Schedule",
-			Settings: map[string]interface{}{
+			Settings: map[string]any{
 				"cron": "* 22 11 * * *",
 			},
 		},
@@ -162,7 +162,7 @@ func TestParamValid(t *testing.T) {
 		},
 		Trigger: &Trigger{
 			Kind: "Schedule",
-			Settings: map[string]interface{}{
+			Settings: map[string]any{
 				"cron": "* 22 11 * * *",
 			},
 		},
@@ -209,7 +209,7 @@ func TestParamValid(t *testing.T) {
 		},
 		Trigger: &Trigger{
 			Kind: "Schedule",
-			Settings: map[string]interface{}{
+			Settings: map[string]any{
 				"cron": "* 22 11 * * *",
 			},
 		},

--- a/src/pkg/retention/policy/rule/index/index.go
+++ b/src/pkg/retention/policy/rule/index/index.go
@@ -253,7 +253,7 @@ func Get(templateID string, parameters rule.Parameters) (rule.Evaluator, error) 
 func Index() []*Metadata {
 	res := make([]*Metadata, 0)
 
-	index.Range(func(_, v interface{}) bool {
+	index.Range(func(_, v any) bool {
 		if item, ok := v.(*indexedItem); ok {
 			res = append(res, item.Meta)
 			return true

--- a/src/pkg/retention/policy/rule/models.go
+++ b/src/pkg/retention/policy/rule/models.go
@@ -84,4 +84,4 @@ type Selector struct {
 type Parameters map[string]Parameter
 
 // Parameter of rule
-type Parameter interface{}
+type Parameter any

--- a/src/pkg/robot/dao/dao_test.go
+++ b/src/pkg/robot/dao/dao_test.go
@@ -89,7 +89,7 @@ func (suite *DaoTestSuite) TestDelete() {
 
 func (suite *DaoTestSuite) TestList() {
 	robots, err := suite.dao.List(orm.Context(), &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"name": "test3",
 		},
 	})
@@ -106,7 +106,7 @@ func (suite *DaoTestSuite) TestList() {
 	_, err = suite.dao.Create(orm.Context(), r)
 	suite.Nil(err)
 	robots, err = suite.dao.List(orm.Context(), &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"name":    "testvisible",
 			"visible": true,
 		},
@@ -133,7 +133,7 @@ func (suite *DaoTestSuite) TestCount() {
 
 	// query by name
 	total, err = suite.dao.Count(orm.Context(), &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"name": "test3",
 		},
 	})
@@ -156,7 +156,7 @@ func (suite *DaoTestSuite) TestUpdate() {
 
 func (suite *DaoTestSuite) TestDeleteByProjectID() {
 	robots, err := suite.dao.List(orm.Context(), &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"project_id": 2,
 		},
 	})
@@ -166,7 +166,7 @@ func (suite *DaoTestSuite) TestDeleteByProjectID() {
 	suite.Nil(err)
 
 	robots, err = suite.dao.List(orm.Context(), &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"project_id": 2,
 		},
 	})

--- a/src/pkg/scan/dao/scan/report_test.go
+++ b/src/pkg/scan/dao/scan/report_test.go
@@ -69,7 +69,7 @@ func (suite *ReportTestSuite) TestReportList() {
 	query1 := &q.Query{
 		PageSize:   1,
 		PageNumber: 1,
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"digest":            "digest1001",
 			"registration_uuid": "ruuid",
 			"mime_type":         v1.MimeTypeNativeReport,
@@ -82,7 +82,7 @@ func (suite *ReportTestSuite) TestReportList() {
 	query2 := &q.Query{
 		PageSize:   1,
 		PageNumber: 1,
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"digest": "digest1002",
 		},
 	}

--- a/src/pkg/scan/dao/scan/vulnerability_test.go
+++ b/src/pkg/scan/dao/scan/vulnerability_test.go
@@ -240,7 +240,7 @@ func (suite *VulnerabilityTestSuite) TestDeleteVulnerabilityRecord() {
 // TestListVulnerabilityRecord gets vulnerability records for scanner
 func (suite *VulnerabilityTestSuite) TestListVulnerabilityRecord() {
 
-	vulns, err := suite.vulnerabilityRecordDao.List(suite.Context(), &q.Query{Keywords: map[string]interface{}{"CVEID": "CVE-ID1"}})
+	vulns, err := suite.vulnerabilityRecordDao.List(suite.Context(), &q.Query{Keywords: map[string]any{"CVEID": "CVE-ID1"}})
 	suite.NoError(err, "Error when fetching vulnerability records for report")
 	suite.True(len(vulns) > 0)
 }

--- a/src/pkg/scan/dao/scanner/model.go
+++ b/src/pkg/scan/dao/scanner/model.go
@@ -66,9 +66,9 @@ type Registration struct {
 	Metadata *v1.ScannerAdapterMetadata `orm:"-" json:"-"`
 
 	// Timestamps
-	CreateTime   time.Time              `orm:"column(create_time);auto_now_add;type(datetime)" json:"create_time"`
-	UpdateTime   time.Time              `orm:"column(update_time);auto_now;type(datetime)" json:"update_time"`
-	Capabilities map[string]interface{} `orm:"-" json:"capabilities,omitempty"`
+	CreateTime   time.Time      `orm:"column(create_time);auto_now_add;type(datetime)" json:"create_time"`
+	UpdateTime   time.Time      `orm:"column(update_time);auto_now;type(datetime)" json:"update_time"`
+	Capabilities map[string]any `orm:"-" json:"capabilities,omitempty"`
 }
 
 // TableName for Endpoint

--- a/src/pkg/scan/dao/scanner/registration_test.go
+++ b/src/pkg/scan/dao/scanner/registration_test.go
@@ -108,7 +108,7 @@ func (suite *RegistrationDAOTestSuite) TestList() {
 	require.Equal(suite.T(), 1, len(l))
 
 	// with query and found items
-	keywords := make(map[string]interface{})
+	keywords := make(map[string]any)
 	keywords["description"] = &q.FuzzyMatchValue{Value: "sample"}
 	l, err = ListRegistrations(suite.Context(), &q.Query{
 		PageSize:   5,
@@ -127,7 +127,7 @@ func (suite *RegistrationDAOTestSuite) TestList() {
 	require.Equal(suite.T(), 0, len(l))
 
 	// Exact match
-	exactKeywords := make(map[string]interface{})
+	exactKeywords := make(map[string]any)
 	exactKeywords["name"] = "forUT"
 	l, err = ListRegistrations(suite.Context(), &q.Query{
 		Keywords: exactKeywords,

--- a/src/pkg/scan/export/manager.go
+++ b/src/pkg/scan/export/manager.go
@@ -164,7 +164,7 @@ func (em *exportManager) buildQuery(ctx context.Context, params Params) (beego_o
 		PageSize:   pageSize,
 		Sorting:    "",
 	}
-	paginationParams := make([]interface{}, 0)
+	paginationParams := make([]any, 0)
 	query, pageLimits := orm.PaginationOnRawSQL(q, sql, paginationParams)
 	// user can open ORM_DEBUG for log the sql
 	return ormer.Raw(query, pageLimits), nil

--- a/src/pkg/scan/export/manager_test.go
+++ b/src/pkg/scan/export/manager_test.go
@@ -174,8 +174,8 @@ func (suite *ExportManagerSuite) generateVulnerabilityRecordsForReport(registrat
 		} else {
 			vulnV2.Severity = "Low"
 		}
-		var vendorAttributes = make(map[string]interface{})
-		vendorAttributes["CVSS"] = map[string]interface{}{"nvd": map[string]interface{}{"V2Score": "4.3"}}
+		var vendorAttributes = make(map[string]any)
+		vendorAttributes["CVSS"] = map[string]any{"nvd": map[string]any{"V2Score": "4.3"}}
 		data, _ := json.Marshal(vendorAttributes)
 		vulnV2.VendorAttributes = string(data)
 		vulns = append(vulns, vulnV2)

--- a/src/pkg/scan/handler.go
+++ b/src/pkg/scan/handler.go
@@ -46,7 +46,7 @@ type Handler interface {
 	// RequiredPermissions defines the permission used by the scan robot account
 	RequiredPermissions() []*types.Policy
 	// RequestParameters defines the parameters for scan request
-	RequestParameters() map[string]interface{}
+	RequestParameters() map[string]any
 	// PostScan defines the operation after scan
 	PostScan(ctx job.Context, sr *v1.ScanRequest, rp *scan.Report, rawReport string, startTime time.Time, robot *model.Robot) (string, error)
 	ReportHandler
@@ -65,5 +65,5 @@ type ReportHandler interface {
 	// GetPlaceHolder get the the report place holder
 	GetPlaceHolder(ctx context.Context, artRepo string, artDigest string, scannerUUID string, mimeType string) (rp *scan.Report, err error)
 	// GetSummary get the summary of the report
-	GetSummary(ctx context.Context, ar *artifact.Artifact, mimeTypes []string) (map[string]interface{}, error)
+	GetSummary(ctx context.Context, ar *artifact.Artifact, mimeTypes []string) (map[string]any, error)
 }

--- a/src/pkg/scan/init_test.go
+++ b/src/pkg/scan/init_test.go
@@ -39,7 +39,7 @@ func TestEnsureScanners(t *testing.T) {
 		scannerManager = mgr
 
 		mgr.On("List", mock.Anything, &q.Query{
-			Keywords: map[string]interface{}{
+			Keywords: map[string]any{
 				"name__in": []string{"scanner"},
 			},
 		}).Return(nil, errors.New("DB error"))
@@ -57,7 +57,7 @@ func TestEnsureScanners(t *testing.T) {
 		scannerManager = mgr
 
 		mgr.On("List", mock.Anything, &q.Query{
-			Keywords: map[string]interface{}{
+			Keywords: map[string]any{
 				"name__in": []string{
 					"trivy",
 				},
@@ -81,7 +81,7 @@ func TestEnsureScanners(t *testing.T) {
 		scannerManager = mgr
 
 		mgr.On("List", mock.Anything, &q.Query{
-			Keywords: map[string]interface{}{
+			Keywords: map[string]any{
 				"name__in": []string{
 					"trivy",
 				},
@@ -136,7 +136,7 @@ func TestEnsureDefaultScanner(t *testing.T) {
 
 		mgr.On("GetDefault", mock.Anything).Return(nil, nil)
 		mgr.On("List", mock.Anything, &q.Query{
-			Keywords: map[string]interface{}{"name": "trivy"},
+			Keywords: map[string]any{"name": "trivy"},
 		}).Return(nil, errors.New("DB error"))
 
 		err := EnsureDefaultScanner(context.TODO(), "trivy")
@@ -150,7 +150,7 @@ func TestEnsureDefaultScanner(t *testing.T) {
 
 		mgr.On("GetDefault", mock.Anything).Return(nil, nil)
 		mgr.On("List", mock.Anything, &q.Query{
-			Keywords: map[string]interface{}{"name": "trivy"},
+			Keywords: map[string]any{"name": "trivy"},
 		}).Return([]*scanner.Registration{
 			{Name: "trivy"},
 			{Name: "trivy"},
@@ -167,7 +167,7 @@ func TestEnsureDefaultScanner(t *testing.T) {
 
 		mgr.On("GetDefault", mock.Anything).Return(nil, nil)
 		mgr.On("List", mock.Anything, &q.Query{
-			Keywords: map[string]interface{}{"name": "trivy"},
+			Keywords: map[string]any{"name": "trivy"},
 		}).Return([]*scanner.Registration{
 			{
 				Name: "trivy",
@@ -188,7 +188,7 @@ func TestEnsureDefaultScanner(t *testing.T) {
 
 		mgr.On("GetDefault", mock.Anything).Return(nil, nil)
 		mgr.On("List", mock.Anything, &q.Query{
-			Keywords: map[string]interface{}{"name": "trivy"},
+			Keywords: map[string]any{"name": "trivy"},
 		}).Return([]*scanner.Registration{
 			{
 				Name: "trivy",
@@ -221,7 +221,7 @@ func TestRemoveImmutableScanners(t *testing.T) {
 		scannerManager = mgr
 
 		mgr.On("List", mock.Anything, &q.Query{
-			Keywords: map[string]interface{}{
+			Keywords: map[string]any{
 				"immutable": true,
 				"name__in":  []string{"scanner"},
 			},
@@ -249,7 +249,7 @@ func TestRemoveImmutableScanners(t *testing.T) {
 			}}
 
 		mgr.On("List", mock.Anything, &q.Query{
-			Keywords: map[string]interface{}{
+			Keywords: map[string]any{
 				"immutable": true,
 				"name__in": []string{
 					"scanner-1",
@@ -285,7 +285,7 @@ func TestRemoveImmutableScanners(t *testing.T) {
 			}}
 
 		mgr.On("List", mock.Anything, &q.Query{
-			Keywords: map[string]interface{}{
+			Keywords: map[string]any{
 				"immutable": true,
 				"name__in": []string{
 					"scanner-1",

--- a/src/pkg/scan/job.go
+++ b/src/pkg/scan/job.go
@@ -501,10 +501,10 @@ func extractMimeTypes(params job.Parameters) ([]string, error) {
 		return nil, errors.Errorf("missing job parameter '%s'", JobParameterMimes)
 	}
 
-	l, ok := v.([]interface{})
+	l, ok := v.([]any)
 	if !ok {
 		return nil, errors.Errorf(
-			"malformed job parameter '%s', expecting []interface{} but got %s",
+			"malformed job parameter '%s', expecting []any but got %s",
 			JobParameterMimes,
 			reflect.TypeOf(v).String(),
 		)

--- a/src/pkg/scan/postprocessors/report_converters.go
+++ b/src/pkg/scan/postprocessors/report_converters.go
@@ -105,7 +105,7 @@ func (c *nativeToRelationalSchemaConverter) toSchema(ctx context.Context, report
 		return err
 	}
 
-	var cveIDs []interface{}
+	var cveIDs []any
 	for _, v := range vulnReport.Vulnerabilities {
 		v.Severity = vuln.ParseSeverityVersion3(v.Severity.String())
 		cveIDs = append(cveIDs, v.ID)
@@ -226,7 +226,7 @@ func (c *nativeToRelationalSchemaConverter) fromSchema(_ context.Context, _ stri
 
 // GetNativeV1ReportFromResolvedData returns the native V1 scan report from the resolved
 // interface data.
-func (c *nativeToRelationalSchemaConverter) getNativeV1ReportFromResolvedData(ctx job.Context, rp interface{}) (*vuln.Report, error) {
+func (c *nativeToRelationalSchemaConverter) getNativeV1ReportFromResolvedData(ctx job.Context, rp any) (*vuln.Report, error) {
 	report, ok := rp.(*vuln.Report)
 	if !ok {
 		return nil, errors.New("Data cannot be converted to v1 report format")
@@ -295,7 +295,7 @@ func toVulnerabilityItem(record *scan.VulnerabilityRecord, artifactDigest string
 	item.Links = append(item.Links, urls...)
 	item.Severity = vuln.ParseSeverityVersion3(record.Severity)
 	item.Package = record.Package
-	var vendorAttributes map[string]interface{}
+	var vendorAttributes map[string]any
 	_ = json.Unmarshal([]byte(record.VendorAttributes), &vendorAttributes)
 	item.VendorAttributes = vendorAttributes
 
@@ -356,7 +356,7 @@ func (c *nativeToRelationalSchemaConverter) updateReport(ctx context.Context, vu
 
 // CVS ...
 type CVS struct {
-	CVSS map[string]map[string]interface{} `json:"CVSS"`
+	CVSS map[string]map[string]any `json:"CVSS"`
 }
 
 func parseScoreFromVendorAttribute(ctx context.Context, vendorAttribute string) float64 {

--- a/src/pkg/scan/report/manager.go
+++ b/src/pkg/scan/report/manager.go
@@ -167,7 +167,7 @@ func (bm *basicManager) GetBy(ctx context.Context, digest string, registrationUU
 		return nil, errors.New("empty digest to get report data")
 	}
 
-	kws := make(map[string]interface{})
+	kws := make(map[string]any)
 	kws["digest"] = digest
 	if len(registrationUUID) > 0 {
 		kws["registration_uuid"] = registrationUUID

--- a/src/pkg/scan/report/report.go
+++ b/src/pkg/scan/report/report.go
@@ -22,7 +22,7 @@ import (
 )
 
 // Merger is a helper function to merge report together
-type Merger func(r1, r2 interface{}) (interface{}, error)
+type Merger func(r1, r2 any) (any, error)
 
 // SupportedMergers declares mappings between mime type and report merger func.
 var SupportedMergers = map[string]Merger{
@@ -31,7 +31,7 @@ var SupportedMergers = map[string]Merger{
 }
 
 // Merge merge report r1 and r2
-func Merge(mimeType string, r1, r2 interface{}) (interface{}, error) {
+func Merge(mimeType string, r1, r2 any) (any, error) {
 	m, ok := SupportedMergers[mimeType]
 	if !ok {
 		return nil, errors.Errorf("no report merger bound with mime type %s", mimeType)
@@ -41,7 +41,7 @@ func Merge(mimeType string, r1, r2 interface{}) (interface{}, error) {
 }
 
 // MergeNativeReport merge report r1 and r2
-func MergeNativeReport(r1, r2 interface{}) (interface{}, error) {
+func MergeNativeReport(r1, r2 any) (any, error) {
 	nr1, ok := r1.(*vuln.Report)
 	if !ok {
 		return nil, errors.New("native report required")
@@ -59,8 +59,8 @@ func MergeNativeReport(r1, r2 interface{}) (interface{}, error) {
 type Reports []*scan.Report
 
 // ResolveData resolve the data from the reports and merge them together
-func (l Reports) ResolveData(mimeType string) (interface{}, error) {
-	var result interface{}
+func (l Reports) ResolveData(mimeType string) (any, error) {
+	var result any
 
 	for _, rp := range l {
 		// Resolve scan report data only when it is ready and its mime type equal the given one

--- a/src/pkg/scan/report/summary.go
+++ b/src/pkg/scan/report/summary.go
@@ -41,7 +41,7 @@ func WithArtifactDigest(artifactDigest string) Option {
 }
 
 // SummaryMerger is a helper function to merge summary together
-type SummaryMerger func(s1, s2 interface{}) (interface{}, error)
+type SummaryMerger func(s1, s2 any) (any, error)
 
 // SupportedSummaryMergers declares mappings between mime type and summary merger func.
 var SupportedSummaryMergers = map[string]SummaryMerger{
@@ -50,7 +50,7 @@ var SupportedSummaryMergers = map[string]SummaryMerger{
 }
 
 // MergeSummary merge summary s1 and s2
-func MergeSummary(mimeType string, s1, s2 interface{}) (interface{}, error) {
+func MergeSummary(mimeType string, s1, s2 any) (any, error) {
 	m, ok := SupportedSummaryMergers[mimeType]
 	if !ok {
 		return nil, errors.Errorf("no summary merger bound with mime type %s", mimeType)
@@ -60,7 +60,7 @@ func MergeSummary(mimeType string, s1, s2 interface{}) (interface{}, error) {
 }
 
 // MergeNativeSummary merge vuln.NativeReportSummary together
-func MergeNativeSummary(s1, s2 interface{}) (interface{}, error) {
+func MergeNativeSummary(s1, s2 any) (any, error) {
 	nrs1, ok := s1.(*vuln.NativeReportSummary)
 	if !ok {
 		return nil, errors.New("native report summary required")
@@ -82,7 +82,7 @@ var SupportedGenerators = map[string]SummaryGenerator{
 
 // GenerateSummary is a helper function to generate report
 // summary based on the given report.
-func GenerateSummary(r *scan.Report, options ...Option) (interface{}, error) {
+func GenerateSummary(r *scan.Report, options ...Option) (any, error) {
 	g, ok := SupportedGenerators[r.MimeType]
 	if !ok {
 		return nil, errors.Errorf("no generator bound with mime type %s", r.MimeType)
@@ -93,10 +93,10 @@ func GenerateSummary(r *scan.Report, options ...Option) (interface{}, error) {
 
 // SummaryGenerator is a func template which used to generated report
 // summary for relevant mime type.
-type SummaryGenerator func(r *scan.Report, options ...Option) (interface{}, error)
+type SummaryGenerator func(r *scan.Report, options ...Option) (any, error)
 
 // GenerateNativeSummary generates the report summary for the native report.
-func GenerateNativeSummary(r *scan.Report, _ ...Option) (interface{}, error) {
+func GenerateNativeSummary(r *scan.Report, _ ...Option) (any, error) {
 	sum := &vuln.NativeReportSummary{}
 	sum.ReportID = r.UUID
 	sum.StartTime = r.StartTime

--- a/src/pkg/scan/report/supported_mimes.go
+++ b/src/pkg/scan/report/supported_mimes.go
@@ -24,14 +24,14 @@ import (
 )
 
 // SupportedMimes indicates what mime types are supported to render at UI end.
-var SupportedMimes = map[string]interface{}{
+var SupportedMimes = map[string]any{
 	// The native report type
 	v1.MimeTypeNativeReport:               (*vuln.Report)(nil),
 	v1.MimeTypeGenericVulnerabilityReport: (*vuln.Report)(nil),
 }
 
 // ResolveData is a helper func to parse the JSON data with the given mime type.
-func ResolveData(mime string, jsonData []byte, options ...Option) (interface{}, error) {
+func ResolveData(mime string, jsonData []byte, options ...Option) (any, error) {
 	// If no resolver defined for the given mime types, directly ignore it.
 	// The raw data will be used.
 	t, ok := SupportedMimes[mime]

--- a/src/pkg/scan/rest/v1/client.go
+++ b/src/pkg/scan/rest/v1/client.go
@@ -59,7 +59,7 @@ type Client interface {
 
 	// GetScanReport gets the scan result for the corresponding ScanRequest identifier.
 	// Note that this is a blocking method which either returns a non `nil` scan report or error.
-	// A caller is supposed to cast the returned interface{} to a structure that corresponds
+	// A caller is supposed to cast the returned any to a structure that corresponds
 	// to the specified MIME type.
 	//
 	//   Arguments:

--- a/src/pkg/scan/rest/v1/models.go
+++ b/src/pkg/scan/rest/v1/models.go
@@ -159,8 +159,8 @@ func (md *ScannerAdapterMetadata) GetCapability(mimeType string) *ScannerCapabil
 }
 
 // ConvertCapability converts the capability to map, used in get scanner API
-func (md *ScannerAdapterMetadata) ConvertCapability() map[string]interface{} {
-	capabilities := make(map[string]interface{})
+func (md *ScannerAdapterMetadata) ConvertCapability() map[string]any {
+	capabilities := make(map[string]any)
 	oldScanner := true
 	for _, c := range md.Capabilities {
 		if len(c.Type) > 0 {
@@ -228,7 +228,7 @@ type ScanType struct {
 	// ProducesMimeTypes defines scanreport should be
 	ProducesMimeTypes []string `json:"produces_mime_types"`
 	// Parameters extra parameters
-	Parameters map[string]interface{} `json:"parameters"`
+	Parameters map[string]any `json:"parameters"`
 }
 
 // FromJSON parses ScanRequest from json data

--- a/src/pkg/scan/sbom/dao/dao_test.go
+++ b/src/pkg/scan/sbom/dao/dao_test.go
@@ -94,7 +94,7 @@ func (suite *ReportTestSuite) TestUpdate() {
 	query1 := &q.Query{
 		PageSize:   1,
 		PageNumber: 1,
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"artifact_id":       111,
 			"registration_uuid": "ruuid",
 			"mime_type":         v1.MimeTypeSBOMReport,
@@ -110,7 +110,7 @@ func (suite *ReportTestSuite) TestReportList() {
 	query1 := &q.Query{
 		PageSize:   1,
 		PageNumber: 1,
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"artifact_id":       111,
 			"registration_uuid": "ruuid",
 			"mime_type":         v1.MimeTypeSBOMReport,
@@ -123,7 +123,7 @@ func (suite *ReportTestSuite) TestReportList() {
 	query2 := &q.Query{
 		PageSize:   1,
 		PageNumber: 1,
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"artifact_id": 222,
 		},
 	}

--- a/src/pkg/scan/sbom/manager.go
+++ b/src/pkg/scan/sbom/manager.go
@@ -152,7 +152,7 @@ func (bm *basicManager) GetBy(ctx context.Context, artifactID int64, registratio
 		return nil, errors.New("no artifact id to get sbom report data")
 	}
 
-	kws := make(map[string]interface{})
+	kws := make(map[string]any)
 	kws["artifact_id"] = artifactID
 	if len(registrationUUID) > 0 {
 		kws["registration_uuid"] = registrationUUID

--- a/src/pkg/scan/sbom/model/report.go
+++ b/src/pkg/scan/sbom/model/report.go
@@ -42,5 +42,5 @@ type RawSBOMReport struct {
 	// MediaType the media type of the report, e.g. application/spdx+json
 	MediaType string `json:"media_type"`
 	// SBOM sbom content
-	SBOM map[string]interface{} `json:"sbom,omitempty"`
+	SBOM map[string]any `json:"sbom,omitempty"`
 }

--- a/src/pkg/scan/sbom/model/summary.go
+++ b/src/pkg/scan/sbom/model/summary.go
@@ -34,7 +34,7 @@ const (
 )
 
 // Summary includes the sbom summary information
-type Summary map[string]interface{}
+type Summary map[string]any
 
 // SBOMAccArt returns the repository and digest of the SBOM
 func (s Summary) SBOMAccArt() (repo, digest string) {

--- a/src/pkg/scan/sbom/sbom.go
+++ b/src/pkg/scan/sbom/sbom.go
@@ -78,8 +78,8 @@ func (h *scanHandler) RequestProducesMineTypes() []string {
 }
 
 // RequestParameters defines the parameters for scan request
-func (h *scanHandler) RequestParameters() map[string]interface{} {
-	return map[string]interface{}{"sbom_media_types": []string{sbomMediaTypeSpdx}}
+func (h *scanHandler) RequestParameters() map[string]any {
+	return map[string]any{"sbom_media_types": []string{sbomMediaTypeSpdx}}
 }
 
 // PostScan defines task specific operations after the scan is complete
@@ -295,7 +295,7 @@ func (h *scanHandler) GetPlaceHolder(ctx context.Context, artRepo string, artDig
 	}, nil
 }
 
-func (h *scanHandler) GetSummary(ctx context.Context, art *artifact.Artifact, mimeTypes []string) (map[string]interface{}, error) {
+func (h *scanHandler) GetSummary(ctx context.Context, art *artifact.Artifact, mimeTypes []string) (map[string]any, error) {
 	if len(mimeTypes) == 0 {
 		return nil, errors.New("no mime types to get report summaries")
 	}
@@ -312,10 +312,10 @@ func (h *scanHandler) GetSummary(ctx context.Context, art *artifact.Artifact, mi
 		return nil, err
 	}
 	if len(reports) == 0 {
-		return map[string]interface{}{}, nil
+		return map[string]any{}, nil
 	}
 	reportContent := reports[0].ReportSummary
-	result := map[string]interface{}{}
+	result := map[string]any{}
 	if len(reportContent) == 0 {
 		status := h.TaskMgrFunc().RetrieveStatusFromTask(ctx, reports[0].UUID)
 		if len(status) > 0 {

--- a/src/pkg/scan/scanner/manager_test.go
+++ b/src/pkg/scan/scanner/manager_test.go
@@ -64,7 +64,7 @@ func (suite *BasicManagerTestSuite) TearDownSuite() {
 
 // TestList tests list registrations
 func (suite *BasicManagerTestSuite) TestList() {
-	m := make(map[string]interface{}, 1)
+	m := make(map[string]any, 1)
 	m["name"] = "forUT"
 
 	l, err := suite.mgr.List(suite.Context(), &q.Query{

--- a/src/pkg/scan/vuln/report.go
+++ b/src/pkg/scan/vuln/report.go
@@ -35,7 +35,7 @@ type Report struct {
 	vulnerabilityItemList *VulnerabilityItemList
 
 	// SBOM sbom content
-	SBOM map[string]interface{} `json:"sbom,omitempty"`
+	SBOM map[string]any `json:"sbom,omitempty"`
 }
 
 // GetVulnerabilityItemList returns VulnerabilityItemList from the Vulnerabilities of report
@@ -225,7 +225,7 @@ type VulnerabilityItem struct {
 	CWEIds []string `json:"cwe_ids"`
 	// A collection of vendor specific attributes for the vulnerability item
 	// with each attribute represented as a key-value pair.
-	VendorAttributes map[string]interface{} `json:"vendor_attributes"`
+	VendorAttributes map[string]any `json:"vendor_attributes"`
 }
 
 // Key returns the uniq key for the item

--- a/src/pkg/scan/vulnerability/vul.go
+++ b/src/pkg/scan/vulnerability/vul.go
@@ -230,7 +230,7 @@ func (h *scanHandler) RequestProducesMineTypes() []string {
 }
 
 // RequestParameters defines the parameters for scan request
-func (h *scanHandler) RequestParameters() map[string]interface{} {
+func (h *scanHandler) RequestParameters() map[string]any {
 	return nil
 }
 
@@ -270,7 +270,7 @@ func (h *scanHandler) Update(ctx context.Context, uuid string, rpt string) error
 	return nil
 }
 
-func (h *scanHandler) GetSummary(ctx context.Context, ar *artifact.Artifact, mimeTypes []string) (map[string]interface{}, error) {
+func (h *scanHandler) GetSummary(ctx context.Context, ar *artifact.Artifact, mimeTypes []string) (map[string]any, error) {
 	bc := h.ScanControllerFunc()
 	if ar == nil {
 		return nil, errors.New("no way to get report summaries for nil artifact")
@@ -280,7 +280,7 @@ func (h *scanHandler) GetSummary(ctx context.Context, ar *artifact.Artifact, mim
 	if err != nil {
 		return nil, err
 	}
-	summaries := make(map[string]interface{}, len(rps))
+	summaries := make(map[string]any, len(rps))
 	for _, rp := range rps {
 		sum, err := report.GenerateSummary(rp)
 		if err != nil {

--- a/src/pkg/scheduler/dao_test.go
+++ b/src/pkg/scheduler/dao_test.go
@@ -76,7 +76,7 @@ func (d *daoTestSuite) TestCreate() {
 
 func (d *daoTestSuite) TestList() {
 	schedules, err := d.dao.List(d.ctx, &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"CallbackFuncName": "callback_func_01",
 		},
 	})

--- a/src/pkg/scheduler/scheduler_test.go
+++ b/src/pkg/scheduler/scheduler_test.go
@@ -57,7 +57,7 @@ func (s *schedulerTestSuite) SetupTest() {
 
 func (s *schedulerTestSuite) TestSchedule() {
 	// empty vendor type
-	extras := make(map[string]interface{})
+	extras := make(map[string]any)
 	id, err := s.scheduler.Schedule(s.ctx, "", 0, "", "0 * * * * *", "callback", nil, extras)
 	s.NotNil(err)
 

--- a/src/pkg/securityhub/dao/security.go
+++ b/src/pkg/securityhub/dao/security.go
@@ -105,7 +105,7 @@ type filterMetaData struct {
 	// ColumnName is the column name in the database, if it is empty, the key will be used as the column name
 	ColumnName string
 	// FilterFunc is the function to generate the filter sql, default is exactMatchFilter
-	FilterFunc func(ctx context.Context, key string, query *q.Query) (sqlStr string, params []interface{})
+	FilterFunc func(ctx context.Context, key string, query *q.Query) (sqlStr string, params []any)
 }
 
 // filterMap define the query condition
@@ -120,9 +120,9 @@ var filterMap = map[string]*filterMetaData{
 	"digest":          &filterMetaData{DataType: stringType, ColumnName: "a.digest"},
 }
 
-var applyFilterFunc func(ctx context.Context, key string, query *q.Query) (sqlStr string, params []interface{})
+var applyFilterFunc func(ctx context.Context, key string, query *q.Query) (sqlStr string, params []any)
 
-func exactMatchFilter(_ context.Context, key string, query *q.Query) (sqlStr string, params []interface{}) {
+func exactMatchFilter(_ context.Context, key string, query *q.Query) (sqlStr string, params []any) {
 	if query == nil {
 		return
 	}
@@ -138,7 +138,7 @@ func exactMatchFilter(_ context.Context, key string, query *q.Query) (sqlStr str
 	return
 }
 
-func rangeFilter(_ context.Context, key string, query *q.Query) (sqlStr string, params []interface{}) {
+func rangeFilter(_ context.Context, key string, query *q.Query) (sqlStr string, params []any) {
 	if query == nil {
 		return
 	}
@@ -151,7 +151,7 @@ func rangeFilter(_ context.Context, key string, query *q.Query) (sqlStr string, 
 	return
 }
 
-func tagFilter(ctx context.Context, _ string, query *q.Query) (sqlStr string, params []interface{}) {
+func tagFilter(ctx context.Context, _ string, query *q.Query) (sqlStr string, params []any) {
 	if query == nil {
 		return
 	}
@@ -272,7 +272,7 @@ func (d *dao) CountVulnerabilities(ctx context.Context, registrationUUID string,
 		return 0, err
 	}
 	sqlStr := vulnerabilitySQL
-	params := []interface{}{registrationUUID}
+	params := []any{registrationUUID}
 	if err := checkQFilter(query, filterMap); err != nil {
 		return 0, err
 	}
@@ -293,7 +293,7 @@ func (d *dao) CountVulnerabilities(ctx context.Context, registrationUUID string,
 }
 
 // countExceedLimit check if the count is exceed to limit 1000, avoid count all record for large table
-func (d *dao) countExceedLimit(ctx context.Context, sqlStr string, params []interface{}) (bool, error) {
+func (d *dao) countExceedLimit(ctx context.Context, sqlStr string, params []any) (bool, error) {
 	o, err := orm.FromContext(ctx)
 	if err != nil {
 		return false, err
@@ -313,7 +313,7 @@ func (d *dao) ListVulnerabilities(ctx context.Context, registrationUUID string, 
 		return nil, err
 	}
 	sqlStr := vulnerabilitySQL
-	params := []interface{}{registrationUUID}
+	params := []any{registrationUUID}
 	if err := checkQFilter(query, filterMap); err != nil {
 		return nil, err
 	}
@@ -324,7 +324,7 @@ func (d *dao) ListVulnerabilities(ctx context.Context, registrationUUID string, 
 	return vulnRecs, err
 }
 
-func applyVulFilter(ctx context.Context, sqlStr string, query *q.Query, params []interface{}) (queryStr string, newParam []interface{}) {
+func applyVulFilter(ctx context.Context, sqlStr string, query *q.Query, params []any) (queryStr string, newParam []any) {
 	if query == nil {
 		return sqlStr, params
 	}
@@ -342,7 +342,7 @@ func applyVulFilter(ctx context.Context, sqlStr string, query *q.Query, params [
 }
 
 // applyVulPagination apply pagination to the query and sort by cvss_score_v3 desc
-func applyVulPagination(sqlStr string, query *q.Query, params []interface{}) (string, []interface{}) {
+func applyVulPagination(sqlStr string, query *q.Query, params []any) (string, []any) {
 	offSet := int64(0)
 	pageSize := int64(15)
 	if query != nil && query.PageNumber > 1 {

--- a/src/pkg/securityhub/dao/security_test.go
+++ b/src/pkg/securityhub/dao/security_test.go
@@ -159,10 +159,10 @@ func (suite *SecurityDaoTestSuite) TestExactMatchFilter() {
 		name       string
 		args       args
 		wantSQLStr string
-		wantParams []interface{}
+		wantParams []any
 	}{
-		{"normal", args{suite.Context(), "cve_id", q.New(q.KeyWords{"cve_id": "CVE-2023-2345"})}, " and cve_id = ?", []interface{}{"CVE-2023-2345"}},
-		{"digest", args{suite.Context(), "digest", q.New(q.KeyWords{"digest": "digest123"})}, " and a.digest = ?", []interface{}{"digest123"}},
+		{"normal", args{suite.Context(), "cve_id", q.New(q.KeyWords{"cve_id": "CVE-2023-2345"})}, " and cve_id = ?", []any{"CVE-2023-2345"}},
+		{"digest", args{suite.Context(), "digest", q.New(q.KeyWords{"digest": "digest123"})}, " and a.digest = ?", []any{"digest123"}},
 	}
 	for _, tt := range tests {
 		suite.Run(tt.name, func() {
@@ -183,9 +183,9 @@ func (suite *SecurityDaoTestSuite) TestRangeFilter() {
 		name       string
 		args       args
 		wantSQLStr string
-		wantParams []interface{}
+		wantParams []any
 	}{
-		{"normal", args{suite.Context(), "cvss_score_v3", q.New(q.KeyWords{"cvss_score_v3": &q.Range{1.0, 2.0}})}, " and cvss_score_v3 between ? and ?", []interface{}{1.0, 2.0}},
+		{"normal", args{suite.Context(), "cvss_score_v3", q.New(q.KeyWords{"cvss_score_v3": &q.Range{1.0, 2.0}})}, " and cvss_score_v3 between ? and ?", []any{1.0, 2.0}},
 	}
 	for _, tt := range tests {
 		suite.Run(tt.name, func() {
@@ -224,7 +224,7 @@ func (suite *SecurityDaoTestSuite) TestTagFilter() {
 		name       string
 		args       args
 		wantSqlStr string
-		wantParams []interface{}
+		wantParams []any
 	}{
 		{"normal", args{suite.Context(), "tag", q.New(q.KeyWords{"tag": "tag_test"})}, " and a.id IN", nil},
 	}
@@ -242,13 +242,13 @@ func (suite *SecurityDaoTestSuite) TestApplyVulFilter() {
 		ctx    context.Context
 		sqlStr string
 		query  *q.Query
-		params []interface{}
+		params []any
 	}
 	tests := []struct {
 		name       string
 		args       args
 		wantSqlStr string
-		wantParams []interface{}
+		wantParams []any
 	}{
 		{"normal", args{suite.Context(), "select * from vulnerability_record", q.New(q.KeyWords{"tag": "tag_test"}), nil}, " and a.id IN", nil},
 	}

--- a/src/pkg/systemartifact/cleanupcriteria.go
+++ b/src/pkg/systemartifact/cleanupcriteria.go
@@ -64,6 +64,6 @@ func (cleanupCriteria *defaultSelector) List(ctx context.Context) ([]*model.Syst
 	duration := time.Duration(DefaultCleanupWindowSeconds) * time.Second
 	timeRange := q.Range{Max: currentTime.Add(-duration).Format(time.RFC3339)}
 	logger.Debugf("Cleaning up system artifacts with range: %v", timeRange)
-	query := q.New(map[string]interface{}{"create_time": &timeRange})
+	query := q.New(map[string]any{"create_time": &timeRange})
 	return cleanupCriteria.dao.List(ctx, query)
 }

--- a/src/pkg/systemartifact/cleanupcriteria_test.go
+++ b/src/pkg/systemartifact/cleanupcriteria_test.go
@@ -144,7 +144,7 @@ func (suite *defaultCleanupCriteriaTestSuite) TestListWithFilters() {
 
 		actualSysArtifactIds := make(map[int64]bool)
 
-		query := q.Query{Keywords: map[string]interface{}{"vendor": "test_vendor37000", "repository": "test_repo37000"}}
+		query := q.Query{Keywords: map[string]any{"vendor": "test_vendor37000", "repository": "test_repo37000"}}
 		sysArtifactList, err := suite.cleanupCriteria.ListWithFilters(suite.ctx, &query)
 
 		for _, sysArtifact := range sysArtifactList {

--- a/src/pkg/systemartifact/dao/dao_test.go
+++ b/src/pkg/systemartifact/dao/dao_test.go
@@ -267,7 +267,7 @@ func (suite *daoTestSuite) TestList() {
 	// attempt to read all the system artifact records
 	{
 		query := q.Query{}
-		query.Keywords = map[string]interface{}{"repository": "test_repo4", "digest": "test_digest4"}
+		query.Keywords = map[string]any{"repository": "test_repo4", "digest": "test_digest4"}
 
 		sysArtifacts, err := suite.dao.List(suite.ctx, &query)
 		suite.NotNilf(sysArtifacts, "Expected system artifacts list to be non-nil")

--- a/src/pkg/tag/dao/dao.go
+++ b/src/pkg/tag/dao/dao.go
@@ -142,7 +142,7 @@ func (d *dao) Delete(ctx context.Context, id int64) error {
 
 func (d *dao) DeleteOfArtifact(ctx context.Context, artifactID int64) error {
 	qs, err := orm.QuerySetter(ctx, &tag.Tag{}, &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"ArtifactID": artifactID,
 		},
 	})

--- a/src/pkg/tag/dao/dao_test.go
+++ b/src/pkg/tag/dao/dao_test.go
@@ -86,7 +86,7 @@ func (d *daoTestSuite) TestCount() {
 	d.True(total > 0)
 	// query by repository ID and name
 	total, err = d.dao.Count(d.ctx, &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"repository_id": 1000,
 			"name":          "latest",
 		},
@@ -110,7 +110,7 @@ func (d *daoTestSuite) TestList() {
 
 	// query by repository ID and name
 	tags, err = d.dao.List(d.ctx, &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"repository_id": 1000,
 			"name":          "latest",
 		},
@@ -251,7 +251,7 @@ func (d *daoTestSuite) TestDeleteOfArtifact() {
 	d.Require().Nil(err)
 
 	tags, err := d.dao.List(d.ctx, &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"ArtifactID": artifactID,
 		},
 	})
@@ -262,7 +262,7 @@ func (d *daoTestSuite) TestDeleteOfArtifact() {
 	d.Require().Nil(err)
 
 	tags, err = d.dao.List(d.ctx, &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"ArtifactID": artifactID,
 		},
 	})

--- a/src/pkg/task/dao/execution.go
+++ b/src/pkg/task/dao/execution.go
@@ -346,7 +346,7 @@ func (e *executionDAO) refreshStatus(ctx context.Context, id int64) (bool, strin
 type jsonbStru struct {
 	keyPrefix string
 	key       string
-	value     interface{}
+	value     any
 }
 
 func (e *executionDAO) querySetter(ctx context.Context, query *q.Query, options ...orm.Option) (orm.QuerySeter, error) {
@@ -359,7 +359,7 @@ func (e *executionDAO) querySetter(ctx context.Context, query *q.Query, options 
 	if query != nil && len(query.Keywords) > 0 {
 		var (
 			jsonbStrus []jsonbStru
-			args       []interface{}
+			args       []any
 		)
 
 		for key, value := range query.Keywords {
@@ -407,13 +407,13 @@ func (e *executionDAO) querySetter(ctx context.Context, query *q.Query, options 
 // key = extra_attrs.a.b.c
 //
 //	==> sql = "select id from execution where extra_attrs->?->?->>?=?", args = {a, b, c, value}
-func buildInClauseSQLForExtraAttrs(jsonbStrus []jsonbStru) (string, []interface{}) {
+func buildInClauseSQLForExtraAttrs(jsonbStrus []jsonbStru) (string, []any) {
 	if len(jsonbStrus) == 0 {
 		return "", nil
 	}
 
 	var cond string
-	var args []interface{}
+	var args []any
 	sql := "select id from execution where"
 
 	for i, jsonbStr := range jsonbStrus {

--- a/src/pkg/task/dao/execution_test.go
+++ b/src/pkg/task/dao/execution_test.go
@@ -66,7 +66,7 @@ func (e *executionDAOTestSuite) TearDownTest() {
 
 func (e *executionDAOTestSuite) TestCount() {
 	count, err := e.executionDAO.Count(e.ctx, &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"VendorType":     "test",
 			"ExtraAttrs.key": "value",
 		},
@@ -75,7 +75,7 @@ func (e *executionDAOTestSuite) TestCount() {
 	e.Equal(int64(1), count)
 
 	count, err = e.executionDAO.Count(e.ctx, &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"VendorType":     "test",
 			"ExtraAttrs.key": "incorrect-value",
 		},
@@ -86,7 +86,7 @@ func (e *executionDAOTestSuite) TestCount() {
 
 func (e *executionDAOTestSuite) TestList() {
 	executions, err := e.executionDAO.List(e.ctx, &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"VendorType":     "test",
 			"ExtraAttrs.key": "value",
 		},
@@ -96,7 +96,7 @@ func (e *executionDAOTestSuite) TestList() {
 	e.Equal(e.executionID, executions[0].ID)
 
 	executions, err = e.executionDAO.List(e.ctx, &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"VendorType":     "test",
 			"ExtraAttrs.key": "incorrect-value",
 		},

--- a/src/pkg/task/dao/task.go
+++ b/src/pkg/task/dao/task.go
@@ -261,7 +261,7 @@ func (t *taskDAO) querySetter(ctx context.Context, query *q.Query, options ...or
 		var (
 			key       string
 			keyPrefix string
-			value     interface{}
+			value     any
 		)
 		for key, value = range query.Keywords {
 			if strings.HasPrefix(key, "ExtraAttrs.") {

--- a/src/pkg/task/dao/task_test.go
+++ b/src/pkg/task/dao/task_test.go
@@ -73,7 +73,7 @@ func (t *taskDAOTestSuite) TearDownTest() {
 
 func (t *taskDAOTestSuite) TestCount() {
 	count, err := t.taskDAO.Count(t.ctx, &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"ExecutionID":    t.executionID,
 			"ExtraAttrs.key": "value",
 		},
@@ -82,7 +82,7 @@ func (t *taskDAOTestSuite) TestCount() {
 	t.Equal(int64(1), count)
 
 	count, err = t.taskDAO.Count(t.ctx, &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"ExecutionID":    t.executionID,
 			"ExtraAttrs.key": "incorrect-value",
 		},
@@ -93,7 +93,7 @@ func (t *taskDAOTestSuite) TestCount() {
 
 func (t *taskDAOTestSuite) TestList() {
 	tasks, err := t.taskDAO.List(t.ctx, &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"ExecutionID":    t.executionID,
 			"ExtraAttrs.key": "value",
 		},
@@ -103,7 +103,7 @@ func (t *taskDAOTestSuite) TestList() {
 	t.Equal(t.taskID, tasks[0].ID)
 
 	tasks, err = t.taskDAO.List(t.ctx, &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"ExecutionID":    t.executionID,
 			"ExtraAttrs.key": "incorrect-value",
 		},

--- a/src/pkg/task/execution.go
+++ b/src/pkg/task/execution.go
@@ -41,9 +41,9 @@ type ExecutionManager interface {
 	// and the "vendorID" specifies the ID of vendor if needed(e.g. policy ID for replication and retention).
 	// The "extraAttrs" can be used to set the customized attributes
 	Create(ctx context.Context, vendorType string, vendorID int64, trigger string,
-		extraAttrs ...map[string]interface{}) (id int64, err error)
+		extraAttrs ...map[string]any) (id int64, err error)
 	// Update the extra attributes of the specified execution
-	UpdateExtraAttrs(ctx context.Context, id int64, extraAttrs map[string]interface{}) (err error)
+	UpdateExtraAttrs(ctx context.Context, id int64, extraAttrs map[string]any) (err error)
 	// MarkDone marks the status of the specified execution as success.
 	// It must be called to update the execution status if the created execution contains no tasks.
 	// In other cases, the execution status can be calculated from the referenced tasks automatically
@@ -96,8 +96,8 @@ func (e *executionManager) Count(ctx context.Context, query *q.Query) (int64, er
 }
 
 func (e *executionManager) Create(ctx context.Context, vendorType string, vendorID int64, trigger string,
-	extraAttrs ...map[string]interface{}) (int64, error) {
-	extras := map[string]interface{}{}
+	extraAttrs ...map[string]any) (int64, error) {
+	extras := map[string]any{}
 	if len(extraAttrs) > 0 && extraAttrs[0] != nil {
 		extras = extraAttrs[0]
 	}
@@ -124,7 +124,7 @@ func (e *executionManager) Create(ctx context.Context, vendorType string, vendor
 	return id, nil
 }
 
-func (e *executionManager) UpdateExtraAttrs(ctx context.Context, id int64, extraAttrs map[string]interface{}) error {
+func (e *executionManager) UpdateExtraAttrs(ctx context.Context, id int64, extraAttrs map[string]any) error {
 	data, err := json.Marshal(extraAttrs)
 	if err != nil {
 		return err
@@ -170,7 +170,7 @@ func (e *executionManager) Stop(ctx context.Context, id int64) error {
 	// when an execution is in final status, if it contains task that is a periodic or retrying job it will
 	// run again in the near future, so we must operate the stop action no matter the status is final or not
 	tasks, err := e.taskDAO.List(ctx, &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"ExecutionID": id,
 		},
 	})
@@ -264,7 +264,7 @@ func (e *executionManager) StopAndWaitWithError(ctx context.Context, id int64, t
 
 func (e *executionManager) Delete(ctx context.Context, id int64) error {
 	tasks, err := e.taskDAO.List(ctx, &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"ExecutionID": id,
 		},
 	})
@@ -294,7 +294,7 @@ func (e *executionManager) Delete(ctx context.Context, id int64) error {
 
 func (e *executionManager) DeleteByVendor(ctx context.Context, vendorType string, vendorID int64) error {
 	executions, err := e.executionDAO.List(ctx, &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"VendorType": vendorType,
 			"VendorID":   vendorID,
 		}})
@@ -355,7 +355,7 @@ func (e *executionManager) populateExecution(ctx context.Context, execution *dao
 	}
 
 	if len(execution.ExtraAttrs) > 0 {
-		extras := map[string]interface{}{}
+		extras := map[string]any{}
 		if err := json.Unmarshal([]byte(execution.ExtraAttrs), &extras); err != nil {
 			log.Errorf("failed to unmarshal the extra attributes of execution %d: %v", execution.ID, err)
 		} else {

--- a/src/pkg/task/execution_test.go
+++ b/src/pkg/task/execution_test.go
@@ -60,7 +60,7 @@ func (e *executionManagerTestSuite) TestCount() {
 func (e *executionManagerTestSuite) TestCreate() {
 	e.execDAO.On("Create", mock.Anything, mock.Anything).Return(int64(1), nil)
 	id, err := e.execMgr.Create(nil, "vendor", 0, ExecutionTriggerManual,
-		map[string]interface{}{"k": "v"})
+		map[string]any{"k": "v"})
 	e.Require().Nil(err)
 	e.Equal(int64(1), id)
 	// sleep to make sure the function in the goroutine run
@@ -70,7 +70,7 @@ func (e *executionManagerTestSuite) TestCreate() {
 
 func (e *executionManagerTestSuite) TestUpdateExtraAttrs() {
 	e.execDAO.On("Update", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
-	err := e.execMgr.UpdateExtraAttrs(nil, 1, map[string]interface{}{"key": "value"})
+	err := e.execMgr.UpdateExtraAttrs(nil, 1, map[string]any{"key": "value"})
 	e.Require().Nil(err)
 	e.execDAO.AssertExpectations(e.T())
 }

--- a/src/pkg/task/hook.go
+++ b/src/pkg/task/hook.go
@@ -69,7 +69,7 @@ func (h *HookHandler) Handle(ctx context.Context, sc *job.StatusChange) error {
 		jobID = sc.Metadata.UpstreamJobID
 	}
 	tasks, err := h.taskDAO.List(ctx, &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"JobID": jobID,
 		},
 	})

--- a/src/pkg/task/model.go
+++ b/src/pkg/task/model.go
@@ -47,10 +47,10 @@ type Execution struct {
 	// trigger type: manual/schedule/event
 	Trigger string `json:"trigger"`
 	// the customized attributes for different kinds of consumers
-	ExtraAttrs map[string]interface{} `json:"extra_attrs"`
-	StartTime  time.Time              `json:"start_time"`
-	UpdateTime time.Time              `json:"update_time"`
-	EndTime    time.Time              `json:"end_time"`
+	ExtraAttrs map[string]any `json:"extra_attrs"`
+	StartTime  time.Time      `json:"start_time"`
+	UpdateTime time.Time      `json:"update_time"`
+	EndTime    time.Time      `json:"end_time"`
 }
 
 // IsOnGoing returns true when the execution is running
@@ -78,7 +78,7 @@ type Task struct {
 	// the ID of jobservice job
 	JobID string `json:"job_id"`
 	// the customized attributes for different kinds of consumers
-	ExtraAttrs map[string]interface{} `json:"extra_attrs"`
+	ExtraAttrs map[string]any `json:"extra_attrs"`
 	// the time that the task record created
 	CreationTime time.Time `json:"creation_time"`
 	// the time that the underlying job starts
@@ -103,7 +103,7 @@ func (t *Task) From(task *dao.Task) {
 	t.EndTime = task.EndTime
 	t.StatusRevision = task.StatusRevision
 	if len(task.ExtraAttrs) > 0 {
-		extras := map[string]interface{}{}
+		extras := map[string]any{}
 		if err := json.Unmarshal([]byte(task.ExtraAttrs), &extras); err != nil {
 			log.Errorf("failed to unmarshal the extra attributes of task %d: %v", task.ID, err)
 			return

--- a/src/pkg/task/sweep_job_test.go
+++ b/src/pkg/task/sweep_job_test.go
@@ -40,7 +40,7 @@ func TestSweepJob(t *testing.T) {
 }
 
 func (suite *sweepJobTestSuite) TestRun() {
-	params := map[string]interface{}{
+	params := map[string]any{
 		"execution_retain_counts": map[string]int{
 			"WEBHOOK":     10,
 			"REPLICATION": 20,

--- a/src/pkg/task/sweep_manager.go
+++ b/src/pkg/task/sweep_manager.go
@@ -68,7 +68,7 @@ func (sm *sweepManager) listVendorIDs(ctx context.Context, vendorType string) ([
 // getCandidateMaxStartTime returns the max start time for candidate executions, obtain the start time of the xth recent one.
 func (sm *sweepManager) getCandidateMaxStartTime(ctx context.Context, vendorType string, vendorID, retainCnt int64) (*time.Time, error) {
 	query := &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"VendorType": vendorType,
 			"VendorID":   vendorID,
 		},
@@ -121,7 +121,7 @@ func (sm *sweepManager) ListCandidates(ctx context.Context, vendorType string, r
 		// count the records for pagination
 		sql := `SELECT COUNT(1) FROM execution WHERE vendor_type = ? AND vendor_id = ? AND start_time < ? AND status IN (?,?,?)`
 		totalOfCandidate := 0
-		params := []interface{}{
+		params := []any{
 			vendorType,
 			vendorID,
 			maxStartTime.Format(timeFormat),
@@ -145,7 +145,7 @@ func (sm *sweepManager) ListCandidates(ctx context.Context, vendorType string, r
 		for i := n; i >= 1; i-- {
 			q2.PageNumber = int64(i)
 			// should copy params as pagination will append the slice
-			paginationParams := make([]interface{}, len(params))
+			paginationParams := make([]any, len(params))
 			copy(paginationParams, params)
 			paginationSQL, paginationParams := orm.PaginationOnRawSQL(q2, sql, paginationParams)
 			ids := make([]int64, 0, defaultPageSize)
@@ -165,7 +165,7 @@ func (sm *sweepManager) Clean(ctx context.Context, execIDs []int64) error {
 		return err
 	}
 	// construct sql params
-	params := make([]interface{}, 0, len(execIDs))
+	params := make([]any, 0, len(execIDs))
 	for _, eid := range execIDs {
 		params = append(params, eid)
 	}

--- a/src/pkg/task/task.go
+++ b/src/pkg/task/task.go
@@ -41,7 +41,7 @@ type Manager interface {
 	// Create submits the job to jobservice and creates a corresponding task record.
 	// An execution must be created first and the task will be linked to it.
 	// The "extraAttrs" can be used to set the customized attributes
-	Create(ctx context.Context, executionID int64, job *Job, extraAttrs ...map[string]interface{}) (id int64, err error)
+	Create(ctx context.Context, executionID int64, job *Job, extraAttrs ...map[string]any) (id int64, err error)
 	// Stop the specified task
 	Stop(ctx context.Context, id int64) (err error)
 	// Get the specified task
@@ -50,7 +50,7 @@ type Manager interface {
 	// Query the "ExtraAttrs" by setting 'query.Keywords["ExtraAttrs.key"]="value"'
 	List(ctx context.Context, query *q.Query) (tasks []*Task, err error)
 	// Update the extra attributes of the specified task
-	UpdateExtraAttrs(ctx context.Context, id int64, extraAttrs map[string]interface{}) (err error)
+	UpdateExtraAttrs(ctx context.Context, id int64, extraAttrs map[string]any) (err error)
 	// Get the log of the specified task
 	GetLog(ctx context.Context, id int64) (log []byte, err error)
 	// GetLogByJobID get the log of specified job id
@@ -101,7 +101,7 @@ func (m *manager) Count(ctx context.Context, query *q.Query) (int64, error) {
 	return m.dao.Count(ctx, query)
 }
 
-func (m *manager) Create(ctx context.Context, executionID int64, jb *Job, extraAttrs ...map[string]interface{}) (int64, error) {
+func (m *manager) Create(ctx context.Context, executionID int64, jb *Job, extraAttrs ...map[string]any) (int64, error) {
 	// create task record in database
 	id, err := m.createTaskRecord(ctx, executionID, extraAttrs...)
 	if err != nil {
@@ -137,12 +137,12 @@ func (m *manager) Create(ctx context.Context, executionID int64, jb *Job, extraA
 	return id, nil
 }
 
-func (m *manager) createTaskRecord(ctx context.Context, executionID int64, extraAttrs ...map[string]interface{}) (int64, error) {
+func (m *manager) createTaskRecord(ctx context.Context, executionID int64, extraAttrs ...map[string]any) (int64, error) {
 	exec, err := m.execDAO.Get(ctx, executionID)
 	if err != nil {
 		return 0, err
 	}
-	extras := map[string]interface{}{}
+	extras := map[string]any{}
 	if len(extraAttrs) > 0 && extraAttrs[0] != nil {
 		extras = extraAttrs[0]
 	}
@@ -255,7 +255,7 @@ func (m *manager) ListScanTasksByReportUUID(ctx context.Context, uuid string) ([
 	return ts, nil
 }
 
-func (m *manager) UpdateExtraAttrs(ctx context.Context, id int64, extraAttrs map[string]interface{}) error {
+func (m *manager) UpdateExtraAttrs(ctx context.Context, id int64, extraAttrs map[string]any) error {
 	data, err := json.Marshal(extraAttrs)
 	if err != nil {
 		return err

--- a/src/pkg/task/task_test.go
+++ b/src/pkg/task/task_test.go
@@ -61,7 +61,7 @@ func (t *taskManagerTestSuite) TestCreate() {
 	t.jsClient.On("SubmitJob", mock.Anything).Return("1", nil)
 	t.dao.On("Update", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
-	id, err := t.mgr.Create(nil, 1, &Job{}, map[string]interface{}{"a": "b"})
+	id, err := t.mgr.Create(nil, 1, &Job{}, map[string]any{"a": "b"})
 	t.Require().Nil(err)
 	t.Equal(int64(1), id)
 	t.dao.AssertExpectations(t.T())
@@ -77,7 +77,7 @@ func (t *taskManagerTestSuite) TestCreate() {
 	t.jsClient.On("SubmitJob", mock.Anything).Return("", errors.New("error"))
 	t.dao.On("Delete", mock.Anything, mock.Anything).Return(nil)
 
-	id, err = t.mgr.Create(nil, 1, &Job{}, map[string]interface{}{"a": "b"})
+	id, err = t.mgr.Create(nil, 1, &Job{}, map[string]any{"a": "b"})
 	t.Require().NotNil(err)
 	t.dao.AssertExpectations(t.T())
 	t.execDAO.AssertExpectations(t.T())
@@ -129,7 +129,7 @@ func (t *taskManagerTestSuite) TestGet() {
 
 func (t *taskManagerTestSuite) TestUpdateExtraAttrs() {
 	t.dao.On("Update", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
-	err := t.mgr.UpdateExtraAttrs(nil, 1, map[string]interface{}{})
+	err := t.mgr.UpdateExtraAttrs(nil, 1, map[string]any{})
 	t.Require().Nil(err)
 	t.dao.AssertExpectations(t.T())
 }

--- a/src/pkg/token/options.go
+++ b/src/pkg/token/options.go
@@ -39,7 +39,7 @@ type Options struct {
 }
 
 // GetKey ...
-func (o *Options) GetKey() (interface{}, error) {
+func (o *Options) GetKey() (any, error) {
 	var err error
 	var privateKey *rsa.PrivateKey
 	var publicKey *rsa.PublicKey

--- a/src/pkg/token/token.go
+++ b/src/pkg/token/token.go
@@ -66,7 +66,7 @@ func Parse(opt *Options, rawToken string, claims jwt.Claims) (*Token, error) {
 		return nil, err
 	}
 	var parser = jwt.NewParser(jwt.WithLeeway(common.JwtLeeway), jwt.WithValidMethods([]string{opt.SignMethod.Alg()}))
-	token, err := parser.ParseWithClaims(rawToken, claims, func(_ *jwt.Token) (interface{}, error) {
+	token, err := parser.ParseWithClaims(rawToken, claims, func(_ *jwt.Token) (any, error) {
 		switch k := key.(type) {
 		case *rsa.PrivateKey:
 			return &k.PublicKey, nil

--- a/src/pkg/user/dao/user.go
+++ b/src/pkg/user/dao/user.go
@@ -94,7 +94,7 @@ func toCommonUser(u *User) *commonmodels.User {
 }
 
 // FilterByUsernameOrEmail generates the query setter to match username or email column to the same value
-func (u *User) FilterByUsernameOrEmail(_ context.Context, qs orm.QuerySeter, _ string, value interface{}) orm.QuerySeter {
+func (u *User) FilterByUsernameOrEmail(_ context.Context, qs orm.QuerySeter, _ string, value any) orm.QuerySeter {
 	usernameOrEmail, ok := value.(string)
 	if !ok {
 		return qs

--- a/src/registryctl/api/base.go
+++ b/src/registryctl/api/base.go
@@ -48,7 +48,7 @@ func HandleError(w http.ResponseWriter, err error) {
 }
 
 // WriteJSON response status code will be written automatically if there is an error
-func WriteJSON(w http.ResponseWriter, v interface{}) error {
+func WriteJSON(w http.ResponseWriter, v any) error {
 	b, err := json.Marshal(v)
 	if err != nil {
 		HandleInternalServerError(w, err)

--- a/src/server/middleware/cosign/cosign_test.go
+++ b/src/server/middleware/cosign/cosign_test.go
@@ -143,7 +143,7 @@ func (suite *MiddlewareTestSuite) TestCosignSignature() {
 		suite.Equal(http.StatusCreated, res.Code)
 
 		accs, err := accessory.Mgr.List(suite.Context(), &q.Query{
-			Keywords: map[string]interface{}{
+			Keywords: map[string]any{
 				"SubjectArtifactDigest": subArtDigest,
 			},
 		})
@@ -173,7 +173,7 @@ func (suite *MiddlewareTestSuite) TestCosignSignatureDup() {
 		suite.Equal(http.StatusCreated, res.Code)
 
 		accs, err := accessory.Mgr.List(suite.Context(), &q.Query{
-			Keywords: map[string]interface{}{
+			Keywords: map[string]any{
 				"ID": accID,
 			},
 		})

--- a/src/server/middleware/csrf/csrf_test.go
+++ b/src/server/middleware/csrf/csrf_test.go
@@ -21,7 +21,7 @@ func resetMiddleware() {
 
 func TestMain(m *testing.M) {
 	test.InitDatabaseFromEnv()
-	conf := map[string]interface{}{}
+	conf := map[string]any{}
 	config.InitWithSettings(conf)
 	result := m.Run()
 	if result != 0 {
@@ -94,12 +94,12 @@ func TestMiddlewareInvalidKey(t *testing.T) {
 
 func TestSecureCookie(t *testing.T) {
 	assert.True(t, secureCookie())
-	conf := map[string]interface{}{
+	conf := map[string]any{
 		common.ExtEndpoint: "http://harbor.test",
 	}
 	config.InitWithSettings(conf)
 
 	assert.False(t, secureCookie())
-	conf = map[string]interface{}{}
+	conf = map[string]any{}
 	config.InitWithSettings(conf)
 }

--- a/src/server/middleware/log/log_test.go
+++ b/src/server/middleware/log/log_test.go
@@ -48,7 +48,7 @@ func (s *MiddlewareTestSuite) TestTableMiddleware() {
 
 	type args struct {
 		headers        map[string]string
-		fields         map[string]interface{}
+		fields         map[string]any
 		ctxTraceparent string
 	}
 	tests := []struct {

--- a/src/server/middleware/security/auth_proxy_test.go
+++ b/src/server/middleware/security/auth_proxy_test.go
@@ -45,7 +45,7 @@ func TestAuthProxy(t *testing.T) {
 	require.Nil(t, err)
 	defer server.Close()
 
-	c := map[string]interface{}{
+	c := map[string]any{
 		common.HTTPAuthProxySkipSearch:          "true",
 		common.HTTPAuthProxyVerifyCert:          "false",
 		common.HTTPAuthProxyEndpoint:            "https://auth.proxy/suffix",

--- a/src/server/middleware/security/robot_test.go
+++ b/src/server/middleware/security/robot_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestRobot(t *testing.T) {
-	conf := map[string]interface{}{
+	conf := map[string]any{
 		common.RobotNamePrefix: "robot@",
 	}
 	config.InitWithSettings(conf)

--- a/src/server/middleware/subject/subject_test.go
+++ b/src/server/middleware/subject/subject_test.go
@@ -177,7 +177,7 @@ func (suite *MiddlewareTestSuite) TestSubject() {
 		suite.Equal(http.StatusCreated, res.Code)
 
 		accs, err := accessory.Mgr.List(suite.Context(), &q.Query{
-			Keywords: map[string]interface{}{
+			Keywords: map[string]any{
 				"SubjectArtifactDigest": subArtDigest,
 			},
 		})
@@ -213,7 +213,7 @@ func (suite *MiddlewareTestSuite) TestSubjectAfterAcc() {
 		suite.Equal(http.StatusCreated, res.Code)
 
 		accs, err := accessory.Mgr.List(suite.Context(), &q.Query{
-			Keywords: map[string]interface{}{
+			Keywords: map[string]any{
 				"SubjectArtifactDigest": subArtDigest,
 				"SubjectArtifactRepo":   name,
 			},
@@ -242,7 +242,7 @@ func (suite *MiddlewareTestSuite) TestSubjectDup() {
 		suite.Equal(http.StatusCreated, res.Code)
 
 		accs, err := accessory.Mgr.List(suite.Context(), &q.Query{
-			Keywords: map[string]interface{}{
+			Keywords: map[string]any{
 				"ID": accID,
 			},
 		})

--- a/src/server/middleware/transaction/transaction_test.go
+++ b/src/server/middleware/transaction/transaction_test.go
@@ -47,10 +47,10 @@ func (m *mockOrmer) Reset() {
 type mockTxOrmer struct {
 	o.TxOrmer
 	commitErr error
-	records   []interface{}
+	records   []any
 }
 
-func (m *mockTxOrmer) Insert(i interface{}) (int64, error) {
+func (m *mockTxOrmer) Insert(i any) (int64, error) {
 	m.records = append(m.records, i)
 	return int64(len(m.records)), nil
 }

--- a/src/server/middleware/v2auth/auth_test.go
+++ b/src/server/middleware/v2auth/auth_test.go
@@ -46,7 +46,7 @@ func TestMain(m *testing.M) {
 	ctl := &projecttesting.Controller{}
 
 	mockGet := func(ctx context.Context,
-		projectIDOrName interface{}, options ...project.Option) (*proModels.Project, error) {
+		projectIDOrName any, options ...project.Option) (*proModels.Project, error) {
 		name := projectIDOrName.(string)
 		id, _ := strconv.Atoi(strings.TrimPrefix(name, "project_"))
 		if id == 0 {
@@ -59,12 +59,12 @@ func TestMain(m *testing.M) {
 	}
 	mock.OnAnything(ctl, "Get").Return(
 		func(ctx context.Context,
-			projectIDOrName interface{}, options ...project.Option) *proModels.Project {
+			projectIDOrName any, options ...project.Option) *proModels.Project {
 			p, _ := mockGet(ctx, projectIDOrName, options...)
 			return p
 		},
 		func(ctx context.Context,
-			projectIDOrName interface{}, options ...project.Option) error {
+			projectIDOrName any, options ...project.Option) error {
 			_, err := mockGet(ctx, projectIDOrName, options...)
 			return err
 		},
@@ -73,7 +73,7 @@ func TestMain(m *testing.M) {
 	checker = reqChecker{
 		ctl: ctl,
 	}
-	conf := map[string]interface{}{
+	conf := map[string]any{
 		common.ExtEndpoint: "https://harbor.test",
 		common.CoreURL:     "https://harbor.core:8443",
 	}

--- a/src/server/registry/referrers.go
+++ b/src/server/registry/referrers.go
@@ -180,7 +180,7 @@ type listReferrersOK struct {
 	/*
 	  In: Body
 	*/
-	Payload interface{} `json:"body,omitempty"`
+	Payload any `json:"body,omitempty"`
 }
 
 // newListReferrersOK creates newlistReferrersOK with default headers values
@@ -207,7 +207,7 @@ func (o *listReferrersOK) WithXTotalCount(xTotalCount int64) *listReferrersOK {
 }
 
 // WithPayload adds the payload to the list accessories o k response
-func (o *listReferrersOK) WithPayload(payload interface{}) *listReferrersOK {
+func (o *listReferrersOK) WithPayload(payload any) *listReferrersOK {
 	o.Payload = payload
 	return o
 }

--- a/src/server/registry/tag.go
+++ b/src/server/registry/tag.go
@@ -69,7 +69,7 @@ func (t *tagHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	}
 
 	tags, err := t.tagCtl.List(req.Context(), &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"RepositoryID": repository.RepositoryID,
 		}}, nil)
 	if err != nil {

--- a/src/server/v2.0/handler/artifact.go
+++ b/src/server/v2.0/handler/artifact.go
@@ -73,7 +73,7 @@ type artifactAPI struct {
 	labelMgr label.Manager
 }
 
-func (a *artifactAPI) Prepare(ctx context.Context, _ string, params interface{}) middleware.Responder {
+func (a *artifactAPI) Prepare(ctx context.Context, _ string, params any) middleware.Responder {
 	if err := unescapePathParams(params, "RepositoryName"); err != nil {
 		a.SendError(ctx, err)
 	}
@@ -406,7 +406,7 @@ func (a *artifactAPI) GetVulnerabilitiesAddition(ctx context.Context, params ope
 		return a.SendError(ctx, err)
 	}
 
-	vulnerabilities := make(map[string]interface{})
+	vulnerabilities := make(map[string]any)
 
 	for _, mimeType := range parseScanReportMimeTypes(params.XAcceptVulnerabilities) {
 		reports, err := a.scanCtl.GetReport(ctx, artifact, []string{mimeType})

--- a/src/server/v2.0/handler/artifact_test.go
+++ b/src/server/v2.0/handler/artifact_test.go
@@ -116,7 +116,7 @@ func (suite *ArtifactTestSuite) TestGetVulnerabilitiesAddition() {
 		// report not found for the default X-Accept-Vulnerabilities
 		suite.onGetReport(v1.MimeTypeNativeReport)
 
-		var body map[string]interface{}
+		var body map[string]any
 		res, err := suite.GetJSON(url, &body, map[string]string{"X-Accept-Vulnerabilities": v1.MimeTypeNativeReport})
 		suite.NoError(err)
 		suite.Equal(200, res.StatusCode)
@@ -127,7 +127,7 @@ func (suite *ArtifactTestSuite) TestGetVulnerabilitiesAddition() {
 		// report found for the default X-Accept-Vulnerabilities
 		suite.onGetReport(v1.MimeTypeNativeReport, suite.report1)
 
-		var body map[string]interface{}
+		var body map[string]any
 		res, err := suite.GetJSON(url, &body, map[string]string{"X-Accept-Vulnerabilities": v1.MimeTypeNativeReport})
 		suite.NoError(err)
 		suite.Equal(200, res.StatusCode)
@@ -139,7 +139,7 @@ func (suite *ArtifactTestSuite) TestGetVulnerabilitiesAddition() {
 		// report found for the X-Accept-Vulnerabilities of "application/vnd.security.vulnerability.report; version=1.1"
 		suite.onGetReport(v1.MimeTypeGenericVulnerabilityReport, suite.report2)
 
-		var body map[string]interface{}
+		var body map[string]any
 		res, err := suite.GetJSON(url, &body, map[string]string{"X-Accept-Vulnerabilities": v1.MimeTypeGenericVulnerabilityReport})
 		suite.NoError(err)
 		suite.Equal(200, res.StatusCode)
@@ -152,7 +152,7 @@ func (suite *ArtifactTestSuite) TestGetVulnerabilitiesAddition() {
 		// and the X-Accept-Vulnerabilities is "application/vnd.security.vulnerability.report; version=1.1, application/vnd.scanner.adapter.vuln.report.harbor+json; version=1.0"
 		suite.onGetReport(v1.MimeTypeGenericVulnerabilityReport, suite.report2)
 
-		var body map[string]interface{}
+		var body map[string]any
 		res, err := suite.GetJSON(url, &body, map[string]string{"X-Accept-Vulnerabilities": v1.MimeTypeGenericVulnerabilityReport + "," + v1.MimeTypeNativeReport})
 		suite.NoError(err)
 		suite.Equal(200, res.StatusCode)
@@ -167,7 +167,7 @@ func (suite *ArtifactTestSuite) TestGetVulnerabilitiesAddition() {
 		suite.onGetReport(v1.MimeTypeGenericVulnerabilityReport)
 		suite.onGetReport(v1.MimeTypeNativeReport, suite.report1)
 
-		var body map[string]interface{}
+		var body map[string]any
 		res, err := suite.GetJSON(url, &body, map[string]string{"X-Accept-Vulnerabilities": v1.MimeTypeGenericVulnerabilityReport + "," + v1.MimeTypeNativeReport})
 		suite.NoError(err)
 		suite.Equal(200, res.StatusCode)
@@ -182,7 +182,7 @@ func (suite *ArtifactTestSuite) TestGetVulnerabilitiesAddition() {
 		suite.onGetReport(v1.MimeTypeGenericVulnerabilityReport)
 		suite.onGetReport(v1.MimeTypeNativeReport)
 
-		var body map[string]interface{}
+		var body map[string]any
 		res, err := suite.GetJSON(url, &body, map[string]string{"X-Accept-Vulnerabilities": v1.MimeTypeGenericVulnerabilityReport + "," + v1.MimeTypeNativeReport})
 		suite.NoError(err)
 		suite.Equal(200, res.StatusCode)

--- a/src/server/v2.0/handler/assembler/report.go
+++ b/src/server/v2.0/handler/assembler/report.go
@@ -118,7 +118,7 @@ func (assembler *ScanReportAssembler) Assemble(ctx context.Context) error {
 				if len(execs) == 0 {
 					continue
 				}
-				artifact.SBOMOverView = map[string]interface{}{
+				artifact.SBOMOverView = map[string]any{
 					sbomModel.ScanStatus: execs[0].Status,
 					sbomModel.StartTime:  execs[0].StartTime,
 					sbomModel.EndTime:    execs[0].EndTime,
@@ -127,7 +127,7 @@ func (assembler *ScanReportAssembler) Assemble(ctx context.Context) error {
 				continue
 			}
 
-			artifact.SBOMOverView = map[string]interface{}{
+			artifact.SBOMOverView = map[string]any{
 				sbomModel.StartTime:  overview[sbomModel.StartTime],
 				sbomModel.EndTime:    overview[sbomModel.EndTime],
 				sbomModel.ScanStatus: overview[sbomModel.ScanStatus],

--- a/src/server/v2.0/handler/assembler/report_test.go
+++ b/src/server/v2.0/handler/assembler/report_test.go
@@ -45,7 +45,7 @@ func (suite *VulAssemblerTestSuite) TestScannable() {
 
 	mock.OnAnything(checker, "IsScannable").Return(true, nil)
 
-	summary := map[string]interface{}{"key": "value"}
+	summary := map[string]any{"key": "value"}
 	mock.OnAnything(scanCtl, "GetSummary").Return(summary, nil)
 
 	var artifact model.Artifact
@@ -67,7 +67,7 @@ func (suite *VulAssemblerTestSuite) TestNotScannable() {
 
 	mock.OnAnything(checker, "IsScannable").Return(false, nil)
 
-	summary := map[string]interface{}{"key": "value"}
+	summary := map[string]any{"key": "value"}
 	mock.OnAnything(scanCtl, "GetSummary").Return(summary, nil)
 
 	var art model.Artifact
@@ -89,7 +89,7 @@ func (suite *VulAssemblerTestSuite) TestAssembleSBOMOverview() {
 	}
 
 	mock.OnAnything(checker, "IsScannable").Return(true, nil)
-	overview := map[string]interface{}{
+	overview := map[string]any{
 		"sbom_digest": "sha256:123456",
 		"scan_status": "Success",
 	}
@@ -117,7 +117,7 @@ func (suite *VulAssemblerTestSuite) TestAssembleSBOMOverviewImageIndex() {
 	}
 
 	mock.OnAnything(checker, "IsScannable").Return(true, nil)
-	overview := map[string]interface{}{}
+	overview := map[string]any{}
 	mock.OnAnything(scanCtl, "GetSummary").Return(overview, nil)
 	execs := []*task.Execution{
 		{ID: 1, Status: "Error"},

--- a/src/server/v2.0/handler/base.go
+++ b/src/server/v2.0/handler/base.go
@@ -46,7 +46,7 @@ var (
 type BaseAPI struct{}
 
 // Prepare default prepare for operation
-func (*BaseAPI) Prepare(_ context.Context, _ string, _ interface{}) middleware.Responder {
+func (*BaseAPI) Prepare(_ context.Context, _ string, _ any) middleware.Responder {
 	return nil
 }
 
@@ -75,7 +75,7 @@ func (b *BaseAPI) HasPermission(ctx context.Context, action rbac.Action, resourc
 }
 
 // HasProjectPermission returns true when the request has action permission on project subresource
-func (b *BaseAPI) HasProjectPermission(ctx context.Context, projectIDOrName interface{}, action rbac.Action, subresource ...rbac.Resource) bool {
+func (b *BaseAPI) HasProjectPermission(ctx context.Context, projectIDOrName any, action rbac.Action, subresource ...rbac.Resource) bool {
 	projectID, projectName, err := utils.ParseProjectIDOrName(projectIDOrName)
 	if err != nil {
 		return false
@@ -105,7 +105,7 @@ func (b *BaseAPI) HasProjectPermission(ctx context.Context, projectIDOrName inte
 
 // RequireProjectAccess checks the permission against the resources according to the context
 // An error will be returned if it doesn't meet the requirement
-func (b *BaseAPI) RequireProjectAccess(ctx context.Context, projectIDOrName interface{}, action rbac.Action, subresource ...rbac.Resource) error {
+func (b *BaseAPI) RequireProjectAccess(ctx context.Context, projectIDOrName any, action rbac.Action, subresource ...rbac.Resource) error {
 	if b.HasProjectPermission(ctx, projectIDOrName, action, subresource...) {
 		return nil
 	}

--- a/src/server/v2.0/handler/config.go
+++ b/src/server/v2.0/handler/config.go
@@ -91,8 +91,8 @@ func (c *configAPI) UpdateConfigurations(ctx context.Context, params configure.U
 	return configure.NewUpdateConfigurationsOK()
 }
 
-func toCfgMap(conf *models.Configurations) (map[string]interface{}, error) {
-	var cfgMap map[string]interface{}
+func toCfgMap(conf *models.Configurations) (map[string]any, error) {
+	var cfgMap map[string]any
 	buf, err := json.Marshal(conf)
 	if err != nil {
 		return cfgMap, err

--- a/src/server/v2.0/handler/gc.go
+++ b/src/server/v2.0/handler/gc.go
@@ -47,7 +47,7 @@ func newGCAPI() *gcAPI {
 	}
 }
 
-func (g *gcAPI) Prepare(_ context.Context, _ string, _ interface{}) middleware.Responder {
+func (g *gcAPI) Prepare(_ context.Context, _ string, _ any) middleware.Responder {
 	return nil
 }
 
@@ -79,9 +79,9 @@ func (g *gcAPI) UpdateGCSchedule(ctx context.Context, params operation.UpdateGCS
 	return operation.NewUpdateGCScheduleOK()
 }
 
-func (g *gcAPI) kick(ctx context.Context, scheType string, cron string, parameters map[string]interface{}) (int64, error) {
+func (g *gcAPI) kick(ctx context.Context, scheType string, cron string, parameters map[string]any) (int64, error) {
 	if parameters == nil {
-		parameters = make(map[string]interface{})
+		parameters = make(map[string]any)
 	}
 	// set the required parameters for GC
 	parameters["redis_url_reg"] = os.Getenv("_REDIS_URL_REG")

--- a/src/server/v2.0/handler/handler.go
+++ b/src/server/v2.0/handler/handler.go
@@ -86,7 +86,7 @@ func New() http.Handler {
 }
 
 // function is called before the Prepare of the operation
-func beforePrepare(ctx context.Context, operation string, _ interface{}) rmiddleware.Responder {
+func beforePrepare(ctx context.Context, operation string, _ any) rmiddleware.Responder {
 	metric.SetMetricOpID(ctx, operation)
 	return nil
 }

--- a/src/server/v2.0/handler/immutable.go
+++ b/src/server/v2.0/handler/immutable.go
@@ -163,7 +163,7 @@ func (ia *immutableAPI) ListImmuRules(ctx context.Context, params operation.List
 		WithPayload(results)
 }
 
-func (ia *immutableAPI) getProjectID(ctx context.Context, projectNameOrID interface{}) (int64, error) {
+func (ia *immutableAPI) getProjectID(ctx context.Context, projectNameOrID any) (int64, error) {
 	projectName, ok := projectNameOrID.(string)
 	if ok {
 		p, err := ia.projectCtr.Get(ctx, projectName, project.Metadata(false))

--- a/src/server/v2.0/handler/model/artifact.go
+++ b/src/server/v2.0/handler/model/artifact.go
@@ -29,8 +29,8 @@ import (
 type Artifact struct {
 	artifact.Artifact
 	// TODO: rename to VulOverview
-	ScanOverview map[string]interface{} `json:"scan_overview"`
-	SBOMOverView map[string]interface{} `json:"sbom_overview"`
+	ScanOverview map[string]any `json:"scan_overview"`
+	SBOMOverView map[string]any `json:"sbom_overview"`
 }
 
 // ToSwagger converts the artifact to the swagger model

--- a/src/server/v2.0/handler/model/quota.go
+++ b/src/server/v2.0/handler/model/quota.go
@@ -75,7 +75,7 @@ type QuotaRefObject struct {
 
 // ToSwagger converts the QuotaRefObject to the swagger model
 func (rl *QuotaRefObject) ToSwagger() models.QuotaRefObject {
-	result := make(map[string]interface{}, len(rl.QuotaRefObject))
+	result := make(map[string]any, len(rl.QuotaRefObject))
 
 	for name, value := range rl.QuotaRefObject {
 		result[string(name)] = value

--- a/src/server/v2.0/handler/preheat.go
+++ b/src/server/v2.0/handler/preheat.go
@@ -65,7 +65,7 @@ type preheatAPI struct {
 	taskCtl      taskCtl.Controller
 }
 
-func (api *preheatAPI) Prepare(_ context.Context, _ string, _ interface{}) middleware.Responder {
+func (api *preheatAPI) Prepare(_ context.Context, _ string, _ any) middleware.Responder {
 	return nil
 }
 
@@ -332,7 +332,7 @@ func (api *preheatAPI) DeletePolicy(ctx context.Context, params operation.Delete
 		}
 		return nil
 	}
-	executions, err := api.executionCtl.List(ctx, &q.Query{Keywords: map[string]interface{}{
+	executions, err := api.executionCtl.List(ctx, &q.Query{Keywords: map[string]any{
 		"vendor_type": job.P2PPreheatVendorType,
 		"vendor_id":   policy.ID,
 	}})
@@ -786,7 +786,7 @@ func (api *preheatAPI) GetPreheatLog(ctx context.Context, params operation.GetPr
 	return operation.NewGetPreheatLogOK().WithPayload(string(l))
 }
 
-func (api *preheatAPI) requireTaskInProject(ctx context.Context, projectNameOrID interface{}, policyName string, executionID, taskID int64) error {
+func (api *preheatAPI) requireTaskInProject(ctx context.Context, projectNameOrID any, policyName string, executionID, taskID int64) error {
 	projectID, err := getProjectID(ctx, projectNameOrID)
 	notFoundErr := fmt.Errorf("project id %d, task id %d not found", projectID, taskID)
 	if err != nil {
@@ -809,7 +809,7 @@ func (api *preheatAPI) requireTaskInProject(ctx context.Context, projectNameOrID
 	return errors.NotFoundError(notFoundErr)
 }
 
-func (api *preheatAPI) requireExecutionInProject(ctx context.Context, projectNameOrID interface{}, policyName string, executionID int64) error {
+func (api *preheatAPI) requireExecutionInProject(ctx context.Context, projectNameOrID any, policyName string, executionID int64) error {
 	projectID, err := getProjectID(ctx, projectNameOrID)
 	notFoundErr := fmt.Errorf("project id %d, execution id %d not found", projectID, executionID)
 	if err != nil {

--- a/src/server/v2.0/handler/project.go
+++ b/src/server/v2.0/handler/project.go
@@ -187,7 +187,7 @@ func (a *projectAPI) CreateProject(ctx context.Context, params operation.CreateP
 	// in most case, it's 1
 	if _, ok := secCtx.(*robotSec.SecurityContext); ok || secCtx.IsSolutionUser() {
 		q := &q.Query{
-			Keywords: map[string]interface{}{
+			Keywords: map[string]any{
 				"sysadmin_flag": true,
 			},
 			Sorts: []*q.Sort{
@@ -753,7 +753,7 @@ func (a *projectAPI) ListArtifactsOfProject(ctx context.Context, params operatio
 		WithPayload(artifacts)
 }
 
-func (a *projectAPI) deletable(ctx context.Context, projectNameOrID interface{}) (*project.Project, *models.ProjectDeletable, error) {
+func (a *projectAPI) deletable(ctx context.Context, projectNameOrID any) (*project.Project, *models.ProjectDeletable, error) {
 	p, err := a.getProject(ctx, projectNameOrID)
 	if err != nil {
 		return nil, nil, err
@@ -768,7 +768,7 @@ func (a *projectAPI) deletable(ctx context.Context, projectNameOrID interface{})
 	return p, result, nil
 }
 
-func (a *projectAPI) getProject(ctx context.Context, projectNameOrID interface{}, options ...project.Option) (*project.Project, error) {
+func (a *projectAPI) getProject(ctx context.Context, projectNameOrID any, options ...project.Option) (*project.Project, error) {
 	p, err := a.projectCtl.Get(ctx, projectNameOrID, options...)
 	if err != nil {
 		return nil, err

--- a/src/server/v2.0/handler/project_test.go
+++ b/src/server/v2.0/handler/project_test.go
@@ -151,7 +151,7 @@ func (suite *ProjectTestSuite) TestListScannerCandidatesOfProject() {
 		mock.OnAnything(suite.scannerCtl, "GetTotalOfRegistrations").Return(int64(0), nil).Once()
 		mock.OnAnything(suite.scannerCtl, "ListRegistrations").Return(nil, nil).Once()
 
-		var scanners []interface{}
+		var scanners []any
 		res, err := suite.GetJSON("/projects/1/scanner/candidates", &scanners)
 		suite.NoError(err)
 		suite.Equal(200, res.StatusCode)
@@ -163,7 +163,7 @@ func (suite *ProjectTestSuite) TestListScannerCandidatesOfProject() {
 		mock.OnAnything(suite.scannerCtl, "GetTotalOfRegistrations").Return(int64(3), nil).Once()
 		mock.OnAnything(suite.scannerCtl, "ListRegistrations").Return([]*scanner.Registration{suite.reg}, nil).Once()
 
-		var scanners []interface{}
+		var scanners []any
 		res, err := suite.GetJSON("/projects/1/scanner/candidates?page_size=1&page=2&name=n&description=d&url=u&ex_name=n&ex_url=u", &scanners)
 		suite.NoError(err)
 		suite.Equal(200, res.StatusCode)
@@ -183,7 +183,7 @@ func (suite *ProjectTestSuite) TestSetScannerOfProject() {
 		// get project failed
 		mock.OnAnything(suite.projectCtl, "Get").Return(nil, fmt.Errorf("failed to get project")).Once()
 
-		res, err := suite.PutJSON("/projects/1/scanner", map[string]interface{}{"uuid": "uuid"})
+		res, err := suite.PutJSON("/projects/1/scanner", map[string]any{"uuid": "uuid"})
 		suite.NoError(err)
 		suite.Equal(500, res.StatusCode)
 	}
@@ -192,7 +192,7 @@ func (suite *ProjectTestSuite) TestSetScannerOfProject() {
 		mock.OnAnything(suite.projectCtl, "Get").Return(suite.project, nil).Once()
 		mock.OnAnything(suite.scannerCtl, "SetRegistrationByProject").Return(nil).Once()
 
-		res, err := suite.PutJSON("/projects/1/scanner", map[string]interface{}{"uuid": "uuid"})
+		res, err := suite.PutJSON("/projects/1/scanner", map[string]any{"uuid": "uuid"})
 		suite.NoError(err)
 		suite.Equal(200, res.StatusCode)
 	}
@@ -202,7 +202,7 @@ func (suite *ProjectTestSuite) TestSetScannerOfProject() {
 		mock.OnAnything(suite.projectCtl, "Get").Return(suite.project, nil).Once()
 		mock.OnAnything(suite.scannerCtl, "SetRegistrationByProject").Return(nil).Once()
 
-		res, err := suite.PutJSON("/projects/library/scanner", map[string]interface{}{"uuid": "uuid"})
+		res, err := suite.PutJSON("/projects/library/scanner", map[string]any{"uuid": "uuid"})
 		suite.NoError(err)
 		suite.Equal(200, res.StatusCode)
 	}

--- a/src/server/v2.0/handler/purge.go
+++ b/src/server/v2.0/handler/purge.go
@@ -90,7 +90,7 @@ func verifyCreateRequest(params purge.CreatePurgeScheduleParams) error {
 	return nil
 }
 
-func retentionHour(m map[string]interface{}) (int, error) {
+func retentionHour(m map[string]any) (int, error) {
 	if ret, ok := m[common.PurgeAuditRetentionHour]; ok {
 		if rh, ok := ret.(json.Number); ok {
 			ret, err := rh.Int64()
@@ -106,9 +106,9 @@ func retentionHour(m map[string]interface{}) (int, error) {
 	return 0, nil
 }
 
-func (p *purgeAPI) kick(ctx context.Context, vendorType string, scheType string, cron string, parameters map[string]interface{}) (int64, error) {
+func (p *purgeAPI) kick(ctx context.Context, vendorType string, scheType string, cron string, parameters map[string]any) (int64, error) {
 	if parameters == nil {
-		parameters = make(map[string]interface{})
+		parameters = make(map[string]any)
 	}
 	var err error
 	var id int64
@@ -140,7 +140,7 @@ func (p *purgeAPI) kick(ctx context.Context, vendorType string, scheType string,
 	return id, err
 }
 
-func (p *purgeAPI) updateSchedule(ctx context.Context, vendorType, cronType, cron string, policy pg.JobPolicy, extraParams map[string]interface{}) error {
+func (p *purgeAPI) updateSchedule(ctx context.Context, vendorType, cronType, cron string, policy pg.JobPolicy, extraParams map[string]any) error {
 	if err := utils.ValidateCronString(cron); err != nil {
 		return errors.New(nil).WithCode(errors.BadRequestCode).
 			WithMessagef("invalid cron string for scheduled log rotation purge: %s, error: %v", cron, err)
@@ -318,7 +318,7 @@ func verifyUpdateRequest(params purge.UpdatePurgeScheduleParams) error {
 	return nil
 }
 
-func (p *purgeAPI) createSchedule(ctx context.Context, vendorType string, cronType string, cron string, policy pg.JobPolicy, extraParam map[string]interface{}) error {
+func (p *purgeAPI) createSchedule(ctx context.Context, vendorType string, cronType string, cron string, policy pg.JobPolicy, extraParam map[string]any) error {
 	_, err := p.schedulerCtl.Create(ctx, vendorType, cronType, cron, pg.SchedulerCallback, policy, extraParam)
 	if err != nil {
 		return err

--- a/src/server/v2.0/handler/purge_test.go
+++ b/src/server/v2.0/handler/purge_test.go
@@ -34,10 +34,10 @@ func Test_verifyUpdateRequest(t *testing.T) {
 		args    args
 		wantErr bool
 	}{
-		{"normal", args{purge.UpdatePurgeScheduleParams{Schedule: &models.Schedule{Schedule: &models.ScheduleObj{}, Parameters: map[string]interface{}{common.PurgeAuditRetentionHour: "168", common.PurgeAuditIncludeEventTypes: "pull_artifact"}}}}, false},
-		{"missing_schedule", args{purge.UpdatePurgeScheduleParams{Schedule: &models.Schedule{Parameters: map[string]interface{}{common.PurgeAuditRetentionHour: "168", common.PurgeAuditIncludeEventTypes: "pull_artifact"}}}}, true},
-		{"missing_retention_hour", args{purge.UpdatePurgeScheduleParams{Schedule: &models.Schedule{Schedule: &models.ScheduleObj{}, Parameters: map[string]interface{}{common.PurgeAuditIncludeEventTypes: "pull_artifact"}}}}, true},
-		{"missing_operations", args{purge.UpdatePurgeScheduleParams{Schedule: &models.Schedule{Schedule: &models.ScheduleObj{}, Parameters: map[string]interface{}{common.PurgeAuditRetentionHour: "168"}}}}, true},
+		{"normal", args{purge.UpdatePurgeScheduleParams{Schedule: &models.Schedule{Schedule: &models.ScheduleObj{}, Parameters: map[string]any{common.PurgeAuditRetentionHour: "168", common.PurgeAuditIncludeEventTypes: "pull_artifact"}}}}, false},
+		{"missing_schedule", args{purge.UpdatePurgeScheduleParams{Schedule: &models.Schedule{Parameters: map[string]any{common.PurgeAuditRetentionHour: "168", common.PurgeAuditIncludeEventTypes: "pull_artifact"}}}}, true},
+		{"missing_retention_hour", args{purge.UpdatePurgeScheduleParams{Schedule: &models.Schedule{Schedule: &models.ScheduleObj{}, Parameters: map[string]any{common.PurgeAuditIncludeEventTypes: "pull_artifact"}}}}, true},
+		{"missing_operations", args{purge.UpdatePurgeScheduleParams{Schedule: &models.Schedule{Schedule: &models.ScheduleObj{}, Parameters: map[string]any{common.PurgeAuditRetentionHour: "168"}}}}, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -57,10 +57,10 @@ func Test_verifyCreateRequest(t *testing.T) {
 		args    args
 		wantErr bool
 	}{
-		{"normal", args{purge.CreatePurgeScheduleParams{Schedule: &models.Schedule{Schedule: &models.ScheduleObj{}, Parameters: map[string]interface{}{common.PurgeAuditRetentionHour: "168", common.PurgeAuditIncludeEventTypes: "pull_artifact"}}}}, false},
-		{"missing_schedule", args{purge.CreatePurgeScheduleParams{Schedule: &models.Schedule{Parameters: map[string]interface{}{common.PurgeAuditRetentionHour: "168", common.PurgeAuditIncludeEventTypes: "pull_artifact"}}}}, true},
-		{"missing_retention_hour", args{purge.CreatePurgeScheduleParams{Schedule: &models.Schedule{Schedule: &models.ScheduleObj{}, Parameters: map[string]interface{}{common.PurgeAuditIncludeEventTypes: "pull_artifact"}}}}, true},
-		{"missing_event_types", args{purge.CreatePurgeScheduleParams{Schedule: &models.Schedule{Schedule: &models.ScheduleObj{}, Parameters: map[string]interface{}{common.PurgeAuditRetentionHour: "168"}}}}, true},
+		{"normal", args{purge.CreatePurgeScheduleParams{Schedule: &models.Schedule{Schedule: &models.ScheduleObj{}, Parameters: map[string]any{common.PurgeAuditRetentionHour: "168", common.PurgeAuditIncludeEventTypes: "pull_artifact"}}}}, false},
+		{"missing_schedule", args{purge.CreatePurgeScheduleParams{Schedule: &models.Schedule{Parameters: map[string]any{common.PurgeAuditRetentionHour: "168", common.PurgeAuditIncludeEventTypes: "pull_artifact"}}}}, true},
+		{"missing_retention_hour", args{purge.CreatePurgeScheduleParams{Schedule: &models.Schedule{Schedule: &models.ScheduleObj{}, Parameters: map[string]any{common.PurgeAuditIncludeEventTypes: "pull_artifact"}}}}, true},
+		{"missing_event_types", args{purge.CreatePurgeScheduleParams{Schedule: &models.Schedule{Schedule: &models.ScheduleObj{}, Parameters: map[string]any{common.PurgeAuditRetentionHour: "168"}}}}, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -74,7 +74,7 @@ func Test_verifyCreateRequest(t *testing.T) {
 
 func Test_checkRetentionHour(t *testing.T) {
 	type args struct {
-		m map[string]interface{}
+		m map[string]any
 	}
 	tests := []struct {
 		name    string
@@ -82,10 +82,10 @@ func Test_checkRetentionHour(t *testing.T) {
 		want    int
 		wantErr assert.ErrorAssertionFunc
 	}{
-		{"normal", args{map[string]interface{}{common.PurgeAuditRetentionHour: 24}}, 24, func(t assert.TestingT, err error, i ...interface{}) bool { return false }},
-		{"overflow", args{map[string]interface{}{common.PurgeAuditRetentionHour: 250000}}, 0, func(t assert.TestingT, err error, i ...interface{}) bool { return true }},
-		{"equal", args{map[string]interface{}{common.PurgeAuditRetentionHour: 240000}}, 240000, func(t assert.TestingT, err error, i ...interface{}) bool { return false }},
-		{"wrong type", args{map[string]interface{}{common.PurgeAuditRetentionHour: "wrong type"}}, 0, func(t assert.TestingT, err error, i ...interface{}) bool { return true }},
+		{"normal", args{map[string]any{common.PurgeAuditRetentionHour: 24}}, 24, func(t assert.TestingT, err error, i ...any) bool { return false }},
+		{"overflow", args{map[string]any{common.PurgeAuditRetentionHour: 250000}}, 0, func(t assert.TestingT, err error, i ...any) bool { return true }},
+		{"equal", args{map[string]any{common.PurgeAuditRetentionHour: 240000}}, 240000, func(t assert.TestingT, err error, i ...any) bool { return false }},
+		{"wrong type", args{map[string]any{common.PurgeAuditRetentionHour: "wrong type"}}, 0, func(t assert.TestingT, err error, i ...any) bool { return true }},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/src/server/v2.0/handler/quota_test.go
+++ b/src/server/v2.0/handler/quota_test.go
@@ -64,7 +64,7 @@ func (suite *QuotaTestSuite) SetupSuite() {
 }
 
 func (suite *QuotaTestSuite) TestAuthorization() {
-	newBody := func(body interface{}) io.Reader {
+	newBody := func(body any) io.Reader {
 		if body == nil {
 			return nil
 		}
@@ -81,7 +81,7 @@ func (suite *QuotaTestSuite) TestAuthorization() {
 	reqs := []struct {
 		method string
 		url    string
-		body   interface{}
+		body   any
 	}{
 		{http.MethodGet, "/quotas/1", nil},
 		{http.MethodGet, "/quotas", nil},
@@ -129,7 +129,7 @@ func (suite *QuotaTestSuite) TestGetQuota() {
 		// quota not found
 		mock.OnAnything(suite.quotaCtl, "Get").Return(nil, errors.NotFoundError(nil)).Once()
 
-		var quota map[string]interface{}
+		var quota map[string]any
 		res, err := suite.GetJSON("/quotas/1", &quota)
 		suite.NoError(err)
 		suite.Equal(404, res.StatusCode)
@@ -139,7 +139,7 @@ func (suite *QuotaTestSuite) TestGetQuota() {
 		// quota found
 		mock.OnAnything(suite.quotaCtl, "Get").Return(suite.quota, nil).Once()
 
-		var quota map[string]interface{}
+		var quota map[string]any
 		res, err := suite.GetJSON("/quotas/1", &quota)
 		suite.NoError(err)
 		suite.Equal(200, res.StatusCode)
@@ -176,7 +176,7 @@ func (suite *QuotaTestSuite) TestListQuotas() {
 		mock.OnAnything(suite.quotaCtl, "Count").Return(int64(0), nil).Once()
 		mock.OnAnything(suite.quotaCtl, "List").Return(nil, nil).Once()
 
-		var quotas []interface{}
+		var quotas []any
 		res, err := suite.GetJSON("/quotas", &quotas)
 		suite.NoError(err)
 		suite.Equal(200, res.StatusCode)
@@ -188,7 +188,7 @@ func (suite *QuotaTestSuite) TestListQuotas() {
 		mock.OnAnything(suite.quotaCtl, "Count").Return(int64(3), nil).Once()
 		mock.OnAnything(suite.quotaCtl, "List").Return([]*quota.Quota{suite.quota}, nil).Once()
 
-		var quotas []interface{}
+		var quotas []any
 		res, err := suite.GetJSON("/quotas?page_size=1&page=2", &quotas)
 		suite.NoError(err)
 		suite.Equal(200, res.StatusCode)

--- a/src/server/v2.0/handler/replication.go
+++ b/src/server/v2.0/handler/replication.go
@@ -46,7 +46,7 @@ type replicationAPI struct {
 	ctl replication.Controller
 }
 
-func (r *replicationAPI) Prepare(_ context.Context, _ string, _ interface{}) middleware.Responder {
+func (r *replicationAPI) Prepare(_ context.Context, _ string, _ any) middleware.Responder {
 	return nil
 }
 
@@ -362,14 +362,14 @@ func (r *replicationAPI) ListReplicationTasks(ctx context.Context, params operat
 	}
 	query.Keywords["ExecutionID"] = params.ID
 	if params.Status != nil {
-		var status interface{} = *params.Status
+		var status any = *params.Status
 		// as we convert the status when responding requests to keep the backward compatibility,
 		// here we need to reverse-convert the status
 		// the status "pending" and "stopped" is same with jobservice, no need to convert
 		switch status {
 		case "InProgress":
 			status = &q.OrList{
-				Values: []interface{}{
+				Values: []any{
 					job.ScheduledStatus.String(),
 					job.RunningStatus.String(),
 				},

--- a/src/server/v2.0/handler/repository.go
+++ b/src/server/v2.0/handler/repository.go
@@ -56,7 +56,7 @@ type repositoryAPI struct {
 	artCtl  artifact.Controller
 }
 
-func (r *repositoryAPI) Prepare(ctx context.Context, _ string, params interface{}) middleware.Responder {
+func (r *repositoryAPI) Prepare(ctx context.Context, _ string, params any) middleware.Responder {
 	if err := unescapePathParams(params, "RepositoryName"); err != nil {
 		r.SendError(ctx, err)
 	}
@@ -117,7 +117,7 @@ func (r *repositoryAPI) listAuthorizedProjectIDs(ctx context.Context) ([]int64, 
 		return nil, errors.UnauthorizedError(errors.New("security context not found"))
 	}
 	query := &q.Query{
-		Keywords: map[string]interface{}{},
+		Keywords: map[string]any{},
 	}
 	if secCtx.IsAuthenticated() {
 		switch v := secCtx.(type) {
@@ -213,7 +213,7 @@ func (r *repositoryAPI) GetRepository(ctx context.Context, params operation.GetR
 func (r *repositoryAPI) assembleRepository(ctx context.Context, repository *model.RepoRecord) *models.Repository {
 	repo := repository.ToSwagger()
 	total, err := r.artCtl.Count(ctx, &q.Query{
-		Keywords: map[string]interface{}{
+		Keywords: map[string]any{
 			"RepositoryID": repo.ID,
 		},
 	})

--- a/src/server/v2.0/handler/retention.go
+++ b/src/server/v2.0/handler/retention.go
@@ -133,7 +133,7 @@ var (
 	}
 )
 
-func (r *retentionAPI) Prepare(ctx context.Context, _ string, _ interface{}) middleware.Responder {
+func (r *retentionAPI) Prepare(ctx context.Context, _ string, _ any) middleware.Responder {
 	if err := r.RequireAuthenticated(ctx); err != nil {
 		return r.SendError(ctx, err)
 	}

--- a/src/server/v2.0/handler/robot.go
+++ b/src/server/v2.0/handler/robot.go
@@ -318,7 +318,7 @@ func (rAPI *robotAPI) requireAccess(ctx context.Context, r *robot.Robot, action 
 	if r.Level == robot.LEVELSYSTEM {
 		return rAPI.RequireSystemAccess(ctx, action, rbac.ResourceRobot)
 	} else if r.Level == robot.LEVELPROJECT {
-		var ns interface{}
+		var ns any
 		if r.ProjectNameOrID != nil {
 			ns = r.ProjectNameOrID
 		} else if r.ProjectID > 0 {

--- a/src/server/v2.0/handler/scan.go
+++ b/src/server/v2.0/handler/scan.go
@@ -42,7 +42,7 @@ type scanAPI struct {
 	scanCtl scan.Controller
 }
 
-func (s *scanAPI) Prepare(ctx context.Context, _ string, params interface{}) middleware.Responder {
+func (s *scanAPI) Prepare(ctx context.Context, _ string, params any) middleware.Responder {
 	if err := unescapePathParams(params, "RepositoryName"); err != nil {
 		s.SendError(ctx, err)
 	}

--- a/src/server/v2.0/handler/scan_all.go
+++ b/src/server/v2.0/handler/scan_all.go
@@ -58,7 +58,7 @@ type scanAllAPI struct {
 	makeCtx    func() context.Context
 }
 
-func (s *scanAllAPI) Prepare(_ context.Context, _ string, _ interface{}) middleware.Responder {
+func (s *scanAllAPI) Prepare(_ context.Context, _ string, _ any) middleware.Responder {
 	return nil
 }
 
@@ -208,7 +208,7 @@ func (s *scanAllAPI) createOrUpdateScanAllSchedule(ctx context.Context, cronType
 		}
 	}
 
-	cbParams := map[string]interface{}{
+	cbParams := map[string]any{
 		// the operator of schedule job is harbor-jobservice
 		"operator": secret.JobserviceUser,
 	}
@@ -289,7 +289,7 @@ func (s *scanAllAPI) getLatestScanAllExecution(ctx context.Context, trigger ...s
 }
 
 func (s *scanAllAPI) requireScanEnabled(ctx context.Context) error {
-	kws := make(map[string]interface{})
+	kws := make(map[string]any)
 	kws["is_default"] = true
 
 	query := &q.Query{

--- a/src/server/v2.0/handler/scan_all_test.go
+++ b/src/server/v2.0/handler/scan_all_test.go
@@ -97,7 +97,7 @@ func (suite *ScanAllTestSuite) SetupSuite() {
 }
 
 func (suite *ScanAllTestSuite) TestAuthorization() {
-	newBody := func(body interface{}) io.Reader {
+	newBody := func(body any) io.Reader {
 		if body == nil {
 			return nil
 		}
@@ -114,7 +114,7 @@ func (suite *ScanAllTestSuite) TestAuthorization() {
 	reqs := []struct {
 		method string
 		url    string
-		body   interface{}
+		body   any
 	}{
 		{http.MethodGet, "/scans/all/metrics", nil},
 		{http.MethodGet, "/scans/schedule/metrics", nil},
@@ -185,7 +185,7 @@ func (suite *ScanAllTestSuite) TestGetLatestScanAllMetrics() {
 		// scan all execution not found
 		mock.OnAnything(suite.execMgr, "List").Return(nil, nil).Once()
 
-		var stats map[string]interface{}
+		var stats map[string]any
 		res, err := suite.GetJSON("/scans/all/metrics", &stats)
 		suite.NoError(err)
 		suite.Equal(200, res.StatusCode)
@@ -223,7 +223,7 @@ func (suite *ScanAllTestSuite) TestGetLatestScheduledScanAllMetrics() {
 		// scan all execution not found
 		mock.OnAnything(suite.execMgr, "List").Return(nil, nil).Once()
 
-		var stats map[string]interface{}
+		var stats map[string]any
 		res, err := suite.GetJSON("/scans/schedule/metrics", &stats)
 		suite.NoError(err)
 		suite.Equal(200, res.StatusCode)

--- a/src/server/v2.0/handler/scanexport.go
+++ b/src/server/v2.0/handler/scanexport.go
@@ -58,7 +58,7 @@ type scanDataExportAPI struct {
 	userMgr           user.Manager
 }
 
-func (se *scanDataExportAPI) Prepare(_ context.Context, _ string, _ interface{}) middleware.Responder {
+func (se *scanDataExportAPI) Prepare(_ context.Context, _ string, _ any) middleware.Responder {
 	return nil
 }
 

--- a/src/server/v2.0/handler/scanexport_test.go
+++ b/src/server/v2.0/handler/scanexport_test.go
@@ -74,7 +74,7 @@ func (suite *ScanExportTestSuite) TestAuthorization() {
 		reqs := []struct {
 			method  string
 			url     string
-			body    interface{}
+			body    any
 			headers map[string]string
 		}{
 			{http.MethodPost, "/export/cve", criteria, map[string]string{"X-Scan-Data-Type": v1.MimeTypeGenericVulnerabilityReport}},
@@ -191,7 +191,7 @@ func (suite *ScanExportTestSuite) TestExportScanData() {
 		suite.Equal(200, res.StatusCode)
 
 		suite.Equal(nil, err)
-		respData := make(map[string]interface{})
+		respData := make(map[string]any)
 		json.NewDecoder(res.Body).Decode(&respData)
 		suite.Equal(int64(100), int64(respData["id"].(float64)))
 

--- a/src/server/v2.0/handler/scanner_test.go
+++ b/src/server/v2.0/handler/scanner_test.go
@@ -66,7 +66,7 @@ func (suite *ScannerTestSuite) SetupSuite() {
 }
 
 func (suite *ScannerTestSuite) TestAuthorization() {
-	newBody := func(body interface{}) io.Reader {
+	newBody := func(body any) io.Reader {
 		if body == nil {
 			return nil
 		}
@@ -79,7 +79,7 @@ func (suite *ScannerTestSuite) TestAuthorization() {
 	reqs := []struct {
 		method string
 		url    string
-		body   interface{}
+		body   any
 	}{
 		{http.MethodGet, "/scanners", nil},
 		{http.MethodPost, "/scanners", suite.reg},
@@ -87,7 +87,7 @@ func (suite *ScannerTestSuite) TestAuthorization() {
 		{http.MethodGet, "/scanners/uuid1", nil},
 		{http.MethodPut, "/scanners/uuid1", suite.reg},
 		{http.MethodDelete, "/scanners/uuid1", nil},
-		{http.MethodPatch, "/scanners/uuid1", map[string]interface{}{"is_default": true}},
+		{http.MethodPatch, "/scanners/uuid1", map[string]any{"is_default": true}},
 		{http.MethodGet, "/scanners/uuid1/metadata", nil},
 	}
 
@@ -124,7 +124,7 @@ func (suite *ScannerTestSuite) TestCreateScannerWithInvalidBody() {
 
 	{
 		// name missing
-		res, err := suite.PostJSON("/scanners", map[string]interface{}{
+		res, err := suite.PostJSON("/scanners", map[string]any{
 			"url": "http://reg:8080",
 		})
 		suite.NoError(err)
@@ -133,7 +133,7 @@ func (suite *ScannerTestSuite) TestCreateScannerWithInvalidBody() {
 
 	{
 		// url missing
-		res, err := suite.PostJSON("/scanners", map[string]interface{}{
+		res, err := suite.PostJSON("/scanners", map[string]any{
 			"name": "reg",
 		})
 		suite.NoError(err)
@@ -142,7 +142,7 @@ func (suite *ScannerTestSuite) TestCreateScannerWithInvalidBody() {
 
 	{
 		// invalid url
-		res, err := suite.PostJSON("/scanners", map[string]interface{}{
+		res, err := suite.PostJSON("/scanners", map[string]any{
 			"name": "reg",
 			"url":  "invalid url",
 		})
@@ -158,7 +158,7 @@ func (suite *ScannerTestSuite) TestCreateScanner() {
 
 	{
 		mock.OnAnything(suite.scannerCtl, "CreateRegistration").Return("", fmt.Errorf("failed to create registration")).Once()
-		res, err := suite.PostJSON("/scanners", map[string]interface{}{
+		res, err := suite.PostJSON("/scanners", map[string]any{
 			"name": "reg",
 			"url":  "http://reg:8080",
 		})
@@ -168,7 +168,7 @@ func (suite *ScannerTestSuite) TestCreateScanner() {
 
 	{
 		mock.OnAnything(suite.scannerCtl, "CreateRegistration").Return("uuid", nil).Once()
-		res, err := suite.PostJSON("/scanners", map[string]interface{}{
+		res, err := suite.PostJSON("/scanners", map[string]any{
 			"name": "reg",
 			"url":  "http://reg:8080",
 		})
@@ -179,7 +179,7 @@ func (suite *ScannerTestSuite) TestCreateScanner() {
 
 	{
 		// access_credential missing
-		res, err := suite.PostJSON("/scanners", map[string]interface{}{
+		res, err := suite.PostJSON("/scanners", map[string]any{
 			"name": "reg",
 			"url":  "http://reg:8080",
 			"auth": "Basic",
@@ -190,7 +190,7 @@ func (suite *ScannerTestSuite) TestCreateScanner() {
 
 	{
 		mock.OnAnything(suite.scannerCtl, "CreateRegistration").Return("uuid", nil).Once()
-		res, err := suite.PostJSON("/scanners", map[string]interface{}{
+		res, err := suite.PostJSON("/scanners", map[string]any{
 			"name":              "reg",
 			"url":               "http://reg:8080",
 			"auth":              "Basic",
@@ -268,7 +268,7 @@ func (suite *ScannerTestSuite) TestGetScanner() {
 		// scanner not found
 		mock.OnAnything(suite.scannerCtl, "GetRegistration").Return(nil, nil).Once()
 
-		var scanner map[string]interface{}
+		var scanner map[string]any
 		res, err := suite.GetJSON("/scanners/uuid", &scanner)
 		suite.NoError(err)
 		suite.Equal(404, res.StatusCode)
@@ -278,7 +278,7 @@ func (suite *ScannerTestSuite) TestGetScanner() {
 		// scanner found
 		mock.OnAnything(suite.scannerCtl, "GetRegistration").Return(suite.reg, nil).Once()
 
-		var scanner map[string]interface{}
+		var scanner map[string]any
 		res, err := suite.GetJSON("/scanners/uuid", &scanner)
 		suite.NoError(err)
 		suite.Equal(200, res.StatusCode)
@@ -340,7 +340,7 @@ func (suite *ScannerTestSuite) TestListScanners() {
 		mock.OnAnything(suite.scannerCtl, "GetTotalOfRegistrations").Return(int64(0), nil).Once()
 		mock.OnAnything(suite.scannerCtl, "ListRegistrations").Return(nil, nil).Once()
 
-		var scanners []interface{}
+		var scanners []any
 		res, err := suite.GetJSON("/scanners", &scanners)
 		suite.NoError(err)
 		suite.Equal(200, res.StatusCode)
@@ -352,7 +352,7 @@ func (suite *ScannerTestSuite) TestListScanners() {
 		mock.OnAnything(suite.scannerCtl, "GetTotalOfRegistrations").Return(int64(3), nil).Once()
 		mock.OnAnything(suite.scannerCtl, "ListRegistrations").Return([]*scanner.Registration{suite.reg}, nil).Once()
 
-		var scanners []interface{}
+		var scanners []any
 		res, err := suite.GetJSON("/scanners?page_size=1&page=2", &scanners)
 		suite.NoError(err)
 		suite.Equal(200, res.StatusCode)
@@ -370,7 +370,7 @@ func (suite *ScannerTestSuite) TestPingScanner() {
 
 	{
 		// bad req
-		res, err := suite.PostJSON("/scanners/ping", map[string]interface{}{
+		res, err := suite.PostJSON("/scanners/ping", map[string]any{
 			"name": "reg",
 			"url":  "http://reg:8080",
 			"auth": "Basic",
@@ -383,7 +383,7 @@ func (suite *ScannerTestSuite) TestPingScanner() {
 		// ping failed
 		mock.OnAnything(suite.scannerCtl, "Ping").Return(nil, fmt.Errorf("failed to ping scanner")).Once()
 
-		res, err := suite.PostJSON("/scanners/ping", map[string]interface{}{
+		res, err := suite.PostJSON("/scanners/ping", map[string]any{
 			"name": "reg",
 			"url":  "http://reg:8080",
 		})
@@ -395,7 +395,7 @@ func (suite *ScannerTestSuite) TestPingScanner() {
 		// ping
 		mock.OnAnything(suite.scannerCtl, "Ping").Return(&suite.metadata, nil).Once()
 
-		res, err := suite.PostJSON("/scanners/ping", map[string]interface{}{
+		res, err := suite.PostJSON("/scanners/ping", map[string]any{
 			"name": "reg",
 			"url":  "http://reg:8080",
 		})
@@ -410,7 +410,7 @@ func (suite *ScannerTestSuite) TestSetScannerAsDefault() {
 	suite.Security.On("Can", mock.Anything, mock.Anything, mock.Anything).Return(true).Times(times)
 
 	{
-		res, err := suite.PatchJSON("/scanners/uuid", map[string]interface{}{
+		res, err := suite.PatchJSON("/scanners/uuid", map[string]any{
 			"is_default": false,
 		})
 		suite.NoError(err)
@@ -421,7 +421,7 @@ func (suite *ScannerTestSuite) TestSetScannerAsDefault() {
 		// set default failed
 		mock.OnAnything(suite.scannerCtl, "SetDefaultRegistration").Return(fmt.Errorf("failed to set default")).Once()
 
-		res, err := suite.PatchJSON("/scanners/uuid", map[string]interface{}{
+		res, err := suite.PatchJSON("/scanners/uuid", map[string]any{
 			"is_default": true,
 		})
 		suite.NoError(err)
@@ -432,7 +432,7 @@ func (suite *ScannerTestSuite) TestSetScannerAsDefault() {
 		// set default
 		mock.OnAnything(suite.scannerCtl, "SetDefaultRegistration").Return(nil).Once()
 
-		res, err := suite.PatchJSON("/scanners/uuid", map[string]interface{}{
+		res, err := suite.PatchJSON("/scanners/uuid", map[string]any{
 			"is_default": true,
 		})
 		suite.NoError(err)
@@ -456,7 +456,7 @@ func (suite *ScannerTestSuite) TestUpdateScanner() {
 		// get scanner failed
 		mock.OnAnything(suite.scannerCtl, "GetRegistration").Return(nil, fmt.Errorf("failed to get registration")).Once()
 
-		res, err := suite.PutJSON("/scanners/uuid", map[string]interface{}{
+		res, err := suite.PutJSON("/scanners/uuid", map[string]any{
 			"name": "reg",
 			"url":  "http://reg:8080",
 		})
@@ -468,7 +468,7 @@ func (suite *ScannerTestSuite) TestUpdateScanner() {
 		// scanner not found
 		mock.OnAnything(suite.scannerCtl, "GetRegistration").Return(nil, nil).Once()
 
-		res, err := suite.PutJSON("/scanners/uuid", map[string]interface{}{
+		res, err := suite.PutJSON("/scanners/uuid", map[string]any{
 			"name": "reg",
 			"url":  "http://reg:8080",
 		})
@@ -480,7 +480,7 @@ func (suite *ScannerTestSuite) TestUpdateScanner() {
 		// immutable scanner
 		mock.OnAnything(suite.scannerCtl, "GetRegistration").Return(&scanner.Registration{Immutable: true}, nil).Once()
 
-		res, err := suite.PutJSON("/scanners/uuid", map[string]interface{}{
+		res, err := suite.PutJSON("/scanners/uuid", map[string]any{
 			"name": "reg",
 			"url":  "http://reg:8080",
 		})
@@ -492,7 +492,7 @@ func (suite *ScannerTestSuite) TestUpdateScanner() {
 		// bad req
 		mock.OnAnything(suite.scannerCtl, "GetRegistration").Return(suite.reg, nil).Once()
 
-		res, err := suite.PutJSON("/scanners/uuid", map[string]interface{}{
+		res, err := suite.PutJSON("/scanners/uuid", map[string]any{
 			"name": "reg",
 			"url":  "http://reg:8080",
 			"auth": "Basic",
@@ -506,7 +506,7 @@ func (suite *ScannerTestSuite) TestUpdateScanner() {
 		mock.OnAnything(suite.scannerCtl, "GetRegistration").Return(suite.reg, nil).Once()
 		mock.OnAnything(suite.scannerCtl, "UpdateRegistration").Return(fmt.Errorf("failed to update the scanner")).Once()
 
-		res, err := suite.PutJSON("/scanners/uuid", map[string]interface{}{
+		res, err := suite.PutJSON("/scanners/uuid", map[string]any{
 			"name": "reg",
 			"url":  "http://reg:8080",
 		})
@@ -519,7 +519,7 @@ func (suite *ScannerTestSuite) TestUpdateScanner() {
 		mock.OnAnything(suite.scannerCtl, "GetRegistration").Return(suite.reg, nil).Once()
 		mock.OnAnything(suite.scannerCtl, "UpdateRegistration").Return(nil).Once()
 
-		res, err := suite.PutJSON("/scanners/uuid", map[string]interface{}{
+		res, err := suite.PutJSON("/scanners/uuid", map[string]any{
 			"name": "reg",
 			"url":  "http://reg:8080",
 		})

--- a/src/server/v2.0/handler/search.go
+++ b/src/server/v2.0/handler/search.go
@@ -167,7 +167,7 @@ func (s *searchAPI) filterRepositories(ctx context.Context, projects []*project.
 
 // searchOK ...
 type searchOK struct {
-	Payload interface{}
+	Payload any
 }
 
 func (o *searchOK) WithPayload(payload *models.Search) *searchOK {

--- a/src/server/v2.0/handler/statistic.go
+++ b/src/server/v2.0/handler/statistic.go
@@ -61,12 +61,12 @@ func (s *statisticAPI) GetStatistic(ctx context.Context, _ operation.GetStatisti
 	if len(pubProjs) == 0 {
 		statistic.PublicRepoCount = 0
 	} else {
-		var ids []interface{}
+		var ids []any
 		for _, p := range pubProjs {
 			ids = append(ids, p.ProjectID)
 		}
 		n, err := s.repoCtl.Count(ctx, &q.Query{
-			Keywords: map[string]interface{}{
+			Keywords: map[string]any{
 				"ProjectID": q.NewOrList(ids),
 			},
 		})
@@ -108,7 +108,7 @@ func (s *statisticAPI) GetStatistic(ctx context.Context, _ operation.GetStatisti
 		}
 		statistic.TotalStorageConsumption = sum + sysArtifactStorageSize
 	} else {
-		var privProjectIDs []interface{}
+		var privProjectIDs []any
 		if sc, ok := securityCtx.(*local.SecurityContext); ok && sc.IsAuthenticated() {
 			user := sc.User()
 			member := &project.MemberQuery{
@@ -130,7 +130,7 @@ func (s *statisticAPI) GetStatistic(ctx context.Context, _ operation.GetStatisti
 			statistic.PrivateRepoCount = 0
 		} else {
 			n, err := s.repoCtl.Count(ctx, &q.Query{
-				Keywords: map[string]interface{}{
+				Keywords: map[string]any{
 					"ProjectID": q.NewOrList(privProjectIDs),
 				},
 			})

--- a/src/server/v2.0/handler/util.go
+++ b/src/server/v2.0/handler/util.go
@@ -64,7 +64,7 @@ func parseScanReportMimeTypes(header *string) []string {
 	return mimeTypes
 }
 
-func unescapePathParams(params interface{}, fieldNames ...string) error {
+func unescapePathParams(params any, fieldNames ...string) error {
 	val := reflect.ValueOf(params)
 	if val.Kind() != reflect.Ptr {
 		return fmt.Errorf("params must be ptr")
@@ -102,7 +102,7 @@ func unescapePathParams(params interface{}, fieldNames ...string) error {
 	return nil
 }
 
-func parseProjectNameOrID(str string, isResourceName *bool) interface{} {
+func parseProjectNameOrID(str string, isResourceName *bool) any {
 	if lib.BoolValue(isResourceName) {
 		// always as projectName
 		return str
@@ -117,7 +117,7 @@ func parseProjectNameOrID(str string, isResourceName *bool) interface{} {
 	return v // projectID
 }
 
-func getProjectID(ctx context.Context, projectNameOrID interface{}) (int64, error) {
+func getProjectID(ctx context.Context, projectNameOrID any) (int64, error) {
 	projectName, ok := projectNameOrID.(string)
 	if ok {
 		p, err := project.Ctl.Get(ctx, projectName, project.Metadata(false))

--- a/src/server/v2.0/handler/util_test.go
+++ b/src/server/v2.0/handler/util_test.go
@@ -28,7 +28,7 @@ func Test_unescapePathParams(t *testing.T) {
 	str := "params"
 
 	type args struct {
-		params     interface{}
+		params     any
 		fieldNames []string
 	}
 	tests := []struct {

--- a/src/server/v2.0/handler/webhook.go
+++ b/src/server/v2.0/handler/webhook.go
@@ -53,11 +53,11 @@ type webhookAPI struct {
 	webhookCtl webhook_ctl.Controller
 }
 
-func (n *webhookAPI) Prepare(_ context.Context, _ string, _ interface{}) middleware.Responder {
+func (n *webhookAPI) Prepare(_ context.Context, _ string, _ any) middleware.Responder {
 	return nil
 }
 
-func (n *webhookAPI) requirePolicyInProject(ctx context.Context, projectIDOrName interface{}, policyID int64) error {
+func (n *webhookAPI) requirePolicyInProject(ctx context.Context, projectIDOrName any, policyID int64) error {
 	projectID, err := getProjectID(ctx, projectIDOrName)
 	if err != nil {
 		return err

--- a/src/server/v2.0/handler/webhook_job.go
+++ b/src/server/v2.0/handler/webhook_job.go
@@ -89,7 +89,7 @@ func (n *webhookJobAPI) ListWebhookJobs(ctx context.Context, params webhookjob.L
 }
 
 // requirePolicyAccess checks whether the project has the permission to the policy.
-func (n *webhookJobAPI) requirePolicyAccess(ctx context.Context, projectNameIrID interface{}, policy *policyModel.Policy) error {
+func (n *webhookJobAPI) requirePolicyAccess(ctx context.Context, projectNameIrID any, policy *policyModel.Policy) error {
 	p, err := n.projectMgr.Get(ctx, projectNameIrID)
 	if err != nil {
 		return err

--- a/src/testing/jobservice/context.go
+++ b/src/testing/jobservice/context.go
@@ -27,7 +27,7 @@ func (mjc *MockJobContext) Build(tracker job.Tracker) (job.Context, error) {
 }
 
 // Get ...
-func (mjc *MockJobContext) Get(prop string) (interface{}, bool) {
+func (mjc *MockJobContext) Get(prop string) (any, bool) {
 	args := mjc.Called(prop)
 	return args.Get(0), args.Bool(1)
 }
@@ -71,51 +71,51 @@ type MockJobLogger struct {
 }
 
 // Debug ...
-func (mjl *MockJobLogger) Debug(v ...interface{}) {
+func (mjl *MockJobLogger) Debug(v ...any) {
 	logger.Debug(v...)
 }
 
 // Debugf ...
-func (mjl *MockJobLogger) Debugf(format string, v ...interface{}) {
+func (mjl *MockJobLogger) Debugf(format string, v ...any) {
 	logger.Debugf(format, v...)
 }
 
 // Info ...
-func (mjl *MockJobLogger) Info(v ...interface{}) {
+func (mjl *MockJobLogger) Info(v ...any) {
 	logger.Info(v...)
 }
 
 // Infof ...
-func (mjl *MockJobLogger) Infof(format string, v ...interface{}) {
+func (mjl *MockJobLogger) Infof(format string, v ...any) {
 	logger.Infof(format, v...)
 }
 
 // Warning ...
-func (mjl *MockJobLogger) Warning(v ...interface{}) {
+func (mjl *MockJobLogger) Warning(v ...any) {
 	logger.Warning(v...)
 }
 
 // Warningf ...
-func (mjl *MockJobLogger) Warningf(format string, v ...interface{}) {
+func (mjl *MockJobLogger) Warningf(format string, v ...any) {
 	logger.Warningf(format, v...)
 }
 
 // Error ...
-func (mjl *MockJobLogger) Error(v ...interface{}) {
+func (mjl *MockJobLogger) Error(v ...any) {
 	logger.Error(v...)
 }
 
 // Errorf ...
-func (mjl *MockJobLogger) Errorf(format string, v ...interface{}) {
+func (mjl *MockJobLogger) Errorf(format string, v ...any) {
 	logger.Errorf(format, v...)
 }
 
 // Fatal ...
-func (mjl *MockJobLogger) Fatal(v ...interface{}) {
+func (mjl *MockJobLogger) Fatal(v ...any) {
 	logger.Fatal(v...)
 }
 
 // Fatalf ...
-func (mjl *MockJobLogger) Fatalf(format string, v ...interface{}) {
+func (mjl *MockJobLogger) Fatalf(format string, v ...any) {
 	logger.Fatalf(format, v...)
 }

--- a/src/testing/lib/orm/orm.go
+++ b/src/testing/lib/orm/orm.go
@@ -26,39 +26,39 @@ import (
 type FakeOrmer struct {
 }
 
-func (f *FakeOrmer) LoadRelated(md interface{}, name string, args ...utils.KV) (int64, error) {
+func (f *FakeOrmer) LoadRelated(md any, name string, args ...utils.KV) (int64, error) {
 	return 0, nil
 }
 
-func (f *FakeOrmer) QueryM2MWithCtx(ctx context.Context, md interface{}, name string) orm.QueryM2Mer {
+func (f *FakeOrmer) QueryM2MWithCtx(ctx context.Context, md any, name string) orm.QueryM2Mer {
 	return nil
 }
 
-func (f *FakeOrmer) QueryTableWithCtx(ctx context.Context, ptrStructOrTableName interface{}) orm.QuerySeter {
+func (f *FakeOrmer) QueryTableWithCtx(ctx context.Context, ptrStructOrTableName any) orm.QuerySeter {
 	return nil
 }
 
-func (f *FakeOrmer) InsertWithCtx(ctx context.Context, md interface{}) (int64, error) {
+func (f *FakeOrmer) InsertWithCtx(ctx context.Context, md any) (int64, error) {
 	return 0, nil
 }
 
-func (f *FakeOrmer) InsertOrUpdateWithCtx(ctx context.Context, md interface{}, colConflitAndArgs ...string) (int64, error) {
+func (f *FakeOrmer) InsertOrUpdateWithCtx(ctx context.Context, md any, colConflitAndArgs ...string) (int64, error) {
 	return 0, nil
 }
 
-func (f *FakeOrmer) InsertMultiWithCtx(ctx context.Context, bulk int, mds interface{}) (int64, error) {
+func (f *FakeOrmer) InsertMultiWithCtx(ctx context.Context, bulk int, mds any) (int64, error) {
 	return 0, nil
 }
 
-func (f *FakeOrmer) UpdateWithCtx(ctx context.Context, md interface{}, cols ...string) (int64, error) {
+func (f *FakeOrmer) UpdateWithCtx(ctx context.Context, md any, cols ...string) (int64, error) {
 	return 0, nil
 }
 
-func (f *FakeOrmer) DeleteWithCtx(ctx context.Context, md interface{}, cols ...string) (int64, error) {
+func (f *FakeOrmer) DeleteWithCtx(ctx context.Context, md any, cols ...string) (int64, error) {
 	return 0, nil
 }
 
-func (f *FakeOrmer) RawWithCtx(ctx context.Context, query string, args ...interface{}) orm.RawSeter {
+func (f *FakeOrmer) RawWithCtx(ctx context.Context, query string, args ...any) orm.RawSeter {
 	return nil
 }
 
@@ -95,68 +95,68 @@ func (f *FakeOrmer) DoTxWithCtxAndOpts(ctx context.Context, opts *sql.TxOptions,
 }
 
 // Read ...
-func (f *FakeOrmer) Read(md interface{}, cols ...string) error {
+func (f *FakeOrmer) Read(md any, cols ...string) error {
 	return nil
 }
 
-func (f *FakeOrmer) ReadWithCtx(ctx context.Context, md interface{}, cols ...string) error {
+func (f *FakeOrmer) ReadWithCtx(ctx context.Context, md any, cols ...string) error {
 	return nil
 }
 
-func (f *FakeOrmer) ReadForUpdateWithCtx(ctx context.Context, md interface{}, cols ...string) error {
+func (f *FakeOrmer) ReadForUpdateWithCtx(ctx context.Context, md any, cols ...string) error {
 	return nil
 }
 
-func (f *FakeOrmer) ReadOrCreateWithCtx(ctx context.Context, md interface{}, col1 string, cols ...string) (bool, int64, error) {
+func (f *FakeOrmer) ReadOrCreateWithCtx(ctx context.Context, md any, col1 string, cols ...string) (bool, int64, error) {
 	return false, 0, nil
 }
 
-func (f *FakeOrmer) LoadRelatedWithCtx(_ context.Context, md interface{}, name string, args ...utils.KV) (int64, error) {
+func (f *FakeOrmer) LoadRelatedWithCtx(_ context.Context, md any, name string, args ...utils.KV) (int64, error) {
 	return 0, nil
 }
 
 // ReadForUpdate ...
-func (f *FakeOrmer) ReadForUpdate(md interface{}, cols ...string) error {
+func (f *FakeOrmer) ReadForUpdate(md any, cols ...string) error {
 	return nil
 }
 
 // ReadOrCreate ...
-func (f *FakeOrmer) ReadOrCreate(md interface{}, col1 string, cols ...string) (bool, int64, error) {
+func (f *FakeOrmer) ReadOrCreate(md any, col1 string, cols ...string) (bool, int64, error) {
 	return false, 0, nil
 }
 
 // Insert ...
-func (f *FakeOrmer) Insert(interface{}) (int64, error) {
+func (f *FakeOrmer) Insert(any) (int64, error) {
 	return 0, nil
 }
 
 // InsertOrUpdate ...
-func (f *FakeOrmer) InsertOrUpdate(md interface{}, colConflitAndArgs ...string) (int64, error) {
+func (f *FakeOrmer) InsertOrUpdate(md any, colConflitAndArgs ...string) (int64, error) {
 	return 0, nil
 }
 
 // InsertMulti ...
-func (f *FakeOrmer) InsertMulti(bulk int, mds interface{}) (int64, error) {
+func (f *FakeOrmer) InsertMulti(bulk int, mds any) (int64, error) {
 	return 0, nil
 }
 
 // Update ...
-func (f *FakeOrmer) Update(md interface{}, cols ...string) (int64, error) {
+func (f *FakeOrmer) Update(md any, cols ...string) (int64, error) {
 	return 0, nil
 }
 
 // Delete ...
-func (f *FakeOrmer) Delete(md interface{}, cols ...string) (int64, error) {
+func (f *FakeOrmer) Delete(md any, cols ...string) (int64, error) {
 	return 0, nil
 }
 
 // QueryM2M ...
-func (f *FakeOrmer) QueryM2M(md interface{}, name string) orm.QueryM2Mer {
+func (f *FakeOrmer) QueryM2M(md any, name string) orm.QueryM2Mer {
 	return nil
 }
 
 // QueryTable ...
-func (f *FakeOrmer) QueryTable(ptrStructOrTableName interface{}) orm.QuerySeter {
+func (f *FakeOrmer) QueryTable(ptrStructOrTableName any) orm.QuerySeter {
 	return nil
 }
 
@@ -181,7 +181,7 @@ func (f *FakeOrmer) Rollback() error {
 }
 
 // Raw ...
-func (f *FakeOrmer) Raw(query string, args ...interface{}) orm.RawSeter {
+func (f *FakeOrmer) Raw(query string, args ...any) orm.RawSeter {
 	return &FakeRawSeter{}
 }
 
@@ -199,51 +199,51 @@ func (f *FakeOrmer) DBStats() *sql.DBStats {
 type FakeTxOrmer struct {
 }
 
-func (f *FakeTxOrmer) Read(md interface{}, cols ...string) error {
+func (f *FakeTxOrmer) Read(md any, cols ...string) error {
 	return nil
 }
 
-func (f *FakeTxOrmer) ReadWithCtx(ctx context.Context, md interface{}, cols ...string) error {
+func (f *FakeTxOrmer) ReadWithCtx(ctx context.Context, md any, cols ...string) error {
 	return nil
 }
 
-func (f *FakeTxOrmer) ReadForUpdate(md interface{}, cols ...string) error {
+func (f *FakeTxOrmer) ReadForUpdate(md any, cols ...string) error {
 	return nil
 }
 
-func (f *FakeTxOrmer) ReadForUpdateWithCtx(ctx context.Context, md interface{}, cols ...string) error {
+func (f *FakeTxOrmer) ReadForUpdateWithCtx(ctx context.Context, md any, cols ...string) error {
 	return nil
 }
 
-func (f *FakeTxOrmer) ReadOrCreate(md interface{}, col1 string, cols ...string) (bool, int64, error) {
+func (f *FakeTxOrmer) ReadOrCreate(md any, col1 string, cols ...string) (bool, int64, error) {
 	return false, 0, nil
 }
 
-func (f *FakeTxOrmer) ReadOrCreateWithCtx(ctx context.Context, md interface{}, col1 string, cols ...string) (bool, int64, error) {
+func (f *FakeTxOrmer) ReadOrCreateWithCtx(ctx context.Context, md any, col1 string, cols ...string) (bool, int64, error) {
 	return false, 0, nil
 }
 
-func (f *FakeTxOrmer) LoadRelated(md interface{}, name string, args ...utils.KV) (int64, error) {
+func (f *FakeTxOrmer) LoadRelated(md any, name string, args ...utils.KV) (int64, error) {
 	return 0, nil
 }
 
-func (f *FakeTxOrmer) LoadRelatedWithCtx(ctx context.Context, md interface{}, name string, args ...utils.KV) (int64, error) {
+func (f *FakeTxOrmer) LoadRelatedWithCtx(ctx context.Context, md any, name string, args ...utils.KV) (int64, error) {
 	return 0, nil
 }
 
-func (f *FakeTxOrmer) QueryM2M(md interface{}, name string) orm.QueryM2Mer {
+func (f *FakeTxOrmer) QueryM2M(md any, name string) orm.QueryM2Mer {
 	return nil
 }
 
-func (f *FakeTxOrmer) QueryM2MWithCtx(ctx context.Context, md interface{}, name string) orm.QueryM2Mer {
+func (f *FakeTxOrmer) QueryM2MWithCtx(ctx context.Context, md any, name string) orm.QueryM2Mer {
 	return nil
 }
 
-func (f *FakeTxOrmer) QueryTable(ptrStructOrTableName interface{}) orm.QuerySeter {
+func (f *FakeTxOrmer) QueryTable(ptrStructOrTableName any) orm.QuerySeter {
 	return nil
 }
 
-func (f *FakeTxOrmer) QueryTableWithCtx(ctx context.Context, ptrStructOrTableName interface{}) orm.QuerySeter {
+func (f *FakeTxOrmer) QueryTableWithCtx(ctx context.Context, ptrStructOrTableName any) orm.QuerySeter {
 	return nil
 }
 
@@ -251,51 +251,51 @@ func (f *FakeTxOrmer) DBStats() *sql.DBStats {
 	return nil
 }
 
-func (f *FakeTxOrmer) Insert(md interface{}) (int64, error) {
+func (f *FakeTxOrmer) Insert(md any) (int64, error) {
 	return 0, nil
 }
 
-func (f *FakeTxOrmer) InsertWithCtx(ctx context.Context, md interface{}) (int64, error) {
+func (f *FakeTxOrmer) InsertWithCtx(ctx context.Context, md any) (int64, error) {
 	return 0, nil
 }
 
-func (f *FakeTxOrmer) InsertOrUpdate(md interface{}, colConflitAndArgs ...string) (int64, error) {
+func (f *FakeTxOrmer) InsertOrUpdate(md any, colConflitAndArgs ...string) (int64, error) {
 	return 0, nil
 }
 
-func (f *FakeTxOrmer) InsertOrUpdateWithCtx(ctx context.Context, md interface{}, colConflitAndArgs ...string) (int64, error) {
+func (f *FakeTxOrmer) InsertOrUpdateWithCtx(ctx context.Context, md any, colConflitAndArgs ...string) (int64, error) {
 	return 0, nil
 }
 
-func (f *FakeTxOrmer) InsertMulti(bulk int, mds interface{}) (int64, error) {
+func (f *FakeTxOrmer) InsertMulti(bulk int, mds any) (int64, error) {
 	return 0, nil
 }
 
-func (f *FakeTxOrmer) InsertMultiWithCtx(ctx context.Context, bulk int, mds interface{}) (int64, error) {
+func (f *FakeTxOrmer) InsertMultiWithCtx(ctx context.Context, bulk int, mds any) (int64, error) {
 	return 0, nil
 }
 
-func (f *FakeTxOrmer) Update(md interface{}, cols ...string) (int64, error) {
+func (f *FakeTxOrmer) Update(md any, cols ...string) (int64, error) {
 	return 0, nil
 }
 
-func (f *FakeTxOrmer) UpdateWithCtx(ctx context.Context, md interface{}, cols ...string) (int64, error) {
+func (f *FakeTxOrmer) UpdateWithCtx(ctx context.Context, md any, cols ...string) (int64, error) {
 	return 0, nil
 }
 
-func (f *FakeTxOrmer) Delete(md interface{}, cols ...string) (int64, error) {
+func (f *FakeTxOrmer) Delete(md any, cols ...string) (int64, error) {
 	return 0, nil
 }
 
-func (f *FakeTxOrmer) DeleteWithCtx(ctx context.Context, md interface{}, cols ...string) (int64, error) {
+func (f *FakeTxOrmer) DeleteWithCtx(ctx context.Context, md any, cols ...string) (int64, error) {
 	return 0, nil
 }
 
-func (f *FakeTxOrmer) Raw(query string, args ...interface{}) orm.RawSeter {
+func (f *FakeTxOrmer) Raw(query string, args ...any) orm.RawSeter {
 	return &FakeRawSeter{}
 }
 
-func (f *FakeTxOrmer) RawWithCtx(ctx context.Context, query string, args ...interface{}) orm.RawSeter {
+func (f *FakeTxOrmer) RawWithCtx(ctx context.Context, query string, args ...any) orm.RawSeter {
 	return nil
 }
 
@@ -323,15 +323,15 @@ func (f FakeRawSeter) Exec() (sql.Result, error) {
 	return nil, nil
 }
 
-func (f FakeRawSeter) QueryRow(containers ...interface{}) error {
+func (f FakeRawSeter) QueryRow(containers ...any) error {
 	return nil
 }
 
-func (f FakeRawSeter) QueryRows(containers ...interface{}) (int64, error) {
+func (f FakeRawSeter) QueryRows(containers ...any) (int64, error) {
 	return 0, nil
 }
 
-func (f FakeRawSeter) SetArgs(i ...interface{}) orm.RawSeter {
+func (f FakeRawSeter) SetArgs(i ...any) orm.RawSeter {
 	return nil
 }
 
@@ -351,7 +351,7 @@ func (f FakeRawSeter) RowsToMap(result *orm.Params, keyCol, valueCol string) (in
 	return 0, nil
 }
 
-func (f FakeRawSeter) RowsToStruct(ptrStruct interface{}, keyCol, valueCol string) (int64, error) {
+func (f FakeRawSeter) RowsToStruct(ptrStruct any, keyCol, valueCol string) (int64, error) {
 	return 0, nil
 }
 

--- a/src/testing/mock/mock.go
+++ b/src/testing/mock/mock.go
@@ -35,11 +35,11 @@ var (
 type Arguments = mock.Arguments
 
 type mockable interface {
-	On(methodName string, arguments ...interface{}) *mock.Call
+	On(methodName string, arguments ...any) *mock.Call
 }
 
 // OnAnything mock method on obj which match any args
-func OnAnything(obj interface{}, methodName string) *mock.Call {
+func OnAnything(obj any, methodName string) *mock.Call {
 	m, ok := obj.(mockable)
 	if !ok {
 		panic("obj not mockable")
@@ -52,7 +52,7 @@ func OnAnything(obj interface{}, methodName string) *mock.Call {
 		panic(fmt.Sprintf("assert: arguments: %s is not a func", v))
 	}
 
-	args := []interface{}{}
+	args := []any{}
 	for i := 0; i < fnType.NumIn(); i++ {
 		args = append(args, mock.Anything)
 	}

--- a/src/testing/server/v2.0/handler/handler.go
+++ b/src/testing/server/v2.0/handler/handler.go
@@ -94,7 +94,7 @@ func (suite *Suite) Get(url string, headers ...map[string]string) (*http.Respons
 }
 
 // GetJSON ...
-func (suite *Suite) GetJSON(url string, js interface{}, headers ...map[string]string) (*http.Response, error) {
+func (suite *Suite) GetJSON(url string, js any, headers ...map[string]string) (*http.Response, error) {
 	res, err := suite.Get(url, headers...)
 	if err != nil {
 		return nil, err
@@ -123,7 +123,7 @@ func (suite *Suite) Patch(url string, body io.Reader, headers ...map[string]stri
 }
 
 // PatchJSON ...
-func (suite *Suite) PatchJSON(url string, js interface{}) (*http.Response, error) {
+func (suite *Suite) PatchJSON(url string, js any) (*http.Response, error) {
 	buf, err := json.Marshal(js)
 	if err != nil {
 		return nil, err
@@ -138,7 +138,7 @@ func (suite *Suite) Post(url string, body io.Reader, headers ...map[string]strin
 }
 
 // PostJSON ...
-func (suite *Suite) PostJSON(url string, js interface{}) (*http.Response, error) {
+func (suite *Suite) PostJSON(url string, js any) (*http.Response, error) {
 	buf, err := json.Marshal(js)
 	if err != nil {
 		return nil, err
@@ -153,7 +153,7 @@ func (suite *Suite) Put(url string, body io.Reader, headers ...map[string]string
 }
 
 // PutJSON ...
-func (suite *Suite) PutJSON(url string, js interface{}) (*http.Response, error) {
+func (suite *Suite) PutJSON(url string, js any) (*http.Response, error) {
 	buf, err := json.Marshal(js)
 	if err != nil {
 		return nil, err

--- a/src/testing/suite.go
+++ b/src/testing/suite.go
@@ -152,7 +152,7 @@ func (suite *Suite) NextHandler(statusCode int, headers map[string]string) http.
 }
 
 // ExecSQL ...
-func (suite *Suite) ExecSQL(query string, args ...interface{}) {
+func (suite *Suite) ExecSQL(query string, args ...any) {
 	o := o.NewOrm()
 
 	_, err := o.Raw(query, args...).Exec()

--- a/tools/swagger/templates/README.md
+++ b/tools/swagger/templates/README.md
@@ -94,7 +94,7 @@ There is also a `restapi.Config`:
 type Config struct {
 	PetAPI
 	StoreAPI
-	Logger func(string, ...interface{})
+	Logger func(string, ...any)
 	// InnerMiddleware is for the handler executors. These do not apply to the swagger.json document.
 	// The middleware executes after routing but before authentication, binding and validation
 	InnerMiddleware func(http.Handler) http.Handler
@@ -265,12 +265,12 @@ Once we created a security definition named "token", a function called "AuthToke
 type Config struct {
     ...
 	// AuthToken Applies when the "Cookie" header is set
-	AuthToken func(token string) (interface{}, error)
+	AuthToken func(token string) (any, error)
 }
 ```
 
-This function gets the content of the Cookie header, and should return an `interface{}` and `error`.
-The `interface{}` is the object that should represent the user that performed the request, it should
+This function gets the content of the Cookie header, and should return an `any` and `error`.
+The `any` is the object that should represent the user that performed the request, it should
 be nil to return an unauthorized 401 HTTP response. If the returned `error` is not nil, an HTTP 500,
 internal server error will be returned.
 

--- a/tools/swagger/templates/server/builder.gotmpl
+++ b/tools/swagger/templates/server/builder.gotmpl
@@ -185,7 +185,7 @@ type {{ pascalize .Name }}API struct {
   PreServerShutdown func()
 
   // ServerShutdown is called when the HTTP(S) server is shut down and done
-  // handling all active connections and does not accept connections any more
+  // handling all active connections and does not accept connections interface{} more
   ServerShutdown func()
 
   // Custom command line argument groups with their descriptions


### PR DESCRIPTION
This pull request replaces all instances of the `interface{}` type with the `any` type across the codebase for improved readability and alignment with Go 1.18+ conventions. The changes span multiple files and functions, including core utilities, APIs, and test files.

### Type Replacement: `interface{}` to `any`

#### Core API and Utility Functions:
* Updated function parameters and return types in `src/common/api/base.go` to use `any` instead of `interface{}` for methods like `DecodeJSONReq`, `Validate`, and `DecodeJSONReqAndValidate`. [[1]](diffhunk://#diff-2719957bcb425342e2ca0225ff15614340a0b4d1d566cdc3106eb065d5b43412L81-R81) [[2]](diffhunk://#diff-2719957bcb425342e2ca0225ff15614340a0b4d1d566cdc3106eb065d5b43412L92-R92) [[3]](diffhunk://#diff-2719957bcb425342e2ca0225ff15614340a0b4d1d566cdc3106eb065d5b43412L111-R111)
* Modified utility functions in `src/common/utils/utils.go` such as `ConvertMapToStruct`, `SafeCastString`, and `SafeCastInt` to replace `interface{}` with `any`. [[1]](diffhunk://#diff-9bfb0613d138e38213564263b08d92d9c3a878fcc83bd0ee32d0410ad395eca6L143-R143) [[2]](diffhunk://#diff-9bfb0613d138e38213564263b08d92d9c3a878fcc83bd0ee32d0410ad395eca6L180-R204) [[3]](diffhunk://#diff-9bfb0613d138e38213564263b08d92d9c3a878fcc83bd0ee32d0410ad395eca6L217-R219)

#### Data Structures and Models:
* Replaced `interface{}` with `any` in type definitions like `Parameters` and `Message` in `src/common/job/models/models.go`. [[1]](diffhunk://#diff-b051c7b3426b353f4776970966b0f575f00128701b98c4a843981eddeb2c094dL18-R18) [[2]](diffhunk://#diff-b051c7b3426b353f4776970966b0f575f00128701b98c4a843981eddeb2c094dL99-R99)
* Adjusted map types in configuration files (e.g., `defaultConfig`) to use `map[string]any` instead of `map[string]interface{}`. [[1]](diffhunk://#diff-cb6ec51ee5b9daad4c7be11c9fe0943b4687209610e47ef3b4ebf8a588b1c390L21-R21) [[2]](diffhunk://#diff-4f83984aa21eaf6f1f40806d013ed60823ff5a39fe57f6c27b481a9a299c6a92L97-R99)

#### HTTP Client and Logging:
* Updated variadic parameters in HTTP client methods (`Get`, `Post`, `Put`) in `src/common/http/client.go` to use `any`. [[1]](diffhunk://#diff-1c004290eedba17588cd109781af736f40732aa1f1010b4d224824061d6ffc82L72-R72) [[2]](diffhunk://#diff-1c004290eedba17588cd109781af736f40732aa1f1010b4d224824061d6ffc82L101-R101) [[3]](diffhunk://#diff-1c004290eedba17588cd109781af736f40732aa1f1010b4d224824061d6ffc82L126-R126)
* Changed logging function parameters in `src/common/dao/base.go` to use `any`.

#### Test Files:
* Refactored test cases and mock data to replace `interface{}` with `any` in files like `src/common/utils/utils_test.go` and `src/controller/artifact/annotation/v1alpha1_test.go`. [[1]](diffhunk://#diff-d2653bd8c7e763f1e36c6625f3af8a094b0a2050adce87b77dac069b51ba6a44L219-R219) [[2]](diffhunk://#diff-ef88ce59ebd158edad679ec6ece67811e297a289533266b7f8f92bad2956fae9L234-R234)

These updates enhance code clarity and leverage Go's modern type system, making the codebase more idiomatic and easier to maintain.Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
