### PR TITLE
Optimize fetching vulnerability records

### DIFF
--- a/src/pkg/scan/dao/scan/vulnerability.go
+++ b/src/pkg/scan/dao/scan/vulnerability.go
@@ -37,7 +37,7 @@ type VulnerabilityRecordDao interface {
 	// Update updates a vulnerability record
 	Update(ctx context.Context, vr *VulnerabilityRecord, cols ...string) error
 	// List lists the vulnerability records
-	List(ctx context.Context, query *q.Query) ([]*VulnerabilityRecord, error)
+	List(ctx context.Context, query *q.Query, cols ...string) ([]*VulnerabilityRecord, error)
 	// InsertForReport inserts vulnerability records for a report
 	InsertForReport(ctx context.Context, reportUUID string, vulnerabilityRecordIDs ...int64) error
 	// GetForReport gets vulnerability records for a report
@@ -96,14 +96,14 @@ func (v *vulnerabilityRecordDao) Update(ctx context.Context, vr *VulnerabilityRe
 // scanners which individually store data about the CVE. In such cases, it is the
 // responsibility of the calling code to de-duplicate the CVE records or bucket them
 // per registered scanner
-func (v *vulnerabilityRecordDao) List(ctx context.Context, query *q.Query) ([]*VulnerabilityRecord, error) {
+func (v *vulnerabilityRecordDao) List(ctx context.Context, query *q.Query, cols ...string) ([]*VulnerabilityRecord, error) {
 	qs, err := orm.QuerySetter(ctx, &VulnerabilityRecord{}, query)
 	if err != nil {
 		return nil, err
 	}
 
 	l := make([]*VulnerabilityRecord, 0)
-	_, err = qs.All(&l)
+	_, err = qs.All(&l, cols...)
 
 	return l, err
 }


### PR DESCRIPTION
In report_converters, existing vulnerability records are fetched from the DB to compare the severity after new scans and update the severity and CVE score.

It is not needed to fetch other fields like description, VendorAttributes etc. Fetching these additional strings and json fields increases memory usage in jobservice significantly.

fixes: #22008