### PR TITLE
Fix: Harbor 2.3: Replication of existing images containing CVEs blocked by the destination project will fail on manifest check early

### DIFF
--- a/src/controller/replication/transfer/image/transfer.go
+++ b/src/controller/replication/transfer/image/transfer.go
@@ -218,6 +218,12 @@ func (t *transfer) copyArtifact(srcRepo, srcRef, dstRepo, dstRef string, overrid
 
 	// check the existence of the artifact on the destination registry
 	exist, digest2, err := t.exist(dstRepo, dstRef)
+	/*
+	Existence-checks with errosr will be treated as returning `false`, if override is enabled.
+	If override is enabled, the existence-check is only used to not push an image that is already existing (with the same digest)
+	This performance-optimisation will be ignored, but the basic function will be restored.  
+	The Consequences of returning this error include the Bug detailed in https://github.com/goharbor/harbor/issues/15283
+	*/
 	if err != nil && !override {
 		return err
 	}


### PR DESCRIPTION
Thank you for contributing to Harbor!

# Comprehensive Summary of your change
Change replication-logic to allow for an error while fetching the manifest of a image, that will be overridden.

# Issue being fixed
Fixes #15283 

Please indicate you've done the following:
- [X] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
