### PR TITLE
Fix project statistics display in dutch

### DIFF
--- a/src/portal/src/app/base/left-side-nav/projects/statictics/statistics-panel.component.html
+++ b/src/portal/src/app/base/left-side-nav/projects/statictics/statistics-panel.component.html
@@ -3,26 +3,26 @@
         <div class="card-block">
             <h4 class="head">{{ 'STATISTICS.PRO_ITEM' | translate }}</h4>
             <div class="clr-row" *ngIf="isValidSession">
-                <div class="clr-col">
+                <div class="clr-col stat-label">
                     {{ 'STATISTICS.INDEX_PRIVATE' | translate }}
                 </div>
-                <div class="clr-col font-weight-700">
+                <div class="clr-col font-weight-700 stat-value">
                     {{ originalCopy?.private_project_count }}
                 </div>
             </div>
             <div class="clr-row">
-                <div class="clr-col">
+                <div class="clr-col stat-label">
                     {{ 'STATISTICS.INDEX_PUB' | translate }}
                 </div>
-                <div class="clr-col font-weight-700">
+                <div class="clr-col font-weight-700 stat-value">
                     {{ originalCopy?.public_project_count }}
                 </div>
             </div>
             <div class="clr-row" *ngIf="isValidSession">
-                <div class="clr-col">
+                <div class="clr-col stat-label">
                     {{ 'STATISTICS.INDEX_TOTAL' | translate }}
                 </div>
-                <div class="clr-col font-weight-700">
+                <div class="clr-col font-weight-700 stat-value">
                     {{ originalCopy?.total_project_count }}
                 </div>
             </div>
@@ -32,26 +32,26 @@
         <div class="card-block">
             <h4 class="head">{{ 'STATISTICS.REPO_ITEM' | translate }}</h4>
             <div class="clr-row" *ngIf="isValidSession">
-                <div class="clr-col">
+                <div class="clr-col stat-label">
                     {{ 'STATISTICS.INDEX_PRIVATE' | translate }}
                 </div>
-                <div class="clr-col font-weight-700">
+                <div class="clr-col font-weight-700 stat-value">
                     {{ originalCopy?.private_repo_count }}
                 </div>
             </div>
             <div class="clr-row">
-                <div class="clr-col">
+                <div class="clr-col stat-label">
                     {{ 'STATISTICS.INDEX_PUB' | translate }}
                 </div>
-                <div class="clr-col font-weight-700">
+                <div class="clr-col font-weight-700 stat-value">
                     {{ originalCopy?.public_repo_count }}
                 </div>
             </div>
             <div class="clr-row" *ngIf="isValidSession">
-                <div class="clr-col">
+                <div class="clr-col stat-label">
                     {{ 'STATISTICS.INDEX_TOTAL' | translate }}
                 </div>
-                <div class="clr-col font-weight-700">
+                <div class="clr-col font-weight-700 stat-value">
                     {{ originalCopy?.total_repo_count }}
                 </div>
             </div>

--- a/src/portal/src/app/base/left-side-nav/projects/statictics/statistics-panel.component.scss
+++ b/src/portal/src/app/base/left-side-nav/projects/statictics/statistics-panel.component.scss
@@ -37,3 +37,11 @@
 .margin-right-5px {
   margin-right: 5px;
 }
+
+.stat-label {
+  min-width: 6.5rem;
+}
+
+.stat-value {
+  text-align: right;
+}


### PR DESCRIPTION
# Comprehensive Summary of your change

Fixes how the display statistics are displayed in Dutch (or when the label of the stats are generaly too long).

This was the problem:

![image](https://github.com/user-attachments/assets/81a3abae-cf43-43f0-9e39-988abc305bae)

I went for this: 
![image](https://github.com/user-attachments/assets/6e08948c-d58f-49d2-886e-3636f8a293ef)

But this is also a possibility:

![dutch-option-nowrap](https://github.com/user-attachments/assets/15be4314-d991-4f88-8de1-7720d1f6b36a)

# Issue being fixed
Fixes https://github.com/goharbor/harbor/issues/21923

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [ ] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
