### PR TITLE
Fix: check docker version 20.10.10+

### DIFF
--- a/make/common.sh
+++ b/make/common.sh
@@ -83,15 +83,18 @@ function check_docker {
 	fi
 
 	# docker has been installed and check its version
-	if [[ $(docker --version) =~ (([0-9]+)\.([0-9]+)([\.0-9]*)) ]]
+	if [[ $(docker --version) =~ (([0-9]+)\.([0-9]+)\.?([0-9]*)) ]]
 	then
 		docker_version=${BASH_REMATCH[1]}
 		docker_version_part1=${BASH_REMATCH[2]}
 		docker_version_part2=${BASH_REMATCH[3]}
+		docker_version_part3=${BASH_REMATCH[4]}
 
 		note "docker version: $docker_version"
 		# the version of docker does not meet the requirement
-		if [ "$docker_version_part1" -lt 17 ] || ([ "$docker_version_part1" -eq 17 ] && [ "$docker_version_part2" -lt 6 ])
+		if [ "$docker_version_part1" -lt 20 ] || \
+           ([ "$docker_version_part1" -eq 20 ] && [ "$docker_version_part2" -lt 10 ]) || \
+           ([ "$docker_version_part1" -eq 20 ] && [ "$docker_version_part2" -eq 10 ] && [ "$docker_version_part3" -lt 10 ])
 		then
 			error "Need to upgrade docker package to 20.10.10+."
 			exit 1


### PR DESCRIPTION
Thank you for contributing to Harbor!

# Comprehensive Summary of your change
When executing the prepare script, the Docker version is checked. However, the actual checking logic stays at the old version, which does not match the new requirement.

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [ ] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [ ] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
