### PR TITLE
chore: Update .gitignore to exclude local build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,10 @@ src/server/v2.0/restapi/
 harborclient/
 openapi-generator-cli.jar
 tests/e2e_setup/robotvars.py
+
+*.log
+make/input/
+make/photon/core/harbor_core
+make/photon/jobservice/harbor_jobservice
+make/photon/registry/config.yml
+make/photon/registryctl/harbor_registryctl


### PR DESCRIPTION
When building the project locally (e.g., by running `make`), several build artifacts and log files are generated. Currently, these files are not included in the root `.gitignore` file.

This leads to a cluttered `git status` output and creates a risk of accidentally committing generated files to the repository. This PR updates the existing `.gitignore` to add patterns for these specific files, ensuring a cleaner local development experience for all contributors