### PR TITLE
added HTTP 409 error

### DIFF
--- a/api/v2.0/swagger.yaml
+++ b/api/v2.0/swagger.yaml
@@ -3204,6 +3204,10 @@ paths:
           $ref: '#/responses/403'
         '404':
           $ref: '#/responses/404'
+        '409':
+          description: Conflict - Robot account with the same name already exists
+          schema:
+            $ref: '#/definitions/Error'
         '500':
           $ref: '#/responses/500'
   '/quotas':


### PR DESCRIPTION
Thank you for contributing to Harbor!

## Summary of your change

issue no #22107 

This PR updates the Harbor backend to return an appropriate `409 Conflict` response when attempting to create a robot account with a name that already exists. 

### What's Included:
- Added a backend check in the robot account creation handler to detect duplicate robot names and return a `409 Conflict` error with a descriptive message.

- Response format:
  ```json
  {
    "code": 409,
    "message": "robot account <name> already exists"
  }
