### PR TITLE
fix: correct the permission of project maintainer role for webhook policy

### DIFF
--- a/src/common/rbac/project/rbac_role.go
+++ b/src/common/rbac/project/rbac_role.go
@@ -162,6 +162,7 @@ var (
 			{Resource: rbac.ResourceRobot, Action: rbac.ActionRead},
 			{Resource: rbac.ResourceRobot, Action: rbac.ActionList},
 
+			{Resource: rbac.ResourceNotificationPolicy, Action: rbac.ActionRead},
 			{Resource: rbac.ResourceNotificationPolicy, Action: rbac.ActionList},
 
 			{Resource: rbac.ResourceScan, Action: rbac.ActionCreate},


### PR DESCRIPTION
This pull request introduces a minor update to the RBAC role definitions in the `src/common/rbac/project/rbac_role.go` file. The change adds a new permission to allow reading `NotificationPolicy` resources.

* [`src/common/rbac/project/rbac_role.go`](diffhunk://#diff-824f8f0eae511582f0ee7909fe81aa3d25a119f2f1bb510ac87e9feb81d8d78fR165): Added a new RBAC rule to grant the `ActionRead` permission for the `NotificationPolicy` resource.

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes https://github.com/goharbor/harbor/issues/22031

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
