### PR TITLE
fix: proxy cache serve local on remote not found

### DIFF
--- a/src/controller/proxy/controller.go
+++ b/src/controller/proxy/controller.go
@@ -172,6 +172,10 @@ func (c *controller) UseLocalManifest(ctx context.Context, art lib.ArtifactInfo,
 		return false, nil, err
 	}
 	if !exist || desc == nil {
+		if a != nil { // if not found, use local if it exists, because a exist, otherwise return error
+			log.Errorf("Artifact not found in remote registry but exists in local cache, serving from local: %v:%v", art.Repository, art.Tag)
+			return true, nil, nil
+		}
 		return false, nil, errors.NotFoundError(fmt.Errorf("repo %v, tag %v not found", art.Repository, art.Tag))
 	}
 


### PR DESCRIPTION
# Comprehensive Summary of your change

This PR updates the proxy cache logic so that if an image exists in the local cache but has been deleted from the remote repository, Harbor will serve the cached image instead of failing with a "not found" error. This brings the implementation in line with the documented behavior and improves reliability when remote repositories are unavailable or images have been removed upstream.

You can find more details about this change in issue #22106.

## Implementation Notes

I hesitated between modifying the `remote.ManifestExist` function in `harbor/src/controller/proxy/controller.go` (since it does not return a 404 error directly in `harbor/src/pkg/registry/client.go`):

```go
func (c *client) ManifestExist(repository, reference string) (bool, *distribution.Descriptor, error) {
	req, err := http.NewRequest(http.MethodHead, buildManifestURL(c.url, repository, reference), nil)
	if err != nil {
		return false, nil, err
	}
	for _, mediaType := range accepts {
		req.Header.Add("Accept", mediaType)
	}
	resp, err := c.do(req)
	if err != nil {
		if errors.IsErr(err, errors.NotFoundCode) {
			return false, nil, nil
		}
		return false, nil, err
	}
	defer resp.Body.Close()
	dig := resp.Header.Get("Docker-Content-Digest")
	contentType := resp.Header.Get("Content-Type")
	contentLen := resp.Header.Get("Content-Length")
	lenth, _ := strconv.Atoi(contentLen)
	return true, &distribution.Descriptor{Digest: digest.Digest(dig), MediaType: contentType, Size: int64(lenth)}, nil
}
```

However, to avoid unintended side effects by changing this function's behavior, I decided to keep the current "404 not found" handling (which returns no error) and instead update the `UseLocalManifest` function in `harbor/src/controller/proxy/controller.go`:

```go
remoteRepo := getRemoteRepo(art)
exist, desc, err := remote.ManifestExist(remoteRepo, getReference(art)) // HEAD
if err != nil {
	if errors.IsRateLimitError(err) && a != nil { // if rate limit, use local if it exists, otherwise return error
		return true, nil, nil
	}
	return false, nil, err
}
if !exist || desc == nil {
	if a != nil { // if not found, use local if it exists, because a exist, otherwise return error
		log.Errorf("Artifact not found in remote registry but exists in local cache, serving from local: %v:%v", art.Repository, art.Tag)
		return true, nil, nil
	}
	return false, nil, errors.NotFoundError(fmt.Errorf("repo %v, tag %v not found", art.Repository, art.Tag))
}
```

# Issue being fixed

Fixes #22106

_No documentation modification is needed because this PR enforces behavior that is already described in the documentation:_
```
If the image has not been updated in the target registry, the cached image is served from the proxy cache project.
If the image has been updated in the target registry, the new image is pulled from the target registry, then served and cached in the proxy cache project.
If the target registry is not reachable, the proxy cache project serves the cached image.
If the image is no longer in the target registry, but is still in the proxy cache project, the cached image is served from the proxy cache project.
```

Please confirm you've completed the following:
- [x] Well Written Title and Summary of the PR
- [ ] Labeled the PR as needed ("release-note/ignore-for-release", "release-note/new-feature", "release-note/update", "release-note/enhancement", "release-note/community", "release-note/breaking-change", "release-note/docs", "release-note/infra", "release-note/deprecation")
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).