### PR TITLE
feat: add regex filter for replication

### DIFF
--- a/src/pkg/reg/util/pattern.go
+++ b/src/pkg/reg/util/pattern.go
@@ -16,6 +16,7 @@ package util
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/bmatcuk/doublestar"
@@ -25,6 +26,14 @@ import (
 func Match(pattern, str string) (bool, error) {
 	if len(pattern) == 0 {
 		return true, nil
+	}
+	if strings.HasPrefix(pattern, "regex:") {
+		regexPattern := strings.TrimPrefix(pattern, "regex:")
+		reg, err := regexp.Compile(regexPattern)
+		if err != nil {
+			return false, fmt.Errorf("invalid regex pattern: %w", err)
+		}
+		return reg.MatchString(str), nil
 	}
 	return doublestar.Match(pattern, str)
 }


### PR DESCRIPTION
Thank you for contributing to Harbor!

# Comprehensive Summary of your change
This change enhances the tag and repository filtering logic by enabling support for regular expressions for replication. Users can now specify filters using the `regex:` prefix, allowing for more flexible and powerful matching patterns. For example, patterns like `regex:^1\.(34\..*|32\.(4|5|6))$` can be used to match specific version formats.


## Screenshots
![image](https://github.com/user-attachments/assets/112fe8a8-7323-4aef-af04-3a480d5e7e2f)

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
