### PR TITLE
Add "status" of CVEs to artfact scan report

### DIFF
--- a/make/migrations/postgresql/0170_2.14.0_schema.up.sql
+++ b/make/migrations/postgresql/0170_2.14.0_schema.up.sql
@@ -6,3 +6,4 @@ ALTER SEQUENCE permission_policy_id_seq AS BIGINT;
 
 ALTER TABLE role_permission ALTER COLUMN permission_policy_id TYPE BIGINT;
 
+ALTER TABLE vulnerability_record ADD COLUMN IF NOT EXISTS status text;

--- a/src/pkg/scan/dao/scan/model.go
+++ b/src/pkg/scan/dao/scan/model.go
@@ -68,6 +68,7 @@ type VulnerabilityRecord struct {
 	PackageVersion   string   `orm:"column(package_version)"`
 	PackageType      string   `orm:"column(package_type)"`
 	Severity         string   `orm:"column(severity)"`
+	Status           string   `orm:"column(status)"`
 	Fix              string   `orm:"column(fixed_version);null"`
 	URLs             string   `orm:"column(urls);null"`
 	CVE3Score        *float64 `orm:"column(cvss_score_v3);null"`

--- a/src/pkg/scan/vuln/report.go
+++ b/src/pkg/scan/vuln/report.go
@@ -206,6 +206,8 @@ type VulnerabilityItem struct {
 	FixVersion string `json:"fix_version"`
 	// A standard scale for measuring the severity of a vulnerability.
 	Severity Severity `json:"severity"`
+	// The status of the vulnerability.
+	Status string `json:"status"`
 	// example: dpkg-source in dpkg 1.3.0 through 1.18.23 is able to use a non-GNU patch program
 	// and does not offer a protection mechanism for blank-indented diff hunks, which allows remote
 	// attackers to conduct directory traversal attacks via a crafted Debian source package, as


### PR DESCRIPTION
This commit adds the field "status" to the struct of a vulnerability and adds column "status" to vulnerability record table.  It makes sure the statuses of CVEs returned by trivy scanner is persisted and can be returned via the vulnerabilities addition API of an artifact.

There will be a minor change in UI so the "status is shown in the vulnerability table, and it will be covered in another PR.

Please indicate you've done the following:
- [X] Well Written Title and Summary of the PR
- [X] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [X] Accepted the DCO. Commits without the DCO will delay acceptance.
- [X] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
