### PR TITLE
add the replicaiton adapter whitelist

### DIFF
--- a/make/photon/prepare/templates/core/env.jinja
+++ b/make/photon/prepare/templates/core/env.jinja
@@ -41,6 +41,7 @@ REGISTRY_CREDENTIAL_PASSWORD={{registry_password}}
 CSRF_KEY={{csrf_key}}
 ROBOT_SCANNER_NAME_PREFIX={{scan_robot_prefix}}
 PERMITTED_REGISTRY_TYPES_FOR_PROXY_CACHE=docker-hub,harbor,azure-acr,ali-acr,aws-ecr,google-gcr,quay,docker-registry,github-ghcr,jfrog-artifactory
+REPLICATION_ADAPTER_WHITELIST=ali-acr,aws-ecr,azure-acr,docker-hub,docker-registry,github-ghcr,google-gcr,harbor,huawei-SWR,jfrog-artifactory,tencent-tcr,volcengine-cr
 
 HTTP_PROXY={{core_http_proxy}}
 HTTPS_PROXY={{core_https_proxy}}

--- a/src/common/const.go
+++ b/src/common/const.go
@@ -252,4 +252,7 @@ const (
 
 	// Global Leeway used for token validation
 	JwtLeeway = 60 * time.Second
+
+	// The replication adapter whitelist
+	ReplicationAdapterWhiteList = "REPLICATION_ADAPTER_WHITELIST"
 )

--- a/src/controller/registry/controller.go
+++ b/src/controller/registry/controller.go
@@ -17,9 +17,12 @@ package registry
 import (
 	"context"
 	"math/rand"
+	"strings"
 	"time"
 
+	"github.com/goharbor/harbor/src/common"
 	"github.com/goharbor/harbor/src/lib"
+	"github.com/goharbor/harbor/src/lib/config"
 	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/lib/log"
 	"github.com/goharbor/harbor/src/lib/q"
@@ -205,12 +208,49 @@ func (c *controller) GetInfo(ctx context.Context, id int64) (*model.RegistryInfo
 	return info, nil
 }
 
+func getWhitelistedAdapters(ctx context.Context) map[string]struct{} {
+	adapterWhitelistRaw := config.GetCfgManager(ctx).Get(ctx, common.ReplicationAdapterWhiteList).GetString()
+	if adapterWhitelistRaw == "" {
+		return nil
+	}
+	adapterWhitelist := make(map[string]struct{})
+	for _, adapter := range strings.Split(adapterWhitelistRaw, ",") {
+		adapter = strings.TrimSpace(adapter)
+		if adapter != "" {
+			adapterWhitelist[adapter] = struct{}{}
+		}
+	}
+	return adapterWhitelist
+}
+
 func (c *controller) ListRegistryProviderTypes(ctx context.Context) ([]string, error) {
-	return c.regMgr.ListRegistryProviderTypes(ctx)
+	allAdapters, err := c.regMgr.ListRegistryProviderTypes(ctx)
+	if err != nil {
+		return []string{}, err
+	}
+	whitelistedAdapters := getWhitelistedAdapters(ctx)
+	var filtered []string
+	for _, t := range allAdapters {
+		if _, ok := whitelistedAdapters[t]; ok {
+			filtered = append(filtered, t)
+		}
+	}
+	return filtered, nil
 }
 
 func (c *controller) ListRegistryProviderInfos(ctx context.Context) (map[string]*model.AdapterPattern, error) {
-	return c.regMgr.ListRegistryProviderInfos(ctx)
+	allAdaptersInfo, err := c.regMgr.ListRegistryProviderInfos(ctx)
+	if err != nil {
+		return nil, err
+	}
+	whitelistedAdapters := getWhitelistedAdapters(ctx)
+	filtered := make(map[string]*model.AdapterPattern)
+	for k, v := range allAdaptersInfo {
+		if _, ok := whitelistedAdapters[k]; ok {
+			filtered[k] = v
+		}
+	}
+	return filtered, nil
 }
 
 func (c *controller) StartRegularHealthCheck(ctx context.Context, closing, done chan struct{}) {

--- a/src/lib/config/metadata/metadatalist.go
+++ b/src/lib/config/metadata/metadatalist.go
@@ -203,5 +203,7 @@ var (
 
 		{Name: common.BeegoMaxMemoryBytes, Scope: SystemScope, Group: BasicGroup, EnvKey: "BEEGO_MAX_MEMORY_BYTES", DefaultValue: fmt.Sprintf("%d", common.DefaultBeegoMaxMemoryBytes), ItemType: &Int64Type{}, Editable: false, Description: `The bytes for limiting the beego max memory, default is 128GB`},
 		{Name: common.BeegoMaxUploadSizeBytes, Scope: SystemScope, Group: BasicGroup, EnvKey: "BEEGO_MAX_UPLOAD_SIZE_BYTES", DefaultValue: fmt.Sprintf("%d", common.DefaultBeegoMaxUploadSizeBytes), ItemType: &Int64Type{}, Editable: false, Description: `The bytes for limiting the beego max upload size, default it 128GB`},
+
+		{Name: common.ReplicationAdapterWhiteList, Scope: SystemScope, Group: BasicGroup, EnvKey: "REPLICATION_ADAPTER_WHITELIST", DefaultValue: "", ItemType: &StringType{}, Editable: false},
 	}
 )


### PR DESCRIPTION
fixes #21925

According to https://github.com/goharbor/harbor/wiki/Harbor-Replicaiton-Adapter-Owner, some replication adapters are no longer actively maintained by the Harbor community. To address this, a whitelist environment variable is introduced to define the list of actively supported adapters, which will be used by the Harbor portal and API to display and allow usage.

If you still wish to view and use the unsupported or inactive adapters, you must manually update the whitelist and include the desired adapter names. For the list of adapter names, refer to https://github.com/goharbor/harbor/blob/main/src/pkg/reg/model/registry.go#L22

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [ ] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [ ] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
