### PR TITLE
Fix: Improper Neutralization of Input During Escaping of Output Reflected cross-site scripting

### DIFF
--- a/src/lib/response_recorder.go
+++ b/src/lib/response_recorder.go
@@ -14,7 +14,10 @@
 
 package lib
 
-import "net/http"
+import (
+	"net/http"
+	"html"
+)
 
 // NewResponseRecorder creates a response recorder
 func NewResponseRecorder(w http.ResponseWriter) *ResponseRecorder {
@@ -35,7 +38,8 @@ func (r *ResponseRecorder) Write(data []byte) (int, error) {
 	if !r.wroteHeader {
 		r.WriteHeader(http.StatusOK)
 	}
-	return r.ResponseWriter.Write(data)
+	escaped := html.EscapeString(string(data))
+	return r.ResponseWriter.Write([]byte(escaped))
 }
 
 // WriteHeader records the status code before writing the code to the underlying writer


### PR DESCRIPTION
https://github.com/goharbor/harbor/blob/ebc340a8f7bb0cab4a3a128a5310122b2e895b16/src/lib/response_recorder.go#L38-L38

Directly writing user input (an HTTP request parameter) to an HTTP response without properly sanitizing the input first, allows for a cross-site scripting vulnerability.This kind of vulnerability is also called reflected cross-site scripting, to distinguish it from other types of cross-site scripting.

fix the reflected XSS vulnerability, we should ensure that any user-controlled data written to an HTTP response is properly escaped for HTML context. In this case, the `Write` method of `ResponseRecorder` should escape the data if it is being used to write log output that may contain user input. The best way to do this is to use Go's `html.EscapeString` function to sanitize the data before writing it to the response. Since `Write` receives a byte slice, we should convert it to a string, escape it, and then write the escaped string as bytes. This change should be made in `src/lib/response_recorder.go`, specifically in the `Write` method. need to import the `html` package in this file to use `html.EscapeString`.

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
