### PR TITLE
Upload build logs to github artifact

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -148,7 +148,12 @@ jobs:
           df -h
           bash ./tests/showtime.sh ./tests/ci/api_run.sh DB $IP
           df -h
-
+      - name: upload_logs
+        uses: actions/upload-artifact@v4
+        with:
+          name: db-api-harbor-logs.tar.gz
+          path: /home/runner/work/harbor/harbor/src/github.com/goharbor/harbor/integration_logs.tar.gz
+          retention-days: 5
   APITEST_DB_PROXY_CACHE:
     env:
       APITEST_DB: true
@@ -203,7 +208,12 @@ jobs:
           df -h
           bash ./tests/showtime.sh ./tests/ci/api_run.sh PROXY_CACHE $IP
           df -h
-
+      - name: upload_logs
+        uses: actions/upload-artifact@v4
+        with:
+          name: proxy-api-harbor-logs.tar.gz
+          path: /home/runner/work/harbor/harbor/src/github.com/goharbor/harbor/integration_logs.tar.gz
+          retention-days: 5
   APITEST_LDAP:
     env:
       APITEST_LDAP: true
@@ -256,7 +266,12 @@ jobs:
           cd src/github.com/goharbor/harbor
           bash ./tests/showtime.sh ./tests/ci/api_run.sh LDAP $IP
           df -h
-
+      - name: upload_logs
+        uses: actions/upload-artifact@v4
+        with:
+          name: ldap-api-harbor-logs.tar.gz
+          path: /home/runner/work/harbor/harbor/src/github.com/goharbor/harbor/integration_logs.tar.gz
+          retention-days: 5
   OFFLINE:
     env:
       OFFLINE: true

--- a/tests/ci/api_run.sh
+++ b/tests/ci/api_run.sh
@@ -36,19 +36,9 @@ else
     rc=999
 fi
 rc=$?
-## --------------------------------------------- Upload Harbor CI Logs -------------------------------------------
-#timestamp=$(date +%s)
-#GIT_COMMIT=$(git rev-parse --short "$GITHUB_SHA")
-#outfile="integration_logs_$timestamp$GIT_COMMIT.tar.gz"
-#sudo tar -zcvf $outfile output.xml log.html /var/log/harbor/*
-#if [ -f "$outfile" ]; then
-#   uploader $outfile $harbor_logs_bucket
-#   echo "----------------------------------------------"
-#   echo "Download test logs:"
-#   echo "https://storage.googleapis.com/harbor-ci-logs/$outfile"
-#   echo "----------------------------------------------"
-#else
-#   echo "No log output file to upload"
-#fi
-
+## --------------------------------------------- Package Harbor CI Logs -------------------------------------------
+outfile="integration_logs.tar.gz"
+sudo tar -zcvf $outfile output.xml log.html /var/log/harbor/*
+pwd
+ls -lh $outfile
 exit $rc


### PR DESCRIPTION
Enable upload log to github for api test, the download link can be found in the build logs.

<img width="1007" height="299" alt="Screenshot 2025-08-12 at 11 17 49" src="https://github.com/user-attachments/assets/dc0c5892-d650-49ae-b2ff-a958a6ac607f" />


Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [ ] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [ ] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
