### PR TITLE
(cherry-pick) Remove port 9443 from harbor IP for webhook event check

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,6 +15,8 @@ env:
    UI_BUILDER_VERSION: 1.6.0
 
 on:
+  # the paths-ignore is the same as the paths in pass-CI.yml, they should be synced together
+  # see https://web.archive.org/web/20230506145443/https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/troubleshooting-required-status-checks#handling-skipped-but-required-checks
   pull_request:
     paths-ignore:
       - 'docs/**'
@@ -23,7 +25,11 @@ on:
       - '!tests/**.sh'
       - '!tests/apitests/**'
       - '!tests/ci/**'
+      - '!tests/resources/**'
+      - '!tests/robot-cases/**'
+      - '!tests/robot-cases/Group1-Nightly/**'      
   push:
+    # the paths-ignore is the same as the paths in pass-CI.yml, they should be synced together
     paths-ignore:
       - 'docs/**'
       - '**.md'
@@ -31,6 +37,9 @@ on:
       - '!tests/**.sh'
       - '!tests/apitests/**'
       - '!tests/ci/**'
+      - '!tests/resources/**'
+      - '!tests/robot-cases/**'
+      - '!tests/robot-cases/Group1-Nightly/**'
 
 jobs:
   UTTEST:

--- a/.github/workflows/pass-CI.yml
+++ b/.github/workflows/pass-CI.yml
@@ -2,6 +2,7 @@ name: CI
 
 on:
   pull_request:
+    # the paths is the same as the paths-ignore in CI.yml, they should be synced together
     paths:
       - 'docs/**'
       - '**.md'
@@ -13,6 +14,7 @@ on:
       - '!tests/robot-cases/**'
       - '!tests/robot-cases/Group1-Nightly/**'
   push:
+    # the paths is the same as the paths-ignore in CI.yml, they should be synced together
     paths:
       - 'docs/**'
       - '**.md'

--- a/tests/resources/TestCaseBody.robot
+++ b/tests/resources/TestCaseBody.robot
@@ -16,10 +16,16 @@
 Documentation  This resource wrap test case body
 Library  ../apitests/python/testutils.py
 Library  ../apitests/python/library/repository.py
+Library  String
 
 *** Variables ***
 
 *** Keywords ***
+Remove Port
+    [Arguments]    ${address}
+    ${result}=    Replace String    ${address}    :9443    ${EMPTY}
+    [Return]    ${result}
+
 Body Of Manage project publicity
     Init Chrome Driver
     ${d}=    Get Current Date  result_format=%m%s
@@ -578,7 +584,8 @@ Verify Webhook By Tag Retention Finished Event
 Verify Webhook By Replication Status Changed Event
     [Arguments]  ${project_name}  ${webhook_name}  ${project_dest_name}  ${replication_rule_name}  ${user}  ${harbor_handle}  ${webhook_handle}  ${payload_format}=Default
     &{replication_finished_property}=  Create Dictionary
-    Run Keyword If  '${payload_format}' == 'Default'  Set To Dictionary  ${replication_finished_property}  type=REPLICATION  operator=${user}  registry_type=harbor  harbor_hostname=${ip}
+    ${cleaned_ip}=    Remove Port    ${ip}
+    Run Keyword If  '${payload_format}' == 'Default'  Set To Dictionary  ${replication_finished_property}  type=REPLICATION  operator=${user}  registry_type=harbor  harbor_hostname=${cleaned_ip}
     ...  ELSE  Set To Dictionary  ${replication_finished_property}  specversion=1.0  type=harbor.replication.status.changed  datacontenttype=application/json  operator=${user}  trigger_type=MANUAL  namespace=${project_name}
     Switch Window  ${webhook_handle}
     Delete All Requests


### PR DESCRIPTION
  for LDAP test, the default port changed from 443 to 9443, the original hostname contains IP:PORT, but the webhook event just contains the IP, need remove port before validation.
  fix issue related to CI pass checks

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [ ] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [ ] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
