### PR TITLE
Fix: Prevent OIDC login blocking when robot_name_prefix is empty

### DIFF
--- a/src/server/middleware/security/oidc_cli.go
+++ b/src/server/middleware/security/oidc_cli.go
@@ -59,7 +59,14 @@ func (o *oidcCli) Generate(req *http.Request) security.Context {
 		return nil
 	}
 
-	if strings.HasPrefix(username, config.RobotPrefix(ctx)) {
+	// Get robot prefix from config
+	robotPrefix := config.RobotPrefix(ctx)
+
+	// If robot prefix is empty, log a warning and skip robot detection
+	if robotPrefix == "" {
+		logger.Warning("robot_name_prefix is empty — skipping robot account detection")
+	} else if strings.HasPrefix(username, robotPrefix) {
+		// Username starts with robot prefix, treat as robot account — skip OIDC auth
 		return nil
 	}
 


### PR DESCRIPTION
### Summary
Fixes a bug where setting `robot_name_prefix` to an empty string caused OIDC users
to be treated as robot accounts, blocking CLI login.

### Changes
- Updated `oidc_cli.go` to handle empty or nil robot_name_prefix safely.
- Ensures proper OIDC login behavior when robot prefix is not configured.

### Related Issue
Fixes #22395
