### PR TITLE
Deploy with podman and podman-compose

### DIFF
--- a/make/common.sh
+++ b/make/common.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 #docker version: 20.10.10+
 #docker-compose version: 1.18.0+
+#podman version: 4.9.3+
+#podman-compose version: 1.0.6+
 #golang version: 1.12.0+
 
 set +e
@@ -75,11 +77,40 @@ function check_golang {
 	fi
 }
 
-function check_docker {
+function check_docker {	
 	if ! docker --version &> /dev/null
 	then
-		error "Need to install docker(20.10.10+) first and run this script again."
+		error "Need to install docker(20.10.10+) or podman(4.9.3+) first and run this script again."
 		exit 1
+	fi
+
+	# either docker is podman
+	if docker --version 2>&1 | grep -qi podman; then
+		note "Detected Podman as the Docker CLI."
+		# Check Podman version
+		# capture major, minor and patch (e.g. 4.9.3)
+		if [[ $(podman --version) =~ (([0-9]+)\.([0-9]+)\.([0-9]+)([\.0-9]*)) ]]
+		then
+			podman_version=${BASH_REMATCH[1]}
+			podman_version_part1=${BASH_REMATCH[2]}
+			podman_version_part2=${BASH_REMATCH[3]}
+			podman_version_part3=${BASH_REMATCH[4]}
+
+			note "Podman version: $podman_version"
+			# the version of Podman does not meet the requirement 4.9.3+
+			if [ "$podman_version_part1" -lt 4 ] || \
+			   ([ "$podman_version_part1" -eq 4 ] && [ "$podman_version_part2" -lt 9 ]) || \
+			   ([ "$podman_version_part1" -eq 4 ] && [ "$podman_version_part2" -eq 9 ] && [ "$podman_version_part3" -lt 3 ])
+			then
+				error "Need to upgrade Podman package to 4.9.3+."
+				exit 1
+			fi
+		else
+			error "Failed to parse Podman version."
+			exit 1
+		fi
+		# Skip Docker version checks if Podman is detected
+		return
 	fi
 
 	# docker has been installed and check its version
@@ -91,7 +122,7 @@ function check_docker {
 
 		note "docker version: $docker_version"
 		# the version of docker does not meet the requirement
-		if [ "$docker_version_part1" -lt 17 ] || ([ "$docker_version_part1" -eq 17 ] && [ "$docker_version_part2" -lt 6 ])
+		if [ "$docker_version_part1" -lt 20 ] || ([ "$docker_version_part1" -eq 20 ] && [ "$docker_version_part2" -lt 10 ])
 		then
 			error "Need to upgrade docker package to 20.10.10+."
 			exit 1

--- a/make/photon/prepare/commands/prepare.py
+++ b/make/photon/prepare/commands/prepare.py
@@ -27,7 +27,8 @@ old_private_key_pem_path, old_crt_path)
 @click.command()
 @click.option('--conf', default=input_config_path, help="the path of Harbor configuration file")
 @click.option('--with-trivy', is_flag=True, help="the Harbor instance is to be deployed with Trivy")
-def prepare(conf, with_trivy):
+@click.option('--with-podman', is_flag=True, help="the Harbor instance will be deployed using Podman (avoid Docker logging options)")
+def prepare(conf, with_trivy, with_podman):
 
     delfile(config_dir)
     config_dict = parse_yaml_config(conf, with_trivy=with_trivy)
@@ -65,4 +66,4 @@ def prepare(conf, with_trivy):
     if with_trivy:
         prepare_trivy_adapter(config_dict)
 
-    prepare_docker_compose(config_dict, with_trivy)
+    prepare_docker_compose(config_dict, with_trivy, with_podman)

--- a/make/photon/prepare/templates/docker_compose/docker-compose.yml.jinja
+++ b/make/photon/prepare/templates/docker_compose/docker-compose.yml.jinja
@@ -1,4 +1,5 @@
 services:
+{% if not with_podman %}
   log:
     image: goharbor/harbor-log:{{version}}
     container_name: harbor-log
@@ -22,6 +23,7 @@ services:
       - 127.0.0.1:1514:10514
     networks:
       - harbor
+{% endif %}
   registry:
     image: goharbor/registry-photon:{{reg_version}}
     container_name: registry
@@ -59,13 +61,24 @@ services:
 {% endif %}
     networks:
       - harbor
+    {% if not with_podman %}
     depends_on:
       - log
+    {% endif %}
+    {% if not with_podman %}
     logging:
       driver: "syslog"
       options:
         syslog-address: "tcp://localhost:1514"
         tag: "registry"
+    {% else %}
+    logging:
+      driver: "json-file"
+      options:
+        path: "{{ log_location }}/registry.log"
+        max-size: "{{ log_rotate_size }}"
+        max-file: "{{ log_rotate_count }}"
+    {% endif %}
   registryctl:
     image: goharbor/harbor-registryctl:{{version}}
     container_name: registryctl
@@ -102,13 +115,24 @@ services:
 {% endif %}
     networks:
       - harbor
+    {% if not with_podman %}
     depends_on:
       - log
+    {% endif %}
+    {% if not with_podman %}
     logging:
       driver: "syslog"
       options:
         syslog-address: "tcp://localhost:1514"
         tag: "registryctl"
+    {% else %}
+    logging:
+      driver: "json-file"
+      options:
+        path: "{{ log_location }}/registryctl.log"
+        max-size: "{{ log_rotate_size }}"
+        max-file: "{{ log_rotate_count }}"
+    {% endif %}
 {% if external_database == False %}
   postgresql:
     image: goharbor/harbor-db:{{version}}
@@ -127,13 +151,24 @@ services:
       harbor:
     env_file:
       - ./common/config/db/env
+    {% if not with_podman %}
     depends_on:
       - log
+    {% endif %}
+    {% if not with_podman %}
     logging:
       driver: "syslog"
       options:
         syslog-address: "tcp://localhost:1514"
         tag: "postgresql"
+    {% else %}
+    logging:
+      driver: "json-file"
+      options:
+        path: "{{ log_location }}/postgresql.log"
+        max-size: "{{ log_rotate_size }}"
+        max-file: "{{ log_rotate_count }}"
+    {% endif %}
     shm_size: '1gb'
 {% endif %}
   core:
@@ -179,19 +214,30 @@ services:
     networks:
       harbor:
     depends_on:
+      {% if not with_podman %}
       - log
+      {% endif %}
       - registry
-{% if external_redis == False %}
+    {% if external_redis == False %}
       - redis
-{% endif %}
-{% if external_database == False %}
+    {% endif %}
+    {% if external_database == False %}
       - postgresql
-{% endif %}
+    {% endif %}
+    {% if not with_podman %}
     logging:
       driver: "syslog"
       options:
         syslog-address: "tcp://localhost:1514"
         tag: "core"
+    {% else %}
+    logging:
+      driver: "json-file"
+      options:
+        path: "{{ log_location }}/core.log"
+        max-size: "{{ log_rotate_size }}"
+        max-file: "{{ log_rotate_count }}"
+    {% endif %}
   portal:
     image: goharbor/harbor-portal:{{version}}
     container_name: harbor-portal
@@ -217,13 +263,24 @@ services:
 {% endif %}
     networks:
       - harbor
+    {% if not with_podman %}
     depends_on:
       - log
+    {% endif %}
+    {% if not with_podman %}
     logging:
       driver: "syslog"
       options:
         syslog-address: "tcp://localhost:1514"
         tag: "portal"
+    {% else %}
+    logging:
+      driver: "json-file"
+      options:
+        path: "{{ log_location }}/portal.log"
+        max-size: "{{ log_rotate_size }}"
+        max-file: "{{ log_rotate_count }}"
+    {% endif %}
 
   jobservice:
     image: goharbor/harbor-jobservice:{{version}}
@@ -257,11 +314,21 @@ services:
       - harbor
     depends_on:
       - core
+    {% if not with_podman %}
     logging:
       driver: "syslog"
       options:
         syslog-address: "tcp://localhost:1514"
         tag: "jobservice"
+    {% endif %}
+    {% if with_podman %}
+    logging:
+      driver: "json-file"
+      options:
+        path: "{{ log_location }}/jobservice.log"
+        max-size: "{{ log_rotate_size }}"
+        max-file: "{{ log_rotate_count }}"
+    {% endif %}
 {% if external_redis == False %}
   redis:
     image: goharbor/redis-photon:{{redis_version}}
@@ -277,13 +344,24 @@ services:
       - {{data_volume}}/redis:/var/lib/redis
     networks:
       harbor:
+    {% if not with_podman %}
     depends_on:
       - log
+    {% endif %}
+    {% if not with_podman %}
     logging:
       driver: "syslog"
       options:
         syslog-address: "tcp://localhost:1514"
         tag: "redis"
+    {% else %}
+    logging:
+      driver: "json-file"
+      options:
+        path: "{{ log_location }}/redis.log"
+        max-size: "{{ log_rotate_size }}"
+        max-file: "{{ log_rotate_count }}"
+    {% endif %}
 {% endif %}
   proxy:
     image: goharbor/nginx-photon:{{version}}
@@ -326,12 +404,23 @@ services:
       - registry
       - core
       - portal
+      {% if not with_podman %}
       - log
+      {% endif %}
+    {% if not with_podman %}
     logging:
       driver: "syslog"
       options:
         syslog-address: "tcp://localhost:1514"
         tag: "proxy"
+    {% else %}
+    logging:
+      driver: "json-file"
+      options:
+        path: "{{ log_location }}/proxy.log"
+        max-size: "{{ log_rotate_size }}"
+        max-file: "{{ log_rotate_count }}"
+    {% endif %}
 {% if with_trivy %}
   trivy-adapter:
     container_name: trivy-adapter
@@ -339,11 +428,19 @@ services:
     restart: always
     cap_drop:
       - ALL
+    {% set _trivy_deps = [] %}
+    {% if not with_podman %}
+    {% set _trivy_deps = _trivy_deps + ['log'] %}
+    {% endif %}
+    {% if external_redis == False %}
+    {% set _trivy_deps = _trivy_deps + ['redis'] %}
+    {% endif %}
+    {% if _trivy_deps %}
     depends_on:
-      - log
-{% if external_redis == False %}
-      - redis
-{% endif %}
+    {% for d in _trivy_deps %}
+      - {{ d }}
+    {% endfor %}
+    {% endif %}
     networks:
       - harbor
     volumes:
@@ -364,11 +461,21 @@ services:
         source: {{internal_tls.trivy_adapter_key_path}}
         target: /etc/harbor/ssl/trivy_adapter.key
 {% endif %}
+    {% if not with_podman %}
     logging:
       driver: "syslog"
       options:
         syslog-address: "tcp://localhost:1514"
         tag: "trivy-adapter"
+    {% endif %}
+    {% if with_podman %}
+    logging:
+      driver: "json-file"
+      options:
+        path: "{{ log_location }}/trivy-adapter.log"
+        max-size: "{{ log_rotate_size }}"
+        max-file: "{{ log_rotate_count }}"
+    {% endif %}
     env_file:
       ./common/config/trivy-adapter/env
 {% endif %}
@@ -383,18 +490,27 @@ services:
       - harbor
     depends_on:
       - core
-  {% if external_database == False %}
+      {% if external_database == False %}
       - postgresql
-  {% endif %}
+      {% endif %}
     volumes:
       - type: bind
         source: ./common/config/shared/trust-certificates
         target: /harbor_cust_cert
+    {% if not with_podman %}
     logging:
       driver: "syslog"
       options:
         syslog-address: "tcp://localhost:1514"
         tag: "exporter"
+    {% else %}
+    logging:
+      driver: "json-file"
+      options:
+        path: "{{ log_location }}/exporter.log"
+        max-size: "{{ log_rotate_size }}"
+        max-file: "{{ log_rotate_count }}"
+    {% endif %}
 {% endif %}
 networks:
   harbor:

--- a/make/photon/prepare/utils/docker_compose.py
+++ b/make/photon/prepare/utils/docker_compose.py
@@ -8,7 +8,7 @@ docker_compose_template_path = os.path.join(templates_dir, 'docker_compose', 'do
 docker_compose_yml_path = '/compose_location/docker-compose.yml'
 
 # render docker-compose
-def prepare_docker_compose(configs, with_trivy):
+def prepare_docker_compose(configs, with_trivy, with_podman):
     versions = parse_versions()
     VERSION_TAG = versions.get('VERSION_TAG') or 'dev'
 
@@ -24,7 +24,12 @@ def prepare_docker_compose(configs, with_trivy):
         'external_redis': configs['external_redis'],
         'external_database': configs['external_database'],
         'with_trivy': with_trivy,
+        'with_podman': with_podman,
     }
+
+    if with_podman:
+        rendering_variables['log_rotate_count'] = configs['log_rotate_count']
+        rendering_variables['log_rotate_size'] = configs['log_rotate_size']
 
     # if configs.get('registry_custom_ca_bundle_path'):
     #     rendering_variables['registry_custom_ca_bundle_path'] = configs.get('registry_custom_ca_bundle_path')

--- a/tests/ci/podman_install.sh
+++ b/tests/ci/podman_install.sh
@@ -1,0 +1,122 @@
+#!/bin/bash
+set -e
+
+REDHAT_PKGS="podman podman-docker podman-compose make"
+
+DATA_VOLUME=${DATA_VOLUME:-/data}
+if [ -d "$DATA_VOLUME" ]; then
+    echo "Data volume $DATA_VOLUME exists. Attempting to stop any docker compose stack inside it."
+    # Only try to run docker compose down if a compose file is present
+    if [ -f "$DATA_VOLUME/docker-compose.yml" ] || [ -f "$DATA_VOLUME/docker-compose.yaml" ] || [ -f "$DATA_VOLUME/docker-compose.override.yml" ]; then
+        if command -v docker >/dev/null 2>&1; then
+            (cd "$DATA_VOLUME" && sudo docker compose down) || echo "docker compose down failed or no running compose"
+        else
+            echo "docker not found, skipping docker compose down"
+        fi
+    else
+        echo "No docker compose files found in $DATA_VOLUME, skipping docker compose down"
+    fi
+    sudo rm -rf "$DATA_VOLUME"
+fi
+sudo mkdir -p "$DATA_VOLUME"
+sudo mkdir -p /var/log/harbor
+# Install required Red Hat packages only if any are missing
+# Build a list of missing packages by checking with rpm -q
+missing=""
+for pkg in $REDHAT_PKGS; do
+    if ! rpm -q "$pkg" &>/dev/null; then
+        missing="$missing $pkg"
+    fi
+done
+if [ -n "$(echo $missing | tr -d ' ')" ]; then
+    echo "Installing missing packages:$missing"
+    sudo dnf install -y $missing
+else
+    echo "All required packages are already installed: $REDHAT_PKGS"
+fi
+sudo sed -i 's/unqualified-search-registries = \["registry.access.redhat.com", "registry.redhat.io", "docker.io"\]/unqualified-search-registries = ["docker.io"]/g' /etc/containers/registries.conf
+
+sudo cp ./make/common.sh ./make/harbor.yml.tmpl ./make/install.sh ./make/prepare "$DATA_VOLUME"/
+
+# sudo chown -R 1000:1000 "$DATA_VOLUME"
+sudo semanage fcontext -a -t container_file_t "$DATA_VOLUME(/.*)?"
+sudo restorecon -R "$DATA_VOLUME"/
+sudo make -f make/photon/Makefile _build_prepare -e BUILD_BASE=true BASEIMAGETAG=dev VERSIONTAG=dev
+sudo mkdir -p "$DATA_VOLUME/common/config"
+sudo mkdir -p "$DATA_VOLUME/cert"
+# Build subjectAltName including loopback and all host IPv4 addresses
+# Prefer `ip` to list addresses; fall back to `hostname -I` if needed.
+ips=$(ip -o -4 addr show 2>/dev/null | awk '{print $4}' | cut -d/ -f1 | sort -u || true)
+if [ -z "$ips" ]; then
+    ips=$(hostname -I 2>/dev/null | tr ' ' '\n' | sed '/^$/d' | sort -u || true)
+fi
+san="subjectAltName=IP:127.0.0.1"
+for ip in $ips; do
+    # skip empty entries
+    [ -z "$ip" ] && continue
+    san="$san,IP:$ip"
+done
+
+sudo openssl req -newkey rsa:4096 -nodes -x509 -days 30 \
+    -subj "/C=AU/ST=Victoria/L=Melbourne/O=deamen/CN=$(hostname)" \
+    -addext "$san" \
+    -keyout "$DATA_VOLUME/cert/harbor.key" \
+    -out "$DATA_VOLUME/cert/harbor.crt"
+
+sudo cp "$DATA_VOLUME/harbor.yml.tmpl" "$DATA_VOLUME/harbor.yml"
+sudo sed -i "s|^hostname:.*|hostname: $(hostname)|" "$DATA_VOLUME/harbor.yml"
+sudo sed -i "s|^  certificate:.*|  certificate: $DATA_VOLUME/cert/harbor.crt|" "$DATA_VOLUME/harbor.yml"
+sudo sed -i "s|^  private_key:.*|  private_key: $DATA_VOLUME/cert/harbor.key|" "$DATA_VOLUME/harbor.yml"
+
+if ! grep -qF 'localhost/goharbor/prepare:dev' "$DATA_VOLUME/prepare"; then
+    sudo sed -i 's|goharbor/prepare:dev|localhost/goharbor/prepare:dev|g' "$DATA_VOLUME/prepare"
+fi
+cd "$DATA_VOLUME"
+
+sudo ./install.sh --with-trivy --with-podman
+
+# Push localhost/goharbor/prepare:dev to 127.0.0.1/library/prepare:dev
+# Username: admin, password from $DATA_VOLUME/harbor.yml (harbor_admin_password)
+HARBOR_YML="$DATA_VOLUME/harbor.yml"
+if [ ! -f "$HARBOR_YML" ]; then
+    echo "WARNING: $HARBOR_YML not found; cannot read harbor_admin_password. Skipping image push."
+else
+    harbor_admin_password=$(sed -n 's/^[[:space:]]*harbor_admin_password:[[:space:]]*//p' "$HARBOR_YML" | sed 's/^"\(.*\)"$/\1/;s/^'"'"'\(.*\)'"'"'$/\1/')
+    harbor_admin_password=$(echo "$harbor_admin_password" | sed 's/^\s*//;s/\s*$//')
+    if [ -z "$harbor_admin_password" ]; then
+        echo "WARNING: harbor_admin_password is empty in $HARBOR_YML; skipping image push."
+    else
+        SRC_IMAGE="localhost/goharbor/prepare:dev"
+        DST_IMAGE="127.0.0.1/library/prepare:dev"
+
+        if ! sudo podman images --format '{{.Repository}}:{{.Tag}}' | grep -q "^$SRC_IMAGE$"; then
+            echo "Source image $SRC_IMAGE not found locally; skipping push."
+        else
+            # Try to login and push with retries since Harbor services may take a moment to become ready
+            max_retries=12
+            delay=5
+            pushed=0
+            for i in $(seq 1 $max_retries); do
+                echo "Attempt $i/$max_retries: pushing $SRC_IMAGE -> $DST_IMAGE"
+                # disable xtrace so password isn't printed
+                set +x
+                if sudo podman login 127.0.0.1 -u admin -p "$harbor_admin_password" --tls-verify=false; then
+                    sudo podman tag "$SRC_IMAGE" "$DST_IMAGE"
+                    if sudo podman push --tls-verify=false "$DST_IMAGE"; then
+                        echo "Image pushed successfully to $DST_IMAGE"
+                        pushed=1
+                        break
+                    else
+                        echo "podman push failed; will retry after $delay seconds"
+                    fi
+                else
+                    echo "podman login failed; will retry after $delay seconds"
+                fi
+                sleep $delay
+            done
+            if [ "$pushed" -ne 1 ]; then
+                echo "ERROR: failed to push $SRC_IMAGE to $DST_IMAGE after $max_retries attempts"
+            fi
+        fi
+    fi
+fi


### PR DESCRIPTION
# Comprehensive Summary of your change
This PR add support for deploying harbor with podman, podman-docker and podman-compose on rhel/centos/rockylinux/almalinux/fedora.

Added `--with-podman` install option:

1. The docker/docker-compose checks have been extended to support podman and podman compose
2. The logging driver is set to `json-file`, configurations are read from harbor.yml, so the log location/names/rotation is the same as using docker 
3. The log container is removed from the rendered `docker-compose.yml` as podman does not support it
4. The `tests/ci/podman_install.sh` is created for testing on redhat distro

# Issue being fixed
Fixes #15105



Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
