### PR TITLE
Update zh-TW Traditional Chinese locale

### DIFF
--- a/src/portal/src/i18n/lang/zh-tw-lang.json
+++ b/src/portal/src/i18n/lang/zh-tw-lang.json
@@ -272,9 +272,9 @@
         "ENDPOINT": "端點",
         "PROXY_CACHE_ENDPOINT": "代理快取端點",
         "NO_PROJECT": "找不到任何專案",
-        "CONNECTION_LIMIT": "Max connection to upstream registry",
-        "PROXY_CACHE_MAX_UPSTREAM_CONN_TIP": "The max connection to the upstream registry for this proxy cache project, if -1, then there is no limit",
-        "PROXY_CACHE_MAX_UPSTREAM_CONN_INPUT_TIP": "Please enter -1 or an integer greater than 0. "
+        "CONNECTION_LIMIT": "上游 Registry 最大連線數",
+        "PROXY_CACHE_MAX_UPSTREAM_CONN_TIP": "此代理快取專案可與上游 Registry 建立的連線數上限。輸入 -1 代表無限制。",
+        "PROXY_CACHE_MAX_UPSTREAM_CONN_INPUT_TIP": "請輸入 -1 或大於 0 的整數。"
     },
     "PROJECT_DETAIL": {
         "SUMMARY": "摘要",


### PR DESCRIPTION
PR summary from GitHub Copilot:

> This pull request updates the Traditional Chinese localization for the proxy cache connection limit settings, improving clarity and accuracy of the translated terms and descriptions.
> 
> Localization improvements for proxy cache settings:
> 
> * Reworded `CONNECTION_LIMIT` to more accurately describe the "maximum connections to upstream registry" in Traditional Chinese.
> * Updated `PROXY_CACHE_MAX_UPSTREAM_CONN_TIP` and `PROXY_CACHE_MAX_UPSTREAM_CONN_INPUT_TIP` to provide clearer instructions and explanations for users configuring connection limits.

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
