### PR TITLE
refactor: replace Split in loops with more efficient SplitSeq

### DIFF
--- a/src/controller/registry/controller.go
+++ b/src/controller/registry/controller.go
@@ -214,7 +214,7 @@ func getWhitelistedAdapters(ctx context.Context) map[string]struct{} {
 		return nil
 	}
 	adapterWhitelist := make(map[string]struct{})
-	for _, adapter := range strings.Split(adapterWhitelistRaw, ",") {
+	for adapter := range strings.SplitSeq(adapterWhitelistRaw, ",") {
 		adapter = strings.TrimSpace(adapter)
 		if adapter != "" {
 			adapterWhitelist[adapter] = struct{}{}


### PR DESCRIPTION


# Comprehensive Summary of your change


strings.SplitSeq (introduced in Go 1.23)  returns a lazy sequence (strings.Seq), allowing gopher to iterate over tokens one by one without creating an intermediate slice.

More info: https://github.com/golang/go/issues/61901



Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
