### PR TITLE
Remove legacy switch from decodeFilters after UI bug #12579 fix

### DIFF
--- a/src/pkg/p2p/preheat/models/policy/policy.go
+++ b/src/pkg/p2p/preheat/models/policy/policy.go
@@ -16,7 +16,6 @@ package policy
 
 import (
 	"encoding/json"
-	"strconv"
 	"time"
 
 	beego_orm "github.com/beego/beego/v2/client/orm"
@@ -198,24 +197,6 @@ func decodeFilters(filterStr string) ([]*Filter, error) {
 	if err := json.Unmarshal([]byte(filterStr), &filters); err != nil {
 		return nil, err
 	}
-
-	// Convert value type
-	// TODO: remove switch after UI bug #12579 fixed
-	for _, f := range filters {
-		if f.Type == FilterTypeVulnerability {
-			switch f.Value.(type) {
-			case string:
-				sev, err := strconv.ParseInt(f.Value.(string), 10, 32)
-				if err != nil {
-					return nil, errors.Wrapf(err, "parse filters")
-				}
-				f.Value = (int)(sev)
-			case float64:
-				f.Value = (int)(f.Value.(float64))
-			}
-		}
-	}
-
 	return filters, nil
 }
 


### PR DESCRIPTION
### Description
Removed the old type conversion switch in `decodeFilters` that handled inconsistent
filter value types due to UI bug #12579. The bug is now fixed, so manual conversion
is no longer needed.

### Changes
- Removed type-conversion switch
- Removed unused `strconv` import
