### PR TITLE
test:add-filterToPatterns-unit-test

### DIFF
--- a/src/pkg/reg/adapter/tencentcr/artifact_registry_test.go
+++ b/src/pkg/reg/adapter/tencentcr/artifact_registry_test.go
@@ -22,7 +22,38 @@ func Test_filterToPatterns(t *testing.T) {
 		wantRepoPattern      string
 		wantTagsPattern      string
 	}{
-		// TODO: Add test cases.
+		{
+			name: "name and tag filters provided",
+			args: args{
+				filters: []*model.Filter{
+					{Type: model.FilterTypeName, Value: "demo/app"},
+					{Type: model.FilterTypeTag, Value: "v1.*"},
+				},
+			},
+			wantNamespacePattern: "demo",
+			wantRepoPattern:      "demo/app",
+			wantTagsPattern:      "v1.*",
+		},
+		{
+			name: "only name filter provided",
+			args: args{
+				filters: []*model.Filter{
+					{Type: model.FilterTypeName, Value: "team/project"},
+				},
+			},
+			wantNamespacePattern: "team",
+			wantRepoPattern:      "team/project",
+			wantTagsPattern:      "",
+		},
+		{
+			name: "empty filters slice",
+			args: args{
+				filters: []*model.Filter{},
+			},
+			wantNamespacePattern: "",
+			wantRepoPattern:      "",
+			wantTagsPattern:      "",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
### Summary
Added a new table-driven unit test for the filterToPatterns function.

### Details
- Tests scenarios with:
  - both name and tag filters provided
  - only name filter provided
  - no filters provided (empty slice)
- Validates returned namespace, repository, and tag patterns
