### PR TITLE
Update Release note template and dependabot labels

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,7 +23,7 @@ updates:
     schedule:
       interval: "weekly"
     labels:
-      - "release-note/update"
+      - "release-note/bump-version"
       - "branch/main"
 
   - package-ecosystem: "gomod"
@@ -32,7 +32,7 @@ updates:
       interval: "weekly"
     target-branch: "release-2.14.0"
     labels:
-      - "release-note/update"
+      - "release-note/bump-version"
       - "branch/release-2.14.0"
 
   # More will be needed

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -31,6 +31,10 @@ changelog:
       labels:
         - release-note/deprecation
 
+    - title: Bump Component Version 🤖
+      labels:
+        - release-note/bump-version
+
     - title: Other Changes
       labels:
         - "*"


### PR DESCRIPTION
Update the release note template so we can have section for automation bump version of components made by dependabot, and not to be mistaken by actual update of the functionality!
Introduce new label - release-note/bump-version for that purpose automatically assigned by dependabot

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
