### PR TITLE
Revert to trivy adapter v0.34.0 and trivy v0.66.0 (#22541)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,8 +111,8 @@ PREPARE_VERSION_NAME=versions
 
 #versions
 REGISTRYVERSION=v2.8.3-patch-redis
-TRIVYVERSION=v0.67.2
-TRIVYADAPTERVERSION=v0.34.1
+TRIVYVERSION=v0.66.0
+TRIVYADAPTERVERSION=v0.34.0
 NODEBUILDIMAGE=node:16.18.0
 
 # version of registry for pulling the source code


### PR DESCRIPTION
Making sure it compiles under golang v1.24

**Note**: This is reverting Trivy's version from an unreleased commit, not reverting the version of Trivy from a released Harbor

Please indicate you've done the following:
- [X] Well Written Title and Summary of the PR
- [X] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [X] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
