### PR TITLE
test: add unit tests for artifact_registry functions

### DIFF
--- a/src/pkg/reg/adapter/tencentcr/artifact_registry.go
+++ b/src/pkg/reg/adapter/tencentcr/artifact_registry.go
@@ -30,6 +30,16 @@ const (
 	tcrQPSLimit = 10
 )
 
+var (
+	isNamespaceExist = func(a *adapter, namespace string) (bool, error) {
+		return a.isNamespaceExist(namespace)
+	}
+
+	listNamespaces = func(a *adapter) ([]string, error) {
+		return a.listNamespaces()
+	}
+)
+
 /**
 	* Implement ArtifactRegistry Interface
 **/
@@ -155,7 +165,7 @@ func (a *adapter) listCandidateNamespaces(namespacePattern string) (namespaces [
 			// Check is exist
 			var exist bool
 			for _, ns := range nms {
-				exist, err = a.isNamespaceExist(ns)
+				exist, err = isNamespaceExist(a, ns)
 				if err != nil {
 					return
 				}
@@ -172,8 +182,7 @@ func (a *adapter) listCandidateNamespaces(namespacePattern string) (namespaces [
 		return namespaces, nil
 	}
 
-	// list all
-	return a.listNamespaces()
+	return listNamespaces(a)
 }
 
 func (a *adapter) DeleteManifest(repository, reference string) (err error) {

--- a/src/pkg/reg/adapter/tencentcr/artifact_registry_test.go
+++ b/src/pkg/reg/adapter/tencentcr/artifact_registry_test.go
@@ -88,14 +88,21 @@ func Test_adapter_FetchArtifacts(t *testing.T) {
 func Test_adapter_listCandidateNamespaces(t *testing.T) {
 	a := &adapter{}
 
-	a.isNamespaceExist = func(name string) (bool, error) {
+	origIsNamespaceExist := isNamespaceExist
+	origListNamespaces := listNamespaces
+	defer func() {
+		isNamespaceExist = origIsNamespaceExist
+		listNamespaces = origListNamespaces
+	}()
+
+	isNamespaceExist = func(ad *adapter, name string) (bool, error) {
 		if name == "exist" {
 			return true, nil
 		}
 		return false, nil
 	}
 
-	a.listNamespaces = func() ([]string, error) {
+	listNamespaces = func(ad *adapter) ([]string, error) {
 		return []string{"exist", "default"}, nil
 	}
 


### PR DESCRIPTION
This PR adds unit tests for the `artifact_registry` package, including:

- `Test_adapter_listCandidateNamespaces` covering existing, non-existing, and empty namespace patterns.

>  **Note:** Work-in-progress. More tests and coverage improvements may be added. Please do not close.
> You can save this PR as a **draft** if needed.