### PR TITLE
feat: custom hex color rendering

### DIFF
--- a/src/portal/src/app/shared/components/label/create-edit-label/create-edit-label.component.html
+++ b/src/portal/src/app/shared/components/label/create-edit-label/create-edit-label.component.html
@@ -38,7 +38,7 @@
                     <clr-dropdown-menu *clrIfOpen>
                         <label
                             class="dropdown-item"
-                            (click)="labelModel.color = i.color"
+                            (click)="selectPresetColor(i.color)"
                             *ngFor="let i of labelColor"
                             [class.borderSty]="i.color === '#FFFFFF'"
                             [ngStyle]="{
@@ -49,16 +49,29 @@
                         >
                     </clr-dropdown-menu>
                 </clr-dropdown>
-                <input
-                    class="label-color-input"
-                    clrInput
-                    type="text"
-                    id="color"
-                    size="8"
-                    name="color"
-                    disabled
-                    [(ngModel)]="labelModel.color"
-                    #color="ngModel" />
+                <label
+                    class="clr-control-container"
+                    [class.clr-error]="!isValidColor && labelModel.color">
+                    <input
+                        class="label-color-input"
+                        clrInput
+                        type="text"
+                        id="color"
+                        size="8"
+                        name="color"
+                        placeholder="#RRGGBB"
+                        [(ngModel)]="labelModel.color"
+                        (ngModelChange)="validateColor()"
+                        #color="ngModel" />
+                    <clr-icon
+                        class="clr-validate-icon"
+                        shape="exclamation-circle"></clr-icon>
+                    <clr-control-error
+                        class="position-ab"
+                        *ngIf="!isValidColor && labelModel.color">
+                        {{ 'LABEL.INVALID_COLOR' | translate }}
+                    </clr-control-error>
+                </label>
             </label>
             <label>
                 <label for="description">{{

--- a/src/portal/src/app/shared/components/label/create-edit-label/create-edit-label.component.ts
+++ b/src/portal/src/app/shared/components/label/create-edit-label/create-edit-label.component.ts
@@ -20,7 +20,7 @@ import {
     OnInit,
     ViewChild,
 } from '@angular/core';
-import { clone, compareValue } from '../../../units/utils';
+import { clone, compareValue, isValidHexColor } from '../../../units/utils';
 import { ErrorHandler } from '../../../units/error-handler';
 import { NgForm } from '@angular/forms';
 import { Subject } from 'rxjs';
@@ -42,6 +42,7 @@ export class CreateEditLabelComponent implements OnInit, OnDestroy {
     labelId = 0;
 
     isLabelNameExist = false;
+    isValidColor = true;
 
     nameChecker = new Subject<string>();
 
@@ -109,6 +110,7 @@ export class CreateEditLabelComponent implements OnInit, OnDestroy {
         this.labelModel = this.initLabel();
         this.formShow = true;
         this.isLabelNameExist = false;
+        this.isValidColor = true;
         this.labelId = 0;
         this.copeLabelModel = null;
     }
@@ -118,6 +120,7 @@ export class CreateEditLabelComponent implements OnInit, OnDestroy {
         this.formShow = true;
         this.labelId = labelId;
         this.copeLabelModel = clone(label[0]);
+        this.validateColor();
     }
 
     public get hasChanged(): boolean {
@@ -127,6 +130,7 @@ export class CreateEditLabelComponent implements OnInit, OnDestroy {
     public get isValid(): boolean {
         return !(
             this.isLabelNameExist ||
+            !this.isValidColor ||
             !(this.currentForm && this.currentForm.valid) ||
             !this.hasChanged ||
             this.inProgress
@@ -139,6 +143,23 @@ export class CreateEditLabelComponent implements OnInit, OnDestroy {
         } else {
             this.isLabelNameExist = false;
         }
+    }
+
+    validateColor(): void {
+        if (this.labelModel.color) {
+            this.isValidColor = isValidHexColor(this.labelModel.color);
+            // Ensure color has # prefix
+            if (this.isValidColor && !this.labelModel.color.startsWith('#')) {
+                this.labelModel.color = '#' + this.labelModel.color;
+            }
+        } else {
+            this.isValidColor = true;
+        }
+    }
+
+    selectPresetColor(color: string): void {
+        this.labelModel.color = color;
+        this.isValidColor = true;
     }
 
     onSubmit(): void {

--- a/src/portal/src/app/shared/components/label/label-piece/label-piece.component.ts
+++ b/src/portal/src/app/shared/components/label/label-piece/label-piece.component.ts
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import { Component, Input, OnChanges } from '@angular/core';
-import { LabelColor } from '../../../entities/shared.const';
 import { Label } from '../../../../../../ng-swagger-gen/models/label';
+import { getTextColorForBackground } from '../../../units/utils';
 
 @Component({
     selector: 'hbr-label-piece',
@@ -25,7 +25,7 @@ export class LabelPieceComponent implements OnChanges {
     @Input() labelWidth: number;
     @Input() hasIcon: boolean = true;
     @Input() withTooltip: boolean = false;
-    labelColor: { [key: string]: string };
+    labelColor: { color: string; textColor: string };
 
     ngOnChanges(): void {
         if (this.label) {
@@ -33,7 +33,11 @@ export class LabelPieceComponent implements OnChanges {
             if (!color) {
                 color = '#FFFFFF';
             }
-            this.labelColor = LabelColor.find(data => data.color === color);
+            // Calculate text color dynamically based on luminance
+            this.labelColor = {
+                color: color,
+                textColor: getTextColorForBackground(color),
+            };
         }
     }
 }

--- a/src/portal/src/app/shared/units/utils.spec.ts
+++ b/src/portal/src/app/shared/units/utils.spec.ts
@@ -25,6 +25,9 @@ import {
     isSameObject,
     setHiddenArrayToLocalStorage,
     setPageSizeToLocalStorage,
+    calculateLuminance,
+    getTextColorForBackground,
+    isValidHexColor,
 } from './utils';
 import { ClrDatagridStateInterface } from '@clr/angular';
 import { QuotaUnit } from '../entities/shared.const';
@@ -168,5 +171,52 @@ describe('functions in utils.ts should work', () => {
             true,
             true,
         ]);
+    });
+
+    it('function calculateLuminance() should work', () => {
+        expect(calculateLuminance).toBeTruthy();
+        // Test black color (low luminance)
+        expect(calculateLuminance('#000000')).toBeLessThan(0.1);
+        // Test white color (high luminance)
+        expect(calculateLuminance('#FFFFFF')).toBeGreaterThan(0.9);
+        // Test without # prefix
+        expect(calculateLuminance('FFFFFF')).toBeGreaterThan(0.9);
+        // Test a mid-range color
+        const midLuminance = calculateLuminance('#808080');
+        expect(midLuminance).toBeGreaterThan(0.1);
+        expect(midLuminance).toBeLessThan(0.9);
+    });
+
+    it('function getTextColorForBackground() should work', () => {
+        expect(getTextColorForBackground).toBeTruthy();
+        // Dark backgrounds should have white text
+        expect(getTextColorForBackground('#000000')).toEqual('white');
+        expect(getTextColorForBackground('#0065AB')).toEqual('white');
+        // Light backgrounds should have black text
+        expect(getTextColorForBackground('#FFFFFF')).toEqual('black');
+        expect(getTextColorForBackground('#FFDC0B')).toEqual('black');
+        // Test without # prefix
+        expect(getTextColorForBackground('000000')).toEqual('white');
+        expect(getTextColorForBackground('FFFFFF')).toEqual('black');
+    });
+
+    it('function isValidHexColor() should work', () => {
+        expect(isValidHexColor).toBeTruthy();
+        // Valid 6-digit hex codes
+        expect(isValidHexColor('#FFFFFF')).toBeTruthy();
+        expect(isValidHexColor('#000000')).toBeTruthy();
+        expect(isValidHexColor('#abc123')).toBeTruthy();
+        // Valid 3-digit hex codes
+        expect(isValidHexColor('#FFF')).toBeTruthy();
+        expect(isValidHexColor('#000')).toBeTruthy();
+        expect(isValidHexColor('#a1b')).toBeTruthy();
+        // Valid without # prefix
+        expect(isValidHexColor('FFFFFF')).toBeTruthy();
+        expect(isValidHexColor('FFF')).toBeTruthy();
+        // Invalid hex codes
+        expect(isValidHexColor('#GGGGGG')).toBeFalsy();
+        expect(isValidHexColor('#12345')).toBeFalsy();
+        expect(isValidHexColor('invalid')).toBeFalsy();
+        expect(isValidHexColor('')).toBeFalsy();
     });
 });

--- a/src/portal/src/app/shared/units/utils.ts
+++ b/src/portal/src/app/shared/units/utils.ts
@@ -1093,3 +1093,50 @@ export enum PageSizeMapKeys {
     PENDING_LIST_COMPONENT = 'PendingListComponent',
     SECURITY_HUB_VUL = 'SecurityHubComponent',
 }
+
+/**
+ * Calculate the relative luminance of a color
+ * Based on WCAG 2.0 formula: https://www.w3.org/TR/WCAG20/#relativeluminancedef
+ * @param hex The hex color code (with or without #)
+ * @returns The relative luminance value (0-1)
+ */
+export function calculateLuminance(hex: string): number {
+    // Remove # if present
+    const color = hex.replace('#', '');
+
+    // Convert to RGB
+    const r = parseInt(color.substring(0, 2), 16) / 255;
+    const g = parseInt(color.substring(2, 4), 16) / 255;
+    const b = parseInt(color.substring(4, 6), 16) / 255;
+
+    // Apply gamma correction
+    const rLinear =
+        r <= 0.03928 ? r / 12.92 : Math.pow((r + 0.055) / 1.055, 2.4);
+    const gLinear =
+        g <= 0.03928 ? g / 12.92 : Math.pow((g + 0.055) / 1.055, 2.4);
+    const bLinear =
+        b <= 0.03928 ? b / 12.92 : Math.pow((b + 0.055) / 1.055, 2.4);
+
+    // Calculate luminance
+    return 0.2126 * rLinear + 0.7152 * gLinear + 0.0722 * bLinear;
+}
+
+/**
+ * Determine if text should be white or black based on background color luminance
+ * @param hex The hex color code of the background
+ * @returns 'white' or 'black' for optimal contrast
+ */
+export function getTextColorForBackground(hex: string): string {
+    const luminance = calculateLuminance(hex);
+    // Use 0.5 as threshold - colors with luminance > 0.5 are considered light
+    return luminance > 0.5 ? 'black' : 'white';
+}
+
+/**
+ * Validate if a string is a valid hex color code
+ * @param hex The hex color code to validate
+ * @returns true if valid, false otherwise
+ */
+export function isValidHexColor(hex: string): boolean {
+    return /^#?([0-9A-F]{3}){1,2}$/i.test(hex);
+}

--- a/src/portal/src/i18n/lang/de-de-lang.json
+++ b/src/portal/src/i18n/lang/de-de-lang.json
@@ -1240,7 +1240,8 @@
         "DELETION_TITLE_TARGET": "Bestätige Löschung des Labels",
         "DELETION_SUMMARY_TARGET": "Soll {{param}} gelöscht werden?",
         "PLACEHOLDER": "Keine Label gefunden!",
-        "NAME_ALREADY_EXISTS": "Label existiert bereits."
+        "NAME_ALREADY_EXISTS": "Label existiert bereits.",
+        "INVALID_COLOR": "Ungültiger Hex-Farbcode (z.B. #RRGGBB oder #RGB)"
     },
     "QUOTA": {
         "PROJECT": "Projekt",

--- a/src/portal/src/i18n/lang/en-us-lang.json
+++ b/src/portal/src/i18n/lang/en-us-lang.json
@@ -1243,7 +1243,8 @@
         "DELETION_TITLE_TARGET": "Confirm Label Deletion",
         "DELETION_SUMMARY_TARGET": "Do you want to delete {{param}}?",
         "PLACEHOLDER": "We couldn't find any labels!",
-        "NAME_ALREADY_EXISTS": "Label name already exists."
+        "NAME_ALREADY_EXISTS": "Label name already exists.",
+        "INVALID_COLOR": "Invalid hex color code (e.g., #RRGGBB or #RGB)"
     },
     "QUOTA": {
         "PROJECT": "Project",

--- a/src/portal/src/i18n/lang/es-es-lang.json
+++ b/src/portal/src/i18n/lang/es-es-lang.json
@@ -1224,7 +1224,6 @@
         "ADD_TAG": "AGREGAR TAG",
         "REMOVE_TAG": "REMOVER TAG",
         "NAME_ALREADY_EXISTS": "Tag ya existe en el repositorio"
-
     },
     "LABEL": {
         "LABEL": "Etiqueta",
@@ -1240,7 +1239,8 @@
         "DELETION_TITLE_TARGET": "Confirmar Borrar Etiqueta",
         "DELETION_SUMMARY_TARGET": "Quieres borrar {{param}}?",
         "PLACEHOLDER": "No pudimos encontrar ninguna etiqueta!",
-        "NAME_ALREADY_EXISTS": "Nombre Etiqueta ya existe."
+        "NAME_ALREADY_EXISTS": "Nombre Etiqueta ya existe.",
+        "INVALID_COLOR": "Código de color hexadecimal no válido (ej. #RRGGBB o #RGB)"
     },
     "QUOTA": {
         "PROJECT": "Proyecto",

--- a/src/portal/src/i18n/lang/fr-fr-lang.json
+++ b/src/portal/src/i18n/lang/fr-fr-lang.json
@@ -1242,7 +1242,8 @@
         "DELETION_TITLE_TARGET": "Confirmer la suppression du label",
         "DELETION_SUMMARY_TARGET": "Voulez-vous supprimer {{param}} ?",
         "PLACEHOLDER": "Nous n'avons trouvé aucun label !",
-        "NAME_ALREADY_EXISTS": "Ce nom de label existe déjà."
+        "NAME_ALREADY_EXISTS": "Ce nom de label existe déjà.",
+        "INVALID_COLOR": "Code de couleur hexadécimal invalide (par ex. #RRGGBB ou #RGB)"
     },
     "QUOTA": {
         "PROJECT": "Projet",

--- a/src/portal/src/i18n/lang/ko-kr-lang.json
+++ b/src/portal/src/i18n/lang/ko-kr-lang.json
@@ -1235,7 +1235,8 @@
         "DELETION_TITLE_TARGET": "라벨 삭제 확인",
         "DELETION_SUMMARY_TARGET": "{{param}}를 삭제하시겠습니까?",
         "PLACEHOLDER": "라벨을 찾을 수 없습니다!",
-        "NAME_ALREADY_EXISTS": "라벨 이름이 이미 존재합니다."
+        "NAME_ALREADY_EXISTS": "라벨 이름이 이미 존재합니다.",
+        "INVALID_COLOR": "잘못된 16진수 색상 코드 (예: #RRGGBB 또는 #RGB)"
     },
     "QUOTA": {
         "PROJECT": "프로젝트",

--- a/src/portal/src/i18n/lang/pt-br-lang.json
+++ b/src/portal/src/i18n/lang/pt-br-lang.json
@@ -1234,7 +1234,8 @@
         "DELETION_TITLE_TARGET": "Confirmar remoção do marcador",
         "DELETION_SUMMARY_TARGET": "Você deseja remover {{param}}?",
         "PLACEHOLDER": "Não foi possível encontrar nenhum marcador!",
-        "NAME_ALREADY_EXISTS": "Marcador já existe."
+        "NAME_ALREADY_EXISTS": "Marcador já existe.",
+        "INVALID_COLOR": "Código de cor hexadecimal inválido (ex. #RRGGBB ou #RGB)"
     },
     "QUOTA": {
         "PROJECT": "Projeto",

--- a/src/portal/src/i18n/lang/ru-ru-lang.json
+++ b/src/portal/src/i18n/lang/ru-ru-lang.json
@@ -1159,7 +1159,8 @@
         "DELETION_TITLE_TARGET": "Подтверждение удаления метки",
         "DELETION_SUMMARY_TARGET": "Вы хотите удалить {{param}}?",
         "PLACEHOLDER": "Мы не смогли найти никаких меток!",
-        "NAME_ALREADY_EXISTS": "Имя метки уже существует."
+        "NAME_ALREADY_EXISTS": "Имя метки уже существует.",
+        "INVALID_COLOR": "Недопустимый шестнадцатеричный код цвета (например, #RRGGBB или #RGB)"
     },
     "QUOTA": {
         "PROJECT": "Проект",

--- a/src/portal/src/i18n/lang/tr-tr-lang.json
+++ b/src/portal/src/i18n/lang/tr-tr-lang.json
@@ -1241,7 +1241,8 @@
         "DELETION_TITLE_TARGET": "Etiket silmeyi onayla",
         "DELETION_SUMMARY_TARGET": "Silmek istiyor musunuz {{param}}?",
         "PLACEHOLDER": "Etiket bulamadık!",
-        "NAME_ALREADY_EXISTS": "Etiket adı zaten var."
+        "NAME_ALREADY_EXISTS": "Etiket adı zaten var.",
+        "INVALID_COLOR": "Geçersiz onaltılık renk kodu (örn. #RRGGBB veya #RGB)"
     },
     "QUOTA": {
         "PROJECT": "Proje",

--- a/src/portal/src/i18n/lang/zh-cn-lang.json
+++ b/src/portal/src/i18n/lang/zh-cn-lang.json
@@ -1241,7 +1241,8 @@
         "DELETION_TITLE_TARGET": "删除标签确认",
         "DELETION_SUMMARY_TARGET": "确认删除标签 {{param}}?",
         "PLACEHOLDER": "未发现任何标签!",
-        "NAME_ALREADY_EXISTS": "标签名已存在。"
+        "NAME_ALREADY_EXISTS": "标签名已存在。",
+        "INVALID_COLOR": "无效的十六进制颜色代码（例如 #RRGGBB 或 #RGB）"
     },
     "QUOTA": {
         "PROJECT": "项目",

--- a/src/portal/src/i18n/lang/zh-tw-lang.json
+++ b/src/portal/src/i18n/lang/zh-tw-lang.json
@@ -1243,7 +1243,8 @@
         "DELETION_TITLE_TARGET": "確認刪除標籤",
         "DELETION_SUMMARY_TARGET": "您確定要刪除 {{param}} 嗎？",
         "PLACEHOLDER": "找不到任何標籤！",
-        "NAME_ALREADY_EXISTS": "標籤名稱已存在。"
+        "NAME_ALREADY_EXISTS": "標籤名稱已存在。",
+        "INVALID_COLOR": "無效的十六進制顏色代碼（例如 #RRGGBB 或 #RGB）"
     },
     "QUOTA": {
         "PROJECT": "專案",


### PR DESCRIPTION
# Comprehensive Summary of your change

- Allow hex code input on label creation
- Display any color for label background
- Text color is calculated using WCAG 2.0 luminance with gamma correction

## Note

I used translation tools for translation strings, as I only speak English and French. Translations for other languages *might* not be accurate.

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).