### PR TITLE
fix(registry): correct parameter in upload status query

### DIFF
--- a/src/pkg/registry/client.go
+++ b/src/pkg/registry/client.go
@@ -467,7 +467,7 @@ func (c *client) PushBlobChunk(repository, digest string, blobSize int64, chunk 
 	resp, err := c.do(req)
 	if err != nil {
 		// if push chunk error, we should query the upload progress for new location and end range.
-		newLocation, newEnd, err1 := c.getUploadStatus(location)
+		newLocation, newEnd, err1 := c.getUploadStatus(url)
 		if err1 == nil {
 			return newLocation, newEnd, err
 		}


### PR DESCRIPTION
This pull request includes a small fix in the `PushBlobChunk` method of the `client` type in `src/pkg/registry/client.go`. The change ensures that the correct variable (`url` instead of `location`) is passed to the `getUploadStatus` function when handling errors during a blob chunk push.

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
