### PR TITLE
lowercase value of metric enable when migrate from old to new version

### DIFF
--- a/make/photon/prepare/migrations/version_2_10_0/harbor.yml.jinja
+++ b/make/photon/prepare/migrations/version_2_10_0/harbor.yml.jinja
@@ -525,7 +525,7 @@ proxy:
 
 {% if metric is defined %}
 metric:
-  enabled: {{ metric.enabled }}
+  enabled: {{ metric.enabled | lower }}
   port: {{ metric.port }}
   path: {{ metric.path }}
 {% else %}

--- a/make/photon/prepare/migrations/version_2_11_0/harbor.yml.jinja
+++ b/make/photon/prepare/migrations/version_2_11_0/harbor.yml.jinja
@@ -593,7 +593,7 @@ proxy:
 
 {% if metric is defined %}
 metric:
-  enabled: {{ metric.enabled }}
+  enabled: {{ metric.enabled  | lower }}
   port: {{ metric.port }}
   path: {{ metric.path }}
 {% else %}

--- a/make/photon/prepare/migrations/version_2_12_0/harbor.yml.jinja
+++ b/make/photon/prepare/migrations/version_2_12_0/harbor.yml.jinja
@@ -593,7 +593,7 @@ proxy:
 
 {% if metric is defined %}
 metric:
-  enabled: {{ metric.enabled }}
+  enabled: {{ metric.enabled  | lower }}
   port: {{ metric.port }}
   path: {{ metric.path }}
 {% else %}

--- a/make/photon/prepare/migrations/version_2_13_0/harbor.yml.jinja
+++ b/make/photon/prepare/migrations/version_2_13_0/harbor.yml.jinja
@@ -518,7 +518,7 @@ external_redis:
   #  # tls configuration for redis connection
   #  # only server-authentication is supported
   #  # mtls for redis connection is not supported
-  #  # tls connection will be disable by default 
+  #  # tls connection will be disable by default
   tlsOptions:
     enable: {{ external_redis.tlsOptions.enable }}
   # if it is a self-signed ca, please set the ca path specifically.
@@ -531,7 +531,7 @@ external_redis:
   #   # tls configuration for redis connection
   #   # only server-authentication is supported
   #   # mtls for redis connection is not supported
-  #   # tls connection will be disable by default 
+  #   # tls connection will be disable by default
   # tlsOptions:
   #   enable: false
   #   # if it is a self-signed ca, please set the ca path specifically.
@@ -570,7 +570,7 @@ external_redis:
 #   # tls configuration for redis connection
 #   # only server-authentication is supported
 #   # mtls for redis connection is not supported
-#   # tls connection will be disable by default 
+#   # tls connection will be disable by default
 #   tlsOptions:
 #     enable: false
 #   # if it is a self-signed ca, please set the ca path specifically.
@@ -631,7 +631,7 @@ proxy:
 
 {% if metric is defined %}
 metric:
-  enabled: {{ metric.enabled }}
+  enabled: {{ metric.enabled  | lower }}
   port: {{ metric.port }}
   path: {{ metric.path }}
 {% else %}

--- a/make/photon/prepare/migrations/version_2_14_0/harbor.yml.jinja
+++ b/make/photon/prepare/migrations/version_2_14_0/harbor.yml.jinja
@@ -518,7 +518,7 @@ external_redis:
   #  # tls configuration for redis connection
   #  # only server-authentication is supported
   #  # mtls for redis connection is not supported
-  #  # tls connection will be disable by default 
+  #  # tls connection will be disable by default
   tlsOptions:
     enable: {{ external_redis.tlsOptions.enable }}
   # if it is a self-signed ca, please set the ca path specifically.
@@ -531,7 +531,7 @@ external_redis:
   #   # tls configuration for redis connection
   #   # only server-authentication is supported
   #   # mtls for redis connection is not supported
-  #   # tls connection will be disable by default 
+  #   # tls connection will be disable by default
   # tlsOptions:
   #   enable: false
   #   # if it is a self-signed ca, please set the ca path specifically.
@@ -570,7 +570,7 @@ external_redis:
 #   # tls configuration for redis connection
 #   # only server-authentication is supported
 #   # mtls for redis connection is not supported
-#   # tls connection will be disable by default 
+#   # tls connection will be disable by default
 #   tlsOptions:
 #     enable: false
 #   # if it is a self-signed ca, please set the ca path specifically.
@@ -631,7 +631,7 @@ proxy:
 
 {% if metric is defined %}
 metric:
-  enabled: {{ metric.enabled }}
+  enabled: {{ metric.enabled  | lower }}
   port: {{ metric.port }}
   path: {{ metric.path }}
 {% else %}

--- a/make/photon/prepare/migrations/version_2_15_0/harbor.yml.jinja
+++ b/make/photon/prepare/migrations/version_2_15_0/harbor.yml.jinja
@@ -645,7 +645,7 @@ proxy:
 
 {% if metric is defined %}
 metric:
-  enabled: {{ metric.enabled }}
+  enabled: {{ metric.enabled | lower }}
   port: {{ metric.port }}
   path: {{ metric.path }}
 {% else %}

--- a/make/photon/prepare/migrations/version_2_3_0/harbor.yml.jinja
+++ b/make/photon/prepare/migrations/version_2_3_0/harbor.yml.jinja
@@ -426,7 +426,7 @@ proxy:
 
 {% if metric is defined %}
 metric:
-  enabled: {{ metric.enabled }}
+  enabled: {{ metric.enabled  | lower }}
   port: {{ metric.port }}
   path: {{ metric.path }}
 {% else %}

--- a/make/photon/prepare/migrations/version_2_4_0/harbor.yml.jinja
+++ b/make/photon/prepare/migrations/version_2_4_0/harbor.yml.jinja
@@ -432,7 +432,7 @@ proxy:
 
 {% if metric is defined %}
 metric:
-  enabled: {{ metric.enabled }}
+  enabled: {{ metric.enabled | lower }}
   port: {{ metric.port }}
   path: {{ metric.path }}
 {% else %}

--- a/make/photon/prepare/migrations/version_2_5_0/harbor.yml.jinja
+++ b/make/photon/prepare/migrations/version_2_5_0/harbor.yml.jinja
@@ -446,7 +446,7 @@ proxy:
 
 {% if metric is defined %}
 metric:
-  enabled: {{ metric.enabled }}
+  enabled: {{ metric.enabled  | lower }}
   port: {{ metric.port }}
   path: {{ metric.path }}
 {% else %}

--- a/make/photon/prepare/migrations/version_2_6_0/harbor.yml.jinja
+++ b/make/photon/prepare/migrations/version_2_6_0/harbor.yml.jinja
@@ -446,7 +446,7 @@ proxy:
 
 {% if metric is defined %}
 metric:
-  enabled: {{ metric.enabled }}
+  enabled: {{ metric.enabled | lower }}
   port: {{ metric.port }}
   path: {{ metric.path }}
 {% else %}
@@ -564,4 +564,3 @@ cache:
   enabled: false
   expire_hours: 24
 {% endif %}
-

--- a/make/photon/prepare/migrations/version_2_7_0/harbor.yml.jinja
+++ b/make/photon/prepare/migrations/version_2_7_0/harbor.yml.jinja
@@ -512,7 +512,7 @@ proxy:
 
 {% if metric is defined %}
 metric:
-  enabled: {{ metric.enabled }}
+  enabled: {{ metric.enabled  | lower }}
   port: {{ metric.port }}
   path: {{ metric.path }}
 {% else %}

--- a/make/photon/prepare/migrations/version_2_8_0/harbor.yml.jinja
+++ b/make/photon/prepare/migrations/version_2_8_0/harbor.yml.jinja
@@ -530,7 +530,7 @@ proxy:
 
 {% if metric is defined %}
 metric:
-  enabled: {{ metric.enabled }}
+  enabled: {{ metric.enabled  | lower }}
   port: {{ metric.port }}
   path: {{ metric.path }}
 {% else %}

--- a/make/photon/prepare/migrations/version_2_9_0/harbor.yml.jinja
+++ b/make/photon/prepare/migrations/version_2_9_0/harbor.yml.jinja
@@ -523,7 +523,7 @@ proxy:
 
 {% if metric is defined %}
 metric:
-  enabled: {{ metric.enabled }}
+  enabled: {{ metric.enabled  | lower }}
   port: {{ metric.port }}
   path: {{ metric.path }}
 {% else %}


### PR DESCRIPTION
Thank you for contributing to Harbor!

when migrate from old to new version with enabled metric, `harbor.yml` is generated like
```
metric:
  enabled: True
```

# Issue being fixed
n/a

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
