### PR TITLE
ci(workflows): simplify label pattern in label_check

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,4 +35,12 @@ updates:
       - "release-note/bump-version"
       - "branch/release-2.14.0"
 
+  - package-ecosystem: "npm"
+    directory: "/src/portal"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+    labels:
+      - "release-note/bump-version"
+
   # More will be needed

--- a/.github/workflows/label_check.yaml
+++ b/.github/workflows/label_check.yaml
@@ -1,7 +1,7 @@
 name: Release Note Label Check
 
 # Trigger the workflow on pull requests only
-on: 
+on:
   pull_request:
     types: [opened, labeled, unlabeled, synchronize]
 
@@ -20,4 +20,5 @@ jobs:
         with:
           mode: minimum
           count: 1
-          labels: "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
+          labels: "release-note/.*"
+          use_regex: true


### PR DESCRIPTION
This pull request makes a small but impactful change to the label check workflow configuration. The label matching logic has been simplified to match any label that starts with `release-note/`, rather than specifying each possible label individually.

* The `labels` parameter in `.github/workflows/label_check.yaml` is updated to use the pattern `"release-note/.*"`, allowing for more flexible and future-proof label matching.

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
