### PR TITLE
Correct the log upload path and make sure it always run

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -159,9 +159,10 @@ jobs:
           df -h
       - name: upload_logs
         uses: actions/upload-artifact@v5
+        if: always()
         with:
           name: db-api-harbor-logs.tar.gz
-          path: /home/runner/work/harbor/harbor/src/github.com/goharbor/harbor/integration_logs.tar.gz
+          path: /home/ubuntu/_work/harbor/harbor/src/github.com/goharbor/harbor/integration_logs.tar.gz
           retention-days: 5
   APITEST_DB_PROXY_CACHE:
     env:
@@ -218,10 +219,11 @@ jobs:
           bash ./tests/showtime.sh ./tests/ci/api_run.sh PROXY_CACHE $IP
           df -h
       - name: upload_logs
+        if: always()
         uses: actions/upload-artifact@v5
         with:
           name: proxy-api-harbor-logs.tar.gz
-          path: /home/runner/work/harbor/harbor/src/github.com/goharbor/harbor/integration_logs.tar.gz
+          path: /home/ubuntu/_work/harbor/harbor/src/github.com/goharbor/harbor/integration_logs.tar.gz
           retention-days: 5
   APITEST_LDAP:
     env:
@@ -276,10 +278,11 @@ jobs:
           bash ./tests/showtime.sh ./tests/ci/api_run.sh LDAP $IP
           df -h
       - name: upload_logs
+        if: always()
         uses: actions/upload-artifact@v5
         with:
           name: ldap-api-harbor-logs.tar.gz
-          path: /home/runner/work/harbor/harbor/src/github.com/goharbor/harbor/integration_logs.tar.gz
+          path: /home/ubuntu/_work/harbor/harbor/src/github.com/goharbor/harbor/integration_logs.tar.gz
           retention-days: 5
   OFFLINE:
     env:


### PR DESCRIPTION
Previous build log is not found and maybe exit if the previous test failed. 
warning message in the build output
<img width="1455" height="102" alt="Screenshot 2025-12-04 at 16 52 32" src="https://github.com/user-attachments/assets/1422835a-9f2f-494d-859c-144753eeeb78" />

If the previous action failed, it will skip to upload logs
<img width="1106" height="408" alt="Screenshot 2025-12-04 at 17 02 48" src="https://github.com/user-attachments/assets/70a3c23a-85fe-4e30-ac34-a28c84057bdd" />


Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [ ] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [ ] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
