### PR TITLE
chore: migrate from deprecated gopkg.in/yaml.v2 to maintained go.yaml.in/yaml/v3

### DIFF
--- a/src/go.mod
+++ b/src/go.mod
@@ -22,12 +22,12 @@ require (
 	github.com/go-asn1-ber/asn1-ber v1.5.8-0.20250403174932-29230038a667
 	github.com/go-ldap/ldap/v3 v3.4.11
 	github.com/go-openapi/errors v0.22.4
-	github.com/go-openapi/loads v0.23.2 // indirect
+	github.com/go-openapi/loads v0.23.2
 	github.com/go-openapi/runtime v0.29.2
-	github.com/go-openapi/spec v0.22.1 // indirect
+	github.com/go-openapi/spec v0.22.1
 	github.com/go-openapi/strfmt v0.25.0
 	github.com/go-openapi/swag v0.23.1
-	github.com/go-openapi/validate v0.25.1 // indirect
+	github.com/go-openapi/validate v0.25.1
 	github.com/go-redis/redis/v8 v8.11.4
 	github.com/gocarina/gocsv v0.0.0-20210516172204-ca9e8a8ddea8
 	github.com/gocraft/work v0.5.1
@@ -66,7 +66,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.38.0
 	go.pinniped.dev v0.37.0
 	go.uber.org/ratelimit v0.3.1
-	go.yaml.in/yaml/v2 v2.4.2
+	go.yaml.in/yaml/v3 v3.0.4
 	golang.org/x/crypto v0.45.0
 	golang.org/x/net v0.47.0
 	golang.org/x/oauth2 v0.28.0
@@ -74,7 +74,6 @@ require (
 	golang.org/x/text v0.31.0
 	golang.org/x/time v0.13.0
 	gopkg.in/h2non/gock.v1 v1.1.2
-	go.yaml.in/yaml/v2 v2.4.2
 	helm.sh/helm/v3 v3.18.5
 	k8s.io/api v0.34.1
 	k8s.io/apimachinery v0.34.1
@@ -187,7 +186,7 @@ require (
 	go.opentelemetry.io/proto/otlp v1.5.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
-	go.yaml.in/yaml/v3 v3.0.4 // indirect
+	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 // indirect
 	golang.org/x/sys v0.38.0 // indirect
 	golang.org/x/term v0.37.0 // indirect
@@ -199,6 +198,7 @@ require (
 	google.golang.org/protobuf v1.36.6 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/utils v0.0.0-20250604170112-4c0f3b243397 // indirect

--- a/src/jobservice/config/config.go
+++ b/src/jobservice/config/config.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 	"time"
 
-	"go.yaml.in/yaml/v2"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/goharbor/harbor/src/jobservice/common/utils"
 	"github.com/goharbor/harbor/src/lib/log"

--- a/src/pkg/chart/operator.go
+++ b/src/pkg/chart/operator.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"strings"
 
-	"go.yaml.in/yaml/v2"
+	"go.yaml.in/yaml/v3"
 	helm_chart "helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chart/loader"
 )

--- a/src/registryctl/config/config.go
+++ b/src/registryctl/config/config.go
@@ -21,7 +21,7 @@ import (
 	"github.com/docker/distribution/configuration"
 	storagedriver "github.com/docker/distribution/registry/storage/driver"
 	"github.com/docker/distribution/registry/storage/driver/factory"
-	yaml "go.yaml.in/yaml/v2"
+	yaml "go.yaml.in/yaml/v3"
 
 	"github.com/goharbor/harbor/src/lib/log"
 )


### PR DESCRIPTION
Thank you for contributing to Harbor!

# Comprehensive Summary of your change
This PR migrates Harbor from the deprecated `gopkg.in/yaml.v2` package to the officially maintained `go.yaml.in/yaml/v3` package provided by the YAML organization. The new package is a drop-in replacement that is fully compatible with the original, actively maintained, and receives security updates.
# Issue being fixed
Fixes #22620 

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
