### PR TITLE
fix: Add distinct to query that is causing high CPU on retention jobs

### DIFF
--- a/src/pkg/blob/dao/dao.go
+++ b/src/pkg/blob/dao/dao.go
@@ -246,7 +246,7 @@ func (d *dao) FindBlobsShouldUnassociatedWithProject(ctx context.Context, projec
 		return nil, err
 	}
 
-	sql := `SELECT b.digest_blob FROM artifact a, artifact_blob b WHERE a.digest = b.digest_af AND a.project_id = ? AND b.digest_blob IN (%s)`
+	sql := `SELECT DISTINCT b.digest_blob FROM artifact a, artifact_blob b WHERE a.digest = b.digest_af AND a.project_id = ? AND b.digest_blob IN (%s)`
 	params := []any{projectID}
 	for _, blob := range blobs {
 		params = append(params, blob.Digest)


### PR DESCRIPTION
fixes #22319

Adds a distinct keyword to ensure the query get only the unique digests, not repeated rows for every time the blob is used by multiple artifacts.
