### PR TITLE
[CHERRY-PICK] fix(artifact): correct typo in artifact_type column definition

### DIFF
--- a/src/pkg/artifact/dao/model.go
+++ b/src/pkg/artifact/dao/model.go
@@ -33,7 +33,7 @@ type Artifact struct {
 	Type              string    `orm:"column(type)"`                // image, chart or other OCI compatible
 	MediaType         string    `orm:"column(media_type)"`          // the media type of artifact
 	ManifestMediaType string    `orm:"column(manifest_media_type)"` // the media type of manifest/index
-	ArtifactType      string    `orm:"colume(artifact_type)"`       // the artifactType of manifest/index
+	ArtifactType      string    `orm:"column(artifact_type)"`       // the artifactType of manifest/index
 	ProjectID         int64     `orm:"column(project_id)"`          // needed for quota
 	RepositoryID      int64     `orm:"column(repository_id)"`
 	RepositoryName    string    `orm:"column(repository_name)"`


### PR DESCRIPTION
This pull request fixes a typo in the struct tag for the `ArtifactType` field in the `Artifact` struct, ensuring correct ORM mapping.

* Bug fix:
  * Corrected the struct tag for `ArtifactType` from `colume` to `column` in `src/pkg/artifact/dao/model.go`.Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [ ] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [ ] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
