### PR TITLE
fix: use correct query key for config DB lookup

### DIFF
--- a/src/pkg/config/db/db.go
+++ b/src/pkg/config/db/db.go
@@ -89,7 +89,7 @@ func (d *Database) Save(ctx context.Context, cfgs map[string]any) error {
 // Get - Get config item from db
 func (d *Database) Get(ctx context.Context, key string) (map[string]any, error) {
 	resultMap := map[string]any{}
-	configEntries, err := d.cfgDAO.GetConfigItem(ctx, q.New(q.KeyWords{"k": key}))
+	configEntries, err := d.cfgDAO.GetConfigItem(ctx, q.New(q.KeyWords{"key": key}))
 	if err != nil {
 		log.Debugf("get config db error: %v", err)
 		return resultMap, err


### PR DESCRIPTION
Thank you for contributing to Harbor!

# Comprehensive Summary of your change
Fix config DB lookup by using the correct query keyword for `ConfigEntry.Key`

# Issue being fixed
Fixes #22674 

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
