### PR TITLE
Migration of Common_gc tests from Robot to Playwright

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,6 @@
 src/portal/node_modules/
+src/portal/playwright-report/
+src/portal/test-results/
 doc/
 docs/
 .git

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,0 +1,91 @@
+name: Playwright Tests
+
+env:
+   POSTGRESQL_HOST: localhost
+   POSTGRESQL_PORT: 5432
+   POSTGRESQL_USR: postgres
+   POSTGRESQL_PWD: root123
+   POSTGRESQL_DATABASE: registry
+   DOCKER_COMPOSE_VERSION: 2.27.1
+   HARBOR_ADMIN: admin
+   HARBOR_ADMIN_PASSWD: Harbor12345
+   CORE_SECRET: tempString
+   KEY_PATH: "/data/secret/keys/secretkey"
+   REDIS_HOST: localhost
+   REG_VERSION: v2.7.1-patch-2819-2553
+   UI_BUILDER_VERSION: 1.6.0
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
+      - 'tests/**'
+      - '!tests/**.sh'
+      - '!tests/apitests/**'
+      - '!tests/ci/**'
+      - '!tests/resources/**'
+      - '!tests/robot-cases/**'
+      - '!tests/robot-cases/Group1-Nightly/**'
+
+permissions:
+  contents: read
+  pull-requests: read
+  actions: read
+
+jobs:
+  E2E_PLAYWRIGHT:
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - name: Set up Go 1.23
+        uses: actions/setup-go@v6
+        with:
+          go-version: 1.23.2
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '18'
+      - uses: actions/checkout@v6
+        with:
+          path: src/github.com/goharbor/harbor
+      - name: setup env
+        run: |
+          cd src/github.com/goharbor/harbor
+          pwd
+          go env
+          echo "GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}" >> $GITHUB_ENV
+          echo "GOPATH=$(go env GOPATH):$GITHUB_WORKSPACE" >> $GITHUB_ENV
+          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
+          echo "TOKEN_PRIVATE_KEY_PATH=${GITHUB_WORKSPACE}/src/github.com/goharbor/harbor/tests/private_key.pem" >> $GITHUB_ENV
+          IP=`hostname -I | awk '{print $1}'`
+          echo "IP=$IP" >> $GITHUB_ENV
+          echo "BASE_URL=https://$IP" >> $GITHUB_ENV
+        shell: bash
+      - name: before_install
+        run: |
+          set -x
+          cd src/github.com/goharbor/harbor
+          curl -L https://github.com/docker/compose/releases/download/v${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
+          chmod +x docker-compose
+          sudo mv docker-compose /usr/local/bin
+      - name: Start Harbor for E2E
+        run: |
+          cd src/github.com/goharbor/harbor
+          docker system prune -a -f
+          bash ./tests/showtime.sh ./tests/ci/api_common_install.sh $IP DB
+      - name: Install Playwright dependencies
+        run: |
+          cd src/github.com/goharbor/harbor/src/portal
+          npm ci
+          npx playwright install --with-deps chromium
+      - name: Run Playwright tests
+        run: |
+          cd src/github.com/goharbor/harbor/src/portal
+          npx playwright test
+      - uses: actions/upload-artifact@v7
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report
+          path: src/github.com/goharbor/harbor/src/portal/playwright-report/
+          retention-days: 30

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -8,7 +8,7 @@ env:
    POSTGRESQL_DATABASE: registry
    DOCKER_COMPOSE_VERSION: 2.27.1
    HARBOR_ADMIN: admin
-   HARBOR_ADMIN_PASSWD: Harbor12345
+   HARBOR_PASSWORD: Harbor12345
    CORE_SECRET: tempString
    KEY_PATH: "/data/secret/keys/secretkey"
    REDIS_HOST: localhost
@@ -43,9 +43,6 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: 1.23.2
-      - uses: actions/setup-node@v6
-        with:
-          node-version: '18'
       - uses: actions/checkout@v6
         with:
           path: src/github.com/goharbor/harbor
@@ -74,15 +71,123 @@ jobs:
           cd src/github.com/goharbor/harbor
           docker system prune -a -f
           bash ./tests/showtime.sh ./tests/ci/api_common_install.sh $IP DB
-      - name: Install Playwright dependencies
-        run: |
-          cd src/github.com/goharbor/harbor/src/portal
-          npm ci
-          npx playwright install --with-deps chromium
       - name: Run Playwright tests
         run: |
-          cd src/github.com/goharbor/harbor/src/portal
-          npx playwright test
+          cd src/github.com/goharbor/harbor
+          make playwright-test \
+            BASE_URL=$BASE_URL \
+            HARBOR_ADMIN=$HARBOR_ADMIN \
+            HARBOR_PASSWORD=$HARBOR_PASSWORD
+      - name: Add Playwright report to job summary
+        if: ${{ !cancelled() }}
+        run: |
+          cd src/github.com/goharbor/harbor
+          node <<'EOF'
+          const fs = require('fs');
+
+          const reportPath = 'src/portal/test-results/results.json';
+          const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+          const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
+
+          const escapeHtml = (value) => String(value)
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;');
+
+          let html = '<h2>Playwright Test Results</h2>\n';
+
+          if (!fs.existsSync(reportPath)) {
+            html += `<p>No JSON report found at <code>${escapeHtml(reportPath)}</code>.</p>\n`;
+            html += `<p>Download the HTML report from the <a href="${runUrl}">workflow artifacts</a>.</p>\n`;
+            fs.appendFileSync(summaryPath, html);
+            process.exit(0);
+          }
+
+          const report = JSON.parse(fs.readFileSync(reportPath, 'utf8'));
+          const counts = { passed: 0, failed: 0, skipped: 0, timedOut: 0, interrupted: 0, flaky: 0 };
+          const failures = [];
+          const tests = [];
+
+          const visitSpec = (spec, file) => {
+            for (const test of spec.tests || []) {
+              const results = test.results || [];
+              const finalResult = results[results.length - 1] || {};
+              const status = finalResult.status || test.status || 'unknown';
+              const flaky = status === 'passed' && results.some((result) => result.status !== 'passed');
+
+              counts[status] = (counts[status] || 0) + 1;
+              if (flaky) counts.flaky += 1;
+
+              tests.push({
+                title: test.title,
+                file,
+                status: flaky ? 'flaky' : status,
+                duration: results.reduce((sum, result) => sum + (result.duration || 0), 0),
+              });
+
+              if (status !== 'passed' && status !== 'skipped') {
+                failures.push({
+                  title: test.title,
+                  file,
+                  status,
+                  error: finalResult.error?.message || '',
+                });
+              }
+            }
+          };
+
+          const visitSuite = (suite) => {
+            for (const spec of suite.specs || []) visitSpec(spec, suite.file);
+            for (const child of suite.suites || []) visitSuite(child);
+          };
+
+          for (const suite of report.suites || []) visitSuite(suite);
+
+          const total = ['passed', 'failed', 'timedOut', 'skipped', 'interrupted']
+            .reduce((sum, status) => sum + (counts[status] || 0), 0);
+
+          html += '<table>\n';
+          html += '<thead><tr><th>Total</th><th>Passed</th><th>Failed</th><th>Timed out</th><th>Skipped</th><th>Interrupted</th><th>Flaky</th></tr></thead>\n';
+          html += '<tbody><tr>';
+          html += `<td align="right">${total}</td>`;
+          html += `<td align="right">${counts.passed || 0}</td>`;
+          html += `<td align="right">${counts.failed || 0}</td>`;
+          html += `<td align="right">${counts.timedOut || 0}</td>`;
+          html += `<td align="right">${counts.skipped || 0}</td>`;
+          html += `<td align="right">${counts.interrupted || 0}</td>`;
+          html += `<td align="right">${counts.flaky || 0}</td>`;
+          html += '</tr></tbody>\n</table>\n';
+          html += `<p>Full HTML report: download <code>playwright-report</code> from the <a href="${runUrl}">workflow artifacts</a>.</p>\n`;
+
+          if (tests.length) {
+            html += '<h3>Test Cases</h3>\n';
+            html += '<table>\n';
+            html += '<thead><tr><th>Status</th><th>Test</th><th>File</th><th>Duration</th></tr></thead>\n<tbody>\n';
+            for (const test of tests) {
+              html += '<tr>';
+              html += `<td>${escapeHtml(test.status)}</td>`;
+              html += `<td>${escapeHtml(test.title)}</td>`;
+              html += `<td><code>${escapeHtml(test.file || '')}</code></td>`;
+              html += `<td align="right">${(test.duration / 1000).toFixed(1)}s</td>`;
+              html += '</tr>\n';
+            }
+            html += '</tbody>\n</table>\n';
+          }
+
+          if (failures.length) {
+            html += '<h3>Failures</h3>\n';
+            for (const failure of failures.slice(0, 10)) {
+              html += '<details>\n';
+              html += `<summary><strong>${escapeHtml(failure.title)}</strong> (${escapeHtml(failure.status)}) in <code>${escapeHtml(failure.file)}</code></summary>\n`;
+              if (failure.error) html += `<pre>${escapeHtml(failure.error.slice(0, 1000))}</pre>\n`;
+              html += '</details>\n';
+            }
+          }
+
+          fs.appendFileSync(summaryPath, html);
+          EOF
       - uses: actions/upload-artifact@v7
         if: ${{ !cancelled() }}
         with:

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,17 @@
 #
 # down:			shutdown Harbor instance
 #
+# playwright-test:	run all Playwright tests in a container against BASE_URL
+#
+# playwright-test-report:
+#			run all Playwright tests and serve the HTML report
+#
+# playwright-image-build:
+#			build the Playwright test runner image
+#
+# playwright-image-push:
+#			push the Playwright test runner image
+#
 # package_online:
 #				prepare online install package
 #			for example: make package_online -e DEVFLAG=false\
@@ -164,8 +175,23 @@ DOCKERRMIMAGE=$(DOCKERCMD) rmi
 DOCKERPULL=$(DOCKERCMD) pull
 DOCKERIMAGES=$(DOCKERCMD) images
 DOCKERSAVE=$(DOCKERCMD) save
+DOCKERPUSH=$(DOCKERCMD) push
 DOCKERCOMPOSECMD=$(shell which docker-compose 2>/dev/null || echo "docker compose")
 DOCKERTAG=$(DOCKERCMD) tag
+PLAYWRIGHT_IMAGE ?= registry.goharbor.io/harbor-ci/goharbor/harbor-e2e-engine:latest-playwright-ui
+BASE_URL ?= http://harbor.128.140.12.238.nip.io
+IP ?= $(shell printf '%s' '$(BASE_URL)' | sed -E 's#^[a-zA-Z][a-zA-Z0-9+.-]*://##; s#/.*##')
+HARBOR_ADMIN ?= admin
+HARBOR_PASSWORD ?= Harbor12345
+PLAYWRIGHT_DOCKERFILE ?= $(PORTAL_PATH)/e2e/Dockerfile
+PLAYWRIGHT_DOCKER_NETWORK ?= host
+PLAYWRIGHT_DOCKER_SOCKET ?= auto
+PLAYWRIGHT_DOCKER_SOCKET_PATH ?= $(shell $(DOCKERCMD) info --format '{{.Host.RemoteSocket.Path}}' 2>/dev/null || printf '/var/run/docker.sock')
+PLAYWRIGHT_DOCKER_HOST ?= unix:///var/run/docker.sock
+PLAYWRIGHT_CI ?= true
+PLAYWRIGHT_ARGS ?= --reporter=list
+PLAYWRIGHT_REPORT_PORT ?= 9323
+PLAYWRIGHT_REPORT_CONTAINER ?= harbor-playwright-report
 
 # go parameters
 GOCMD=$(shell which go)
@@ -583,6 +609,68 @@ down:
 	@echo "Done."
 
 restart: down prepare start
+
+playwright-image-build:
+	@$(DOCKERBUILD) --target bundled -f $(PLAYWRIGHT_DOCKERFILE) -t $(PLAYWRIGHT_IMAGE) $(BUILDPATH)
+
+playwright-image-push:
+	@$(DOCKERPUSH) $(PLAYWRIGHT_IMAGE)
+
+playwright-test:
+	@mkdir -p $(PORTAL_PATH)/test-results $(PORTAL_PATH)/playwright-report
+	@set -e; \
+		docker_socket_opt=""; \
+		docker_socket_path="$(PLAYWRIGHT_DOCKER_SOCKET_PATH)"; \
+		podman_service_pid=""; \
+		cleanup() { if [ -n "$$podman_service_pid" ]; then kill "$$podman_service_pid" >/dev/null 2>&1 || true; fi; }; \
+		trap cleanup EXIT INT TERM; \
+		if [ "$(PLAYWRIGHT_DOCKER_SOCKET)" != "false" ] && [ ! -S "$$docker_socket_path" ] && $(DOCKERCMD) version 2>/dev/null | grep -q 'Podman Engine'; then \
+			mkdir -p $(BUILDPATH)/.opencode/tmp; \
+			docker_socket_path="$(BUILDPATH)/.opencode/tmp/playwright-podman.sock"; \
+			rm -f "$$docker_socket_path"; \
+			$(DOCKERCMD) system service --time=0 "unix://$$docker_socket_path" > $(BUILDPATH)/.opencode/tmp/playwright-podman-service.log 2>&1 & \
+			podman_service_pid=$$!; \
+			for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20; do [ -S "$$docker_socket_path" ] && break; sleep 0.2; done; \
+		fi; \
+		if [ "$(PLAYWRIGHT_DOCKER_SOCKET)" = "true" ] || { [ "$(PLAYWRIGHT_DOCKER_SOCKET)" = "auto" ] && [ -S "$$docker_socket_path" ]; }; then \
+			docker_socket_opt="-v $$docker_socket_path:/var/run/docker.sock"; \
+		fi; \
+		if ! $(DOCKERCMD) image inspect $(PLAYWRIGHT_IMAGE) >/dev/null 2>&1; then \
+			$(DOCKERPULL) $(PLAYWRIGHT_IMAGE) || { \
+				echo "Failed to pull $(PLAYWRIGHT_IMAGE). Run 'make playwright-image-build' to build it locally, or log in before retrying."; \
+				exit 1; \
+			}; \
+		fi; \
+		$(DOCKERCMD) run --rm --network $(PLAYWRIGHT_DOCKER_NETWORK) \
+			$$docker_socket_opt \
+			-v $(PORTAL_PATH)/e2e:/app/e2e:ro \
+			-v $(PORTAL_PATH)/playwright.config.ts:/app/playwright.config.ts:ro \
+			-v $(PORTAL_PATH)/test-results:/app/test-results \
+			-v $(PORTAL_PATH)/playwright-report:/app/playwright-report \
+			-e BASE_URL=$(BASE_URL) \
+			-e IP=$(IP) \
+			-e HARBOR_ADMIN=$(HARBOR_ADMIN) \
+			-e HARBOR_PASSWORD=$(HARBOR_PASSWORD) \
+			-e DOCKER_HOST=$(PLAYWRIGHT_DOCKER_HOST) \
+			-e CI=$(PLAYWRIGHT_CI) \
+			-w /app \
+			$(PLAYWRIGHT_IMAGE) npx playwright test $(PLAYWRIGHT_ARGS)
+
+playwright-test-report:
+	@set -e; \
+		test_status=0; \
+		make playwright-test || test_status=$$?; \
+		$(DOCKERCMD) rm -f $(PLAYWRIGHT_REPORT_CONTAINER) >/dev/null 2>&1 || true; \
+		cleanup() { $(DOCKERCMD) rm -f $(PLAYWRIGHT_REPORT_CONTAINER) >/dev/null 2>&1 || true; }; \
+		trap cleanup INT TERM EXIT; \
+		echo "Serving Playwright report at http://localhost:$(PLAYWRIGHT_REPORT_PORT). Press Ctrl+C to stop."; \
+		$(DOCKERCMD) run -d --name $(PLAYWRIGHT_REPORT_CONTAINER) \
+			-p $(PLAYWRIGHT_REPORT_PORT):$(PLAYWRIGHT_REPORT_PORT) \
+			-v $(PORTAL_PATH)/playwright-report:/app/playwright-report:ro \
+			-w /app \
+			$(PLAYWRIGHT_IMAGE) npx playwright show-report playwright-report --host 0.0.0.0 --port $(PLAYWRIGHT_REPORT_PORT) >/dev/null; \
+		$(DOCKERCMD) wait $(PLAYWRIGHT_REPORT_CONTAINER) >/dev/null || true; \
+		exit $$test_status
 
 swagger_client:
 	@echo "Generate swagger client"

--- a/src/portal/.gitignore
+++ b/src/portal/.gitignore
@@ -1,0 +1,7 @@
+
+# Playwright
+node_modules/
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/

--- a/src/portal/.sample.env
+++ b/src/portal/.sample.env
@@ -1,0 +1,5 @@
+HARBOR_USERNAME="<your_admin_username>" # e.g., admin
+HARBOR_PASSWORD="<your_admin_password>" # e.g., Harbor12345
+HARBOR_BASE_URL="<your_harbor_instance_url>" # e.g., https://harbor.mycompany.com
+LOCAL_REGISTRY="<your_registry_hostname>" # e.g., docker.io
+LOCAL_REGISTRY_NAMESPACE="<namespace_in_registry>" #e.g., library

--- a/src/portal/.sample.env
+++ b/src/portal/.sample.env
@@ -1,6 +1,11 @@
 HARBOR_USERNAME="<your_admin_username>" # e.g., admin
 HARBOR_PASSWORD="<your_admin_password>" # e.g., Harbor12345
-HARBOR_IP="<ip_of_harbor_instance" #e.g., harbor.mycompany.com
-HARBOR_BASE_URL="<your_harbor_instance_url>" # e.g., https://harbor.mycompany.com
+IP="<ip_of_harbor_instance" #e.g., harbor.mycompany.com
+BASE_URL="<your_harbor_instance_url>" # e.g., https://harbor.mycompany.com
 LOCAL_REGISTRY="<your_registry_hostname>" # e.g., docker.io
 LOCAL_REGISTRY_NAMESPACE="<namespace_in_registry>" #e.g., library
+
+# Do not modify
+COSIGN_PASSWORD=""
+COSIGN_EXPERIMENTAL=1
+COSIGN_OCI_EXPERIMENTAL=1

--- a/src/portal/.sample.env
+++ b/src/portal/.sample.env
@@ -1,5 +1,6 @@
 HARBOR_USERNAME="<your_admin_username>" # e.g., admin
 HARBOR_PASSWORD="<your_admin_password>" # e.g., Harbor12345
+HARBOR_IP="<ip_of_harbor_instance" #e.g., harbor.mycompany.com
 HARBOR_BASE_URL="<your_harbor_instance_url>" # e.g., https://harbor.mycompany.com
 LOCAL_REGISTRY="<your_registry_hostname>" # e.g., docker.io
 LOCAL_REGISTRY_NAMESPACE="<namespace_in_registry>" #e.g., library

--- a/src/portal/.sample.env
+++ b/src/portal/.sample.env
@@ -1,4 +1,4 @@
-HARBOR_USERNAME="<your_admin_username>" # e.g., admin
+HARBOR_ADMIN="<your_admin_username>" # e.g., admin
 HARBOR_PASSWORD="<your_admin_password>" # e.g., Harbor12345
 IP="<ip_of_harbor_instance" #e.g., harbor.mycompany.com
 BASE_URL="<your_harbor_instance_url>" # e.g., https://harbor.mycompany.com

--- a/src/portal/e2e/Dockerfile
+++ b/src/portal/e2e/Dockerfile
@@ -1,0 +1,64 @@
+FROM ubuntu:20.04 AS runtime
+
+ENV TZ=Asia/Shanghai \
+    DEBIAN_FRONTEND=noninteractive
+ENV LANG=C.UTF-8
+ENV HELM_EXPERIMENTAL_OCI=1
+ENV COSIGN_PASSWORD=Harbor12345
+ENV COSIGN_EXPERIMENTAL=1
+ENV COSIGN_OCI_EXPERIMENTAL=1
+ENV NOTATION_EXPERIMENTAL=1
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    wget \
+    curl \
+    gnupg2 \
+    apt-transport-https \
+    ca-certificates \
+    lsb-release \
+    libseccomp2 \
+    git \
+    iproute2 \
+    iptables \
+    build-essential \
+    sed \
+    libssl-dev \
+    tar \
+    unzip \
+    gzip \
+    jq \
+    libnss3-tools \
+    sudo
+
+RUN wget --no-check-certificate -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
+    sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends google-chrome-stable
+
+RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
+    apt-get install -y nodejs && \
+    npm install -g npm@latest
+
+RUN DOCKER_VERSION=27.1.1 && \
+    wget https://download.docker.com/linux/static/stable/x86_64/docker-$DOCKER_VERSION.tgz && \
+    tar --strip-components=1 -xvzf docker-$DOCKER_VERSION.tgz -C /usr/bin && \
+    rm docker-$DOCKER_VERSION.tgz
+
+WORKDIR /app
+
+RUN mkdir -p $HOME/.pki/nssdb && \
+    echo Harbor12345 > password.ca && \
+    certutil -d sql:$HOME/.pki/nssdb -N -f password.ca
+
+VOLUME /var/lib/docker
+
+CMD ["npx", "playwright", "test", "--reporter=html"]
+
+FROM runtime AS bundled
+
+COPY api/v2.0/swagger.yaml /api/v2.0/swagger.yaml
+COPY src/portal/package.json src/portal/package-lock.json ./
+COPY src/portal/scripts ./scripts
+RUN npm ci && \
+    npx playwright install --with-deps chromium && \
+    apt-get clean all

--- a/src/portal/e2e/common-gc.spec.ts
+++ b/src/portal/e2e/common-gc.spec.ts
@@ -27,7 +27,8 @@ interface PushImageWithTagOptions {
 }
 
 
-const harborIp = process.env.HARBOR_BASE_URL?.replace(/^https?:\/\//, '') || 'localhost';
+const harborIp = process.env.HARBOR_IP || 'localhost';
+const base_url = process.env.HARBOR_BASE_URL || 'https://localhost'
 const harborUser = process.env.HARBOR_USERNAME || 'admin';
 const harborPassword = process.env.HARBOR_USERNAME || 'Harbor12345';
 const localRegistryName = process.env.LOCAL_REGISTRY || 'docker.io';
@@ -350,7 +351,7 @@ async function getLatestGCJobId(page: Page): Promise<string> {
 }
 
 async function verifyGCSuccess(page: Page, jobId: string, expectedMessage: string) {
-  const response = await page.request.get(`https://${harborIp}/api/v2.0/system/gc/${jobId}/log`, {
+  const response = await page.request.get(`${base_url}/api/v2.0/system/gc/${jobId}/log`, {
     headers: {
       'Authorization': `Basic ${Buffer.from(`${harborUser}:${harborPassword}`).toString('base64')}`,
     },
@@ -369,7 +370,7 @@ async function waitForGCToComplete(page: Page, jobId: string, timeoutMs: number 
   
   while (Date.now() - startTime < timeoutMs) {
     try {
-      const response = await page.request.get(`https://${harborIp}/api/v2.0/system/gc/${jobId}/log`, {
+      const response = await page.request.get(`${base_url}/api/v2.0/system/gc/${jobId}/log`, {
         headers: {
           'Authorization': `Basic ${Buffer.from(`${harborUser}:${harborPassword}`).toString('base64')}`,
         },

--- a/src/portal/e2e/common-gc.spec.ts
+++ b/src/portal/e2e/common-gc.spec.ts
@@ -101,38 +101,40 @@ async function switchToProjectQuotas(page: Page) {
 
 async function checkProjectQuotaSorting(
   page: Page, 
-  proj1: string, 
-  proj2: string
+  smaller_proj: string, 
+  larger_proj: string
 ) {
-  // Get the Storage column header button
   const storageHeader = page.locator(
     "//div[@class='datagrid-table']//div[@class='datagrid-header']//button[normalize-space()='Storage']"
   );
 
-  // Click to sort ascending (smaller first)
+  // Ascending (smaller first)
   await storageHeader.click();
+  console.log(`smaller project: ${smaller_proj}`);
+  console.log(`larger project: ${larger_proj}`);
+
   
-  // Verify proj1 (alpine, smaller) appears in row 2
+  // smaller proj : in row 1
   await expect(
-    page.locator(`//div[@class='datagrid-table']//clr-dg-row[2]//clr-dg-cell[1]//a[contains(text(), '${proj1}')]`)
+    page.locator(`//div[@class='datagrid-table']//clr-dg-row[1]//clr-dg-cell[1]//a[contains(text(), '${smaller_proj}')]`)
   ).toBeVisible();
   
-  // Verify proj2 (photon, larger) appears in row 3
+  // larger proj : in row 2
   await expect(
-    page.locator(`//div[@class='datagrid-table']//clr-dg-row[3]//clr-dg-cell[1]//a[contains(text(), '${proj2}')]`)
+    page.locator(`//div[@class='datagrid-table']//clr-dg-row[2]//clr-dg-cell[1]//a[contains(text(), '${larger_proj}')]`)
   ).toBeVisible();
 
-  // Click to sort descending (larger first)
+  // Descending (larger first)
   await storageHeader.click();
   
-  // Verify proj2 (photon, larger) now in row 1
+  // larger proj : in row 1
   await expect(
-    page.locator(`//div[@class='datagrid-table']//clr-dg-row[1]//clr-dg-cell[1]//a[contains(text(), '${proj2}')]`)
+    page.locator(`//div[@class='datagrid-table']//clr-dg-row[1]//clr-dg-cell[1]//a[contains(text(), '${larger_proj}')]`)
   ).toBeVisible();
   
-  // Verify proj1 (alpine, smaller) now in row 2
+  // smaller proj : in row 2
   await expect(
-    page.locator(`//div[@class='datagrid-table']//clr-dg-row[2]//clr-dg-cell[1]//a[contains(text(), '${proj1}')]`)
+    page.locator(`//div[@class='datagrid-table']//clr-dg-row[2]//clr-dg-cell[1]//a[contains(text(), '${smaller_proj}')]`)
   ).toBeVisible();
 }
 
@@ -185,11 +187,12 @@ test('Project Quota Sorting', async ({ page }) => {
       project: project2,
       image: 'alpine',
       needPullFirst: false,
-      tag: '2.6'
+      tag: 'latest'
     });
 
+    // alpine < photon
     await switchToProjectQuotas(page);
-    await checkProjectQuotaSorting(page, project1, project2);
+    await checkProjectQuotaSorting(page, project2, project1);
 
     await deleteRepo(page, project1, 'photon');
     await deleteRepo(page, project2, 'alpine');

--- a/src/portal/e2e/common-gc.spec.ts
+++ b/src/portal/e2e/common-gc.spec.ts
@@ -13,8 +13,14 @@ interface PushImageOptions {
   localNamespace?: string;
 }
 
+const harborIp = process.env.HARBOR_BASE_URL?.replace(/^https?:\/\//, '') || 'localhost';
+const harborUser = process.env.HARBOR_USERNAME || 'admin';
+const harborPassword = process.env.HARBOR_USERNAME || 'Harbor12345';
+const localRegistryName = process.env.LOCAL_REGISTRY || 'docker.io';
+const localRegistryNamespace = process.env.LOCAL_REGISTRY_NAMESPACE || 'library';
+
 async function loginAsAdmin(page: Page) {
-    await page.goto('/');
+    await page.goto(harborIp);
     await page.getByRole('textbox', { name: 'Username' }).fill('admin');
     await page.getByRole('textbox', { name: 'Password' }).fill('Harbor12345');
     await page.getByRole('button', { name: 'LOG IN' }).click();
@@ -41,8 +47,8 @@ async function pushImage(options: PushImageOptions) {
     image,
     tag = 'latest',
     needPullFirst = true,
-    localRegistry = 'docker.io',
-    localNamespace = 'library'
+    localRegistry = localRegistryName,
+    localNamespace = localRegistryNamespace,
   } = options;
 
   const imageWithTag = `${image}:${tag}`;
@@ -162,9 +168,9 @@ test('Project Quota Sorting', async ({ page }) => {
     const larger_repo_tag = 'latest';
 
     await pushImage({
-      ip: 'localhost:80',
-      user: 'admin',
-      pwd: 'Harbor12345',
+      ip: harborIp,
+      user: harborUser,
+      pwd: harborPassword,
       project: project1,
       image: smaller_repo,
       needPullFirst: true,
@@ -177,9 +183,9 @@ test('Project Quota Sorting', async ({ page }) => {
     await createProject(page, project2);
 
     await pushImage({
-      ip: 'localhost:80',
-      user: 'admin',
-      pwd: 'Harbor12345',
+      ip: harborIp,
+      user: harborUser,
+      pwd: harborPassword,
       project: project2,
       image: larger_repo,
       needPullFirst: true,

--- a/src/portal/e2e/common-gc.spec.ts
+++ b/src/portal/e2e/common-gc.spec.ts
@@ -827,11 +827,11 @@ test('Garbage Collection', async ({ page }) => {
   
   await deleteRepo(page, project1, repo);
   await runGC(page, 5);
-  const latestJobId = await getLatestGCJobId(page);
-  console.log(`Latest GC Job ID: ${latestJobId}`);
-  await waitUntilGCComplete(page, latestJobId);
-  await verifyGCSuccess(page, latestJobId, '7 blobs and 1 manifests eligible for deletion');
-  await verifyGCSuccess(page, latestJobId, 'The GC job actual frees up 34 MB space');
+  const jobId = await runGC(page, 5);
+  console.log(`Latest GC Job ID: ${jobId}`);
+  await waitUntilGCComplete(page, jobId);
+  await verifyGCSuccess(page, jobId, '7 blobs and 1 manifests eligible for deletion');
+  await verifyGCSuccess(page, jobId, 'The GC job actual frees up 34 MB space');
 })
 
 test('GC Untagged Images', async ({ page }) => {
@@ -862,8 +862,7 @@ test('GC Untagged Images', async ({ page }) => {
   
   // Run GC without delete untagged artifacts (should not delete hello-world)
   await switchToGarbageCollection(page);
-  await runGC(page, 3);
-  let jobId = await getLatestGCJobId(page);
+  let jobId = await runGC(page, 3);
   await waitUntilGCComplete(page, jobId);
   
   // Verify artifact still exists
@@ -873,8 +872,7 @@ test('GC Untagged Images', async ({ page }) => {
   
   // Run GC WITH delete untagged artifacts (should delete hello-world)
   await switchToGarbageCollection(page);
-  await runGC(page, 2, true);
-  jobId = await getLatestGCJobId(page);
+  jobId = await runGC(page, 2, true);
   await waitUntilGCComplete(page, jobId);
   
   // Verify no artifacts exist
@@ -915,8 +913,7 @@ test('Project Quotas Control Under GC', async ({ page }) => {
     console.log(`GC iteration ${i + 1}/10`);
     
     await switchToGarbageCollection(page);
-    await runGC(page);
-    const jobId = await getLatestGCJobId(page);
+    const jobId = await runGC(page);
     await waitUntilGCComplete(page, jobId);
     
     const actualQuota = await getProjectStorageQuota(page, project);
@@ -949,8 +946,7 @@ test('Garbage Collection Accessory', async ({ page }) => {
   await loginAsAdmin(page);
   
   // Initial GC - verify no artifacts to delete
-  await runGC(page, gcWorkers, false);
-  let jobId = await getLatestGCJobId(page);
+  let jobId = await runGC(page);
   await waitUntilGCComplete(page, jobId);
   await checkGCHistory(page, jobId, '0 blob(s) and 0 manifest(s) deleted');
   await checkGCLog(page, jobId, logContaining, logExcluding);
@@ -985,8 +981,7 @@ test('Garbage Collection Accessory', async ({ page }) => {
   await deleteAccessoryByAccessoryRow(page, signatureOfSignatureRow);
 
   gcWorkers = 2;
-  await runGC(page, gcWorkers, false);
-  jobId = await getLatestGCJobId(page);
+  jobId = await runGC(page, gcWorkers, false);
   await waitUntilGCComplete(page, jobId);
   await checkGCHistory(page, jobId, '2 blob(s) and 1 manifest(s) deleted');
   
@@ -1011,8 +1006,7 @@ test('Garbage Collection Accessory', async ({ page }) => {
   await deleteAccessoryByAccessoryRow(page, signatureRow);
 
   gcWorkers = 3;
-  await runGC(page, gcWorkers, false);
-  jobId = await getLatestGCJobId(page);
+  jobId = await runGC(page, gcWorkers, false);
   await waitUntilGCComplete(page, jobId);
   await checkGCHistory(page, jobId, '2 blob(s) and 1 manifest(s) deleted');
   
@@ -1035,8 +1029,7 @@ test('Garbage Collection Accessory', async ({ page }) => {
   await deleteAccessoryByAccessoryRow(page, sbomRow);
 
   gcWorkers = 4;
-  await runGC(page, gcWorkers, false);
-  jobId = await getLatestGCJobId(page);
+  jobId = await runGC(page, gcWorkers, false);
   await waitUntilGCComplete(page, jobId);
   await checkGCHistory(page, jobId, '4 blob(s) and 2 manifest(s) deleted');
   
@@ -1063,8 +1056,7 @@ test('Garbage Collection Accessory', async ({ page }) => {
 
   // Run GC without untagged images
   gcWorkers = 5;
-  await runGC(page, gcWorkers, false);
-  jobId = await getLatestGCJobId(page);
+  jobId = await runGC(page, gcWorkers, false);
   await waitUntilGCComplete(page, jobId);
   await checkGCHistory(page, jobId, '0 blob(s) and 0 manifest(s) deleted, 0 space freed up');
   
@@ -1081,8 +1073,7 @@ test('Garbage Collection Accessory', async ({ page }) => {
   await checkGCLog(page, jobId, logContaining, logExcluding);
 
   // Run GC with untagged images
-  await runGC(page, gcWorkers, false);
-  jobId = await getLatestGCJobId(page);
+  jobId = await runGC(page, gcWorkers, false);
   await waitUntilGCComplete(page, jobId);
   await checkGCHistory(page, jobId, '10 blob(s) and 5 manifest(s) deleted');
 

--- a/src/portal/e2e/common-gc.spec.ts
+++ b/src/portal/e2e/common-gc.spec.ts
@@ -8,6 +8,22 @@ async function loginAsAdmin(page: Page) {
     await expect(page.getByRole('link', { name: 'Projects' })).toBeVisible();
 }
 
+async function createProject(page: Page, projectName: string, isPublic: boolean = false) {
+    await page.getByRole("link", { name: "Projects" }).click();
+    await page.getByRole("button", { name: "NEW PROJECT" }).click();
+    await page.locator("//*[@id='create_project_name']").fill(projectName);
+    if (isPublic) {
+        await page.locator(`xpath=//input[@name='public']/..//label[contains(@class,'clr-control-label')]`).check();
+    }
+    await page.getByRole('button', { name: 'OK' }).click();
+    await expect(page.getByRole('link', {name: projectName})).toBeVisible()
+}
+
 test('Project Quota Sorting', async ({ page }) => {
     await loginAsAdmin(page);
+
+    const timestamp1 = Date.now();
+    const project1 = `project${timestamp1}`;
+    console.log(project1);
+    await createProject(page, project1);
 })

--- a/src/portal/e2e/common-gc.spec.ts
+++ b/src/portal/e2e/common-gc.spec.ts
@@ -8,6 +8,7 @@ interface PushImageOptions {
   project: string;
   image: string;
   tag?: string;
+  tag1: string;
   needPullFirst?: boolean;
   localRegistry?: string;
   localNamespace?: string;
@@ -45,13 +46,14 @@ async function pushImage(options: PushImageOptions) {
     pwd,
     project,
     image,
-    tag = 'latest',
+    tag,
+    tag1 = 'latest',
     needPullFirst = true,
     localRegistry = localRegistryName,
     localNamespace = localRegistryNamespace,
   } = options;
 
-  const imageWithTag = `${image}:${tag}`;
+  const imageWithTag = `${image}:${tag1}`;
   const sourceImage = `${localRegistry}/${localNamespace}/${imageWithTag}`;
   const targetImage = `${ip}/${project}/${imageWithTag}`;
 
@@ -62,7 +64,7 @@ async function pushImage(options: PushImageOptions) {
     }
     
     console.log(`Logging in to ${ip}...`);
-    execSync(`docker login -u ${user} -p ${pwd} ${ip}`, { stdio: 'inherit' });
+    execSync(`docker login -u ${user} -p ${pwd} ${ip}`, { stdio: 'pipe' });
 
     const srcImage = needPullFirst ? sourceImage : imageWithTag;
     execSync(`docker tag ${srcImage} ${targetImage}`, { stdio: 'inherit' });
@@ -175,6 +177,7 @@ test('Project Quota Sorting', async ({ page }) => {
       image: smaller_repo,
       needPullFirst: true,
       tag: smaller_repo_tag,
+      tag1: 'latest',
     });
 
     const timestamp2 = Date.now();
@@ -190,6 +193,7 @@ test('Project Quota Sorting', async ({ page }) => {
       image: larger_repo,
       needPullFirst: true,
       tag: larger_repo_tag,
+      tag1: 'latest'
     });
 
     await switchToProjectQuotas(page);

--- a/src/portal/e2e/common-gc.spec.ts
+++ b/src/portal/e2e/common-gc.spec.ts
@@ -125,11 +125,11 @@ test('Project Quota Sorting', async ({ page }) => {
       user: 'admin',
       pwd: 'Harbor12345',
       project: project1,
-      image: 'busybox',
+      image: 'photon',
       needPullFirst: false,
-      tag: 'latest'
+      tag: '2.0'
     });
 
-    await deleteRepo(page, project1, 'busybox');
+    await deleteRepo(page, project1, 'photon');
     await runGC(page)
 })

--- a/src/portal/e2e/common-gc.spec.ts
+++ b/src/portal/e2e/common-gc.spec.ts
@@ -1,0 +1,13 @@
+import { expect, Page, test } from '@playwright/test'
+
+async function loginAsAdmin(page: Page) {
+    await page.goto('/');
+    await page.getByRole('textbox', { name: 'Username' }).fill('admin');
+    await page.getByRole('textbox', { name: 'Password' }).fill('Harbor12345');
+    await page.getByRole('button', { name: 'LOG IN' }).click();
+    await expect(page.getByRole('link', { name: 'Projects' })).toBeVisible();
+}
+
+test('Project Quota Sorting', async ({ page }) => {
+    await loginAsAdmin(page);
+})

--- a/src/portal/e2e/common-gc.spec.ts
+++ b/src/portal/e2e/common-gc.spec.ts
@@ -19,6 +19,23 @@ async function createProject(page: Page, projectName: string, isPublic: boolean 
     await expect(page.getByRole('link', {name: projectName})).toBeVisible()
 }
 
+async function goIntoProject(page: Page, projectName: string) {
+    await page.getByRole('link', { name: 'Projects' }).click();
+    await expect(page.getByRole('link', {name: projectName})).toBeVisible()
+    await page.getByRole('link', {name: projectName}).click();
+}
+
+async function deleteRepo(page: Page, projectName: string, repoName: string) {
+    await goIntoProject(page, projectName);
+    const repoRow = page.locator(` xpath=//clr-dg-row[contains(.,'${projectName}/${repoName}')]//div[contains(@class,'clr-checkbox-wrapper')]//label[contains(@class,'clr-control-label')]`);
+    await repoRow.check();
+
+    await page.getByRole('button', { name: 'DELETE' }).click();
+    await page.locator("xpath=//button[contains(.,'DELETE')]").click();
+    await expect(repoRow).not.toBeVisible();
+
+}
+
 test('Project Quota Sorting', async ({ page }) => {
     await loginAsAdmin(page);
 
@@ -26,4 +43,6 @@ test('Project Quota Sorting', async ({ page }) => {
     const project1 = `project${timestamp1}`;
     console.log(project1);
     await createProject(page, project1);
+
+    await deleteRepo(page, project1, 'busybox');
 })

--- a/src/portal/e2e/common-gc.spec.ts
+++ b/src/portal/e2e/common-gc.spec.ts
@@ -27,10 +27,10 @@ interface PushImageWithTagOptions {
 }
 
 
-const harborIp = process.env.HARBOR_IP || 'localhost';
-const base_url = process.env.HARBOR_BASE_URL || 'https://localhost'
 const harborUser = process.env.HARBOR_USERNAME || 'admin';
-const harborPassword = process.env.HARBOR_USERNAME || 'Harbor12345';
+const harborPassword = process.env.HARBOR_PASSWORD || 'Harbor12345';
+const harborIp = process.env.IP || 'localhost';
+const base_url = process.env.BASE_URL || 'https://localhost';
 const localRegistryName = process.env.LOCAL_REGISTRY || 'docker.io';
 const localRegistryNamespace = process.env.LOCAL_REGISTRY_NAMESPACE || 'library';
 
@@ -626,34 +626,3 @@ test('Project Quotas Control Under GC', async ({ page }) => {
   
   expect(quotaMatches).toBeTruthy();
 })
-
-test('Garbage Collection Accessory', async ({ page }) => {
-  // Setup
-  const timestamp = Date.now();
-  const projectName = `project${timestamp}`;
-  const imageName = 'hello-world';
-  const imageTag = 'latest';
-  
-  // Initialize
-  await loginAsAdmin(page);
-  
-  // 1. Initial GC - verify no artifacts to delete
-  await switchToGarbageCollection(page);
-  await runGC(page, 1, false);
-  let jobId = await getLatestGCJobId(page);
-  await waitForGCToComplete(page, jobId);
-  await checkGCHistory(page, jobId, '0 blob(s) and 0 manifest(s) deleted');
-  await checkGCLog(page, jobId, ['workers: 1'], []);
-  
-  // 2. Create project and push image
-  await createProject(page, projectName);
-  await pushImageWithTag({
-    ip: harborIp,
-    user: harborUser,
-    pwd: harborPassword,
-    project: projectName,
-    image: imageName,
-    tag: imageTag,
-    tag1: imageTag,
-  });
-});

--- a/src/portal/e2e/common-gc.spec.ts
+++ b/src/portal/e2e/common-gc.spec.ts
@@ -93,6 +93,25 @@ async function deleteRepo(page: Page, projectName: string, repoName: string) {
 
 }
 
+async function runGC(page: Page, workers?: number, deleteUntagged: boolean = false, gc_now: boolean = false) {
+    await page.locator(" //clr-main-container//clr-vertical-nav-group//span[contains(.,'Clean Up')]").click();
+    await page.getByRole('link', { name: 'Garbage Collection' }).click();
+
+    if (workers) {
+        await page.selectOption('#workers', workers.toString())
+    }
+
+    if (deleteUntagged) {
+        await page.locator('#delete_untagged').click();
+    }
+
+    if (gc_now) {
+        await page.getByRole("button", { name: 'DRY RUN' }).click()
+    } else {
+        await page.getByRole('button', { name: 'GC NOW' }).click();
+    }
+}
+
 test('Project Quota Sorting', async ({ page }) => {
     await loginAsAdmin(page);
 
@@ -112,4 +131,5 @@ test('Project Quota Sorting', async ({ page }) => {
     });
 
     await deleteRepo(page, project1, 'busybox');
+    await runGC(page)
 })

--- a/src/portal/e2e/common-gc.spec.ts
+++ b/src/portal/e2e/common-gc.spec.ts
@@ -21,22 +21,22 @@ const localRegistryName = process.env.LOCAL_REGISTRY || 'docker.io';
 const localRegistryNamespace = process.env.LOCAL_REGISTRY_NAMESPACE || 'library';
 
 async function loginAsAdmin(page: Page) {
-    await page.goto(harborIp);
-    await page.getByRole('textbox', { name: 'Username' }).fill('admin');
-    await page.getByRole('textbox', { name: 'Password' }).fill('Harbor12345');
-    await page.getByRole('button', { name: 'LOG IN' }).click();
-    await expect(page.getByRole('link', { name: 'Projects' })).toBeVisible();
+  await page.goto(harborIp);
+  await page.getByRole('textbox', { name: 'Username' }).fill('admin');
+  await page.getByRole('textbox', { name: 'Password' }).fill('Harbor12345');
+  await page.getByRole('button', { name: 'LOG IN' }).click();
+  await expect(page.getByRole('link', { name: 'Projects' })).toBeVisible();
 }
 
 async function createProject(page: Page, projectName: string, isPublic: boolean = false) {
-    await page.getByRole("link", { name: "Projects" }).click();
-    await page.getByRole("button", { name: "NEW PROJECT" }).click();
-    await page.locator("//*[@id='create_project_name']").fill(projectName);
-    if (isPublic) {
-        await page.locator(`xpath=//input[@name='public']/..//label[contains(@class,'clr-control-label')]`).check();
-    }
-    await page.getByRole('button', { name: 'OK' }).click();
-    await expect(page.getByRole('link', {name: projectName})).toBeVisible()
+  await page.getByRole("link", { name: "Projects" }).click();
+  await page.getByRole("button", { name: "NEW PROJECT" }).click();
+  await page.locator("//*[@id='create_project_name']").fill(projectName);
+  if (isPublic) {
+      await page.locator(`xpath=//input[@name='public']/..//label[contains(@class,'clr-control-label')]`).check();
+  }
+  await page.getByRole('button', { name: 'OK' }).click();
+  await expect(page.getByRole('link', {name: projectName})).toBeVisible()
 }
 
 async function pushImage(options: PushImageOptions) {
@@ -80,19 +80,19 @@ async function pushImage(options: PushImageOptions) {
 }
 
 async function goIntoProject(page: Page, projectName: string) {
-    await page.getByRole('link', { name: 'Projects' }).click();
-    await expect(page.getByRole('link', {name: projectName})).toBeVisible()
-    await page.getByRole('link', {name: projectName}).click();
+  await page.getByRole('link', { name: 'Projects' }).click();
+  await expect(page.getByRole('link', {name: projectName})).toBeVisible()
+  await page.getByRole('link', {name: projectName}).click();
 }
 
 async function deleteRepo(page: Page, projectName: string, repoName: string) {
-    await goIntoProject(page, projectName);
-    const repoRow = page.locator(` xpath=//clr-dg-row[contains(.,'${projectName}/${repoName}')]//div[contains(@class,'clr-checkbox-wrapper')]//label[contains(@class,'clr-control-label')]`);
-    await repoRow.check();
+  await goIntoProject(page, projectName);
+  const repoRow = page.locator(` xpath=//clr-dg-row[contains(.,'${projectName}/${repoName}')]//div[contains(@class,'clr-checkbox-wrapper')]//label[contains(@class,'clr-control-label')]`);
+  await repoRow.check();
 
-    await page.getByRole('button', { name: 'DELETE' }).click();
-    await page.locator("xpath=//button[contains(.,'DELETE')]").click();
-    await expect(repoRow).not.toBeVisible();
+  await page.getByRole('button', { name: 'DELETE' }).click();
+  await page.locator("xpath=//button[contains(.,'DELETE')]").click();
+  await expect(repoRow).not.toBeVisible();
 
 }
 
@@ -138,68 +138,68 @@ async function checkProjectQuotaSorting(
 }
 
 async function runGC(page: Page, workers?: number, deleteUntagged: boolean = false, gc_now: boolean = false) {
-    await page.locator(" //clr-main-container//clr-vertical-nav-group//span[contains(.,'Clean Up')]").click();
-    await page.getByRole('link', { name: 'Garbage Collection' }).click();
+  await page.locator(" //clr-main-container//clr-vertical-nav-group//span[contains(.,'Clean Up')]").click();
+  await page.getByRole('link', { name: 'Garbage Collection' }).click();
 
-    if (workers) {
-        await page.selectOption('#workers', workers.toString())
-    }
+  if (workers) {
+      await page.selectOption('#workers', workers.toString())
+  }
 
-    if (deleteUntagged) {
-        await page.locator('#delete_untagged').click();
-    }
+  if (deleteUntagged) {
+      await page.locator('#delete_untagged').click();
+  }
 
-    if (gc_now) {
-        await page.getByRole("button", { name: 'DRY RUN' }).click()
-    } else {
-        await page.getByRole('button', { name: 'GC NOW' }).click();
-    }
+  if (gc_now) {
+      await page.getByRole("button", { name: 'DRY RUN' }).click()
+  } else {
+      await page.getByRole('button', { name: 'GC NOW' }).click();
+  }
 }
 
 test('Project Quota Sorting', async ({ page }) => {
-    await loginAsAdmin(page);
+  await loginAsAdmin(page);
 
-    const timestamp1 = Date.now();
-    const project1 = `project${timestamp1}`;
-    console.log(project1);
-    await createProject(page, project1);
+  const timestamp1 = Date.now();
+  const project1 = `project${timestamp1}`;
+  console.log(project1);
+  await createProject(page, project1);
 
-    const smaller_repo = 'alpine';
-    const smaller_repo_tag = 'latest';
-    const larger_repo = 'photon';
-    const larger_repo_tag = 'latest';
+  const smaller_repo = 'alpine';
+  const smaller_repo_tag = 'latest';
+  const larger_repo = 'photon';
+  const larger_repo_tag = 'latest';
 
-    await pushImage({
-      ip: harborIp,
-      user: harborUser,
-      pwd: harborPassword,
-      project: project1,
-      image: smaller_repo,
-      needPullFirst: true,
-      tag: smaller_repo_tag,
-      tag1: 'latest',
-    });
+  await pushImage({
+    ip: harborIp,
+    user: harborUser,
+    pwd: harborPassword,
+    project: project1,
+    image: smaller_repo,
+    needPullFirst: true,
+    tag: smaller_repo_tag,
+    tag1: 'latest',
+  });
 
-    const timestamp2 = Date.now();
-    const project2 = `project${timestamp2}`;
-    console.log(project2);
-    await createProject(page, project2);
+  const timestamp2 = Date.now();
+  const project2 = `project${timestamp2}`;
+  console.log(project2);
+  await createProject(page, project2);
 
-    await pushImage({
-      ip: harborIp,
-      user: harborUser,
-      pwd: harborPassword,
-      project: project2,
-      image: larger_repo,
-      needPullFirst: true,
-      tag: larger_repo_tag,
-      tag1: 'latest'
-    });
+  await pushImage({
+    ip: harborIp,
+    user: harborUser,
+    pwd: harborPassword,
+    project: project2,
+    image: larger_repo,
+    needPullFirst: true,
+    tag: larger_repo_tag,
+    tag1: 'latest'
+  });
 
-    await switchToProjectQuotas(page);
-    await checkProjectQuotaSorting(page, project1, project2);
+  await switchToProjectQuotas(page);
+  await checkProjectQuotaSorting(page, project1, project2);
 
-    await deleteRepo(page, project1, smaller_repo);
-    await deleteRepo(page, project2, larger_repo);
-    await runGC(page)
+  await deleteRepo(page, project1, smaller_repo);
+  await deleteRepo(page, project2, larger_repo);
+  await runGC(page)
 })

--- a/src/portal/e2e/common-gc.spec.ts
+++ b/src/portal/e2e/common-gc.spec.ts
@@ -27,7 +27,7 @@ interface PushImageWithTagOptions {
 }
 
 
-const harborUser = process.env.HARBOR_USERNAME || 'admin';
+const harborUser = process.env.HARBOR_ADMIN || 'admin';
 const harborPassword = process.env.HARBOR_PASSWORD || 'Harbor12345';
 const harborIp = process.env.IP || 'localhost';
 const base_url = process.env.BASE_URL || 'https://localhost';
@@ -166,8 +166,11 @@ async function loginAsAdmin(page: Page) {
 }
 
 async function createProject(page: Page, projectName: string, isPublic: boolean = false, storageQuota?: number, storageQuotaUnit?: string) {
+  // Open create project modal
   await page.getByRole("link", { name: "Projects" }).click();
   await page.getByRole("button", { name: "NEW PROJECT" }).click();
+
+  // Fill in Project details
   await page.locator("#create_project_name").fill(projectName);
   
   if (isPublic) {
@@ -181,7 +184,10 @@ async function createProject(page: Page, projectName: string, isPublic: boolean 
   }
   
   await page.getByRole('button', { name: 'OK' }).click();
+
+  // Check that the project is created
   await expect(page.getByRole('link', {name: projectName})).toBeVisible()
+  console.log(`Creating project ${projectName}`);
 }
 
 
@@ -192,21 +198,22 @@ async function goIntoProject(page: Page, projectName: string) {
 }
 
 async function goIntoRepo(page: Page, projectName: string, repoName: string) {
-  await goIntoProject(page, projectName);
   await expect(page.getByRole('link', {name: `${projectName}/${repoName}`})).toBeVisible()
   await page.getByRole('link', {name: `${projectName}/${repoName}`}).click();
-  
+
+  // Check that the repo heading is the given repo
   await expect(page.locator('artifact-list-page h2', { hasText: repoName })).toBeVisible();
 }
 
 async function goIntoArtifact(page: Page, tag: string) {
-  await page.locator('clr-datagrid clr-spinner').waitFor({ state: 'hidden' }).catch((() => {}));
   
   const artifactLink = page.locator('clr-dg-row', {hasText: `${tag}`}).locator('a', {hasText: 'sha256'});
   await expect(artifactLink).toBeVisible();
   await artifactLink.click();
   
   await expect(page.locator('artifact-tag')).toBeVisible();
+
+  // Wait until the loading icon has dissappeared
   await page.locator('clr-datagrid clr-spinner').waitFor({ state: 'hidden' }).catch(() => {});
 }
 
@@ -239,59 +246,27 @@ async function shouldNotContainAnyArtifact(page: Page) {
 }
 
 async function refreshRepositories(page: Page): Promise<void> {
-  console.log('Refreshing repos');
   const refreshBtn = page.locator('span.refresh-btn');
   await expect(refreshBtn).toBeVisible({ timeout: 10000 });
   await refreshBtn.click(); 
 
-  // Check if spinner exists
   const spinner = page.locator('clr-datagrid clr-spinner');
-  const spinnerVisible = await spinner.isVisible().catch(() => false);
-  
-  if (spinnerVisible) {
-    // Wait for spinner to disappear
-    await expect(spinner).not.toBeVisible({ timeout: 30000 });
-  } else {
-    // Spinner didn't appear (instant refresh), just wait a bit
-    console.log('Spinner did not appear (instant refresh)');
-    await page.waitForTimeout(1000);
-  }
+  // Wait for spinner to appear
+  await spinner.waitFor({ state: 'visible', timeout: 500 }).catch(() => {});
+  // Wait for spinner to disappear
+  await spinner.waitFor({ state: 'hidden', timeout: 30000 }).catch(() => {});
 }
 
-/**
- * Refreshes the artifacts list by clicking the refresh button
- * Handles cases where spinner might not appear or refresh is instant
- */
 async function refreshArtifacts(page: Page): Promise<void> {
-  console.log('Refreshing artifacts...');
-  
-  try {
-    // Click the refresh button
-    const refreshBtn = page.locator('artifact-list-tab span.refresh-btn');
-    await expect(refreshBtn).toBeVisible({ timeout: 10000 });
-    await refreshBtn.click();
-    
-    // Wait a moment for spinner to appear
-    // await page.waitForTimeout(500);
-    
-    // Check if spinner exists
-    const spinner = page.locator('clr-datagrid clr-spinner');
-    const spinnerVisible = await spinner.isVisible().catch(() => false);
-    
-    if (spinnerVisible) {
-      // Wait for spinner to disappear
-      await expect(spinner).not.toBeVisible({ timeout: 30000 });
-    } else {
-      // Spinner didn't appear (instant refresh), just wait a bit
-      console.log('Spinner did not appear (instant refresh)');
-      await page.waitForTimeout(1000);
-    }
-    
-    console.log('✓ Artifacts refreshed');
-  } catch (error) {
-    console.error('Failed to refresh artifacts:', error);
-    throw error;
-  }
+  const refreshBtn = page.locator('artifact-list-tab span.refresh-btn');
+  await expect(refreshBtn).toBeVisible({ timeout: 10000 });
+  await refreshBtn.click(); 
+
+  const spinner = page.locator('clr-datagrid clr-spinner');
+  // Wait for spinner to appear
+  await spinner.waitFor({ state: 'visible', timeout: 500 }).catch(() => {});
+  // Wait for spinner to disappear
+  await spinner.waitFor({ state: 'hidden', timeout: 30000 }).catch(() => {});
 }
 
 async function cannotPushImage(ip: string, user: string, pwd: string, project: string, imageWithTag: string, expectedErrorMessage: string) {
@@ -340,12 +315,18 @@ async function deleteRepo(page: Page, projectName: string, repoName: string) {
   await page.locator('hbr-repository-gridview').getByRole('button', { name: 'Delete', exact: true }).click();
   await page.getByRole('button', { name: 'DELETE', exact: true }).click();
   await expect(repoRow).not.toBeVisible();
+  console.log(`Deleted repository ${projectName}/${repoName}`)
 }
 
 async function switchToProjectQuotas(page: Page) {
   // Navigate to Administration → Project Quotas
   await page.locator('clr-vertical-nav-group-children a', { hasText: 'Project Quotas' }).click();
-  await page.waitForTimeout(1000);
+
+  const spinner = page.locator('clr-datagrid clr-spinner');
+  // Wait for spinner to appear
+  await spinner.waitFor({ state: 'visible', timeout: 500 }).catch(() => {});
+  // Wait for spinner to disappear
+  await spinner.waitFor({ state: 'hidden', timeout: 30000 }).catch(() => {});
 }
 
 async function checkProjectQuotaSorting(
@@ -355,8 +336,8 @@ async function checkProjectQuotaSorting(
 ) {
   const storageHeader = page.locator('.datagrid-table .datagrid-header button', { hasText: 'Storage' });
   
-  console.log(`smaller project: ${smaller_proj}`);
-  console.log(`larger project: ${larger_proj}`);
+  console.log(`Smaller project: ${smaller_proj}`);
+  console.log(`Larger project: ${larger_proj}`);
   
   // Ascending (smaller first)
   await storageHeader.click();
@@ -382,6 +363,7 @@ async function checkProjectQuotaSorting(
 }
 
 async function runGC(page: Page, workers?: number, deleteUntagged: boolean = false, dry_run: boolean = false): Promise<string> {
+  console.log("Running GC")
   await page.locator('clr-main-container clr-vertical-nav-group span', { hasText: 'Clean Up' }).click();
   await page.getByRole('link', { name: 'Garbage Collection' }).click();
 
@@ -400,7 +382,7 @@ async function runGC(page: Page, workers?: number, deleteUntagged: boolean = fal
   }
   await expect(page.locator('clr-datagrid clr-dg-row').first().locator('clr-dg-cell').nth(3)).toContainText('Running')
   const jobId =  await getLatestGCJobId(page);
-  console.log(jobId);
+  console.log(`GC Job Id: ${jobId}`);
   return jobId;
 }
 
@@ -436,18 +418,16 @@ async function waitUntilGCComplete(
 ): Promise<void> {
   console.log(`Waiting for GC job ${gcJobId} to reach status: ${status}...`);
 
-  // Step 1: Find the row by job ID using filter with exact text match
+  // Find the row by job ID using filter with exact text match
   const jobRow = page.locator('clr-dg-row').filter({ has: page.locator('clr-dg-cell', { hasText: new RegExp(`^${gcJobId}$`) }) });
   await expect(jobRow).toBeVisible({ timeout: 10000 });
 
-  // Step 2: Find the status cell (4th column)
-  const statusCell = jobRow.locator('clr-dg-cell').nth(3); // 0-indexed, so 3 = 4th column
+  const statusCell = jobRow.locator('clr-dg-cell').nth(3);
   
-  // Step 3: Wait for the status cell to contain the expected text
-  // This handles cases where text changes from "Running" -> "SUCCESS"
+  // Wait for the status cell to contain the expected text
   await expect(statusCell).toHaveText(status, { timeout });
 
-  console.log(`✓ GC job ${gcJobId} completed with status: ${status}`);
+  console.log(`GC job ${gcJobId} completed with status: ${status}`);
 }
 
 async function checkGCLog(
@@ -499,6 +479,7 @@ async function checkGCHistory(
   const statusCell = jobRow.locator('clr-dg-cell').nth(3);
   const detailsCell = jobRow.locator('clr-dg-cell').nth(4).locator('span');
 
+  // Checking GC status from GC history table
   await expect(triggerCell).toBeVisible({ timeout: 30000 });
   await expect(dryRunCell).toBeVisible({ timeout: 30000 });
   await expect(statusCell).toBeVisible({ timeout: 30000 });
@@ -508,7 +489,6 @@ async function checkGCHistory(
   await expect(dryRunCell).toHaveText(dryRun, { timeout: 30000 });
   await expect(statusCell).toHaveText(status, { timeout: 30000 });
 
-  // Details cell contains a dynamic summary; assert substring match
   if(details) {
     await expect(detailsCell).toContainText(details, { timeout: 30000 });
   }
@@ -527,6 +507,7 @@ async function prepareAccessories(
   image: string,
   tag: string
 ): Promise<AccessoryDigests> {
+  console.log('Creating image accessories')
   const harborRegistry = `${harborIp}:${harborPort}`;
   const artifact = `${harborRegistry}/${project}/${image}:${tag}`;
   dockerLogin(harborRegistry, harborUser, harborPassword);
@@ -535,13 +516,14 @@ async function prepareAccessories(
   cosignPushSbom(artifact);
   
   // Navigate to repository and open accessories
+  await goIntoProject(page, project);
   await goIntoRepo(page, project, image);
   await page.getByRole('button', {name: 'Open'}).click();
   await page.waitForTimeout(1000); //why dependant on this?
   
   /* Get SBOM digest */
 
-  // // Open action button of sbom digest
+  // Open action button of sbom digest
   console.log('Getting SBOM digest...');
   const sbomRow = page.locator('clr-dg-row clr-dg-row').filter({ hasText: 'subject.accessory' }).first();
   await expect(sbomRow).toBeVisible({ timeout: 10000 });
@@ -674,11 +656,13 @@ async function deleteAccessoryByAccessoryRow(
   page:Page,
   accessoryRowLocator: Locator
 ) {
+  // Click on action button of accessory row and press delete
   const actionBtn = accessoryRowLocator.getByRole('button', { name: 'Available Actions'});
   await expect(actionBtn).toBeVisible();
   await actionBtn.click();
   await page.getByRole('button', {name: 'Delete'}).click();
-  await page.getByRole('button', {name: 'DELETE'}).click();
+  // Confirm the delete
+  await page.getByRole('button', {name: 'DELETE', exact: true}).click();
 }
 
 /**
@@ -694,7 +678,7 @@ function cosignGenerateKeyPair(): void {
       // Ignore if files don't exist
     }
     
-    // Generate new key pair (using COSIGN_PASSWORD env var to avoid interactive prompt)
+    // Generate new key pair
     console.log('Generating Cosign key pair...');
     execCommand(`COSIGN_PASSWORD=${cosignPassword} cosign generate-key-pair`);
     console.log('Cosign key pair generated successfully');
@@ -705,8 +689,8 @@ function cosignGenerateKeyPair(): void {
 
 /**
  * Sign an artifact with Cosign
- * @param artifact - Full artifact reference (e.g., registry/project/image:tag)
  * Note: Requires prior authentication to the registry via docker login or cosign login
+ * If using localhost, docker login with port (ie localhost:443) is required
  */
 function cosignSign(artifact: string): void {
   try {
@@ -718,11 +702,7 @@ function cosignSign(artifact: string): void {
   }
 }
 
-/**
- * Verify an artifact signature with Cosign
- * @param artifact - Full artifact reference (e.g., registry/project/image:tag)
- * @param shouldBeSigned - Whether the artifact should be signed (true) or unsigned (false)
- */
+// Verify an artifact signature with Cosign
 function cosignVerify(artifact: string, shouldBeSigned: boolean): void {
   try {
     console.log(`Verifying artifact signature: ${artifact}`);
@@ -741,7 +721,7 @@ function cosignVerify(artifact: string, shouldBeSigned: boolean): void {
 }
 
 /**
- * Attach an SBOM (Software Bill of Materials) to an artifact using Cosign
+ * Attach an SBOM to an artifact using Cosign
  * @param artifact - Full artifact reference (e.g., registry/project/image:tag)
  * @param sbomPath - Path to SBOM file (default uses test SBOM from Harbor tests)
  * @param type - SBOM format type (default: spdx)
@@ -767,7 +747,6 @@ test('Project Quota Sorting', async ({ page }) => {
 
   const timestamp1 = Date.now();
   const project1 = `project${timestamp1}`;
-  console.log(project1);
   await createProject(page, project1);
 
   const smaller_repo = 'alpine';
@@ -787,7 +766,6 @@ test('Project Quota Sorting', async ({ page }) => {
 
   const timestamp2 = Date.now();
   const project2 = `project${timestamp2}`;
-  console.log(project2);
   await createProject(page, project2);
 
   await pushImageWithTag({
@@ -846,6 +824,8 @@ test('GC Untagged Images', async ({ page }) => {
   const timestamp = Date.now();
   await loginAsAdmin(page);
   const project = `project${timestamp}`;
+  const image = 'hello-world';
+  const tag = 'latest';
   
   await runGC(page, 4);
   
@@ -855,18 +835,18 @@ test('GC Untagged Images', async ({ page }) => {
     user: harborUser,
     pwd: harborPassword,
     project: project,
-    image: 'hello-world',
-    tag: 'latest',
-    tag1: 'latest'
+    image: image,
+    tag: tag,
+    tag1: tag
   });
   
   // Make hello-world untagged by deleting the 'latest' tag
   await goIntoProject(page, project);
-  await goIntoRepo(page, project, 'hello-world');
-  await goIntoArtifact(page, 'latest');
-  await shouldContainTag(page, 'latest');
-  await deleteTag(page, 'latest');
-  await shouldNotContainTag(page, 'latest');
+  await goIntoRepo(page, project, image);
+  await goIntoArtifact(page, tag);
+  await shouldContainTag(page, tag);
+  await deleteTag(page, tag);
+  await shouldNotContainTag(page, tag);
   
   // Run GC without delete untagged artifacts (should not delete hello-world)
   await switchToGarbageCollection(page);
@@ -875,7 +855,7 @@ test('GC Untagged Images', async ({ page }) => {
   
   // Verify artifact still exists
   await goIntoProject(page, project);
-  await goIntoRepo(page, project, 'hello-world');
+  await goIntoRepo(page, project, image);
   await shouldContainArtifact(page);
   
   // Run GC WITH delete untagged artifacts (should delete hello-world)
@@ -885,7 +865,7 @@ test('GC Untagged Images', async ({ page }) => {
   
   // Verify no artifacts exist
   await goIntoProject(page, project);
-  await goIntoRepo(page, project, 'hello-world');
+  await goIntoRepo(page, project, image);
   await shouldNotContainAnyArtifact(page);
 })
 
@@ -931,8 +911,6 @@ test('Project Quotas Control Under GC', async ({ page }) => {
       quotaMatches = true;
       break;
     }
-    
-    await page.waitForTimeout(5000);
   }
   
   expect(quotaMatches).toBeTruthy();
@@ -1026,12 +1004,12 @@ test('Garbage Collection Accessory', async ({ page }) => {
 
 
   await checkGCLog(page, jobId, logContaining, logExcluding);
+  
+  // Delete the Signature
   await goIntoProject(page, projectName);
   await goIntoRepo(page, projectName, imageName);
   await page.getByRole('button', {name: 'Open'}).click();
   await page.waitForTimeout(1000); 
-
-  // Delete the Signature
   await deleteAccessoryByAccessoryRow(page, signatureRow);
 
   gcWorkers = 3;
@@ -1071,12 +1049,12 @@ test('Garbage Collection Accessory', async ({ page }) => {
   
 
   await checkGCLog(page, jobId, logContaining, logExcluding);
+  
+  // Delete the SBOM
   await goIntoProject(page, projectName);
   await goIntoRepo(page, projectName, imageName);
   await page.getByRole('button', {name: 'Open'}).click();
   await page.waitForTimeout(1000); 
-
-  // Delete the SBOM
   await deleteAccessoryByAccessoryRow(page, sbomRow);
 
   gcWorkers = 4;
@@ -1123,6 +1101,7 @@ test('Garbage Collection Accessory', async ({ page }) => {
   } = await prepareAccessories(page, projectName, imageName, imageTag));
 
   // Delete image tags
+  await goIntoProject(page, projectName);
   await goIntoRepo(page, projectName, imageName);
   await goIntoArtifact(page, imageTag);
   await deleteTag(page, imageTag);
@@ -1168,6 +1147,7 @@ test('Garbage Collection Accessory', async ({ page }) => {
   
   logExcluding = [];
    */
+
   logContaining = [
     `workers: ${gcWorkers}`
   ];

--- a/src/portal/e2e/db-testcases.spec.ts
+++ b/src/portal/e2e/db-testcases.spec.ts
@@ -1,0 +1,322 @@
+import { test, expect, Page } from '@playwright/test';
+
+async function createUser(page: Page): Promise<string> {
+    await page.goto('/');
+    await page.getByRole('link', { name: 'Sign up for an account' }).click();
+
+    let timestamp = Date.now();
+    let username = "harbor-user" + timestamp;
+    await page.locator('#username').click();
+    await page.locator('#username').fill(username);
+
+    let email = username + "@example.com";
+    await page.locator('#email').click();
+    await page.locator('#email').fill(email);
+    await page.getByRole('textbox', { name: 'First and last name*' }).click();
+    await page.getByRole('textbox', { name: 'First and last name*' }).fill(username);
+    await page.getByRole('textbox', { name: 'Password*', exact: true }).click();
+    await page.getByRole('textbox', { name: 'Password*', exact: true }).fill('Harbor12345');
+    await page.getByRole('textbox', { name: 'Confirm Password*' }).click();
+    await page.getByRole('textbox', { name: 'Confirm Password*' }).fill('Harbor12345');
+    await page.getByRole('textbox', { name: 'Comments' }).click();
+    await page.getByRole('textbox', { name: 'Comments' }).fill('harbortest');
+
+    await page.getByRole('button', { name: 'SIGN UP' }).click();
+
+    return username;
+}
+
+async function checkSelfRegistration(page: Page) {
+    // Login
+    await page.goto('/');
+    await page.getByRole('textbox', { name: 'Username' }).click();
+    await page.getByRole('textbox', { name: 'Username' }).fill('admin');
+    await page.getByRole('textbox', { name: 'Password' }).click();
+    await page.getByRole('textbox', { name: 'Password' }).fill('Harbor12345');
+
+    await page.getByRole('button', { name: 'LOG IN' }).click();
+
+    await expect(page.getByRole('link', { name: 'Configuration' })).toBeVisible();
+
+    //Select Configuration
+    await page.getByRole('link', { name: 'Configuration' }).click();
+
+    //check self-registration Status if it is unchecked
+    if (!(await page.locator('clr-checkbox-wrapper label').isChecked())) {
+        await page.locator('clr-checkbox-wrapper label').check();
+        await page.getByRole('button', { name: 'SAVE' }).click();
+        await expect(page.locator('global-message')).toContainText('Configuration has been successfully saved.');
+    }
+
+    //Logout
+    await page.getByRole('button', { name: 'admin', exact: true }).click();
+    await page.getByRole('menuitem', { name: 'Log Out' }).dblclick();
+}
+
+test('Create An New User', async ({ page }) => {
+    // Checks slef registration enabled or not, if disabled it enables it.
+    await checkSelfRegistration(page);
+
+    //Creating user
+    await createUser(page);
+});
+
+test('Update User Comment', async ({ page }) => {
+    // Checks slef registration enabled or not, if disabled it enables it.
+    await checkSelfRegistration(page);
+
+    // Creating user
+    const username = await createUser(page);
+
+    //Login with user credentials
+    await page.getByRole('textbox', { name: 'Username' }).click();
+    await page.getByRole('textbox', { name: 'Username' }).fill(username);
+    await page.getByRole('textbox', { name: 'Password' }).click();
+    await page.getByRole('textbox', { name: 'Password' }).fill("Harbor12345");
+
+    await page.getByRole('button', { name: 'LOG IN' }).click();
+
+    // Updating user comment
+    await page.getByRole('button', { name: username }).click();
+    await page.getByRole('menuitem', { name: 'User Profile' }).click();
+    await page.getByRole('textbox', { name: 'Comments' }).click();
+    await page.getByRole('textbox', { name: 'Comments' }).fill('test1234');
+    await page.getByRole('button', { name: 'OK' }).click();
+});
+
+test('Update User Password', async ({ page }) => {
+    // Checks slef registration enabled or not, if disabled it enables it.
+    await checkSelfRegistration(page);
+
+    // Create user
+    const username = await createUser(page);
+
+    // Login with user credentials
+    await page.getByRole('textbox', { name: 'Username' }).click();
+    await page.getByRole('textbox', { name: 'Username' }).fill(username);
+    await page.getByRole('textbox', { name: 'Password' }).click();
+    await page.getByRole('textbox', { name: 'Password' }).fill("Harbor12345");
+
+    await page.getByRole('button', { name: 'LOG IN' }).click();
+
+    // Update Password
+    await page.getByRole('button', { name: username }).click();
+    await page.getByRole('menuitem', { name: 'Change Password' }).click();
+    await page.getByRole('textbox', { name: 'Current Password*' }).click();
+    await page.getByRole('textbox', { name: 'Current Password*' }).fill('Harbor12345');
+    await page.getByRole('textbox', { name: 'New Password*' }).click();
+    await page.getByRole('textbox', { name: 'New Password*' }).fill('Test1234');
+    await page.getByRole('textbox', { name: 'Confirm Password*' }).click();
+    await page.getByRole('textbox', { name: 'Confirm Password*' }).fill('Test1234');
+    await page.getByRole('button', { name: 'OK' }).click();
+
+    // Logout after update
+    await page.getByRole('button', { name: username }).click();
+    await page.getByRole('menuitem', { name: 'Log Out' }).click();
+
+    // Login with Updated Password
+    await page.getByRole('textbox', { name: 'Username' }).click();
+    await page.getByRole('textbox', { name: 'Username' }).fill(username);
+    await page.getByRole('textbox', { name: 'Password' }).click();
+    await page.getByRole('textbox', { name: 'Password' }).fill('Test1234');
+
+    await page.getByRole('button', { name: 'LOG IN' }).click();
+
+    // Logout
+    await page.getByRole('button', { name: username }).click();
+    await page.getByRole('menuitem', { name: 'Log Out' }).click();
+});
+
+test('Edit Self Registration', async ({ page }) => {
+    // Login
+    await page.goto('/');
+    await page.getByRole('textbox', { name: 'Username' }).click();
+    await page.getByRole('textbox', { name: 'Username' }).fill('admin');
+    await page.getByRole('textbox', { name: 'Password' }).click();
+    await page.getByRole('textbox', { name: 'Password' }).fill('Harbor12345');
+
+    await page.getByRole('button', { name: 'LOG IN' }).click();
+
+    await expect(page.getByRole('link', { name: 'Configuration' })).toBeVisible();
+
+    //Select Configuration
+    await page.getByRole('link', { name: 'Configuration' }).click();
+
+    //Uncheck self-registration Status
+    if (await page.locator('clr-checkbox-wrapper label').isChecked()) {
+        await page.locator('clr-checkbox-wrapper label').uncheck();
+        await page.getByRole('button', { name: 'SAVE' }).click();
+        await expect(page.locator('global-message')).toContainText('Configuration has been successfully saved.');
+    }
+
+    //Logout
+    await page.getByRole('button', { name: 'admin', exact: true }).click();
+    await page.getByRole('menuitem', { name: 'Log Out' }).dblclick();
+
+    // Checks whether Signup is visible or not
+    await expect(page.getByText('Sign up for an account')).not.toBeVisible();
+
+    // Login
+    await page.goto('/');
+    await page.getByRole('textbox', { name: 'Username' }).click();
+    await page.getByRole('textbox', { name: 'Username' }).fill('admin');
+    await page.getByRole('textbox', { name: 'Password' }).click();
+    await page.getByRole('textbox', { name: 'Password' }).fill('Harbor12345');
+
+    await page.getByRole('button', { name: 'LOG IN' }).click();
+
+    await expect(page.getByRole('link', { name: 'Configuration' })).toBeVisible();
+
+    //Select Configuration
+    await page.getByRole('link', { name: 'Configuration' }).click();
+
+    await expect(page.locator('clr-checkbox-wrapper label')).not.toBeChecked();
+
+    //Check self-registration Status if it is unchecked
+    if (!(await page.locator('clr-checkbox-wrapper label').isChecked())) {
+        await page.locator('clr-checkbox-wrapper label').check();
+        await page.getByRole('button', { name: 'SAVE' }).click();
+        await expect(page.locator('global-message')).toContainText('Configuration has been successfully saved.');
+    }
+
+    //Logout
+    await page.getByRole('button', { name: 'admin', exact: true }).click();
+    await page.getByRole('menuitem', { name: 'Log Out' }).dblclick();
+});
+
+test('Delete Multi User', async ({ page }) => {
+    // Checks slef registration enabled or not, if disabled it enables it.
+    await checkSelfRegistration(page);
+
+    // Create multiple users
+    const user1 = await createUser(page);
+    const user2 = await createUser(page);
+    const user3 = await createUser(page);
+    const users = [user1, user2, user3];
+
+    // Login with admin credentials
+    await page.getByRole('textbox', { name: 'Username' }).fill('admin');
+    await page.getByRole('textbox', { name: 'Password' }).fill('Harbor12345');
+    await page.getByRole('button', { name: 'LOG IN' }).click();
+
+    // Navigate to Users
+    const usersLink = page.getByRole('link', { name: 'Users' });
+    await expect(usersLink).toBeVisible(); // Wait for the link to be visible
+    await usersLink.click();
+
+    // Select Users
+    await page.locator('hbr-filter clr-icon').click();
+    const filterInput = page.getByRole('textbox', { name: 'Filter users' });
+    await expect(filterInput).toBeVisible();
+
+    for (const user of users) {
+        await page.getByRole('textbox', { name: 'Filter users' }).fill(user);
+        await page.getByRole('row', { name: 'Select Select ' +user }).locator('label').click();
+    }
+
+    // Delete Selected Users
+    // Now that all 3 users are selected, we can proceed with deletion.
+    await page.getByText('Actions').click();
+    await page.getByRole('button', { name: 'Delete' }).click();
+    await page.getByRole('button', { name: 'DELETE' }).click();
+
+    // Assert Deletion
+    await expect(page.getByText('Deleted successfully')).toBeVisible();
+
+    // Logout
+    await page.getByRole('button', { name: 'admin', exact: true }).click();
+
+    const logoutMenuItem = page.getByRole('menuitem', { name: 'Log Out' });
+    await expect(logoutMenuItem).toBeVisible(); // Wait for logout to be visible
+    await logoutMenuItem.click();
+});
+
+test('Admin Add New Users', async ({ page }) => {
+    // Checks slef registration enabled or not, if disabled it enables it.
+    await checkSelfRegistration(page);
+
+    //Login with Admin Credentials
+    await page.getByRole('textbox', { name: 'Username' }).click();
+    await page.getByRole('textbox', { name: 'Username' }).fill('admin');
+    await page.getByRole('textbox', { name: 'Password' }).click();
+    await page.getByRole('textbox', { name: 'Password' }).fill('Harbor12345');
+    await page.getByRole('button', { name: 'LOG IN' }).click();
+
+    // Assert Self registration is Enabled
+    await page.getByRole('link', { name: 'Configuration' }).click();
+    await expect(page.locator('clr-checkbox-wrapper label')).toBeChecked();
+
+    // Add users with self registration is enabled
+    await page.getByRole('link', { name: 'Users' }).click();
+    await page.getByRole('button', { name: 'New User' }).click();
+
+    let timestamp = Date.now();
+    let username = "harbor-user" + timestamp;
+    await page.locator('#username').click();
+    await page.locator('#username').fill(username);
+
+    let email = username + "@example.com";
+    await page.locator('#email').click();
+    await page.locator('#email').fill(email);
+    await page.getByRole('textbox', { name: 'First and last name*' }).click();
+    await page.getByRole('textbox', { name: 'First and last name*' }).fill(username);
+    await page.getByRole('textbox', { name: 'Password*', exact: true }).click();
+    await page.getByRole('textbox', { name: 'Password*', exact: true }).fill('Harbor12345');
+    await page.getByRole('textbox', { name: 'Confirm Password*' }).click();
+    await page.getByRole('textbox', { name: 'Confirm Password*' }).fill('Harbor12345');
+    await page.getByRole('textbox', { name: 'Comments' }).click();
+    await page.getByRole('textbox', { name: 'Comments' }).fill('harbortest');
+
+    await page.getByRole('button', { name: 'OK' }).click();
+
+    await expect(page.getByText('New user created successfully.')).toBeVisible();
+
+    // Add users with self registration is disabled
+    await page.getByRole('link', { name: 'Configuration' }).click();
+
+    // Uncheck self registration
+    await page.locator('clr-checkbox-wrapper label').uncheck();
+    await expect(page.locator('clr-checkbox-wrapper label')).not.toBeChecked();
+
+    await page.getByRole('button', { name: 'SAVE' }).click();
+    await expect(page.locator('global-message')).toContainText('Configuration has been successfully saved.');
+
+    await page.getByRole('link', { name: 'Users' }).click();
+    await page.getByRole('button', { name: 'New User' }).click();
+    timestamp = Date.now();
+    username = "harbor-user" + timestamp;
+    await page.locator('#username').click();
+    await page.locator('#username').fill(username);
+
+    email = username + "@example.com";
+    await page.locator('#email').click();
+    await page.locator('#email').fill(email);
+    await page.getByRole('textbox', { name: 'First and last name*' }).click();
+    await page.getByRole('textbox', { name: 'First and last name*' }).fill(username);
+    await page.getByRole('textbox', { name: 'Password*', exact: true }).click();
+    await page.getByRole('textbox', { name: 'Password*', exact: true }).fill('Harbor12345');
+    await page.getByRole('textbox', { name: 'Confirm Password*' }).click();
+    await page.getByRole('textbox', { name: 'Confirm Password*' }).fill('Harbor12345');
+    await page.getByRole('textbox', { name: 'Comments' }).click();
+    await page.getByRole('textbox', { name: 'Comments' }).fill('harbortest');
+
+    await page.getByRole('button', { name: 'OK' }).click();
+
+    await expect(page.getByText('New user created successfully.')).toBeVisible();
+
+    // Update self registration to default
+    await page.getByRole('link', { name: 'Configuration' }).click();
+
+    await page.locator('clr-checkbox-wrapper label').check();
+    await expect(page.locator('clr-checkbox-wrapper label')).toBeChecked();
+
+    await page.getByRole('button', { name: 'SAVE' }).click();
+    await expect(page.locator('global-message')).toContainText('Configuration has been successfully saved.');
+
+    // Logout
+    await page.getByRole('button', { name: 'admin', exact: true }).click();
+
+    const logoutMenuItem = page.getByRole('menuitem', { name: 'Log Out' });
+    await expect(logoutMenuItem).toBeVisible(); // Wait for logout to be visible
+    await logoutMenuItem.click();
+});

--- a/src/portal/e2e/db-testcases.spec.ts
+++ b/src/portal/e2e/db-testcases.spec.ts
@@ -1,5 +1,21 @@
 import { test, expect, Page } from '@playwright/test';
 
+const harborUser = process.env.HARBOR_ADMIN || 'admin';
+const harborPassword = process.env.HARBOR_PASSWORD || 'Harbor12345';
+const updatedPassword = 'Test1234';
+
+test.describe.configure({ mode: 'serial', timeout: 60 * 1000 });
+
+async function login(page: Page, username = harborUser, password = harborPassword) {
+    await expect(page.locator('.modal-backdrop')).toBeHidden();
+    const usernameInput = page.getByRole('textbox', { name: 'Username' });
+    const passwordInput = page.getByRole('textbox', { name: 'Password', exact: true });
+    await usernameInput.fill(username);
+    await passwordInput.fill(password);
+    await expect(passwordInput).toHaveValue(password);
+    await page.getByRole('button', { name: 'LOG IN' }).click();
+}
+
 async function createUser(page: Page): Promise<string> {
     await page.goto('/');
     await page.getByRole('link', { name: 'Sign up for an account' }).click();
@@ -15,13 +31,15 @@ async function createUser(page: Page): Promise<string> {
     await page.getByRole('textbox', { name: 'First and last name*' }).click();
     await page.getByRole('textbox', { name: 'First and last name*' }).fill(username);
     await page.getByRole('textbox', { name: 'Password*', exact: true }).click();
-    await page.getByRole('textbox', { name: 'Password*', exact: true }).fill('Harbor12345');
+    await page.getByRole('textbox', { name: 'Password*', exact: true }).fill(harborPassword);
     await page.getByRole('textbox', { name: 'Confirm Password*' }).click();
-    await page.getByRole('textbox', { name: 'Confirm Password*' }).fill('Harbor12345');
+    await page.getByRole('textbox', { name: 'Confirm Password*' }).fill(harborPassword);
     await page.getByRole('textbox', { name: 'Comments' }).click();
     await page.getByRole('textbox', { name: 'Comments' }).fill('harbortest');
 
     await page.getByRole('button', { name: 'SIGN UP' }).click();
+    await expect(page.locator('.modal-backdrop')).toBeHidden();
+    await expect(page.getByRole('textbox', { name: 'Username' })).toBeVisible();
 
     return username;
 }
@@ -29,12 +47,7 @@ async function createUser(page: Page): Promise<string> {
 async function checkSelfRegistration(page: Page) {
     // Login
     await page.goto('/');
-    await page.getByRole('textbox', { name: 'Username' }).click();
-    await page.getByRole('textbox', { name: 'Username' }).fill('admin');
-    await page.getByRole('textbox', { name: 'Password' }).click();
-    await page.getByRole('textbox', { name: 'Password' }).fill('Harbor12345');
-
-    await page.getByRole('button', { name: 'LOG IN' }).click();
+    await login(page);
 
     await expect(page.getByRole('link', { name: 'Configuration' })).toBeVisible();
 
@@ -49,7 +62,7 @@ async function checkSelfRegistration(page: Page) {
     }
 
     //Logout
-    await page.getByRole('button', { name: 'admin', exact: true }).click();
+    await page.getByRole('button', { name: harborUser, exact: true }).click();
     await page.getByRole('menuitem', { name: 'Log Out' }).dblclick();
 }
 
@@ -69,12 +82,7 @@ test('Update User Comment', async ({ page }) => {
     const username = await createUser(page);
 
     //Login with user credentials
-    await page.getByRole('textbox', { name: 'Username' }).click();
-    await page.getByRole('textbox', { name: 'Username' }).fill(username);
-    await page.getByRole('textbox', { name: 'Password' }).click();
-    await page.getByRole('textbox', { name: 'Password' }).fill("Harbor12345");
-
-    await page.getByRole('button', { name: 'LOG IN' }).click();
+    await login(page, username);
 
     // Updating user comment
     await page.getByRole('button', { name: username }).click();
@@ -92,22 +100,17 @@ test('Update User Password', async ({ page }) => {
     const username = await createUser(page);
 
     // Login with user credentials
-    await page.getByRole('textbox', { name: 'Username' }).click();
-    await page.getByRole('textbox', { name: 'Username' }).fill(username);
-    await page.getByRole('textbox', { name: 'Password' }).click();
-    await page.getByRole('textbox', { name: 'Password' }).fill("Harbor12345");
-
-    await page.getByRole('button', { name: 'LOG IN' }).click();
+    await login(page, username);
 
     // Update Password
     await page.getByRole('button', { name: username }).click();
     await page.getByRole('menuitem', { name: 'Change Password' }).click();
     await page.getByRole('textbox', { name: 'Current Password*' }).click();
-    await page.getByRole('textbox', { name: 'Current Password*' }).fill('Harbor12345');
+    await page.getByRole('textbox', { name: 'Current Password*' }).fill(harborPassword);
     await page.getByRole('textbox', { name: 'New Password*' }).click();
-    await page.getByRole('textbox', { name: 'New Password*' }).fill('Test1234');
+    await page.getByRole('textbox', { name: 'New Password*' }).fill(updatedPassword);
     await page.getByRole('textbox', { name: 'Confirm Password*' }).click();
-    await page.getByRole('textbox', { name: 'Confirm Password*' }).fill('Test1234');
+    await page.getByRole('textbox', { name: 'Confirm Password*' }).fill(updatedPassword);
     await page.getByRole('button', { name: 'OK' }).click();
 
     // Logout after update
@@ -115,12 +118,7 @@ test('Update User Password', async ({ page }) => {
     await page.getByRole('menuitem', { name: 'Log Out' }).click();
 
     // Login with Updated Password
-    await page.getByRole('textbox', { name: 'Username' }).click();
-    await page.getByRole('textbox', { name: 'Username' }).fill(username);
-    await page.getByRole('textbox', { name: 'Password' }).click();
-    await page.getByRole('textbox', { name: 'Password' }).fill('Test1234');
-
-    await page.getByRole('button', { name: 'LOG IN' }).click();
+    await login(page, username, updatedPassword);
 
     // Logout
     await page.getByRole('button', { name: username }).click();
@@ -130,12 +128,7 @@ test('Update User Password', async ({ page }) => {
 test('Edit Self Registration', async ({ page }) => {
     // Login
     await page.goto('/');
-    await page.getByRole('textbox', { name: 'Username' }).click();
-    await page.getByRole('textbox', { name: 'Username' }).fill('admin');
-    await page.getByRole('textbox', { name: 'Password' }).click();
-    await page.getByRole('textbox', { name: 'Password' }).fill('Harbor12345');
-
-    await page.getByRole('button', { name: 'LOG IN' }).click();
+    await login(page);
 
     await expect(page.getByRole('link', { name: 'Configuration' })).toBeVisible();
 
@@ -150,7 +143,7 @@ test('Edit Self Registration', async ({ page }) => {
     }
 
     //Logout
-    await page.getByRole('button', { name: 'admin', exact: true }).click();
+    await page.getByRole('button', { name: harborUser, exact: true }).click();
     await page.getByRole('menuitem', { name: 'Log Out' }).dblclick();
 
     // Checks whether Signup is visible or not
@@ -158,12 +151,7 @@ test('Edit Self Registration', async ({ page }) => {
 
     // Login
     await page.goto('/');
-    await page.getByRole('textbox', { name: 'Username' }).click();
-    await page.getByRole('textbox', { name: 'Username' }).fill('admin');
-    await page.getByRole('textbox', { name: 'Password' }).click();
-    await page.getByRole('textbox', { name: 'Password' }).fill('Harbor12345');
-
-    await page.getByRole('button', { name: 'LOG IN' }).click();
+    await login(page);
 
     await expect(page.getByRole('link', { name: 'Configuration' })).toBeVisible();
 
@@ -180,7 +168,7 @@ test('Edit Self Registration', async ({ page }) => {
     }
 
     //Logout
-    await page.getByRole('button', { name: 'admin', exact: true }).click();
+    await page.getByRole('button', { name: harborUser, exact: true }).click();
     await page.getByRole('menuitem', { name: 'Log Out' }).dblclick();
 });
 
@@ -195,9 +183,7 @@ test('Delete Multi User', async ({ page }) => {
     const users = [user1, user2, user3];
 
     // Login with admin credentials
-    await page.getByRole('textbox', { name: 'Username' }).fill('admin');
-    await page.getByRole('textbox', { name: 'Password' }).fill('Harbor12345');
-    await page.getByRole('button', { name: 'LOG IN' }).click();
+    await login(page);
 
     // Navigate to Users
     const usersLink = page.getByRole('link', { name: 'Users' });
@@ -210,8 +196,11 @@ test('Delete Multi User', async ({ page }) => {
     await expect(filterInput).toBeVisible();
 
     for (const user of users) {
-        await page.getByRole('textbox', { name: 'Filter users' }).fill(user);
-        await page.getByRole('row', { name: 'Select Select ' +user }).locator('label').click();
+        await filterInput.fill(user);
+        await filterInput.press('Enter');
+        const row = page.getByRole('row').filter({ hasText: user });
+        await expect(row).toBeVisible();
+        await row.locator('label').first().click();
     }
 
     // Delete Selected Users
@@ -224,7 +213,7 @@ test('Delete Multi User', async ({ page }) => {
     await expect(page.getByText('Deleted successfully')).toBeVisible();
 
     // Logout
-    await page.getByRole('button', { name: 'admin', exact: true }).click();
+    await page.getByRole('button', { name: harborUser, exact: true }).click();
 
     const logoutMenuItem = page.getByRole('menuitem', { name: 'Log Out' });
     await expect(logoutMenuItem).toBeVisible(); // Wait for logout to be visible
@@ -236,11 +225,7 @@ test('Admin Add New Users', async ({ page }) => {
     await checkSelfRegistration(page);
 
     //Login with Admin Credentials
-    await page.getByRole('textbox', { name: 'Username' }).click();
-    await page.getByRole('textbox', { name: 'Username' }).fill('admin');
-    await page.getByRole('textbox', { name: 'Password' }).click();
-    await page.getByRole('textbox', { name: 'Password' }).fill('Harbor12345');
-    await page.getByRole('button', { name: 'LOG IN' }).click();
+    await login(page);
 
     // Assert Self registration is Enabled
     await page.getByRole('link', { name: 'Configuration' }).click();
@@ -261,9 +246,9 @@ test('Admin Add New Users', async ({ page }) => {
     await page.getByRole('textbox', { name: 'First and last name*' }).click();
     await page.getByRole('textbox', { name: 'First and last name*' }).fill(username);
     await page.getByRole('textbox', { name: 'Password*', exact: true }).click();
-    await page.getByRole('textbox', { name: 'Password*', exact: true }).fill('Harbor12345');
+    await page.getByRole('textbox', { name: 'Password*', exact: true }).fill(harborPassword);
     await page.getByRole('textbox', { name: 'Confirm Password*' }).click();
-    await page.getByRole('textbox', { name: 'Confirm Password*' }).fill('Harbor12345');
+    await page.getByRole('textbox', { name: 'Confirm Password*' }).fill(harborPassword);
     await page.getByRole('textbox', { name: 'Comments' }).click();
     await page.getByRole('textbox', { name: 'Comments' }).fill('harbortest');
 
@@ -294,9 +279,9 @@ test('Admin Add New Users', async ({ page }) => {
     await page.getByRole('textbox', { name: 'First and last name*' }).click();
     await page.getByRole('textbox', { name: 'First and last name*' }).fill(username);
     await page.getByRole('textbox', { name: 'Password*', exact: true }).click();
-    await page.getByRole('textbox', { name: 'Password*', exact: true }).fill('Harbor12345');
+    await page.getByRole('textbox', { name: 'Password*', exact: true }).fill(harborPassword);
     await page.getByRole('textbox', { name: 'Confirm Password*' }).click();
-    await page.getByRole('textbox', { name: 'Confirm Password*' }).fill('Harbor12345');
+    await page.getByRole('textbox', { name: 'Confirm Password*' }).fill(harborPassword);
     await page.getByRole('textbox', { name: 'Comments' }).click();
     await page.getByRole('textbox', { name: 'Comments' }).fill('harbortest');
 
@@ -314,7 +299,7 @@ test('Admin Add New Users', async ({ page }) => {
     await expect(page.locator('global-message')).toContainText('Configuration has been successfully saved.');
 
     // Logout
-    await page.getByRole('button', { name: 'admin', exact: true }).click();
+    await page.getByRole('button', { name: harborUser, exact: true }).click();
 
     const logoutMenuItem = page.getByRole('menuitem', { name: 'Log Out' });
     await expect(logoutMenuItem).toBeVisible(); // Wait for logout to be visible

--- a/src/portal/e2e/login-logout.spec.ts
+++ b/src/portal/e2e/login-logout.spec.ts
@@ -1,0 +1,16 @@
+import { test } from '@playwright/test';
+
+test('login and logout', async ({ page }) => {
+    // login
+    await page.goto('/');
+    await page.getByRole('textbox', { name: 'Username' }).click();
+    await page.getByRole('textbox', { name: 'Username' }).fill('admin');
+    await page.getByRole('textbox', { name: 'Password' }).click();
+    await page.getByRole('textbox', { name: 'Password' }).fill('Harbor12345');
+    await page.getByRole('button', { name: 'LOG IN' }).click();
+
+    // logout
+    await page.getByRole('button', { name: 'admin', exact: true }).waitFor();
+    await page.getByRole('button', { name: 'admin', exact: true }).click();
+    await page.getByRole('menuitem', { name: 'Log Out' }).click();
+});

--- a/src/portal/e2e/login-logout.spec.ts
+++ b/src/portal/e2e/login-logout.spec.ts
@@ -1,16 +1,19 @@
 import { test } from '@playwright/test';
 
+const harborUser = process.env.HARBOR_ADMIN || 'admin';
+const harborPassword = process.env.HARBOR_PASSWORD || 'Harbor12345';
+
 test('login and logout', async ({ page }) => {
     // login
     await page.goto('/');
     await page.getByRole('textbox', { name: 'Username' }).click();
-    await page.getByRole('textbox', { name: 'Username' }).fill('admin');
+    await page.getByRole('textbox', { name: 'Username' }).fill(harborUser);
     await page.getByRole('textbox', { name: 'Password' }).click();
-    await page.getByRole('textbox', { name: 'Password' }).fill('Harbor12345');
+    await page.getByRole('textbox', { name: 'Password' }).fill(harborPassword);
     await page.getByRole('button', { name: 'LOG IN' }).click();
 
     // logout
-    await page.getByRole('button', { name: 'admin', exact: true }).waitFor();
-    await page.getByRole('button', { name: 'admin', exact: true }).click();
+    await page.getByRole('button', { name: harborUser, exact: true }).waitFor();
+    await page.getByRole('button', { name: harborUser, exact: true }).click();
     await page.getByRole('menuitem', { name: 'Log Out' }).click();
 });

--- a/src/portal/package-lock.json
+++ b/src/portal/package-lock.json
@@ -44,6 +44,7 @@
         "@angular/cli": "^16.2.16",
         "@angular/compiler-cli": "^16.2.9",
         "@cypress/schematic": "^2.5.2",
+        "@playwright/test": "^1.59.1",
         "@types/express": "^4.17.21",
         "@types/jasmine": "~4.3.1",
         "@types/node": "^16.18.108",
@@ -4005,6 +4006,22 @@
         "node": ">=14"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@schematics/angular": {
       "version": "16.2.16",
       "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-16.2.16.tgz",
@@ -7105,6 +7122,16 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/cytoscape": {
+      "version": "3.33.3",
+      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.3.tgz",
+      "integrity": "sha512-Gej7U+OKR+LZ8kvX7rb2HhCYJ0IhvEFsnkud4SB1PR+BUY/TsSO0dmOW59WEVLu51b1Rm+gQRKoz4bLYxGSZ2g==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/cytoscape-cose-bilkent": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/cytoscape-cose-bilkent/-/cytoscape-cose-bilkent-4.1.0.tgz",
@@ -7473,6 +7500,16 @@
         "d3-color": "1 - 3",
         "d3-interpolate": "1 - 3"
       },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "optional": true,
       "engines": {
         "node": ">=12"
       }
@@ -14793,6 +14830,52 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/src/portal/package.json
+++ b/src/portal/package.json
@@ -63,6 +63,7 @@
     "@angular/cli": "^16.2.16",
     "@angular/compiler-cli": "^16.2.9",
     "@cypress/schematic": "^2.5.2",
+    "@playwright/test": "^1.59.1",
     "@types/express": "^4.17.21",
     "@types/jasmine": "~4.3.1",
     "@types/node": "^16.18.108",

--- a/src/portal/playwright.config.ts
+++ b/src/portal/playwright.config.ts
@@ -1,0 +1,82 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Read environment variables from file.
+ * https://github.com/motdotla/dotenv
+ */
+// import dotenv from 'dotenv';
+// import path from 'path';
+// dotenv.config({ path: path.resolve(__dirname, '.env') });
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+export default defineConfig({
+    testDir: './e2e',
+    /* Run tests in files in parallel */
+    fullyParallel: false,
+    /* Fail the build on CI if you accidentally left test.only in the source code. */
+    forbidOnly: !!process.env.CI,
+    /* Retry on CI only */
+    retries: process.env.CI ? 2 : 0,
+    /* Opt out of parallel tests on CI. */
+    workers: process.env.CI ? 1 : undefined,
+    /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+    reporter: 'html',
+    /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+    use: {
+        headless: true,
+        video: 'retain-on-failure', // record video of the test
+        screenshot: 'only-on-failure',
+        // 👇 Ignore self-signed / invalid HTTPS certificates
+        ignoreHTTPSErrors: true,
+        baseURL: process.env.BASE_URL,
+        /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+        trace: 'on-first-retry',
+    },
+
+    /* Configure projects for major browsers */
+    projects: [
+        {
+            name: 'chromium',
+            use: { ...devices['Desktop Chrome'] },
+        },
+
+        // {
+        //   name: 'firefox',
+        //   use: { ...devices['Desktop Firefox'] },
+        // },
+
+        // {
+        //   name: 'webkit',
+        //   use: { ...devices['Desktop Safari'] },
+        // },
+
+        /* Test against mobile viewports. */
+        // {
+        //   name: 'Mobile Chrome',
+        //   use: { ...devices['Pixel 5'] },
+        // },
+        // {
+        //   name: 'Mobile Safari',
+        //   use: { ...devices['iPhone 12'] },
+        // },
+
+        /* Test against branded browsers. */
+        // {
+        //   name: 'Microsoft Edge',
+        //   use: { ...devices['Desktop Edge'], channel: 'msedge' },
+        // },
+        // {
+        //   name: 'Google Chrome',
+        //   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
+        // },
+    ],
+
+    /* Run your local dev server before starting the tests */
+    // webServer: {
+    //   command: 'npm run start',
+    //   url: 'http://localhost:3000',
+    //   reuseExistingServer: !process.env.CI,
+    // },
+});

--- a/src/portal/playwright.config.ts
+++ b/src/portal/playwright.config.ts
@@ -8,6 +8,9 @@ import { defineConfig, devices } from '@playwright/test';
 // import path from 'path';
 // dotenv.config({ path: path.resolve(__dirname, '.env') });
 
+// Use system CA certificates for HTTPS requests
+process.env.NODE_OPTIONS = '--use-system-ca';
+
 /**
  * See https://playwright.dev/docs/test-configuration.
  */

--- a/src/portal/playwright.config.ts
+++ b/src/portal/playwright.config.ts
@@ -22,7 +22,12 @@ export default defineConfig({
     /* Opt out of parallel tests on CI. */
     workers: process.env.CI ? 1 : undefined,
     /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-    reporter: 'html',
+    reporter: process.env.CI
+        ? [
+              ['html'],
+              ['json', { outputFile: 'test-results/results.json' }],
+          ]
+        : 'html',
     /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
     use: {
         headless: true,

--- a/src/portal/playwright.config.ts
+++ b/src/portal/playwright.config.ts
@@ -32,6 +32,12 @@ export default defineConfig({
           ]
         : 'html',
     /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+    /* Timeout for each test (30 minuites) */
+    timeout: 1800000,
+    expect: {
+        // Timeout for expect assertions(1 minuite)
+        timeout: 60000
+    },
     use: {
         headless: true,
         video: 'retain-on-failure', // record video of the test


### PR DESCRIPTION
# Comprehensive Summary of your change
This PR implements the migration of Common_GC.robot to Playwright.

Changes made:

- Adds Common_GC Playwright tests
- Adds setup, cleanup, navigation, image push/pull/tag helper flows needed by the suite
- Keeps tests independent and self-contained

# Issue being fixed
Fixes #22134

### Test Migration Status

- [x] Project Quota Sorting
- [x] Garbage Collection
- [x] GC Untagged Images
- [x] Project Quotas Control Under GC
- [x] Garbage Collection Accessory

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #22462
2. #22472
3. **#22707** 👈 current
<!-- stack:links:end -->