### PR TITLE
fix(ldap): use custom orm.ReadOrCreate to prevent LDAP login failure …

### DIFF
--- a/src/lib/orm/test/orm_test.go
+++ b/src/lib/orm/test/orm_test.go
@@ -41,6 +41,10 @@ func (foo *Foo) GetID() int64 {
 	return foo.ID
 }
 
+func init() {
+	RegisterModel(&Foo{})
+}
+
 func addFoo(ctx context.Context, foo Foo) (int64, error) {
 	o, err := FromContext(ctx)
 	if err != nil {
@@ -104,7 +108,6 @@ type OrmSuite struct {
 
 // SetupSuite ...
 func (suite *OrmSuite) SetupSuite() {
-	RegisterModel(&Foo{})
 	dao.PrepareTestForPostgresSQL()
 
 	o, err := FromContext(Context())

--- a/src/lib/orm/test/readorcreate_transaction_test.go
+++ b/src/lib/orm/test/readorcreate_transaction_test.go
@@ -66,11 +66,13 @@ func (suite *ReadOrCreateTransactionSuite) TestBeegoNativeCorruptsTransaction() 
 	var gotError25P02 bool
 
 	WithTransaction(func(txCtx context.Context) error {
-		o, _ := FromContext(txCtx)
+		o, err := FromContext(txCtx)
+		suite.Require().NoError(err)
 
 		// Insert a record, then try to insert duplicate (simulates race condition)
-		o.Insert(&Foo{Name: uniqueName})
-		_, err := o.Insert(&Foo{Name: uniqueName}) // duplicate key error
+		_, err = o.Insert(&Foo{Name: uniqueName})
+		suite.Require().NoError(err)
+		_, err = o.Insert(&Foo{Name: uniqueName}) // duplicate key error
 		suite.Error(err, "Should get duplicate key error")
 
 		// Try another operation - this WILL fail with 25P02

--- a/src/lib/orm/test/readorcreate_transaction_test.go
+++ b/src/lib/orm/test/readorcreate_transaction_test.go
@@ -37,7 +37,6 @@ type ReadOrCreateTransactionSuite struct {
 
 func (suite *ReadOrCreateTransactionSuite) SetupSuite() {
 	dao.PrepareTestForPostgresSQL()
-	RegisterModel(&Foo{})
 
 	o, err := FromContext(Context())
 	suite.Require().NoError(err)

--- a/src/lib/orm/test/readorcreate_transaction_test.go
+++ b/src/lib/orm/test/readorcreate_transaction_test.go
@@ -1,0 +1,129 @@
+//  Copyright Project Harbor Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/beego/beego/v2/client/orm"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/goharbor/harbor/src/common/dao"
+	. "github.com/goharbor/harbor/src/lib/orm"
+)
+
+// ReadOrCreateTransactionSuite compares beego's native ReadOrCreate with
+// the custom orm.ReadOrCreate to demonstrate why the custom version is needed.
+// This is a regression test for the LDAP login bug (SQLSTATE 25P02).
+type ReadOrCreateTransactionSuite struct {
+	suite.Suite
+}
+
+func (suite *ReadOrCreateTransactionSuite) SetupSuite() {
+	dao.PrepareTestForPostgresSQL()
+	RegisterModel(&Foo{})
+
+	o, err := FromContext(Context())
+	suite.Require().NoError(err)
+
+	_, err = o.Raw(`CREATE TABLE IF NOT EXISTS foo (
+		id SERIAL PRIMARY KEY NOT NULL,
+		name VARCHAR(30),
+		UNIQUE (name)
+	)`).Exec()
+	suite.Require().NoError(err)
+}
+
+func (suite *ReadOrCreateTransactionSuite) TearDownSuite() {
+	o, _ := FromContext(Context())
+	o.Raw(`DROP TABLE IF EXISTS foo`).Exec()
+}
+
+// TestBeegoNativeCorruptsTransaction demonstrates that beego's native method
+// corrupts the transaction when any database error occurs.
+// This is the ROOT CAUSE of the LDAP login bug.
+//
+// EXPECTED: This test PASSES by proving the transaction IS corrupted (25P02).
+func (suite *ReadOrCreateTransactionSuite) TestBeegoNativeCorruptsTransaction() {
+	ctx := NewContext(context.TODO(), orm.NewOrm())
+	uniqueName := fmt.Sprintf("beego%d", time.Now().UnixNano())
+	var gotError25P02 bool
+
+	WithTransaction(func(txCtx context.Context) error {
+		o, _ := FromContext(txCtx)
+
+		// Insert a record, then try to insert duplicate (simulates race condition)
+		o.Insert(&Foo{Name: uniqueName})
+		_, err := o.Insert(&Foo{Name: uniqueName}) // duplicate key error
+		suite.Error(err, "Should get duplicate key error")
+
+		// Try another operation - this WILL fail with 25P02
+		_, err = o.Insert(&Foo{Name: fmt.Sprintf("next%d", time.Now().UnixNano())})
+		if err != nil && strings.Contains(err.Error(), "25P02") {
+			gotError25P02 = true
+		}
+		return err
+	})(ctx)
+
+	suite.True(gotError25P02, "Beego's native method SHOULD corrupt the transaction (25P02)")
+}
+
+// TestCustomReadOrCreateDoesNotCorruptTransaction demonstrates that the custom
+// orm.ReadOrCreate handles errors gracefully without corrupting the transaction.
+// This is the FIX for the LDAP login bug.
+//
+// EXPECTED: This test PASSES by proving the transaction is NOT corrupted.
+func (suite *ReadOrCreateTransactionSuite) TestCustomReadOrCreateDoesNotCorruptTransaction() {
+	ctx := NewContext(context.TODO(), orm.NewOrm())
+	recordName := fmt.Sprintf("custom%d", time.Now().UnixNano())
+
+	// Pre-insert a record (simulates concurrent request that won the race)
+	_, err := orm.NewOrm().Insert(&Foo{Name: recordName})
+	suite.Require().NoError(err)
+
+	var transactionHealthy = true
+	err = WithTransaction(func(txCtx context.Context) error {
+		// Custom ReadOrCreate finds existing record (no error, no corruption)
+		foo := &Foo{Name: recordName}
+		created, _, err := ReadOrCreate(txCtx, foo, "Name")
+		if err != nil {
+			return err
+		}
+		suite.False(created, "Should find existing record")
+
+		// Subsequent operations MUST still work
+		foo2 := &Foo{Name: fmt.Sprintf("new%d", time.Now().UnixNano())}
+		created2, _, err := ReadOrCreate(txCtx, foo2, "Name")
+		if err != nil {
+			if strings.Contains(err.Error(), "25P02") {
+				transactionHealthy = false
+			}
+			return err
+		}
+		suite.True(created2, "Should create new record")
+		return nil
+	})(ctx)
+
+	suite.NoError(err)
+	suite.True(transactionHealthy, "Custom ReadOrCreate should NOT corrupt the transaction")
+}
+
+func TestReadOrCreateTransactionSuite(t *testing.T) {
+	suite.Run(t, new(ReadOrCreateTransactionSuite))
+}

--- a/src/lib/orm/test/readorcreate_transaction_test.go
+++ b/src/lib/orm/test/readorcreate_transaction_test.go
@@ -1,0 +1,185 @@
+//  Copyright Project Harbor Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/beego/beego/v2/client/orm"
+	"github.com/jackc/pgx/v5/pgconn"
+
+	. "github.com/goharbor/harbor/src/lib/orm"
+)
+
+const postgresTransactionAbortedCode = "25P02"
+
+// TestDuplicateKeyErrorAbortsTransactionWithoutSavepoint demonstrates that an
+// unisolated duplicate-key error aborts a PostgreSQL transaction.
+//
+// EXPECTED: This test passes by proving the transaction is aborted (25P02).
+func (suite *OrmSuite) TestDuplicateKeyErrorAbortsTransactionWithoutSavepoint() {
+	ctx := NewContext(context.TODO(), orm.NewOrm())
+	uniqueName := fmt.Sprintf("beego%d", time.Now().UnixNano())
+	var gotError25P02 bool
+
+	WithTransaction(func(txCtx context.Context) error {
+		o, err := FromContext(txCtx)
+		suite.Require().NoError(err)
+
+		// Insert a record, then try to insert duplicate (simulates race condition)
+		_, err = o.Insert(&Foo{Name: uniqueName})
+		suite.Require().NoError(err)
+		_, err = o.Insert(&Foo{Name: uniqueName}) // duplicate key error
+		suite.Error(err, "Should get duplicate key error")
+
+		// Try another operation - this WILL fail with 25P02
+		_, err = o.Insert(&Foo{Name: fmt.Sprintf("next%d", time.Now().UnixNano())})
+		if isPostgresErrorCode(err, postgresTransactionAbortedCode) {
+			gotError25P02 = true
+		}
+		return err
+	})(ctx)
+
+	suite.True(gotError25P02, "duplicate-key error should abort the transaction (25P02) when not isolated")
+}
+
+// TestCustomReadOrCreateDoesNotAbortTransactionOnDuplicateKey demonstrates that
+// the custom orm.ReadOrCreate isolates duplicate-key errors and retries the read.
+//
+// EXPECTED: This test PASSES by proving the transaction is NOT corrupted.
+func (suite *OrmSuite) TestCustomReadOrCreateDoesNotAbortTransactionOnDuplicateKey() {
+	recordName := fmt.Sprintf("custom%d", time.Now().UnixNano())
+	releaseFirstTransaction := make(chan struct{})
+	firstReady := make(chan error, 1)
+	firstDone := make(chan error, 1)
+	secondPID := make(chan backendPIDResult, 1)
+	secondDone := make(chan error, 1)
+	released := false
+	defer func() {
+		if !released {
+			close(releaseFirstTransaction)
+		}
+	}()
+
+	go func() {
+		ctx := NewContext(context.TODO(), orm.NewOrm())
+		firstDone <- WithTransaction(func(txCtx context.Context) error {
+			foo := &Foo{Name: recordName}
+			created, _, err := ReadOrCreate(txCtx, foo, "Name")
+			if err != nil {
+				firstReady <- fmt.Errorf("first ReadOrCreate: %w", err)
+				return err
+			}
+			if !created {
+				firstReady <- fmt.Errorf("first ReadOrCreate should create %q", recordName)
+				return nil
+			}
+
+			firstReady <- nil
+			<-releaseFirstTransaction
+			return nil
+		})(ctx)
+	}()
+
+	suite.Require().NoError(<-firstReady)
+
+	go func() {
+		ctx := NewContext(context.TODO(), orm.NewOrm())
+		secondDone <- WithTransaction(func(txCtx context.Context) error {
+			pid, err := postgresBackendPID(txCtx)
+			if err != nil {
+				secondPID <- backendPIDResult{err: err}
+				return err
+			}
+			secondPID <- backendPIDResult{pid: pid}
+
+			foo := &Foo{Name: recordName}
+			created, _, err := ReadOrCreate(txCtx, foo, "Name")
+			if err != nil {
+				return fmt.Errorf("racing ReadOrCreate: %w", err)
+			}
+			if created {
+				return fmt.Errorf("racing ReadOrCreate should find %q after duplicate-key retry", recordName)
+			}
+
+			foo2 := &Foo{Name: fmt.Sprintf("new%d", time.Now().UnixNano())}
+			created, _, err = ReadOrCreate(txCtx, foo2, "Name")
+			if err != nil {
+				if isPostgresErrorCode(err, postgresTransactionAbortedCode) {
+					return fmt.Errorf("transaction was aborted after duplicate-key retry: %w", err)
+				}
+				return fmt.Errorf("subsequent ReadOrCreate: %w", err)
+			}
+			if !created {
+				return fmt.Errorf("subsequent ReadOrCreate should create %q", foo2.Name)
+			}
+
+			return nil
+		})(ctx)
+	}()
+
+	pidResult := <-secondPID
+	suite.Require().NoError(pidResult.err)
+	suite.Require().Eventually(func() bool {
+		waiting, err := postgresBackendWaitingOnLock(pidResult.pid)
+		return err == nil && waiting
+	}, 5*time.Second, 50*time.Millisecond, "second transaction should block on the first transaction's unique-key insert")
+
+	close(releaseFirstTransaction)
+	released = true
+	suite.Require().NoError(<-firstDone)
+	suite.NoError(<-secondDone)
+}
+
+type backendPIDResult struct {
+	pid int
+	err error
+}
+
+func postgresBackendPID(ctx context.Context) (int, error) {
+	o, err := FromContext(ctx)
+	if err != nil {
+		return 0, err
+	}
+
+	var pid int
+	if err := o.Raw("SELECT pg_backend_pid()").QueryRow(&pid); err != nil {
+		return 0, err
+	}
+	return pid, nil
+}
+
+func postgresBackendWaitingOnLock(pid int) (bool, error) {
+	o, err := FromContext(Context())
+	if err != nil {
+		return false, err
+	}
+
+	var waiting bool
+	err = o.Raw(`SELECT EXISTS (
+		SELECT 1
+		FROM pg_stat_activity
+		WHERE pid = ? AND wait_event_type = 'Lock'
+	)`, pid).QueryRow(&waiting)
+	return waiting, err
+}
+
+func isPostgresErrorCode(err error, code string) bool {
+	var pgErr *pgconn.PgError
+	return errors.As(err, &pgErr) && pgErr.Code == code
+}

--- a/src/pkg/usergroup/dao/dao.go
+++ b/src/pkg/usergroup/dao/dao.go
@@ -147,13 +147,11 @@ func (d *dao) UpdateName(ctx context.Context, id int, groupName string) error {
 	return err
 }
 
-// ReadOrCreate read or create user group
+// ReadOrCreate read or create user group.
+// Uses the custom orm.ReadOrCreate which handles errors gracefully
+// within transactions, preventing transaction corruption during LDAP group onboarding.
 func (d *dao) ReadOrCreate(ctx context.Context, g *model.UserGroup, keyAttribute string, combinedKeyAttributes ...string) (bool, int64, error) {
-	o, err := orm.FromContext(ctx)
-	if err != nil {
-		return false, 0, err
-	}
-	return o.ReadOrCreate(g, keyAttribute, combinedKeyAttributes...)
+	return orm.ReadOrCreate(ctx, g, keyAttribute, combinedKeyAttributes...)
 }
 
 func (d *dao) Count(ctx context.Context, query *q.Query) (int64, error) {

--- a/src/pkg/usergroup/dao/dao_test.go
+++ b/src/pkg/usergroup/dao/dao_test.go
@@ -15,10 +15,13 @@
 package dao
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
 
+	"github.com/goharbor/harbor/src/lib/orm"
+	"github.com/goharbor/harbor/src/lib/q"
 	"github.com/goharbor/harbor/src/pkg/usergroup/model"
 	htesting "github.com/goharbor/harbor/src/testing"
 )
@@ -94,6 +97,44 @@ func (s *DaoTestSuite) TestSearchByName() {
 	s.Equal(10, len(results2))
 	// the first one should be "group"
 	s.Equal("group", results2[0].GroupName)
+}
+
+// TestReadOrCreateKeepsTransactionUsable is the regression test for #22716.
+// Onboarding an LDAP group reads by ldap_group_dn, but user_group is unique on
+// group_name, so a group already onboarded under a different DN makes the
+// insert fail with a duplicate key. That error must stay contained: the caller
+// keeps a usable transaction instead of a PostgreSQL 25P02 on every following
+// statement.
+func (s *DaoTestSuite) TestReadOrCreateKeepsTransactionUsable() {
+	ctx := s.Context()
+
+	_, err := s.dao.Add(ctx, model.UserGroup{
+		GroupName:   "harbor_qa",
+		GroupType:   1,
+		LdapGroupDN: "cn=harbor_qa,ou=groups,dc=example,dc=com",
+	})
+	s.Require().NoError(err)
+
+	err = orm.WithTransaction(func(txCtx context.Context) error {
+		_, _, err := s.dao.ReadOrCreate(txCtx, &model.UserGroup{
+			GroupName:   "harbor_qa",
+			GroupType:   1,
+			LdapGroupDN: "cn=harbor_qa,ou=other,dc=example,dc=com",
+		}, "LdapGroupDN", "GroupType")
+		s.Require().Error(err)
+
+		_, err = s.dao.Add(txCtx, model.UserGroup{
+			GroupName:   "harbor_ops",
+			GroupType:   1,
+			LdapGroupDN: "cn=harbor_ops,ou=groups,dc=example,dc=com",
+		})
+		return err
+	})(ctx)
+	s.Require().NoError(err)
+
+	ugs, err := s.dao.Query(ctx, q.New(q.KeyWords{"GroupName": "harbor_ops"}))
+	s.Require().NoError(err)
+	s.Len(ugs, 1)
 }
 
 func TestDaoTestSuite(t *testing.T) {

--- a/src/pkg/usergroup/model/model.go
+++ b/src/pkg/usergroup/model/model.go
@@ -30,6 +30,11 @@ func (u *UserGroup) TableName() string {
 	return UserGroupTable
 }
 
+// GetID returns the ID of the user group
+func (u *UserGroup) GetID() int64 {
+	return int64(u.ID)
+}
+
 // UserGroupsFromName ...
 func UserGroupsFromName(groupNames []string, groupType int) []UserGroup {
 	groups := make([]UserGroup, 0)


### PR DESCRIPTION
## Summary

LDAP logins fail with `SQLSTATE 25P02` as soon as one of the user's groups cannot be inserted during onboarding. The usergroup DAO calls beego's native `ReadOrCreate`, which returns the duplicate key error but leaves the request transaction aborted. Switching to the savepoint-aware `orm.ReadOrCreate` that Harbor already ships in `src/lib/orm` fixes it.

Fixes #22716

## Symptom

A user authenticates successfully against LDAP and still gets a login error. The core log shows the onboarding warning followed by the login failure, both with the same PostgreSQL error:

```
[WARNING] failed to onboard user group {...}, error ERROR: current transaction is aborted, commands ignored until end of transaction block (SQLSTATE 25P02)
[ERROR] [/core/controllers/base.go:101]: Error occurred in UserLogin: ERROR: current transaction is aborted, commands ignored until end of transaction block (SQLSTATE 25P02)
```

Reported against 2.14; the code path is unchanged on `main`. There is no workaround short of deleting or renaming the conflicting group.

## Why it breaks

Every core request runs inside a single database transaction (`server/middleware/transaction`). In PostgreSQL, one failed statement aborts that transaction: every statement issued afterwards is rejected with `25P02` until the transaction is rolled back.

During LDAP login, `usergroup.Manager.Onboard` first checks for a name clash by `group_name` + `group_type`, then calls the DAO's `ReadOrCreate` keyed on `ldap_group_dn` + `group_type`. But `user_group` is unique on `group_name` alone (`unique_group_name`, 1.8.2 schema), so both lookups can miss while the insert still collides:

- a group with the same name already exists under another group type, for example an OIDC or HTTP-auth group. The name pre-check filters by type and does not see it, the insert hits `unique_group_name`. This one is deterministic and reproduces on every login of every member of that group.
- two first logins of members of the same LDAP group race: both miss the read and one loses the insert.

`pkg/usergroup/dao.ReadOrCreate` handed this to beego's `Ormer.ReadOrCreate`, which is `Read`, then `Insert` on `ErrNoRows`, with the insert error returned as is. The duplicate key itself would be harmless: `PopulateUserGroups` logs it and continues with the next group. But the transaction is already aborted by then, so the next group, the user lookup and everything else in the request fail with `25P02`, and the login is rejected even though LDAP said yes.

This has been the case since the usergroup package was refactored onto the DAO model in 2021 (ac5e90859). Harbor gained a transaction-safe `orm.ReadOrCreate` in `src/lib/orm` shortly before that (#14176) for exactly this problem in the scan report DAO, but the usergroup DAO never moved to it.

## Fix

`pkg/usergroup/dao.ReadOrCreate` now delegates to `orm.ReadOrCreate`, and `model.UserGroup` gets the `GetID()` accessor that helper requires.

`orm.ReadOrCreate` performs the insert through `WithTransaction`. When the caller already holds a transaction, `WithTransaction` opens a `SAVEPOINT` instead of a new transaction, so a duplicate key rolls back only that savepoint, the helper re-reads by the same key, and the caller's transaction stays usable. A group that lost the race resolves to the row the winner created; a group whose name is taken by another type is skipped with the existing `failed to onboard user group` warning. Either way the login completes.

Verified against `main` with a throwaway manager test (OIDC group `X`, then `Onboard` of LDAP group `X` inside `WithTransaction`): before the change `Onboard` returns `23505`, the next statement returns `25P02` and the commit rolls back; after the change the transaction commits.

## Tests

- `pkg/usergroup/dao`: `TestReadOrCreateKeepsTransactionUsable` reproduces the report against the real `user_group` table (same name, different DN, inside a transaction) and asserts the transaction can still insert and commit afterwards. It fails against the previous DAO with `25P02` and passes with this change.
- `lib/orm/test`, on `OrmSuite`:
  - `TestDuplicateKeyErrorAbortsTransactionWithoutSavepoint`: an unisolated duplicate key aborts the transaction; the next statement returns `25P02`, checked through `pgconn.PgError`.
  - `TestCustomReadOrCreateDoesNotAbortTransactionOnDuplicateKey`: two transactions race on the same key. The first holds its uncommitted insert, the second blocks on the unique index (observed via `pg_stat_activity`), then gets the duplicate key once the first commits. `orm.ReadOrCreate` rolls back to its savepoint, re-reads the winner's row, and the second transaction can still insert and commit.
  - `Foo` is registered from `init()` so the suite no longer depends on setup order.

## Backport

Applies to every maintained release branch (2.12 to 2.15); the DAO line is identical there.
