### PR TITLE
fix: typos in comments

### DIFF
--- a/src/controller/p2p/preheat/enforcer.go
+++ b/src/controller/p2p/preheat/enforcer.go
@@ -179,7 +179,7 @@ func NewEnforcer() Enforcer {
 
 // EnforcePolicy enforces preheating action by the given policy
 func (de *defaultEnforcer) EnforcePolicy(ctx context.Context, policyID int64) (int64, error) {
-	// Get the the given policy data
+	// Get the given policy data
 	pl, err := de.policyMgr.Get(ctx, policyID)
 	if err != nil {
 		return -1, enforceError(err)

--- a/src/lib/orm/error.go
+++ b/src/lib/orm/error.go
@@ -47,7 +47,7 @@ func WrapConflictError(err error, format string, args ...any) error {
 	return err
 }
 
-// AsNotFoundError checks whether the err is orm.ErrNoRows. If it it, wrap it
+// AsNotFoundError checks whether the err is orm.ErrNoRows. If it is, wrap it
 // as a src/internal/error.Error with not found error code, else return nil
 func AsNotFoundError(err error, messageFormat string, args ...any) *errors.Error {
 	if errors.Is(err, orm.ErrNoRows) {
@@ -72,7 +72,7 @@ func AsConflictError(err error, messageFormat string, args ...any) *errors.Error
 	return nil
 }
 
-// AsForeignKeyError checks whether the err is violating foreign key constraint error. If it it, wrap it
+// AsForeignKeyError checks whether the err is violating foreign key constraint error. If it is, wrap it
 // as a src/internal/error.Error with violating foreign key constraint error code, else return nil
 func AsForeignKeyError(err error, messageFormat string, args ...any) *errors.Error {
 	if isViolatingForeignKeyConstraintError(err) {

--- a/src/pkg/scan/handler.go
+++ b/src/pkg/scan/handler.go
@@ -62,7 +62,7 @@ type ReportHandler interface {
 	Update(ctx context.Context, uuid string, report string) error
 	// MakePlaceHolder make the report place holder, if exist, delete it and create a new one
 	MakePlaceHolder(ctx context.Context, art *artifact.Artifact, r *scanner.Registration) (rps []*scan.Report, err error)
-	// GetPlaceHolder get the the report place holder
+	// GetPlaceHolder get the report place holder
 	GetPlaceHolder(ctx context.Context, artRepo string, artDigest string, scannerUUID string, mimeType string) (rp *scan.Report, err error)
 	// GetSummary get the summary of the report
 	GetSummary(ctx context.Context, ar *artifact.Artifact, mimeTypes []string) (map[string]any, error)


### PR DESCRIPTION
Fix typos: `the the` → `the`, `it it` → `it is`