### PR TITLE
Bump up trivy and trivy-adapter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,8 +111,8 @@ PREPARE_VERSION_NAME=versions
 
 #versions
 REGISTRYVERSION=v2.8.3-patch-redis
-TRIVYVERSION=v0.65.0
-TRIVYADAPTERVERSION=v0.34.0-rc.1
+TRIVYVERSION=v0.68.2
+TRIVYADAPTERVERSION=v0.34.2
 NODEBUILDIMAGE=node:16.18.0
 
 # version of registry for pulling the source code


### PR DESCRIPTION
We may use trivy v0.68.2 and trivy-adapter v0.34.2 for Harbor v2.15.0 if trivy v0.69.0 is not ready 
by the time of the RC of Harbor.

Please indicate you've done the following:
- [X] Well Written Title and Summary of the PR
- [X] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [X] Accepted the DCO. Commits without the DCO will delay acceptance.
- [X] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
