### PR TITLE
ci: migrate build workflows to ubuntu-latest runners

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -11,8 +11,7 @@ jobs:
   BUILD_PACKAGE:
     env:
         BUILD_PACKAGE: true
-    runs-on:
-      - oracle-vm-24cpu-96gb-x86-64
+    runs-on: ubuntu-latest
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v5.1.1
@@ -86,7 +85,7 @@ jobs:
           else
             build_base_params=" BUILD_BASE=true PULL_BASE_FROM_DOCKERHUB=true PUSHBASEIMAGE=true REGISTRYUSER=\"${{ secrets.DOCKER_HUB_USERNAME }}\" REGISTRYPASSWORD=\"${{ secrets.DOCKER_HUB_PASSWORD }}\""
           fi
-        
+
           sudo make package_offline GOBUILDTAGS="include_oss include_gcs" BASEIMAGETAG=${Harbor_Build_Base_Tag} VERSIONTAG=${Harbor_Assets_Version} PKGVERSIONTAG=${Harbor_Package_Version} TRIVYFLAG=true EXPORTERFLAG=true HTTPPROXY= ${build_base_params}
           sudo make package_online GOBUILDTAGS="include_oss include_gcs" BASEIMAGETAG=${Harbor_Build_Base_Tag} VERSIONTAG=${Harbor_Assets_Version} PKGVERSIONTAG=${Harbor_Package_Version} TRIVYFLAG=true EXPORTERFLAG=true HTTPPROXY= ${build_base_params}
           harbor_offline_build_bundle=$(basename harbor-offline-installer-*.tgz)
@@ -99,9 +98,9 @@ jobs:
           cp ${harbor_online_build_bundle}                  harbor-online-installer-latest.tgz
           uploader ${harbor_offline_build_bundle}           $harbor_target_bucket
           uploader ${harbor_online_build_bundle}            $harbor_target_bucket
-          uploader harbor-offline-installer-latest.tgz      $harbor_target_bucket  
-          uploader harbor-online-installer-latest.tgz       $harbor_target_bucket 
+          uploader harbor-offline-installer-latest.tgz      $harbor_target_bucket
+          uploader harbor-online-installer-latest.tgz       $harbor_target_bucket
           echo "BUILD_BUNDLE=$harbor_offline_build_bundle" >> $GITHUB_ENV
           echo "harbor_target_bucket=$harbor_target_bucket" >> $GITHUB_ENV
-      
+
           publishImage $target_branch $Harbor_Assets_Version "${{ secrets.DOCKER_HUB_USERNAME }}" "${{ secrets.DOCKER_HUB_PASSWORD }}"

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   release:
-    runs-on: oracle-vm-24cpu-96gb-x86-64
+    runs-on: ubuntu-latest
     permissions:
       contents: write   # Required for creating GitHub releases and uploading assets
       id-token: write  # Required for Cosign keyless signing
@@ -42,7 +42,7 @@ jobs:
           src_online_package=harbor-online-installer-${{ env.BASE_TAG }}-${{ env.BUILD_NO }}.tgz
           dst_offline_package=harbor-offline-installer-${{ env.CUR_TAG }}.tgz
           dst_online_package=harbor-online-installer-${{ env.CUR_TAG }}.tgz
-          
+
           aws s3 cp s3://${{ secrets.HARBOR_RELEASE_BUILD }}/${{ env.BRANCH }}/${src_offline_package} s3://${{ secrets.HARBOR_RELEASE_BUILD }}/${{ env.BRANCH }}/${dst_offline_package}
           aws s3 cp s3://${{ secrets.HARBOR_RELEASE_BUILD }}/${{ env.BRANCH }}/${src_online_package} s3://${{ secrets.HARBOR_RELEASE_BUILD }}/${{ env.BRANCH }}/${dst_online_package}
 
@@ -58,15 +58,15 @@ jobs:
           cosign sign-blob --yes \
             --bundle=./assets/harbor-offline-installer-${{ env.CUR_TAG }}.tgz.sigstore.json \
             ${{ env.OFFLINE_PACKAGE_PATH }}
-          
+
           if [ "${{ env.PRERELEASE }}" = "false" ]; then
             cosign sign-blob --yes \
               --bundle=./assets/harbor-online-installer-${{ env.CUR_TAG }}.tgz.sigstore.json \
               ${{ env.ONLINE_PACKAGE_PATH }}
           fi
-          
+
           echo "OFFLINE_SIGSTORE_PATH=./assets/harbor-offline-installer-${{ env.CUR_TAG }}.tgz.sigstore.json" >> $GITHUB_ENV
-          
+
           if [ "${{ env.PRERELEASE }}" = "false" ]; then
             echo "ONLINE_SIGSTORE_PATH=./assets/harbor-online-installer-${{ env.CUR_TAG }}.tgz.sigstore.json" >> $GITHUB_ENV
           fi


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to use the `ubuntu-latest` runner instead of a self-hosted Oracle VM runner. This change should improve compatibility and reliability by using GitHub-hosted runners.

**CI/CD Infrastructure Updates:**

* Updated the `BUILD_PACKAGE` job in `.github/workflows/build-package.yml` to use `runs-on: ubuntu-latest` instead of `oracle-vm-24cpu-96gb-x86-64`.
* Updated the `release` job in `.github/workflows/publish_release.yml` to use `runs-on: ubuntu-latest` instead of `oracle-vm-24cpu-96gb-x86-64`.Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes https://github.com/goharbor/harbor/issues/22749

Please indicate you've done the following:
- [ ] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [ ] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
