### PR TITLE
ci: fix the publishImage script with new docker version

### DIFF
--- a/tests/ci/build_util.sh
+++ b/tests/ci/build_util.sh
@@ -10,7 +10,7 @@ function s3_to_https() {
     local bucket="${BASH_REMATCH[1]}"
     local path="${BASH_REMATCH[2]}"
     # current s3 bucket is create in this region
-    local region="us-west-1"  
+    local region="us-west-1"
     echo "https://${bucket}.s3.${region}.amazonaws.com/${path}"
   else
     echo "Invalid S3 URL: $s3_url" >&2
@@ -39,7 +39,8 @@ function publishImage {
     # rename the images with tag "dev" and push to Docker Hub
     docker images
     docker login -u $3 -p $4
-    docker images | grep goharbor | grep -v "\-base" | sed -n "s|\(goharbor/[-._a-z0-9]*\)\s*\(.*$2\).*|docker tag \1:\2 \1:$image_tag;docker push \1:$image_tag|p" | bash
+    # format the output to be compatible with both old and new Docker versions.
+    docker images --format "table {{.Repository}}\t{{.Tag}}\t{{.ID}}\t{{.CreatedAt}}\t{{.Size}}"| grep goharbor | grep -v "\-base" | sed -n "s|\(goharbor/[-._a-z0-9]*\)\s*\(.*$2\).*|docker tag \1:\2 \1:$image_tag;docker push \1:$image_tag|p" | bash
     echo "Images are published successfully"
     docker images
 }


### PR DESCRIPTION
This pull request updates the `publishImage` function in `build_util.sh` to improve compatibility with different Docker versions when listing images before tagging and pushing them. The main change is updating the `docker images` command to use a consistent output format.

**Improvements to Docker image publishing:**

* Updated the `docker images` command to use the `--format` option, ensuring compatibility with both old and new Docker versions when filtering and processing images for tagging and pushing.Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [ ] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [ ] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
