### PR TITLE
feat: Add support to sort artifacts based on tags

### DIFF
--- a/src/portal/package-lock.json
+++ b/src/portal/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "harbor",
-  "version": "2.13.0",
+  "version": "2.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "harbor",
-      "version": "2.13.0",
+      "version": "2.15.0",
       "hasInstallScript": true,
       "dependencies": {
         "@angular/animations": "^16.2.12",
@@ -24,6 +24,7 @@
         "@clr/ui": "15.4.0",
         "@ngx-translate/core": "15.0.0",
         "@ngx-translate/http-loader": "8.0.0",
+        "@types/semver": "^7.7.1",
         "cron-validator": "^1.3.1",
         "echarts": "^5.5.1",
         "js-yaml": "^4.1.0",
@@ -31,6 +32,7 @@
         "ngx-cookie": "^6.0.1",
         "ngx-markdown": "16.0.0",
         "rxjs": "^7.4.0",
+        "semver": "^7.7.3",
         "tslib": "^2.7.0",
         "zone.js": "^0.13.3"
       },
@@ -223,11 +225,47 @@
         }
       }
     },
+    "node_modules/@angular-devkit/build-angular/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@angular-devkit/build-angular/node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@angular-devkit/build-angular/node_modules/tslib": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
       "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
       "dev": true
+    },
+    "node_modules/@angular-devkit/build-angular/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/@angular-devkit/build-webpack": {
       "version": "0.1602.16",
@@ -395,6 +433,7 @@
       "version": "16.2.12",
       "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-16.2.12.tgz",
       "integrity": "sha512-MD0ElviEfAJY8qMOd6/jjSSvtqER2RDAi0lxe6EtUacC1DHCYkaPrKW4vLqY+tmZBg1yf+6n+uS77pXcHHcA3w==",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -427,6 +466,7 @@
       "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-16.2.16.tgz",
       "integrity": "sha512-aqfNYZ45ndrf36i+7AhQ9R8BCm025j7TtYaUmvvjT4LwiUg6f6KtlZPB/ivBlXmd1g9oXqW4advL0AIi8A/Ozg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@angular-devkit/architect": "0.1602.16",
         "@angular-devkit/core": "16.2.16",
@@ -456,10 +496,47 @@
         "yarn": ">= 1.13.0"
       }
     },
+    "node_modules/@angular/cli/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@angular/cli/node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@angular/cli/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/@angular/common": {
       "version": "16.2.12",
       "resolved": "https://registry.npmjs.org/@angular/common/-/common-16.2.12.tgz",
       "integrity": "sha512-B+WY/cT2VgEaz9HfJitBmgdk4I333XG/ybC98CMC4Wz8E49T8yzivmmxXB3OD6qvjcOB6ftuicl6WBqLbZNg2w==",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -475,6 +552,7 @@
       "version": "16.2.12",
       "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-16.2.12.tgz",
       "integrity": "sha512-6SMXUgSVekGM7R6l1Z9rCtUGtlg58GFmgbpMCsGf+VXxP468Njw8rjT2YZkf5aEPxEuRpSHhDYjqz7n14cwCXQ==",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -494,6 +572,7 @@
       "version": "16.2.12",
       "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-16.2.12.tgz",
       "integrity": "sha512-pWSrr152562ujh6lsFZR8NfNc5Ljj+zSTQO44DsuB0tZjwEpnRcjJEgzuhGXr+CoiBf+jTSPZKemtSktDk5aaA==",
+      "peer": true,
       "dependencies": {
         "@babel/core": "7.23.2",
         "@jridgewell/sourcemap-codec": "^1.4.14",
@@ -590,6 +669,7 @@
       "version": "16.2.12",
       "resolved": "https://registry.npmjs.org/@angular/core/-/core-16.2.12.tgz",
       "integrity": "sha512-GLLlDeke/NjroaLYOks0uyzFVo6HyLl7VOm0K1QpLXnYvW63W9Ql/T3yguRZa7tRkOAeFZ3jw+1wnBD4O8MoUA==",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -728,6 +808,7 @@
       "version": "16.2.12",
       "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-16.2.12.tgz",
       "integrity": "sha512-NnH7ju1iirmVEsUq432DTm0nZBGQsBrU40M3ZeVHMQ2subnGiyUs3QyzDz8+VWLL/T5xTxWLt9BkDn65vgzlIQ==",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -810,6 +891,7 @@
       "version": "7.22.9",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.9.tgz",
       "integrity": "sha512-G2EgeufBcYw27U4hhoIwFcgc1XU7TlXJ3mv04oOv1WCuo900U/anZSPzEqNjwdjgffkk2Gs0AN0dW1CKVLcG7w==",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.22.5",
@@ -2623,6 +2705,7 @@
       "version": "6.4.2",
       "resolved": "https://registry.npmjs.org/@cds/core/-/core-6.4.2.tgz",
       "integrity": "sha512-m18JDBenj8qL+msOZkYs3tn8Yq3w9FzbaKRN1FFjL/pp5S9w2wUXazuA+Kuin84LN72K/LAy3LyUVYMkZSqM7A==",
+      "peer": true,
       "dependencies": {
         "lit": "^2.1.3",
         "ramda": "^0.29.0",
@@ -2637,6 +2720,7 @@
       "version": "15.4.0",
       "resolved": "https://registry.npmjs.org/@clr/angular/-/angular-15.4.0.tgz",
       "integrity": "sha512-6DaQUUV4cN0gZHVttN/o7Y7mtZmRFVG10NQsD0i8FP/o92BCjL/pO5+AvvSi5E/3ArMmuqlhVaSjpvsMfg9yww==",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -3516,6 +3600,7 @@
       "version": "15.0.0",
       "resolved": "https://registry.npmjs.org/@ngx-translate/core/-/core-15.0.0.tgz",
       "integrity": "sha512-Am5uiuR0bOOxyoercDnAA3rJVizo4RRqJHo8N3RqJ+XfzVP/I845yEnMADykOHvM6HkVm4SZSnJBOiz0Anx5BA==",
+      "peer": true,
       "engines": {
         "node": "^16.13.0 || >=18.10.0"
       },
@@ -4345,7 +4430,8 @@
       "version": "16.18.108",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.108.tgz",
       "integrity": "sha512-fj42LD82fSv6yN9C6Q4dzS+hujHj+pTv0IpRR3kI20fnYeS0ytBpjFO9OjmDowSPPt4lNKN46JLaKbCyP+BW2A==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/@types/node-forge": {
       "version": "1.3.11",
@@ -4393,10 +4479,10 @@
       "dev": true
     },
     "node_modules/@types/semver": {
-      "version": "7.5.8",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
-      "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
-      "dev": true
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
+      "license": "MIT"
     },
     "node_modules/@types/send": {
       "version": "0.17.4",
@@ -4512,6 +4598,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz",
       "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.62.0",
         "@typescript-eslint/types": "5.62.0",
@@ -5048,6 +5135,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
       "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5173,6 +5261,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
       "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -5825,6 +5914,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001646",
         "electron-to-chromium": "^1.5.4",
@@ -7075,15 +7165,6 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
-    "node_modules/cytoscape": {
-      "version": "3.30.2",
-      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.30.2.tgz",
-      "integrity": "sha512-oICxQsjW8uSaRmn4UK/jkczKOqTrVqt5/1WL0POiJUT2EKNc9STM4hYFHv917yu55aTBMFNRzymlJhVAiWPCxw==",
-      "optional": true,
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
     "node_modules/cytoscape-cose-bilkent": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/cytoscape-cose-bilkent/-/cytoscape-cose-bilkent-4.1.0.tgz",
@@ -7452,15 +7533,6 @@
         "d3-color": "1 - 3",
         "d3-interpolate": "1 - 3"
       },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-selection": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
-      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
-      "optional": true,
       "engines": {
         "node": ">=12"
       }
@@ -8230,6 +8302,7 @@
       "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.4.1.tgz",
       "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "ansi-colors": "^4.1.1",
         "strip-ansi": "^6.0.1"
@@ -8460,6 +8533,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
       "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -11243,7 +11317,8 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-4.5.0.tgz",
       "integrity": "sha512-9PMzyvhtocxb3aXJVOPqBDswdgyAeSB81QnLop4npOpbqnheaTEwPc9ZloQeVswugPManznQBjD8kWDTjlnHuw==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/jasmine-spec-reporter": {
       "version": "7.0.0",
@@ -11544,6 +11619,7 @@
       "resolved": "https://registry.npmjs.org/karma/-/karma-6.4.2.tgz",
       "integrity": "sha512-C6SU/53LB31BEgRg+omznBEMY4SjHU3ricV6zBcAe1EeILKkeScr+fZXtaI5WyDbkVowJxxAI6h73NcFPmXolQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@colors/colors": "1.5.0",
         "body-parser": "^1.19.0",
@@ -11786,6 +11862,7 @@
       "resolved": "https://registry.npmjs.org/less/-/less-4.1.3.tgz",
       "integrity": "sha512-w16Xk/Ta9Hhyei0Gpz9m7VS8F28nieJaL/VyShID7cYvP6IL5oHeL6p4TXSDJqZE/lNv0oJ2pGVjJsRkfwm5FA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "copy-anything": "^2.0.1",
         "parse-node-version": "^1.0.1",
@@ -13766,6 +13843,7 @@
       "integrity": "sha512-I3hJRE4hG7JWAtncWwDEO3GVeGPpN0TtM8xH5ArZXyDuVeTth/i3TtJzdDzqXO1HHtIoAQN0xeq4n9cLuMil5g==",
       "dev": true,
       "hasInstallScript": true,
+      "peer": true,
       "dependencies": {
         "@nrwl/tao": "16.5.1",
         "@parcel/watcher": "2.0.4",
@@ -14735,6 +14813,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.6",
         "picocolors": "^1.0.0",
@@ -14884,6 +14963,7 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
       "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -14912,6 +14992,7 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
       "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
       "dev": true,
+      "peer": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
@@ -15751,6 +15832,7 @@
       "version": "7.8.1",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
       "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -15786,6 +15868,7 @@
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.64.1.tgz",
       "integrity": "sha512-16rRACSOFEE8VN7SCgBu1MpYCyN7urj9At898tyzdXFhC+a+yOX5dXwAR7L8/IdPJ1NB8OYoXmD55DM30B2kEQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",
@@ -15899,12 +15982,10 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -15917,22 +15998,6 @@
       "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
       "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
       "dev": true
-    },
-    "node_modules/semver/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/semver/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/send": {
       "version": "0.19.0",
@@ -16908,6 +16973,7 @@
       "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-14.16.1.tgz",
       "integrity": "sha512-ErlzR/T3hhbV+a925/gbfc3f3Fep9/bnspMiJPorfGEmcBbXdS+oo6LrVtoUZ/w9fqD6o6k7PtUlCOsCRdjX/A==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@csstools/selector-specificity": "^2.0.2",
         "balanced-match": "^2.0.0",
@@ -17371,6 +17437,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -17817,6 +17884,7 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
       "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -18076,6 +18144,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.5.tgz",
       "integrity": "sha512-ifW3Lb2sMdX+WU91s3R0FyQlAyLxOzCSCP37ujw0+r5POeHPwe6udWVIElKQq8gk3t7b8rkmvqC6IHBpCff4GQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.18.10",
         "postcss": "^8.4.27",
@@ -18232,6 +18301,7 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.94.0.tgz",
       "integrity": "sha512-KcsGn50VT+06JH/iunZJedYGUJS5FGjow8wb9c0v5n1Om8O1g4L6LjtfxwlXIATopoQu+vOXXa7gYisWxCoPyg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@types/estree": "^1.0.5",
         "@webassemblyjs/ast": "^1.12.1",
@@ -18306,6 +18376,7 @@
       "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.15.1.tgz",
       "integrity": "sha512-5hbAst3h3C3L8w6W4P96L5vaV0PxSmJhxZvWKYIdgxOQm8pNZ5dEOmmSLBVpP85ReeyRt6AS1QJNyo/oFFPeVA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@types/bonjour": "^3.5.9",
         "@types/connect-history-api-fallback": "^1.3.5",
@@ -18461,6 +18532,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",

--- a/src/portal/package.json
+++ b/src/portal/package.json
@@ -42,6 +42,7 @@
     "@clr/ui": "15.4.0",
     "@ngx-translate/core": "15.0.0",
     "@ngx-translate/http-loader": "8.0.0",
+    "@types/semver": "^7.7.1",
     "cron-validator": "^1.3.1",
     "echarts": "^5.5.1",
     "js-yaml": "^4.1.0",
@@ -49,6 +50,7 @@
     "ngx-cookie": "^6.0.1",
     "ngx-markdown": "16.0.0",
     "rxjs": "^7.4.0",
+    "semver": "^7.7.3",
     "tslib": "^2.7.0",
     "zone.js": "^0.13.3"
   },

--- a/src/portal/src/app/base/project/repository/artifact/artifact-list-page/artifact-list/artifact-list-tab/artifact-list-tab.component.html
+++ b/src/portal/src/app/base/project/repository/artifact/artifact-list-page/artifact-list/artifact-list-tab/artifact-list-tab.component.html
@@ -201,7 +201,7 @@
                     {{ 'REPOSITORY.PLATFORM' | translate }}
                 </ng-template>
             </clr-dg-column>
-            <clr-dg-column>
+            <clr-dg-column [clrDgSortBy]="tagsComparator">
                 <ng-template [clrDgHideableColumn]="{ hidden: hiddenArray[2] }">
                     {{ 'REPOSITORY.TAGS' | translate }}
                 </ng-template>

--- a/src/portal/src/app/base/project/repository/artifact/artifact-list-page/artifact-list/artifact-list-tab/artifact-list-tab.component.ts
+++ b/src/portal/src/app/base/project/repository/artifact/artifact-list-page/artifact-list/artifact-list-tab/artifact-list-tab.component.ts
@@ -123,7 +123,7 @@ export class ArtifactListTabComponent implements OnInit, OnDestroy {
             const aTag = a?.tags?.[0]?.name || '';
             const bTag = b?.tags?.[0]?.name || '';
             return aTag.localeCompare(bTag);
-        }
+        },
     };
 
     loading = true;
@@ -357,7 +357,10 @@ export class ArtifactListTabComponent implements OnInit, OnDestroy {
 
         this.artifactList.forEach(artifact => {
             if (artifact.tags?.length > 1) {
-                artifact.tags = this.sortTagsBySemver(artifact.tags, isDescending);
+                artifact.tags = this.sortTagsBySemver(
+                    artifact.tags,
+                    isDescending
+                );
             }
         });
 
@@ -379,14 +382,17 @@ export class ArtifactListTabComponent implements OnInit, OnDestroy {
     }
 
     private compareSemverTags(tagA: string, tagB: string): number {
-        if (tagA.toLowerCase() === 'latest' && tagB.toLowerCase() === 'latest') {
+        if (
+            tagA.toLowerCase() === 'latest' &&
+            tagB.toLowerCase() === 'latest'
+        ) {
             return 0;
         }
         if (tagA.toLowerCase() === 'latest') {
-            return 1; 
+            return 1;
         }
         if (tagB.toLowerCase() === 'latest') {
-            return -1; 
+            return -1;
         }
 
         const normalizedA = this.normalizeSemverTag(tagA);
@@ -412,15 +418,15 @@ export class ArtifactListTabComponent implements OnInit, OnDestroy {
             }
 
             if (prereleaseA && !prereleaseB) {
-                return -1; 
+                return -1;
             }
             if (!prereleaseA && prereleaseB) {
-                return 1; 
+                return 1;
             }
             if (prereleaseA && prereleaseB) {
                 return prereleaseA.localeCompare(prereleaseB);
             }
-            return 0; 
+            return 0;
         }
 
         if ((parsedA || coercedA) && !(parsedB || coercedB)) {
@@ -429,32 +435,32 @@ export class ArtifactListTabComponent implements OnInit, OnDestroy {
         if (!(parsedA || coercedA) && (parsedB || coercedB)) {
             return -1;
         }
-        
+
         return tagA.localeCompare(tagB);
     }
 
     private normalizeSemverTag(tag: string): string {
         let normalized = tag;
-        
+
         if (normalized.startsWith('v') || normalized.startsWith('V')) {
             normalized = normalized.substring(1);
         }
-        
+
         const prereleaseMatch = normalized.match(/^([^-]+)(-.*)?$/);
         if (prereleaseMatch) {
             const versionPart = prereleaseMatch[1];
             const prereleasePart = prereleaseMatch[2] || '';
-            
+
             const components = versionPart.split('.').map(component => {
                 if (/^\d+$/.test(component)) {
                     return String(parseInt(component, 10));
                 }
                 return component;
             });
-            
+
             normalized = components.join('.') + prereleasePart;
         }
-        
+
         return normalized;
     }
 
@@ -488,7 +494,7 @@ export class ArtifactListTabComponent implements OnInit, OnDestroy {
                 | string
                 | ClrDatagridComparatorInterface<any>;
             sortBy = sortBy.fieldName ? sortBy.fieldName : sortBy;
-            // Skip tags sorting on server side, as it is handled on the client 
+            // Skip tags sorting on server side, as it is handled on the client
             if (sortBy === 'tags' || sortBy === '-tags') {
                 sortBy = '';
             } else {

--- a/src/portal/src/app/base/project/repository/artifact/artifact-list-page/artifact-list/artifact-list-tab/artifact-list-tab.component.ts
+++ b/src/portal/src/app/base/project/repository/artifact/artifact-list-page/artifact-list/artifact-list-tab/artifact-list-tab.component.ts
@@ -86,6 +86,7 @@ import { Tag } from '../../../../../../../../../ng-swagger-gen/models/tag';
 import { CopyArtifactComponent } from './copy-artifact/copy-artifact.component';
 import { CopyDigestComponent } from './copy-digest/copy-digest.component';
 import { Scanner } from '../../../../../../left-side-nav/interrogation-services/scanner/scanner';
+import * as semver from 'semver';
 
 export const AVAILABLE_TIME = '0001-01-01T00:00:00.000Z';
 

--- a/src/portal/src/app/base/project/repository/artifact/artifact-list-page/artifact-list/artifact-list-tab/artifact-list-tab.component.ts
+++ b/src/portal/src/app/base/project/repository/artifact/artifact-list-page/artifact-list/artifact-list-tab/artifact-list-tab.component.ts
@@ -117,6 +117,14 @@ export class ArtifactListTabComponent implements OnInit, OnDestroy {
         'push_time',
         'date'
     );
+    tagsComparator: Comparator<Artifact> & { fieldName: string } = {
+        fieldName: 'tags',
+        compare: (a: Artifact, b: Artifact): number => {
+            const aTag = a?.tags?.[0]?.name || '';
+            const bTag = b?.tags?.[0]?.name || '';
+            return aTag.localeCompare(bTag);
+        }
+    };
 
     loading = true;
     selectedRow: Artifact[] = [];
@@ -327,9 +335,133 @@ export class ArtifactListTabComponent implements OnInit, OnDestroy {
 
     clrDgRefresh(state: ClrDatagridStateInterface) {
         setTimeout(() => {
-            //add setTimeout to avoid ng check error
+            if (this.isTagsSorting(state) && this.artifactList?.length > 0) {
+                this.sortArtifactsByTags(state);
+                return;
+            }
             this.clrLoad(state);
         }, 0);
+    }
+
+    private isTagsSorting(state: ClrDatagridStateInterface): boolean {
+        if (!state?.sort?.by) {
+            return false;
+        }
+        const sortBy = state.sort.by as any;
+        const fieldName = sortBy.fieldName ? sortBy.fieldName : sortBy;
+        return fieldName === 'tags';
+    }
+
+    private sortArtifactsByTags(state: ClrDatagridStateInterface): void {
+        const isDescending = state.sort?.reverse ?? false;
+
+        this.artifactList.forEach(artifact => {
+            if (artifact.tags?.length > 1) {
+                artifact.tags = this.sortTagsBySemver(artifact.tags, isDescending);
+            }
+        });
+
+        this.artifactList = [...this.artifactList].sort((a, b) => {
+            const aRepTag = a?.tags?.[0]?.name || '';
+            const bRepTag = b?.tags?.[0]?.name || '';
+            const comparison = this.compareSemverTags(aRepTag, bRepTag);
+            return isDescending ? -comparison : comparison;
+        });
+
+        this.currentState = state;
+    }
+
+    private sortTagsBySemver(tags: Tag[], descending: boolean): Tag[] {
+        return [...tags].sort((a, b) => {
+            const comparison = this.compareSemverTags(a.name, b.name);
+            return descending ? -comparison : comparison;
+        });
+    }
+
+    private compareSemverTags(tagA: string, tagB: string): number {
+        if (tagA.toLowerCase() === 'latest' && tagB.toLowerCase() === 'latest') {
+            return 0;
+        }
+        if (tagA.toLowerCase() === 'latest') {
+            return 1; 
+        }
+        if (tagB.toLowerCase() === 'latest') {
+            return -1; 
+        }
+
+        const normalizedA = this.normalizeSemverTag(tagA);
+        const normalizedB = this.normalizeSemverTag(tagB);
+
+        const parsedA = semver.parse(normalizedA);
+        const parsedB = semver.parse(normalizedB);
+
+        if (parsedA && parsedB) {
+            return semver.compare(parsedA, parsedB);
+        }
+
+        const coercedA = semver.coerce(normalizedA);
+        const coercedB = semver.coerce(normalizedB);
+
+        if (coercedA && coercedB) {
+            const prereleaseA = this.extractPrerelease(normalizedA);
+            const prereleaseB = this.extractPrerelease(normalizedB);
+
+            const baseCompare = semver.compare(coercedA, coercedB);
+            if (baseCompare !== 0) {
+                return baseCompare;
+            }
+
+            if (prereleaseA && !prereleaseB) {
+                return -1; 
+            }
+            if (!prereleaseA && prereleaseB) {
+                return 1; 
+            }
+            if (prereleaseA && prereleaseB) {
+                return prereleaseA.localeCompare(prereleaseB);
+            }
+            return 0; 
+        }
+
+        if ((parsedA || coercedA) && !(parsedB || coercedB)) {
+            return 1;
+        }
+        if (!(parsedA || coercedA) && (parsedB || coercedB)) {
+            return -1;
+        }
+        
+        return tagA.localeCompare(tagB);
+    }
+
+    private normalizeSemverTag(tag: string): string {
+        let normalized = tag;
+        
+        if (normalized.startsWith('v') || normalized.startsWith('V')) {
+            normalized = normalized.substring(1);
+        }
+        
+        const prereleaseMatch = normalized.match(/^([^-]+)(-.*)?$/);
+        if (prereleaseMatch) {
+            const versionPart = prereleaseMatch[1];
+            const prereleasePart = prereleaseMatch[2] || '';
+            
+            const components = versionPart.split('.').map(component => {
+                if (/^\d+$/.test(component)) {
+                    return String(parseInt(component, 10));
+                }
+                return component;
+            });
+            
+            normalized = components.join('.') + prereleasePart;
+        }
+        
+        return normalized;
+    }
+
+    private extractPrerelease(version: string): string | null {
+        // Match patterns like: 1.0-rc, 1.0.0-rc1, 1.0-alpha.1
+        const match = version.match(/^[\d.]+[-](.+)$/);
+        return match ? match[1] : null;
     }
 
     clrLoad(state: ClrDatagridStateInterface): void {
@@ -356,7 +488,12 @@ export class ArtifactListTabComponent implements OnInit, OnDestroy {
                 | string
                 | ClrDatagridComparatorInterface<any>;
             sortBy = sortBy.fieldName ? sortBy.fieldName : sortBy;
-            sortBy = state.sort.reverse ? `-${sortBy}` : sortBy;
+            // Skip tags sorting on server side, as it is handled on the client 
+            if (sortBy === 'tags' || sortBy === '-tags') {
+                sortBy = '';
+            } else {
+                sortBy = state.sort.reverse ? `-${sortBy}` : sortBy;
+            }
         }
         this.currentState = state;
 

--- a/src/portal/src/app/base/project/repository/artifact/artifact-list-page/artifact-list/artifact-list-tab/artifact-list-tab.component.ts
+++ b/src/portal/src/app/base/project/repository/artifact/artifact-list-page/artifact-list/artifact-list-tab/artifact-list-tab.component.ts
@@ -522,7 +522,7 @@ export class ArtifactListTabComponent implements OnInit, OnDestroy {
                 withLabel: true,
                 withScanOverview: true,
                 withSbomOverview: true,
-                withTag: false,
+                withTag: true,
                 XAcceptVulnerabilities: DEFAULT_SUPPORTED_MIME_TYPES,
                 withAccessory: false,
             };
@@ -547,7 +547,7 @@ export class ArtifactListTabComponent implements OnInit, OnDestroy {
                                     withLabel: true,
                                     withScanOverview: true,
                                     withSbomOverview: true,
-                                    withTag: false,
+                                    withTag: true,
                                     XAcceptVulnerabilities:
                                         DEFAULT_SUPPORTED_MIME_TYPES,
                                     withAccessory: false,
@@ -576,7 +576,7 @@ export class ArtifactListTabComponent implements OnInit, OnDestroy {
                                         platFormAttr[index].platform
                                     );
                                 });
-                                this.getArtifactTagsAsync(this.artifactList);
+                                // this.getArtifactTagsAsync(this.artifactList);
                                 this.getAccessoriesAsync(this.artifactList);
                                 this.checkCosignAndSbomAsync(this.artifactList);
                                 this.getIconsFromBackEnd();
@@ -597,7 +597,7 @@ export class ArtifactListTabComponent implements OnInit, OnDestroy {
                 withLabel: true,
                 withScanOverview: true,
                 withSbomOverview: true,
-                withTag: false,
+                withTag: true,
                 sort: getSortingString(state),
                 XAcceptVulnerabilities: DEFAULT_SUPPORTED_MIME_TYPES,
                 withAccessory: false,
@@ -616,7 +616,7 @@ export class ArtifactListTabComponent implements OnInit, OnDestroy {
                             }
                         }
                         this.artifactList = res.body;
-                        this.getArtifactTagsAsync(this.artifactList);
+                        // this.getArtifactTagsAsync(this.artifactList);
                         this.getAccessoriesAsync(this.artifactList);
                         this.checkCosignAndSbomAsync(this.artifactList);
                         this.getIconsFromBackEnd();


### PR DESCRIPTION
# Comprehensive Summary of change

# Issue being fixed
Fixes #22647 

## Overview
> This feature is developed with respect to suggestions and recommendations discussed in the [issue](#22647).

This PR adds functionality to **sort the artifacts** in the repositories based on the **tag names**. 
According to [this](https://github.com/goharbor/harbor/issues/22647#issuecomment-3669989096) statement, the feature supports sorting **both semver and non-semver tags**, also priortizing special tag name such as `latest` in the ranking over the others.

So here's the priority order from highest to lowest (descending order), 
1. `latest` tag
2. Numeric semver tags *(e.g. `1.0`, `1.1`, `1.2.3`)*
3. Alphanumeric semver tags *(e.g. `v1.0`, `v1.0-rc`)*
4. Alphabetic / Non-semver tags *(e.g. `stable`, `unstable`)*

In addition to that, this PR offer improvisation of this [comment ](https://github.com/goharbor/harbor/issues/22647#issuecomment-3670648823). For example, In case of tags such as `v1.1.0`, `v1.10.0` and `v1.2.0`, the resultant order will be,

`v1.1.0` < `v1.2.0` < `v1.10.0`, *Instead of,*
`v1.1.0` < `v1.10.0` < `v1.2.0`

So here the semver tags are respected and sorted accordingly, instead of naive lexicographical sorting.

### Example Preview
> The artifacts and their tags are of the official `alpine` image, pulled from DockerHub.
 
<table>
  <tbody>
    <tr><td>
      Ascending order
    </td></tr>
    <tr><td>      
<img width="1637" height="869" alt="asclist_tag" src="https://github.com/user-attachments/assets/c2a50b78-bfc0-4c69-8dd5-508455c34204" />
    </td></tr>
    <tr><td>
      Descending order
    </td></tr>
    <tr><td>
<img width="1629" height="866" alt="desclist_tag" src="https://github.com/user-attachments/assets/020bae83-1701-46b1-ba8f-41634b247eb0" />
    </td></tr>
  </tbody>
</table>

---

Also in case of multiple tags, similar flow is followed. The inner tag list is sorted first and then the outer tags list is sorted.

### Example Preview
> The following example contains artifacts of official `busybox` image with **custom tags** assigned manually for testing.

<table>
  <tbody>
    <tr><td>
      Ascending order
    </td></tr>
    <tr><td>      
<img width="1597" height="623" alt="asclist_tags" src="https://github.com/user-attachments/assets/7bef06d6-ade5-44e9-aa97-8ff78bfcb79f" />
    </td></tr>
    <tr><td>
      Descending order
    </td></tr>
    <tr><td>
<img width="1604" height="621" alt="desclist_tags" src="https://github.com/user-attachments/assets/9562f245-c5b4-456d-a7b2-76f5c788370e" />
    </td></tr>
  </tbody>
</table>

---

I believe these changes fulfill the requirements and goals. 
The branch is rebased on the `main` and is ready to be merged. So I request the maintainers @bupd @Vad1mo @OrlinVasilev @chlins to review and test the changes once. 

---

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. `release-note/new-feature`, `release-note/update`, `release-note/enhancement`
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
