### PR TITLE
Fix: Set GitHub Workflow Token Permissions to Read-Only by Default

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -41,6 +41,9 @@ on:
       - '!tests/robot-cases/**'
       - '!tests/robot-cases/Group1-Nightly/**'
 
+permissions:
+  contents: read
+
 jobs:
   UTTEST:
     env:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -41,13 +41,12 @@ on:
       - '!tests/robot-cases/**'
       - '!tests/robot-cases/Group1-Nightly/**'
 
-permissions:
-  contents: read
-
 jobs:
   UTTEST:
     env:
        UTTEST: true
+    permissions:
+      contents: read
     runs-on:
       #- self-hosted
       - oracle-vm-24cpu-96gb-x86-64
@@ -109,6 +108,8 @@ jobs:
   APITEST_DB:
     env:
       APITEST_DB: true
+    permissions:
+      contents: read
     runs-on:
       #- self-hosted
       - oracle-vm-24cpu-96gb-x86-64
@@ -170,6 +171,8 @@ jobs:
   APITEST_DB_PROXY_CACHE:
     env:
       APITEST_DB: true
+    permissions:
+      contents: read
     runs-on:
       #- self-hosted
       - oracle-vm-24cpu-96gb-x86-64
@@ -231,6 +234,8 @@ jobs:
   APITEST_LDAP:
     env:
       APITEST_LDAP: true
+    permissions:
+      contents: read
     runs-on:
       #- self-hosted
       - oracle-vm-24cpu-96gb-x86-64
@@ -290,6 +295,8 @@ jobs:
   OFFLINE:
     env:
       OFFLINE: true
+    permissions:
+      contents: read
     runs-on:
       #- self-hosted
       - oracle-vm-24cpu-96gb-x86-64
@@ -342,6 +349,8 @@ jobs:
   UI_UT:
     env:
       UI_UT: true
+    permissions:
+      contents: read
     runs-on:
       #- self-hosted
       - oracle-vm-24cpu-96gb-x86-64

--- a/.github/workflows/auto_assign_prs.yml
+++ b/.github/workflows/auto_assign_prs.yml
@@ -7,10 +7,16 @@ on:
   pull_request_target:
     types: [opened, reopened, ready_for_review]
 
+permissions:
+  contents: read
+
 jobs:
   # Automatically assigns reviewers and owner
   add-reviews:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Set the author of a PR as the assignee
         uses: kentaro-m/auto-assign-action@v2.0.0

--- a/.github/workflows/auto_assign_prs.yml
+++ b/.github/workflows/auto_assign_prs.yml
@@ -7,9 +7,6 @@ on:
   pull_request_target:
     types: [opened, reopened, ready_for_review]
 
-permissions:
-  contents: read
-
 jobs:
   # Automatically assigns reviewers and owner
   add-reviews:

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -7,6 +7,9 @@ on:
     branches:
       - main
       - release-*
+
+permissions:
+  contents: read
 jobs:
   BUILD_PACKAGE:
     env:

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -7,8 +7,6 @@ on:
     branches:
       - main
       - release-*
-
-
 jobs:
   BUILD_PACKAGE:
     env:

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -8,12 +8,13 @@ on:
       - main
       - release-*
 
-permissions:
-  contents: read
+
 jobs:
   BUILD_PACKAGE:
     env:
         BUILD_PACKAGE: true
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Configure AWS credentials

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -6,10 +6,15 @@ on:
   schedule:
     - cron: '0 16 * * 6'
 
+permissions:
+  contents: read
+
 jobs:
   CodeQL-Build:
 
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -6,14 +6,13 @@ on:
   schedule:
     - cron: '0 16 * * 6'
 
-permissions:
-  contents: read
-
 jobs:
   CodeQL-Build:
 
     runs-on: ubuntu-latest
     permissions:
+      actions: read
+      contents: read
       security-events: write
 
     steps:

--- a/.github/workflows/conformance_test.yml
+++ b/.github/workflows/conformance_test.yml
@@ -9,13 +9,12 @@ on:
   schedule:
     - cron: '0 6 * * *'
 
-permissions:
-  contents: read
-
 jobs:
   CONFORMANCE_TEST:
     env:
       CONFORMANCE_TEST: true
+    permissions:
+      contents: read
     runs-on:
       #- self-hosted
       - oracle-vm-24cpu-96gb-x86-64

--- a/.github/workflows/conformance_test.yml
+++ b/.github/workflows/conformance_test.yml
@@ -9,6 +9,9 @@ on:
   schedule:
     - cron: '0 6 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   CONFORMANCE_TEST:
     env:

--- a/.github/workflows/housekeeping-stale-issues-prs.yaml
+++ b/.github/workflows/housekeeping-stale-issues-prs.yaml
@@ -3,13 +3,11 @@ on:
   schedule:
     - cron: '0 9 * * *'
 
-permissions:
-  contents: read
-
 jobs:
   stale:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       issues: write
       pull-requests: write
     steps:

--- a/.github/workflows/housekeeping-stale-issues-prs.yaml
+++ b/.github/workflows/housekeeping-stale-issues-prs.yaml
@@ -3,9 +3,15 @@ on:
   schedule:
     - cron: '0 9 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   stale:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/stale@v10.0.0
         with:

--- a/.github/workflows/label_check.yaml
+++ b/.github/workflows/label_check.yaml
@@ -5,6 +5,9 @@ on:
   pull_request:
     types: [opened, labeled, unlabeled, synchronize]
 
+permissions:
+  contents: read
+
 env:
   GOPROXY: https://proxy.golang.org/
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/label_check.yaml
+++ b/.github/workflows/label_check.yaml
@@ -5,9 +5,6 @@ on:
   pull_request:
     types: [opened, labeled, unlabeled, synchronize]
 
-permissions:
-  contents: read
-
 env:
   GOPROXY: https://proxy.golang.org/
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
@@ -18,6 +15,9 @@ jobs:
   check-label:
     name: Check release-note label set
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       - uses: mheap/github-action-required-labels@v5
         with:

--- a/.github/workflows/nightly-trivy-scan.yml
+++ b/.github/workflows/nightly-trivy-scan.yml
@@ -18,6 +18,7 @@ jobs:
         versions: [dev, v2.12.0-dev]
         # list of images that need to be scanned
         images: [harbor-core, harbor-db, harbor-exporter, harbor-jobservice, harbor-log, harbor-portal, harbor-registryctl, prepare]
+    permissions:
       security-events: write  # for github/codeql-action/upload-sarif to upload SARIF results
 
     runs-on: ubuntu-latest

--- a/.github/workflows/nightly-trivy-scan.yml
+++ b/.github/workflows/nightly-trivy-scan.yml
@@ -3,9 +3,6 @@ on:
   schedule:
     - cron: '0 2 * * *' # run at 2 AM UTC
 
-permissions:
-  contents: read
-
 
 jobs:
   nightly-scan:
@@ -19,6 +16,7 @@ jobs:
         # list of images that need to be scanned
         images: [harbor-core, harbor-db, harbor-exporter, harbor-jobservice, harbor-log, harbor-portal, harbor-registryctl, prepare]
     permissions:
+      contents: read
       security-events: write  # for github/codeql-action/upload-sarif to upload SARIF results
 
     runs-on: ubuntu-latest

--- a/.github/workflows/nightly-trivy-scan.yml
+++ b/.github/workflows/nightly-trivy-scan.yml
@@ -3,6 +3,9 @@ on:
   schedule:
     - cron: '0 2 * * *' # run at 2 AM UTC
 
+permissions:
+  contents: read
+
 
 jobs:
   nightly-scan:
@@ -15,7 +18,6 @@ jobs:
         versions: [dev, v2.12.0-dev]
         # list of images that need to be scanned
         images: [harbor-core, harbor-db, harbor-exporter, harbor-jobservice, harbor-log, harbor-portal, harbor-registryctl, prepare]
-    permissions:
       security-events: write  # for github/codeql-action/upload-sarif to upload SARIF results
 
     runs-on: ubuntu-latest

--- a/.github/workflows/nightly-trivy-scan.yml
+++ b/.github/workflows/nightly-trivy-scan.yml
@@ -17,7 +17,6 @@ jobs:
         images: [harbor-core, harbor-db, harbor-exporter, harbor-jobservice, harbor-log, harbor-portal, harbor-registryctl, prepare]
     permissions:
       contents: read
-      security-events: write  # for github/codeql-action/upload-sarif to upload SARIF results
 
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/nightly-trivy-scan.yml
+++ b/.github/workflows/nightly-trivy-scan.yml
@@ -17,6 +17,7 @@ jobs:
         images: [harbor-core, harbor-db, harbor-exporter, harbor-jobservice, harbor-log, harbor-portal, harbor-registryctl, prepare]
     permissions:
       contents: read
+      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
 
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pass-CI.yml
+++ b/.github/workflows/pass-CI.yml
@@ -26,41 +26,50 @@ on:
       - '!tests/robot-cases/**'
       - '!tests/robot-cases/Group1-Nightly/**'
 
-permissions:
-  contents: read
-
 jobs:
   UTTEST:
+    permissions:
+      contents: read
     runs-on:
       - ubuntu-latest
     steps:
       - run: 'echo "No run required"'
 
   APITEST_DB:
+    permissions:
+      contents: read
     runs-on:
       - ubuntu-latest
     steps:
       - run: 'echo "No run required"'
 
   APITEST_DB_PROXY_CACHE:
+    permissions:
+      contents: read
     runs-on:
       - ubuntu-latest
     steps:
       - run: 'echo "No run required"'
 
   APITEST_LDAP:
+    permissions:
+      contents: read
     runs-on:
       - ubuntu-latest
     steps:
       - run: 'echo "No run required"'
 
   OFFLINE:
+    permissions:
+      contents: read
     runs-on:
       - ubuntu-latest
     steps:
       - run: 'echo "No run required"'
 
   UI_UT:
+    permissions:
+      contents: read
     runs-on:
       - ubuntu-latest
     steps:

--- a/.github/workflows/pass-CI.yml
+++ b/.github/workflows/pass-CI.yml
@@ -26,6 +26,9 @@ on:
       - '!tests/robot-cases/**'
       - '!tests/robot-cases/Group1-Nightly/**'
 
+permissions:
+  contents: read
+
 jobs:
   UTTEST:
     runs-on:


### PR DESCRIPTION
Thank you for contributing to Harbor!

# Description
Set all affected workflows to use **read-only GITHUB_TOKEN by default** and scope elevated permissions only at job level where required.

# Issue
Fixes #22760

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).

