### PR TITLE
fix(exporter): add Docker HEALTHCHECK

### DIFF
--- a/make/photon/exporter/Dockerfile
+++ b/make/photon/exporter/Dockerfile
@@ -30,6 +30,7 @@ RUN chown -R harbor:harbor /etc/pki/tls/certs \
 
 WORKDIR /harbor
 USER harbor
+# Default port 8001 matches helm chart; docker-compose sets HARBOR_EXPORTER_PORT=8080 via env template
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
   CMD sh -c 'curl -fs http://127.0.0.1:${HARBOR_EXPORTER_PORT:-8001}/metrics || exit 1'
 

--- a/make/photon/exporter/Dockerfile
+++ b/make/photon/exporter/Dockerfile
@@ -30,5 +30,7 @@ RUN chown -R harbor:harbor /etc/pki/tls/certs \
 
 WORKDIR /harbor
 USER harbor
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD curl -fs http://127.0.0.1:8001/metrics || exit 1
 
 ENTRYPOINT ["/harbor/entrypoint.sh"]

--- a/make/photon/exporter/Dockerfile
+++ b/make/photon/exporter/Dockerfile
@@ -31,6 +31,6 @@ RUN chown -R harbor:harbor /etc/pki/tls/certs \
 WORKDIR /harbor
 USER harbor
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-  CMD curl -fs http://127.0.0.1:8001/metrics || exit 1
+  CMD sh -c 'curl -fs http://127.0.0.1:${HARBOR_EXPORTER_PORT:-8001}/metrics || exit 1'
 
 ENTRYPOINT ["/harbor/entrypoint.sh"]


### PR DESCRIPTION
Thank you for contributing to Harbor!

# Description
This PR adds a Docker HEALTHCHECK to the `harbor-exporter` container using an
HTTP-based check against the existing `/metrics` endpoint. The healthcheck
returns healthy only when the exporter responds successfully, providing a
reliable container-level health signal for monitoring and orchestration.

Explicit interval, timeout, start-period, and retry parameters are defined to
avoid false negatives during startup and to ensure stable health reporting.

# Issue 
Fixes #21285

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. `release-note/enhancement`
- [x] Accepted the DCO. Commits include `Signed-off-by`
- [x] Made sure tests are passing and test coverage is added if needed
- [x] Considered the docs impact and determined no documentation changes are required
