### PR TITLE
release-note/new-feature SBOM generation to harbor release

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -104,3 +104,20 @@ jobs:
           echo "harbor_target_bucket=$harbor_target_bucket" >> $GITHUB_ENV
 
           publishImage $target_branch $Harbor_Assets_Version "${{ secrets.DOCKER_HUB_USERNAME }}" "${{ secrets.DOCKER_HUB_PASSWORD }}"
+      - name: Install Syft
+        uses: anchore/sbom-action/download-syft@v0
+      - name: Generate Dev Image SBOMs
+        if: startsWith(github.ref, 'refs/heads/release-')
+        run: |
+          cd src/github.com/goharbor/harbor
+          target_release_version=$(cat ./VERSION)
+          mkdir -p ./sboms
+          images="$(docker images --format "{{.Repository}}" --filter=reference='goharbor/*:${target_release_version}' | xargs)"
+          for image in $images; do
+            shortName=$(basename "$image")
+            echo "Generating SBOM for $image:${target_release_version}"
+            syft "$image:${target_release_version}" -o spdx-json="./sboms/${shortName}.spdx.json" || true
+          done
+          for f in ./sboms/*.spdx.json; do
+            aws s3 cp "$f" "s3://${{ env.harbor_target_bucket }}/sboms/$(basename $f)"
+          done

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -11,6 +11,7 @@ jobs:
     permissions:
       contents: write   # Required for creating GitHub releases and uploading assets
       id-token: write  # Required for Cosign keyless signing
+      packages: write   # Required for GHCR image signing and SBOM attachment
     steps:
       - uses: actions/checkout@v6
       - name: Setup env
@@ -53,6 +54,8 @@ jobs:
           echo "MD5SUM_PATH=$assets_path/md5sum" >> $GITHUB_ENV
       - name: Install Cosign
         uses: sigstore/cosign-installer@v4.0.0
+      - name: Install Syft
+        uses: anchore/sbom-action/download-syft@v0
       - name: Sign Release Artifacts
         run: |
           cosign sign-blob --yes \
@@ -80,9 +83,24 @@ jobs:
           tar -zxf ${{ env.OFFLINE_PACKAGE_PATH }}
           docker load -i ./harbor/harbor.${{ env.BASE_TAG }}.tar.gz
           images="$(docker images --format "{{.Repository}}" --filter=reference='goharbor/*:${{ env.BASE_TAG }}' | xargs)"
+          echo "HARBOR_IMAGES=$images" >> $GITHUB_ENV
           source tools/release/release_utils.sh
           publishImages ${{ env.CUR_TAG }} ${{ env.BASE_TAG }} "${{ secrets.DOCKER_HUB_USERNAME }}" "${{ secrets.DOCKER_HUB_PASSWORD }}" $images
           publishPackages ${{ env.CUR_TAG }} ${{ env.BASE_TAG }} ${{ github.actor }} ${{ secrets.GITHUB_TOKEN }} $images
+      - name: Generate SBOMs
+        run: |
+          mkdir -p ./assets/sboms
+          source tools/release/release_utils.sh
+          generateSBOMs "${{ env.CUR_TAG }}" "${{ env.BASE_TAG }}" "./assets/sboms" ${{ env.HARBOR_IMAGES }}
+          echo "SBOM_CONSOLIDATED_PATH=./assets/sboms/harbor-sbom-${{ env.CUR_TAG }}.spdx.json" >> $GITHUB_ENV
+      - name: Sign Container Images and Attach SBOMs
+        run: |
+          docker login -u "${{ secrets.DOCKER_HUB_USERNAME }}" -p "${{ secrets.DOCKER_HUB_PASSWORD }}"
+          docker login ghcr.io -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }}
+          source tools/release/release_utils.sh
+          signAndAttachSBOMs "${{ env.CUR_TAG }}" "./assets/sboms" ${{ env.HARBOR_IMAGES }}
+          docker logout
+          docker logout ghcr.io
       - name: Generate release notes
         run: |
           release_notes_path=$(pwd)/release-notes.txt
@@ -97,6 +115,7 @@ jobs:
             ${{ env.OFFLINE_PACKAGE_PATH }}
             ${{ env.OFFLINE_SIGSTORE_PATH }}
             ${{ env.MD5SUM_PATH }}
+            ${{ env.SBOM_CONSOLIDATED_PATH }}
       - name: GA Release
         uses: softprops/action-gh-release@v2
         if: ${{ env.PRERELEASE == 'false' }}
@@ -108,3 +127,4 @@ jobs:
             ${{ env.ONLINE_PACKAGE_PATH }}
             ${{ env.ONLINE_SIGSTORE_PATH }}
             ${{ env.MD5SUM_PATH }}
+            ${{ env.SBOM_CONSOLIDATED_PATH }}

--- a/docs/signature-verification.md
+++ b/docs/signature-verification.md
@@ -75,6 +75,46 @@ cosign verify-blob \
   harbor-online-installer-v2.15.0.tgz
 ```
 
+### 4. Verify Container Image Signatures
+
+All Harbor container images are signed using Cosign keyless signing on both Docker Hub and GHCR.
+
+```bash
+# Verify a Docker Hub image
+cosign verify \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  --certificate-identity-regexp '^https://github.com/goharbor/harbor/.github/workflows/publish_release.yml@refs/tags/v.*$' \
+  docker.io/goharbor/harbor-core:v2.15.0
+
+# Verify a GHCR image
+cosign verify \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  --certificate-identity-regexp '^https://github.com/goharbor/harbor/.github/workflows/publish_release.yml@refs/tags/v.*$' \
+  ghcr.io/goharbor/harbor-core:v2.15.0
+```
+
+Replace `harbor-core` with any Harbor component (e.g., `harbor-portal`, `harbor-jobservice`, `harbor-db`, `nginx-photon`, `redis-photon`, `registry-photon`, `harbor-registryctl`, `harbor-log`, `prepare`, `trivy-adapter-photon`, `harbor-exporter`).
+
+### 5. Retrieve and Inspect SBOM
+
+SPDX-formatted SBOMs are attached to every Harbor container image.
+
+```bash
+# Download the SBOM for a specific image
+cosign download sbom docker.io/goharbor/harbor-core:v2.15.0 > harbor-core-sbom.spdx.json
+
+# Inspect the SBOM contents
+cat harbor-core-sbom.spdx.json | jq '.packages | length'
+
+# Download from GHCR
+cosign download sbom ghcr.io/goharbor/harbor-core:v2.15.0 > harbor-core-sbom.spdx.json
+```
+
+A consolidated SBOM covering all Harbor images is also available as a release asset:
+```bash
+wget https://github.com/goharbor/harbor/releases/download/v2.15.0/harbor-sbom-v2.15.0.spdx.json
+```
+
 ## Troubleshooting
 
 ### Certificate identity doesn't match
@@ -98,6 +138,8 @@ cosign verify-blob \
 - **File authenticity** - Signed by official Harbor CI/CD workflow  
 - **File integrity** - No modifications since signing  
 - **Build provenance** - Logged in public Sigstore transparency log
+- **Container image authenticity** - Each image signed with keyless Cosign signature on Docker Hub and GHCR
+- **Software bill of materials** - SPDX SBOM attached to each container image and included as a consolidated release asset
 
 ## Resources
 


### PR DESCRIPTION

# Comprehensive Summary of your change

- Add SBOM (Software Bill of Materials) generation using Syft for all Harbor container images in 
  SPDX JSON format                                                                                 
  - Sign all container images on Docker Hub and GHCR with Cosign keyless signing (Sigstore/Fulcio) 
  - Attach per-image SBOMs to container images on both registries via cosign attach sbom           
  - Include a consolidated SBOM as a GitHub release asset                                          
  - Generate SBOMs during release-branch builds and upload to S3  

# Issue being fixed
Fixes #22761 

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
