### PR TITLE
 feat: add Prometheus metrics for proxy cache monitoring

### DIFF
--- a/src/pkg/exporter/exporter.go
+++ b/src/pkg/exporter/exporter.go
@@ -52,6 +52,7 @@ func NewExporter(opt *Opt) *Exporter {
 		NewProjectCollector(),
 		NewJobServiceCollector(),
 		NewStatisticsCollector(),
+		NewProxyCollector(),
 	)
 	if err != nil {
 		log.Warningf("calling RegisterCollector() errored out, error: %v", err)

--- a/src/pkg/exporter/proxy_collector.go
+++ b/src/pkg/exporter/proxy_collector.go
@@ -1,0 +1,50 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exporter
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/goharbor/harbor/src/pkg/metrics"
+)
+
+const (
+	proxyCollectorName string = "ProxyCollector"
+)
+
+// NewProxyCollector creates a new proxy cache metrics collector
+func NewProxyCollector() *ProxyCollector {
+	return &ProxyCollector{}
+}
+
+// ProxyCollector collects proxy cache metrics
+type ProxyCollector struct{}
+
+// Describe implements prometheus.Collector
+func (pc *ProxyCollector) Describe(c chan<- *prometheus.Desc) {
+	metrics.RegistryRequestsTotal.Describe(c)
+	metrics.ProxyUpstreamRequestsTotal.Describe(c)
+}
+
+// Collect implements prometheus.Collector
+func (pc *ProxyCollector) Collect(c chan<- prometheus.Metric) {
+	metrics.RegistryRequestsTotal.Collect(c)
+	metrics.ProxyUpstreamRequestsTotal.Collect(c)
+}
+
+// GetName returns the name of the proxy collector
+func (pc *ProxyCollector) GetName() string {
+	return proxyCollectorName
+}

--- a/src/pkg/metrics/proxy.go
+++ b/src/pkg/metrics/proxy.go
@@ -1,0 +1,46 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	// RegistryRequestsTotal counts total number of registry pull/head requests
+	// received by the proxy cache
+	RegistryRequestsTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "harbor",
+			Subsystem: "core",
+			Name:      "registry_requests_total",
+			Help:      "Total number of registry pull/head requests received by proxy cache",
+		},
+		[]string{"project", "repo", "method"},
+	)
+
+	// ProxyUpstreamRequestsTotal counts requests that were proxied to upstream
+	// (cache miss)
+	ProxyUpstreamRequestsTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "harbor",
+			Subsystem: "core",
+			Name:      "proxy_upstream_requests_total",
+			Help:      "Number of requests proxied to upstream registry (cache miss)",
+		},
+		[]string{"project", "upstream_url", "status"},
+	)
+)


### PR DESCRIPTION
# Pull Request: Add Prometheus Metrics for Proxy Cache Monitoring

## Summary

This PR adds Prometheus metrics to Harbor's proxy cache feature, enabling monitoring of cache efficiency and distinguishing between cache hits and cache misses.

## Problem Statement

Currently, Harbor's proxy cache has no metrics to track cache performance. Users cannot:
- Monitor cache hit ratio
- Detect when upstream registries are being hit unnecessarily
- Alert on cache miss spikes
- Measure bandwidth/cost savings from caching

The only way to track this is by manually parsing debug logs, which doesn't scale for high-traffic environments.

## Solution

Added two new Prometheus counter metrics:

### 1. `harbor_core_registry_requests_total`
- **Type**: Counter
- **Description**: Total number of registry pull/head requests received by proxy cache
- **Labels**: `project`, `repo`, `method`

### 2. `harbor_core_proxy_upstream_requests_total`
- **Type**: Counter  
- **Description**: Number of requests proxied to upstream registry (cache miss)
- **Labels**: `project`, `upstream_url`, `status`

## Cache Hit Ratio Calculation

```promql
Cache_Hit_Ratio = 1 - (
  harbor_core_proxy_upstream_requests_total / 
  harbor_core_registry_requests_total
)
```

## Changes Made

### New Files
- `src/pkg/metrics/proxy.go` - Metric definitions
- `src/pkg/exporter/proxy_collector.go` - Prometheus collector

### Modified Files
- `src/pkg/exporter/exporter.go` - Register proxy collector
- `src/controller/proxy/controller.go` - Track cache misses in `ProxyBlob()`
- `src/server/middleware/repoproxy/proxy.go` - Track total requests in middleware

## Example Metrics Output

```prometheus
# HELP harbor_core_registry_requests_total Total number of registry pull/head requests received by proxy cache
# TYPE harbor_core_registry_requests_total counter
harbor_core_registry_requests_total{method="GET",project="docker-proxy",repo="library/nginx"} 10

# HELP harbor_core_proxy_upstream_requests_total Number of requests proxied to upstream registry (cache miss)
# TYPE harbor_core_proxy_upstream_requests_total counter
harbor_core_proxy_upstream_requests_total{project="docker-proxy",status="200",upstream_url="library/nginx"} 3
```

**Cache Hit Ratio**: `1 - (3/10) = 70%`

## Testing

### Manual Testing
1. Set up proxy cache project pointing to Docker Hub
2. Pull image first time (cache miss):
   ```bash
   docker pull localhost/docker-proxy/nginx:alpine
   ```
3. Check metrics - both counters increment
4. Pull same image again (cache hit):
   ```bash
   docker pull localhost/docker-proxy/nginx:alpine
   ```
5. Check metrics - only total counter increments

### Metrics Verification
```bash
curl http://localhost:8001/metrics | grep harbor_core
```

## Use Cases

### 1. Monitor Cache Efficiency
```promql
# Cache hit ratio over time
100 * (1 - (
  sum(rate(harbor_core_proxy_upstream_requests_total[5m])) 
  / 
  sum(rate(harbor_core_registry_requests_total[5m]))
))
```

### 2. Alert on High Cache Miss Rate
```yaml
- alert: HighCacheMissRate
  expr: |
    sum(rate(harbor_core_proxy_upstream_requests_total[5m])) 
    / 
    sum(rate(harbor_core_registry_requests_total[5m])) > 0.5
  annotations:
    summary: "Cache miss rate above 50%"
```

### 3. Track Bandwidth Savings

By monitoring upstream requests vs total requests, platform engineers can calculate actual bandwidth and cost savings from the cache.

## Benefits

✅ **Visibility**: Clear metrics on cache performance  
✅ **Cost Optimization**: Measure bandwidth/money saved  
✅ **Rate Limit Protection**: Detect when hitting upstream too much  
✅ **Alerting**: Set up alerts for cache degradation  
✅ **Capacity Planning**: Understand cache usage patterns


## Checklist

- [x] Code follows Harbor style guidelines
- [x] Metrics follow Prometheus naming conventions
- [x] Both cache hits and misses are tracked
- [x] Error cases are handled
- [ ] Unit tests added 
- [ ] Documentation updated 
- [x] Signed-off commits


