### PR TITLE
feat: add proxy cache hit/miss metrics #22799

### DIFF
--- a/src/controller/proxy/controller.go
+++ b/src/controller/proxy/controller.go
@@ -238,6 +238,8 @@ func manifestListContentTypeKey(rep string, art lib.ArtifactInfo) string {
 }
 
 func (c *controller) ProxyManifest(ctx context.Context, art lib.ArtifactInfo, remote RemoteInterface) (distribution.Manifest, error) {
+	//Count the totalrequest
+	ProxyRequestsTotal.WithLabelValues(art.ProjectName, art.Repository, "GET").Inc()
 	var man distribution.Manifest
 	remoteRepo := getRemoteRepo(art)
 	ref := getReference(art)
@@ -245,6 +247,8 @@ func (c *controller) ProxyManifest(ctx context.Context, art lib.ArtifactInfo, re
 	if err != nil {
 		return man, err
 	}
+	
+	ProxyUpstreamRequestsTotal.WithLabelValues(art.ProjectName, art.Repository, "GET").Inc()
 	ct, _, err := man.Payload()
 	if err != nil {
 		return man, err
@@ -288,8 +292,12 @@ func (c *controller) HeadManifest(_ context.Context, art lib.ArtifactInfo, remot
 }
 
 func (c *controller) ProxyBlob(ctx context.Context, p *proModels.Project, art lib.ArtifactInfo) (int64, io.ReadCloser, error) {
+	//Count the total request
+	ProxyRequestsTotal.WithLabelValues(art.ProjectName, art.Repository, "GET").Inc()
 	remoteRepo := getRemoteRepo(art)
 	log.Debugf("The blob doesn't exist, proxy the request to the target server, url:%v", remoteRepo)
+	//Count the upstream request
+	ProxyUpstreamRequestsTotal.WithLabelValues(art.ProjectName, art.Repository, "GET").Inc()
 	rHelper, err := NewRemoteHelper(ctx, p.RegistryID, WithSpeed(p.ProxyCacheSpeed()))
 	if err != nil {
 		return 0, nil, err

--- a/src/controller/proxy/metrics.go
+++ b/src/controller/proxy/metrics.go
@@ -1,0 +1,27 @@
+package proxy
+
+import "github.com/prometheus/client_golang/prometheus"
+
+var (
+	ProxyRequestsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "harbor_core_registry_requests_total",
+			Help: "Total number of registry requests received by the proxy.",
+		},
+
+		[]string{"project", "repo", "method"},
+	)
+
+	ProxyUpstreamRequestsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "harbor_core_proxy_upstream_requests_total",
+			Help: "Total number of proxy requests that were sent to the upstream server.",
+		},
+		[]string{"project", "repo", "method"},
+	)
+)
+
+func init() {
+	prometheus.MustRegister(ProxyRequestsTotal)
+	prometheus.MustRegister(ProxyUpstreamRequestsTotal)
+}

--- a/src/controller/proxy/metrics.go
+++ b/src/controller/proxy/metrics.go
@@ -22,6 +22,6 @@ var (
 )
 
 func init() {
-	prometheus.MustRegister(ProxyRequestsTotal)
-	prometheus.MustRegister(ProxyUpstreamRequestsTotal)
+	_ = prometheus.Register(ProxyRequestsTotal)
+	_ = prometheus.Register(ProxyUpstreamRequestsTotal)
 }


### PR DESCRIPTION
# Comprehensive Summary of your change
Added Prometheus metrics to track Proxy Cache performance.

Introduced harbor_core_registry_requests_total for all incoming requests.

Introduced harbor_core_proxy_upstream_requests_total for upstream misses.

Included project, repo, and method labels for granular monitoring.

# Issue being fixed
Fixes #22799

Please indicate you've done the following:
- [X] Well Written Title and Summary of the PR
- [X] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [X] Accepted the DCO. Commits without the DCO will delay acceptance.
- [X] Made sure tests are passing and test coverage is added if needed.
- [X] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
