### PR TITLE
Bump up trivy and trivy adapter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,8 +111,8 @@ PREPARE_VERSION_NAME=versions
 
 #versions
 REGISTRYVERSION=v2.8.3-patch-redis
-TRIVYVERSION=v0.68.2
-TRIVYADAPTERVERSION=v0.35.0-rc.1
+TRIVYVERSION=v0.69.1
+TRIVYADAPTERVERSION=v0.35.0-rc.2
 NODEBUILDIMAGE=node:16.18.0
 
 # version of registry for pulling the source code

--- a/src/.golangci.yaml
+++ b/src/.golangci.yaml
@@ -34,7 +34,7 @@ linters:
       - linters:
           - revive
         text: "var-naming: avoid meaningless package names"
-        path: "(common/|core/utils/|core/api/|jobservice/api/|registryctl/api/|pkg/permission/types/|pkg/quota/types/|server/middleware/util/|server/registry/util/|pkg/reg/util/)"
+        path: "(common/|core/utils/|core/api/|jobservice/api/|registryctl/api/|pkg/permission/types/|pkg/quota/types/|server/middleware/util/|server/registry/util/|pkg/reg/util/|controller/event/handler/util/)"
       # TODO: Fix package naming - these packages conflict with Go stdlib
       - linters:
           - revive


### PR DESCRIPTION
This commit bumps up trivy to v0.69.1 and trivy adapter to v0.35.0-rc.2 It also updates the setting of revive to skip a package naming error

Please indicate you've done the following:
- [X] Well Written Title and Summary of the PR
- [X] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [X] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
