### PR TITLE
Resolve issues listing catalog by non-admin users

### DIFF
--- a/src/server/middleware/v2auth/auth_test.go
+++ b/src/server/middleware/v2auth/auth_test.go
@@ -194,7 +194,7 @@ func TestMiddleware(t *testing.T) {
 		},
 		{
 			input:  req3.WithContext(baseCtx),
-			status: http.StatusUnauthorized,
+			status: http.StatusOK,
 		},
 		{
 			input:  req4.WithContext(ctx3),

--- a/src/server/registry/catalog_test.go
+++ b/src/server/registry/catalog_test.go
@@ -15,6 +15,7 @@
 package registry
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -22,9 +23,14 @@ import (
 
 	"github.com/stretchr/testify/suite"
 
+	"github.com/goharbor/harbor/src/common/rbac"
+	rbac_project "github.com/goharbor/harbor/src/common/rbac/project"
+	"github.com/goharbor/harbor/src/common/security"
 	"github.com/goharbor/harbor/src/pkg"
+	"github.com/goharbor/harbor/src/pkg/permission/types"
 	"github.com/goharbor/harbor/src/pkg/repository"
 	"github.com/goharbor/harbor/src/pkg/repository/model"
+	securitytesting "github.com/goharbor/harbor/src/testing/common/security"
 	"github.com/goharbor/harbor/src/testing/mock"
 	repotesting "github.com/goharbor/harbor/src/testing/pkg/repository"
 )
@@ -128,6 +134,126 @@ func (c *catalogTestSuite) TestCatalogPaginationN2() {
 	c.Nil(err)
 	c.Equal(2, len(ctlg.Repositories))
 	c.Equal("hello-world", ctlg.Repositories[1])
+}
+
+func (c *catalogTestSuite) TestCatalogFiltersByPermission() {
+	req := httptest.NewRequest(http.MethodGet, "/v2/_catalog", nil)
+	sc := &securitytesting.Context{}
+	sc.On("IsAuthenticated").Return(true)
+	project1RepositoryResource := rbac_project.NewNamespace(1).Resource(rbac.ResourceRepository)
+	sc.On("IsSysAdmin").Return(false)
+	mock.OnAnything(sc, "Can").Return(func(_ context.Context, action types.Action, resource types.Resource) bool {
+		return resource == project1RepositoryResource && action == rbac.ActionPull
+	})
+	req = req.WithContext(security.NewContext(context.Background(), sc))
+
+	mock.OnAnything(c.repoMgr, "NonEmptyRepos").Return([]*model.RepoRecord{
+		{
+			RepositoryID: 1,
+			Name:         "project_1/hello-world",
+			ProjectID:    1,
+		},
+		{
+			RepositoryID: 2,
+			Name:         "project_2/busybox",
+			ProjectID:    2,
+		},
+	}, nil)
+
+	w := httptest.NewRecorder()
+	newRepositoryHandler().ServeHTTP(w, req)
+	c.Equal(http.StatusOK, w.Code)
+
+	var ctlg struct {
+		Repositories []string `json:"repositories"`
+	}
+	decoder := json.NewDecoder(w.Body)
+	err := decoder.Decode(&ctlg)
+	c.Nil(err)
+	c.Equal([]string{"project_1/hello-world"}, ctlg.Repositories)
+}
+
+func (c *catalogTestSuite) TestCatalogFiltersEmptyWithoutRepoPermission() {
+	req := httptest.NewRequest(http.MethodGet, "/v2/_catalog", nil)
+	sc := &securitytesting.Context{}
+	sc.On("IsAuthenticated").Return(true)
+	sc.On("IsSysAdmin").Return(false)
+	mock.OnAnything(sc, "Can").Return(false)
+	req = req.WithContext(security.NewContext(context.Background(), sc))
+
+	mock.OnAnything(c.repoMgr, "NonEmptyRepos").Return([]*model.RepoRecord{
+		{
+			RepositoryID: 1,
+			Name:         "project_1/hello-world",
+			ProjectID:    1,
+		},
+	}, nil)
+
+	w := httptest.NewRecorder()
+	newRepositoryHandler().ServeHTTP(w, req)
+	c.Equal(http.StatusOK, w.Code)
+
+	var ctlg struct {
+		Repositories []string `json:"repositories"`
+	}
+	decoder := json.NewDecoder(w.Body)
+	err := decoder.Decode(&ctlg)
+	c.Nil(err)
+	c.Empty(ctlg.Repositories)
+}
+
+func (c *catalogTestSuite) TestCatalogReturnsEmptyForUnauthenticatedUser() {
+	req := httptest.NewRequest(http.MethodGet, "/v2/_catalog", nil)
+	sc := &securitytesting.Context{}
+	sc.On("IsAuthenticated").Return(false)
+	req = req.WithContext(security.NewContext(context.Background(), sc))
+
+	w := httptest.NewRecorder()
+	newRepositoryHandler().ServeHTTP(w, req)
+	c.Equal(http.StatusOK, w.Code)
+
+	var ctlg struct {
+		Repositories []string `json:"repositories"`
+	}
+	decoder := json.NewDecoder(w.Body)
+	err := decoder.Decode(&ctlg)
+	c.Nil(err)
+	c.Empty(ctlg.Repositories)
+	c.repoMgr.AssertNotCalled(c.T(), "NonEmptyRepos", mock.Anything)
+}
+
+func (c *catalogTestSuite) TestCatalogReturnsAllRepositoriesForSysAdmin() {
+	req := httptest.NewRequest(http.MethodGet, "/v2/_catalog", nil)
+	sc := &securitytesting.Context{}
+	sc.On("IsAuthenticated").Return(true)
+	sc.On("IsSysAdmin").Return(true)
+
+	req = req.WithContext(security.NewContext(context.Background(), sc))
+
+	mock.OnAnything(c.repoMgr, "NonEmptyRepos").Return([]*model.RepoRecord{
+		{
+			RepositoryID: 1,
+			Name:         "project_1/hello-world",
+			ProjectID:    1,
+		},
+		{
+			RepositoryID: 2,
+			Name:         "project_2/busybox",
+			ProjectID:    2,
+		},
+	}, nil)
+
+	w := httptest.NewRecorder()
+	newRepositoryHandler().ServeHTTP(w, req)
+	c.Equal(http.StatusOK, w.Code)
+
+	var ctlg struct {
+		Repositories []string `json:"repositories"`
+	}
+	decoder := json.NewDecoder(w.Body)
+	err := decoder.Decode(&ctlg)
+	c.Nil(err)
+	c.Len(ctlg.Repositories, 2)
 }
 
 func (c *catalogTestSuite) TestCatalogPaginationN3() {


### PR DESCRIPTION
This pull request updates the `/v2/_catalog` endpoint to improve repository listing security and access control. Now, only authenticated users can see repositories, and the list is filtered based on the user's permissions: system admins see all repositories, while other users only see repositories they have pull access to. The changes also include comprehensive tests for these behaviors.

**Access control and filtering improvements:**

* The `/v2/_catalog` endpoint now returns an empty list for unauthenticated users, and only lists repositories the user is authorized to pull for authenticated non-admin users. System admins see all repositories. (`src/server/registry/catalog.go`, [[1]](diffhunk://#diff-3a14ce0a64b3c9a6b9e49cc955d9c2b90b529f0c409d82e34532eb6273142526L57-R73) [[2]](diffhunk://#diff-3a14ce0a64b3c9a6b9e49cc955d9c2b90b529f0c409d82e34532eb6273142526R142-R161)
* The authentication check in the v2 auth middleware was simplified: listing the catalog now only requires authentication, not a specific RBAC permission. (`src/server/middleware/v2auth/auth.go`, [[1]](diffhunk://#diff-edd064faf1fbcc9e06edbc98d605eb9892995277d2ae94178756ed9c1d22fcc0L27) [[2]](diffhunk://#diff-edd064faf1fbcc9e06edbc98d605eb9892995277d2ae94178756ed9c1d22fcc0L60-R60)

**Testing enhancements:**

* Added new test cases to verify catalog filtering for: users with pull access to some repositories, users with no repository permissions, unauthenticated users, and system admins. (`src/server/registry/catalog_test.go`, [src/server/registry/catalog_test.goR139-R260](diffhunk://#diff-ae1dfd8efaf0d06e973c2ad903f50a6e8a3aaafd34195ef30d2a219d93145e7fR139-R260))
* Updated an existing test to expect a 200 OK for authenticated catalog requests. (`src/server/middleware/v2auth/auth_test.go`, [src/server/middleware/v2auth/auth_test.goL197-R197](diffhunk://#diff-5bd9c92e7791bce2c16ec3fb391951dd10a46827ac4568fb7b06c2fd7d8a7bebL197-R197))

**Dependency and import updates:**

* Added and removed imports to support new access control logic and testing. (`src/server/registry/catalog.go`, [[1]](diffhunk://#diff-3a14ce0a64b3c9a6b9e49cc955d9c2b90b529f0c409d82e34532eb6273142526R18-R31); `src/server/registry/catalog_test.go`, [[2]](diffhunk://#diff-ae1dfd8efaf0d06e973c2ad903f50a6e8a3aaafd34195ef30d2a219d93145e7fR18-R33)
* 
# Issue being fixed
Fixes #22194 

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
