### PR TITLE
fix: treat HTTP 202 as mount failure in MountBlob per OCI spec

### DIFF
--- a/src/controller/replication/transfer/image/transfer.go
+++ b/src/controller/replication/transfer/image/transfer.go
@@ -349,8 +349,9 @@ func (t *transfer) tryMountBlob(_, dstRepo, digest string) (bool, error) {
 	}
 	if mount {
 		if err = t.dst.MountBlob(repository, digest, dstRepo); err != nil {
-			t.logger.Errorf("failed to mount the blob %s on the destination registry: %v", digest, err)
-			return false, err
+			t.logger.Warningf("failed to mount blob %s from %s, falling back to regular copy: %v",
+				digest, repository, err)
+			return false, nil
 		}
 		t.logger.Infof("the blob %s mounted from the repository %s on the destination registry directly", digest, repository)
 		return true, nil


### PR DESCRIPTION
## Summary

Per the [OCI Distribution Spec](https://github.com/opencontainers/distribution-spec/blob/main/spec.md#mounting-a-blob-from-another-repository), a cross-repository blob mount request should return:
- **201 Created** — mount succeeded, blob is available in the destination repository
- **202 Accepted** — mount was rejected, a regular upload session was started instead

Harbor's `MountBlob()` currently treats *any* 2xx response as success because `do()` only returns errors for non-2xx status codes. This means a 202 Accepted silently returns `nil`, causing the replication controller to skip the blob transfer entirely. When the manifest is subsequently pushed, the destination registry returns `MANIFEST_BLOB_UNKNOWN` because the blob was never actually uploaded.

This bug causes **persistent replication failures** in environments where cross-repository mounts frequently return 202 (e.g., due to stale `artifact_blob` database records pointing to repositories without valid `_layers` links in storage).

## Changes

1. **`src/pkg/registry/client.go`** — `MountBlob()` now explicitly checks for HTTP 201 Created and returns an error for any other status code
2. **`src/controller/replication/transfer/image/transfer.go`** — `tryMountBlob()` treats `MountBlob` errors as non-fatal, logging a warning and falling back to regular blob copy instead of aborting the entire transfer
3. **`src/pkg/registry/client_test.go`** — Fixes existing `TestMountBlob` which incorrectly asserted success on 202; adds `TestMountBlobFallbackOn202`
4. **`src/controller/replication/transfer/image/transfer_test.go`** — Adds `TestTryMountBlobFallbackOnMountError` to verify graceful fallback behavior

## Test plan

- [x] `go test ./pkg/registry/... -run TestClientTestSuite -v` — all pass
- [x] `go test ./controller/replication/transfer/image/... -v` — all pass
- [x] Deployed patched jobservice to production Harbor v2.14.2 — replication succeeds with mount failures gracefully falling back to direct upload

Closes #18575
Closes #16620
Relates #21003
Relates #16624