### PR TITLE
fix: logging of unredacted payloads through OperationDescription in audit events

### DIFF
--- a/src/pkg/auditext/event/config/config.go
+++ b/src/pkg/auditext/event/config/config.go
@@ -56,7 +56,7 @@ func (c *resolver) Resolve(ce *commonevent.Metadata, evt *event.Event) error {
 	if len(ce.RequestPayload) > payloadSizeLimit {
 		ce.RequestPayload = fmt.Sprintf("%v...", ce.RequestPayload[:payloadSizeLimit])
 	}
-	e.OperationDescription = fmt.Sprintf("update configuration: %v", ce.RequestPayload)
+	e.OperationDescription = fmt.Sprintf("update configuration: %v", e.Payload)
 	if ce.ResponseCode == http.StatusOK {
 		e.IsSuccessful = true
 	}

--- a/src/pkg/auditext/event/config/config.go
+++ b/src/pkg/auditext/event/config/config.go
@@ -53,8 +53,8 @@ func (c *resolver) Resolve(ce *commonevent.Metadata, evt *event.Event) error {
 	e.ResourceName = rbac.ResourceConfiguration.String()
 	e.Payload = ext.Redact(ce.RequestPayload, c.SensitiveAttributes)
 	e.OcurrAt = time.Now()
-	if len(ce.RequestPayload) > payloadSizeLimit {
-		ce.RequestPayload = fmt.Sprintf("%v...", ce.RequestPayload[:payloadSizeLimit])
+	if len(e.Payload) > payloadSizeLimit {
+		e.Payload = fmt.Sprintf("%v...", e.Payload[:payloadSizeLimit])
 	}
 	e.OperationDescription = fmt.Sprintf("update configuration: %v", e.Payload)
 	if ce.ResponseCode == http.StatusOK {


### PR DESCRIPTION
Thank you for contributing to Harbor!

# Comprehensive Summary of your change

Changes the `OperationDescription` field in audit events to have the redacted payload, rather than the original payload. This makes sure secrets are properly redacted in the visible log entries in the Harbor portal.

# Issue being fixed
Fixes #22878 

Please indicate you've done the following:
- [X] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [X] Accepted the DCO. Commits without the DCO will delay acceptance.
- [X] Made sure tests are passing and test coverage is added if needed.
- [X] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
