### PR TITLE
[CHERRY_PICK] fix(session): use correct maxlifetime in SessionRegenerate

### DIFF
--- a/src/core/session/session.go
+++ b/src/core/session/session.go
@@ -172,7 +172,7 @@ func (rp *Provider) SessionRegenerate(ctx context.Context, oldsid, sid string) (
 	}
 	maxlifetime := time.Duration(systemSessionTimeout(ctx, rp.maxlifetime))
 	if isExist, _ := rp.SessionExist(ctx, oldsid); !isExist {
-		err := rp.c.Save(ctx, sid, map[any]any{}, time.Duration(rp.maxlifetime))
+		err := rp.c.Save(ctx, sid, map[any]any{}, maxlifetime)
 		if err != nil {
 			log.Debugf("failed to save sid=%s, where oldsid=%s, error: %s", sid, oldsid, err)
 		}


### PR DESCRIPTION
Thank you for contributing to Harbor!

# Comprehensive Summary of your change

This pull request makes a small but important fix to the session regeneration logic. The change ensures that the session's maximum lifetime is correctly set when saving a new session after regenerating the session ID.

* Corrected the duration used in the `SessionRegenerate` method to use the computed `maxlifetime` value instead of the raw `rp.maxlifetime` when saving a new session in `session.go`.

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
