### PR TITLE
[CHERRY_PICK] fix(session): fix SessionRegenerate save args and lifetime

### DIFF
--- a/src/core/session/session.go
+++ b/src/core/session/session.go
@@ -172,7 +172,7 @@ func (rp *Provider) SessionRegenerate(ctx context.Context, oldsid, sid string) (
 	}
 	maxlifetime := time.Duration(systemSessionTimeout(ctx, rp.maxlifetime))
 	if isExist, _ := rp.SessionExist(ctx, oldsid); !isExist {
-		err := rp.c.Save(ctx, sid, "", time.Duration(rp.maxlifetime))
+		err := rp.c.Save(ctx, sid, map[any]any{}, maxlifetime)
 		if err != nil {
 			log.Debugf("failed to save sid=%s, where oldsid=%s, error: %s", sid, oldsid, err)
 		}

--- a/src/core/session/session_test.go
+++ b/src/core/session/session_test.go
@@ -86,6 +86,9 @@ func (s *sessionTestSuite) TestSessionRegenerate() {
 
 		err = s.provider.SessionDestroy(ctx, "session-003")
 		s.NoError(err)
+
+		err = s.provider.SessionDestroy(ctx, "session-004")
+		s.NoError(err)
 	}()
 
 	_, err = s.provider.SessionRegenerate(ctx, "session-001", "session-003")
@@ -93,6 +96,10 @@ func (s *sessionTestSuite) TestSessionRegenerate() {
 
 	s.True(s.provider.SessionExist(ctx, "session-003"))
 	s.False(s.provider.SessionExist(ctx, "session-001"))
+
+	_, err = s.provider.SessionRegenerate(ctx, "session-001", "session-004")
+	s.NoError(err, "session regenerate should not error")
+	s.True(s.provider.SessionExist(ctx, "session-004"))
 }
 
 func (s *sessionTestSuite) TestSessionDestroy() {


### PR DESCRIPTION
Thank you for contributing to Harbor!

# Comprehensive Summary of your change

It's a cherry pick of https://github.com/goharbor/harbor/pull/22873 and https://github.com/goharbor/harbor/pull/22726.

This pull request makes improvements to session regeneration handling and enhances test coverage for session management. The main changes ensure that empty session data is stored with the correct type and add additional tests to verify session regeneration behavior.

Session regeneration improvements:

* Modified `SessionRegenerate` in `session.go` to store empty session data as a map instead of an empty string, ensuring correct session data type and consistency.

Session management test enhancements:

* Added new assertions in `TestSessionRegenerate` in `session_test.go` to test session regeneration for a new session ID (`session-004`), verifying that the session is properly created and exists after regeneration.

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
