### PR TITLE
feat(proxy): implement local cache with LRU eviction for object storage backends (#21212)

### DIFF
--- a/src/controller/proxy/controller.go
+++ b/src/controller/proxy/controller.go
@@ -100,15 +100,21 @@ func ControllerInstance() Controller {
 		}
 
 		// Initialize LRU proxy blob cache with an environment variable limit (default 10GB)
+		// Set PROXY_LOCAL_CACHE_SIZE_MB=0 to disable caching/eviction.
 		// Eviction callback physically deletes the cached file
 		sizeLimitMBStr := os.Getenv("PROXY_LOCAL_CACHE_SIZE_MB")
 		var sizeLimit int64 = 10 * 1024 * 1024 * 1024 // 10GB default
-		if parsed, err := strconv.ParseInt(sizeLimitMBStr, 10, 64); err == nil && parsed > 0 {
-			sizeLimit = parsed * 1024 * 1024
+		if sizeLimitMBStr != "" {
+			if parsed, err := strconv.ParseInt(sizeLimitMBStr, 10, 64); err == nil {
+				sizeLimit = parsed * 1024 * 1024
+			}
 		}
 		BlobCache = NewLocalLRUCache(sizeLimit, func(digest string) error {
 			cachePath := filepath.Join(os.TempDir(), "lru_blob_cache", digest)
-			return os.Remove(cachePath)
+			if err := os.Remove(cachePath); err != nil && !os.IsNotExist(err) {
+				return err
+			}
+			return nil
 		})
 	})
 

--- a/src/controller/proxy/local.go
+++ b/src/controller/proxy/local.go
@@ -110,12 +110,6 @@ func (l *localHelper) PushBlob(localRepo string, desc distribution.Descriptor, b
 	}
 	defer inflightChecker.removeRequest(artName)
 	err := l.registry.PushBlob(localRepo, ref, desc.Size, bReader)
-	if err == nil && BlobCache != nil {
-		// Log tracking addition
-		log.Debugf("LRU Cache: Tracking pulled blob %v (Size: %d bytes)", desc.Digest, desc.Size)
-		// Assuming we pass context.TODO() here as we just want background tracking
-		BlobCache.Add(context.TODO(), string(desc.Digest), desc.Size)
-	}
 	return err
 }
 

--- a/src/controller/proxy/local.go
+++ b/src/controller/proxy/local.go
@@ -110,6 +110,12 @@ func (l *localHelper) PushBlob(localRepo string, desc distribution.Descriptor, b
 	}
 	defer inflightChecker.removeRequest(artName)
 	err := l.registry.PushBlob(localRepo, ref, desc.Size, bReader)
+	if err == nil && BlobCache != nil {
+		// Log tracking addition
+		log.Debugf("LRU Cache: Tracking pulled blob %v (Size: %d bytes)", desc.Digest, desc.Size)
+		// Assuming we pass context.TODO() here as we just want background tracking
+		BlobCache.Add(context.TODO(), string(desc.Digest), desc.Size)
+	}
 	return err
 }
 

--- a/src/controller/proxy/lru_cache.go
+++ b/src/controller/proxy/lru_cache.go
@@ -1,0 +1,162 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proxy
+
+import (
+	"container/list"
+	"context"
+	"sync"
+	"time"
+
+	"github.com/goharbor/harbor/src/lib/log"
+)
+
+// LRUEntry represents an item in the LRU Cache tracking system.
+// We only track the digest and size; the actual blob data remains on the filesystem (local registry).
+type LRUEntry struct {
+	Digest       string
+	Size         int64
+	LastAccessed time.Time
+}
+
+// LocalLRUCache tracks image blobs pulled through the proxy cache
+// and handles eviction when the overall size exceeds the limit.
+type LocalLRUCache struct {
+	mu           sync.RWMutex
+	maxSizeBytes int64
+	currentSize  int64
+
+	// evictList holds *LRUEntry. Front is most recently used.
+	evictList *list.List
+	// items maps digest -> list element pointer
+	items map[string]*list.Element
+
+	// evictionCallback is triggered when an item must be deleted from local disk
+	evictionCallback func(digest string) error
+}
+
+// NewLocalLRUCache creates a new bounded LRU cache for tracking proxy blobs.
+// maxSizeBytes configures the hard limit of the cache. If 0, no eviction happens.
+// evictionCallback handles the physical deletion of the blob from the local registry.
+func NewLocalLRUCache(maxSizeBytes int64, cb func(digest string) error) *LocalLRUCache {
+	return &LocalLRUCache{
+		maxSizeBytes:     maxSizeBytes,
+		evictList:        list.New(),
+		items:            make(map[string]*list.Element),
+		evictionCallback: cb,
+	}
+}
+
+// Add tracks a new blob or updates an existing one's access time.
+// Triggers eviction if the new size exceeds maxSizeBytes.
+func (c *LocalLRUCache) Add(ctx context.Context, digest string, size int64) {
+	c.mu.Lock()
+
+	// If tracking is disabled (maxSize == 0), don't bother
+	if c.maxSizeBytes <= 0 {
+		c.mu.Unlock()
+		return
+	}
+
+	if ent, ok := c.items[digest]; ok {
+		// Existing item: Update access time and move to front
+		c.evictList.MoveToFront(ent)
+		entry := ent.Value.(*LRUEntry)
+
+		// Adjust size differential if somehow the size changed
+		c.currentSize += (size - entry.Size)
+		entry.Size = size
+		entry.LastAccessed = time.Now()
+	} else {
+		// New item: Add to tracker
+		ent := &LRUEntry{
+			Digest:       digest,
+			Size:         size,
+			LastAccessed: time.Now(),
+		}
+		element := c.evictList.PushFront(ent)
+		c.items[digest] = element
+		c.currentSize += size
+	}
+
+	// Collect eviction candidates while holding the lock; data structures are
+	// updated here so that concurrent readers see a consistent size immediately.
+	victims := c.collectEvictees()
+	c.mu.Unlock()
+
+	// Execute I/O outside the lock so that concurrent Add/Access/Remove calls
+	// are not blocked by potentially slow filesystem or registry operations.
+	for _, v := range victims {
+		if c.evictionCallback != nil {
+			if err := c.evictionCallback(v.Digest); err != nil {
+				log.Errorf("LRU Cache: Failed to evict blob digest %s: %v", v.Digest, err)
+			} else {
+				log.Infof("LRU Cache: Successfully evicted proxy blob %s (size: %d) to maintain cache limits", v.Digest, v.Size)
+			}
+		}
+	}
+}
+
+// Access marks a blob as recently used, moving it to the front of the LRU queue.
+func (c *LocalLRUCache) Access(digest string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if ent, ok := c.items[digest]; ok {
+		c.evictList.MoveToFront(ent)
+		ent.Value.(*LRUEntry).LastAccessed = time.Now()
+	}
+}
+
+// Remove manually drops a blob from the tracker (e.g. if deleted manually by user/registry).
+func (c *LocalLRUCache) Remove(digest string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if ent, ok := c.items[digest]; ok {
+		c.removeElement(ent)
+	}
+}
+
+// collectEvictees removes over-limit entries from the data structures and returns
+// them so the caller can invoke the eviction callback outside the lock.
+// Must be called with c.mu held.
+func (c *LocalLRUCache) collectEvictees() []*LRUEntry {
+	var victims []*LRUEntry
+	for c.currentSize > c.maxSizeBytes && c.evictList.Len() > 0 {
+		element := c.evictList.Back()
+		if element == nil {
+			break
+		}
+		entry := element.Value.(*LRUEntry)
+		c.removeElement(element)
+		victims = append(victims, entry)
+	}
+	return victims
+}
+
+func (c *LocalLRUCache) removeElement(e *list.Element) {
+	c.evictList.Remove(e)
+	entry := e.Value.(*LRUEntry)
+	delete(c.items, entry.Digest)
+	c.currentSize -= entry.Size
+}
+
+// GetCurrentSize returns the tracked size in bytes.
+func (c *LocalLRUCache) GetCurrentSize() int64 {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.currentSize
+}

--- a/src/controller/proxy/lru_cache.go
+++ b/src/controller/proxy/lru_cache.go
@@ -24,7 +24,8 @@ import (
 )
 
 // LRUEntry represents an item in the LRU Cache tracking system.
-// We only track the digest and size; the actual blob data remains on the filesystem (local registry).
+// We only track the digest and size; the actual blob data resides in the
+// local disk cache directory (os.TempDir()/lru_blob_cache).
 type LRUEntry struct {
 	Digest       string
 	Size         int64
@@ -101,7 +102,14 @@ func (c *LocalLRUCache) Add(ctx context.Context, digest string, size int64) {
 	for _, v := range victims {
 		if c.evictionCallback != nil {
 			if err := c.evictionCallback(v.Digest); err != nil {
-				log.Errorf("LRU Cache: Failed to evict blob digest %s: %v", v.Digest, err)
+				log.Errorf("LRU Cache: Failed to evict blob digest %s: %v, re-adding to tracker", v.Digest, v.Size)
+				// Re-add the entry so in-memory accounting stays consistent
+				// with disk usage.
+				c.mu.Lock()
+				ent := c.evictList.PushBack(v)
+				c.items[v.Digest] = ent
+				c.currentSize += v.Size
+				c.mu.Unlock()
 			} else {
 				log.Infof("LRU Cache: Successfully evicted proxy blob %s (size: %d) to maintain cache limits", v.Digest, v.Size)
 			}

--- a/src/controller/proxy/lru_cache_test.go
+++ b/src/controller/proxy/lru_cache_test.go
@@ -1,0 +1,72 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proxy
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLocalLRUCache(t *testing.T) {
+	ctx := context.TODO()
+
+	var deletedDigests []string
+	evictionCb := func(digest string) error {
+		deletedDigests = append(deletedDigests, digest)
+		return nil
+	}
+
+	// 100 bytes max size
+	cache := NewLocalLRUCache(100, evictionCb)
+
+	// Add 40 byte item
+	cache.Add(ctx, "digest-1", 40)
+	assert.Equal(t, int64(40), cache.GetCurrentSize())
+	assert.Empty(t, deletedDigests)
+
+	// Add 50 byte item (Total: 90/100)
+	cache.Add(ctx, "digest-2", 50)
+	assert.Equal(t, int64(90), cache.GetCurrentSize())
+
+	// Access digest-1, making digest-2 the LRU
+	time.Sleep(1 * time.Millisecond)
+	cache.Access("digest-1")
+
+	// Add 30 byte item (Total: 120/100 -> Evict digest-2 to bring total to 70/100)
+	cache.Add(ctx, "digest-3", 30)
+	assert.Equal(t, int64(70), cache.GetCurrentSize())
+
+	assert.Contains(t, deletedDigests, "digest-2")
+	assert.NotContains(t, deletedDigests, "digest-1")
+
+	// Add 50 byte item (Total: 120/100 -> Evict digest-1 to bring total to 80/100)
+	cache.Add(ctx, "digest-4", 50)
+	assert.Contains(t, deletedDigests, "digest-1")
+	assert.Equal(t, int64(80), cache.GetCurrentSize())
+
+	// Test failing eviction handler
+	cache = NewLocalLRUCache(50, func(d string) error {
+		return errors.New("delete failed")
+	})
+	cache.Add(ctx, "fail-1", 40)
+	cache.Add(ctx, "fail-2", 20)
+
+	// Because eviction callback returned error, we still remove it from tracking to prevent infinite loops.
+	assert.Equal(t, int64(20), cache.GetCurrentSize())
+}

--- a/src/controller/proxy/lru_cache_test.go
+++ b/src/controller/proxy/lru_cache_test.go
@@ -67,6 +67,7 @@ func TestLocalLRUCache(t *testing.T) {
 	cache.Add(ctx, "fail-1", 40)
 	cache.Add(ctx, "fail-2", 20)
 
-	// Because eviction callback returned error, we still remove it from tracking to prevent infinite loops.
-	assert.Equal(t, int64(20), cache.GetCurrentSize())
+	// Eviction callback failed, so fail-1 is re-added to keep disk/memory consistent.
+	// Both entries remain tracked and the cache sits over-limit until the I/O error resolves.
+	assert.Equal(t, int64(60), cache.GetCurrentSize())
 }

--- a/src/server/middleware/repoproxy/caching_writer.go
+++ b/src/server/middleware/repoproxy/caching_writer.go
@@ -1,0 +1,83 @@
+package repoproxy
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+
+	"github.com/goharbor/harbor/src/controller/proxy"
+	"github.com/goharbor/harbor/src/lib/log"
+)
+
+type CachingResponseWriter struct {
+	http.ResponseWriter
+	file       *os.File
+	digest     string
+	written    int64
+	tempPath   string
+	statusCode int
+}
+
+func NewCachingResponseWriter(w http.ResponseWriter, digest string) *CachingResponseWriter {
+	cacheDir := filepath.Join(os.TempDir(), "lru_blob_cache")
+	os.MkdirAll(cacheDir, 0755)
+
+	tempPath := filepath.Join(cacheDir, digest+".tmp")
+	f, err := os.OpenFile(tempPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
+	if err != nil {
+		log.Errorf("Failed to open cache temp file for %s: %v", digest, err)
+		f = nil
+	}
+
+	return &CachingResponseWriter{
+		ResponseWriter: w,
+		file:           f,
+		digest:         digest,
+		tempPath:       tempPath,
+		statusCode:     0,
+	}
+}
+
+func (w *CachingResponseWriter) WriteHeader(statusCode int) {
+	if w.statusCode == 0 {
+		w.statusCode = statusCode
+		w.ResponseWriter.WriteHeader(statusCode)
+	}
+}
+
+func (w *CachingResponseWriter) Write(b []byte) (int, error) {
+	if w.statusCode == 0 {
+		w.WriteHeader(http.StatusOK)
+	}
+	n, err := w.ResponseWriter.Write(b)
+	if w.statusCode >= 200 && w.statusCode < 300 && n > 0 && w.file != nil {
+		w.file.Write(b[:n])
+		w.written += int64(n)
+	}
+	return n, err
+}
+
+func (w *CachingResponseWriter) Close() {
+	if w.file != nil {
+		w.file.Close()
+
+		if w.statusCode >= 200 && w.statusCode < 300 {
+			contentLengthStr := w.Header().Get("Content-Length")
+			expectedSize, _ := strconv.ParseInt(contentLengthStr, 10, 64)
+
+			if expectedSize > 0 && w.written == expectedSize {
+				finalPath := filepath.Join(filepath.Dir(w.tempPath), w.digest)
+				os.Rename(w.tempPath, finalPath)
+				if proxy.BlobCache != nil {
+					proxy.BlobCache.Add(context.Background(), w.digest, w.written)
+				}
+				log.Infof("LRU Cache: Successfully cached blob %s to local disk (size: %d)", w.digest, w.written)
+				return
+			}
+			log.Debugf("LRU Cache: Incomplete blob read across proxy. Written: %d, expected: %d", w.written, expectedSize)
+		}
+		os.Remove(w.tempPath)
+	}
+}

--- a/src/server/middleware/repoproxy/caching_writer.go
+++ b/src/server/middleware/repoproxy/caching_writer.go
@@ -11,6 +11,9 @@ import (
 	"github.com/goharbor/harbor/src/lib/log"
 )
 
+// cacheDirPerm restricts cache directory access to owner only.
+const cacheDirPerm = 0700
+
 type CachingResponseWriter struct {
 	http.ResponseWriter
 	file       *os.File
@@ -18,25 +21,28 @@ type CachingResponseWriter struct {
 	written    int64
 	tempPath   string
 	statusCode int
+	writeErr   bool // set on first disk write failure
 }
 
 func NewCachingResponseWriter(w http.ResponseWriter, digest string) *CachingResponseWriter {
 	cacheDir := filepath.Join(os.TempDir(), "lru_blob_cache")
-	os.MkdirAll(cacheDir, 0755)
+	os.MkdirAll(cacheDir, cacheDirPerm)
 
-	tempPath := filepath.Join(cacheDir, digest+".tmp")
-	f, err := os.OpenFile(tempPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
+	// Use a per-request unique temp file to avoid races when multiple
+	// goroutines pull the same digest concurrently.
+	f, err := os.CreateTemp(cacheDir, digest+".*.tmp")
 	if err != nil {
-		log.Errorf("Failed to open cache temp file for %s: %v", digest, err)
-		f = nil
+		log.Errorf("Failed to create cache temp file for %s: %v", digest, err)
+		return &CachingResponseWriter{ResponseWriter: w, digest: digest}
 	}
+	// Restrict file permissions to owner only.
+	os.Chmod(f.Name(), 0600)
 
 	return &CachingResponseWriter{
 		ResponseWriter: w,
 		file:           f,
 		digest:         digest,
-		tempPath:       tempPath,
-		statusCode:     0,
+		tempPath:       f.Name(),
 	}
 }
 
@@ -52,9 +58,16 @@ func (w *CachingResponseWriter) Write(b []byte) (int, error) {
 		w.WriteHeader(http.StatusOK)
 	}
 	n, err := w.ResponseWriter.Write(b)
-	if w.statusCode >= 200 && w.statusCode < 300 && n > 0 && w.file != nil {
-		w.file.Write(b[:n])
-		w.written += int64(n)
+	if w.statusCode >= 200 && w.statusCode < 300 && n > 0 && w.file != nil && !w.writeErr {
+		if _, wErr := w.file.Write(b[:n]); wErr != nil {
+			log.Errorf("LRU Cache: disk write error for %s, abandoning cache: %v", w.digest, wErr)
+			w.writeErr = true
+			w.file.Close()
+			os.Remove(w.tempPath)
+			w.file = nil
+		} else {
+			w.written += int64(n)
+		}
 	}
 	return n, err
 }
@@ -63,13 +76,17 @@ func (w *CachingResponseWriter) Close() {
 	if w.file != nil {
 		w.file.Close()
 
-		if w.statusCode >= 200 && w.statusCode < 300 {
+		if w.statusCode >= 200 && w.statusCode < 300 && !w.writeErr {
 			contentLengthStr := w.Header().Get("Content-Length")
 			expectedSize, _ := strconv.ParseInt(contentLengthStr, 10, 64)
 
 			if expectedSize > 0 && w.written == expectedSize {
 				finalPath := filepath.Join(filepath.Dir(w.tempPath), w.digest)
-				os.Rename(w.tempPath, finalPath)
+				if err := os.Rename(w.tempPath, finalPath); err != nil {
+					log.Errorf("LRU Cache: failed to finalize blob %s: %v", w.digest, err)
+					os.Remove(w.tempPath)
+					return
+				}
 				if proxy.BlobCache != nil {
 					proxy.BlobCache.Add(context.Background(), w.digest, w.written)
 				}

--- a/src/server/middleware/repoproxy/caching_writer_test.go
+++ b/src/server/middleware/repoproxy/caching_writer_test.go
@@ -1,0 +1,81 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package repoproxy
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCachingResponseWriter_CacheMiss(t *testing.T) {
+	digest := "sha256:test-cache-miss"
+	rec := httptest.NewRecorder()
+	cw := NewCachingResponseWriter(rec, digest)
+
+	data := []byte("hello world")
+	cw.WriteHeader(http.StatusOK)
+	n, err := cw.Write(data)
+	assert.NoError(t, err)
+	assert.Equal(t, len(data), n)
+
+	// Set Content-Length as the upstream would.
+	cw.Header().Set("Content-Length", strconv.Itoa(len(data)))
+	cw.Close()
+
+	// Verify blob was cached to disk.
+	finalPath := filepath.Join(os.TempDir(), "lru_blob_cache", digest)
+	stat, err := os.Stat(finalPath)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(len(data)), stat.Size())
+
+	// Cleanup.
+	os.Remove(finalPath)
+}
+
+func TestCachingResponseWriter_NonSuccessSkipsCache(t *testing.T) {
+	digest := "sha256:test-non-success"
+	rec := httptest.NewRecorder()
+	cw := NewCachingResponseWriter(rec, digest)
+
+	cw.WriteHeader(http.StatusNotFound)
+	cw.Write([]byte("not found"))
+	cw.Close()
+
+	// Blob should NOT be cached.
+	finalPath := filepath.Join(os.TempDir(), "lru_blob_cache", digest)
+	_, err := os.Stat(finalPath)
+	assert.True(t, os.IsNotExist(err))
+}
+
+func TestCachingResponseWriter_TempFileIsUnique(t *testing.T) {
+	digest := "sha256:test-unique-temp"
+	rec1 := httptest.NewRecorder()
+	rec2 := httptest.NewRecorder()
+
+	cw1 := NewCachingResponseWriter(rec1, digest)
+	cw2 := NewCachingResponseWriter(rec2, digest)
+
+	// Two writers for the same digest should use different temp files.
+	assert.NotEqual(t, cw1.tempPath, cw2.tempPath)
+
+	cw1.Close()
+	cw2.Close()
+}

--- a/src/server/middleware/repoproxy/proxy.go
+++ b/src/server/middleware/repoproxy/proxy.go
@@ -107,16 +107,14 @@ func handleBlob(w http.ResponseWriter, r *http.Request, next http.Handler) error
 		if proxy.BlobCache != nil {
 			proxy.BlobCache.Access(art.Digest)
 		}
+		setHeaders(w, stat.Size(), "application/octet-stream", art.Digest)
 		http.ServeFile(w, r, cachePath)
 		return nil
 	}
 	// ------------------------------------
 
-	cw := NewCachingResponseWriter(w, art.Digest)
-	defer cw.Close()
-
 	if !canProxy(r.Context(), p) || proxyCtl.UseLocalBlob(ctx, art) {
-		next.ServeHTTP(cw, r)
+		next.ServeHTTP(w, r)
 		return nil
 	}
 
@@ -140,6 +138,13 @@ func handleBlob(w http.ResponseWriter, r *http.Request, next http.Handler) error
 		return err
 	}
 	defer reader.Close()
+
+	cw := NewCachingResponseWriter(w, art.Digest)
+	defer cw.Close()
+
+	// Set headers before streaming so they reach the client.
+	setHeaders(cw, size, "application/octet-stream", art.Digest)
+
 	// Use io.CopyN to avoid out of memory when pulling big blob
 	written, err := io.CopyN(cw, reader, size)
 	if err != nil {
@@ -148,7 +153,6 @@ func handleBlob(w http.ResponseWriter, r *http.Request, next http.Handler) error
 	if written != size {
 		return errors.Errorf("The size mismatch, actual:%d, expected: %d", written, size)
 	}
-	setHeaders(cw, size, "", art.Digest)
 	return nil
 }
 
@@ -335,6 +339,7 @@ func setHeaders(w http.ResponseWriter, size int64, mediaType string, dig string)
 	}
 	h.Set(dockerContentDigest, dig)
 	h.Set(etag, dig)
+	h.Set("X-Content-Type-Options", "nosniff")
 }
 
 // isProxySession check if current security context is proxy session


### PR DESCRIPTION
fixes #21212

## What this PR does / why we need it:
This PR introduces a bounded Local Disk LRU Cache layer for the Proxy Cache feature, specifically designed to eliminate redundant egress costs when using Object Storage (S3, GCS).

It intercepts downstream HTTP blob pulls via a custom CachingResponseWriter in the repoproxy middleware and concurrently streams the bits to a local disk buffer (default max 10GB). Subsequent pulls for the same digest bypass the remote backend entirely and stream straight from local disk.

Sync GC evictions are performed using an O(1) in-memory LRU tracking list to purge the oldest disk bytes.

## PR Checklist
- [x] I have read the CONTRIBUTING.md
- [x] My commits are signed off
- [x] I have added unit tests for my changes
- [x] All existing tests pass