### PR TITLE
update the GitHub Actions workflows to use the ubuntu-latest runner

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -13,7 +13,7 @@ jobs:
     env:
         BUILD_PACKAGE: true
     runs-on:
-      - ubuntu-22.04
+      - ubuntu-latest
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4.1.0


### PR DESCRIPTION
Fix the failure from the build package workflow, ERROR: failed to initialize builder mybuilder (mybuilder0): Error response from daemon: client version 1.52 is too new. Maximum supported API version is 1.41.

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [ ] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [ ] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
