### PR TITLE
feat: add webhook trigger for tag created event (#22640)

### DIFF
--- a/src/controller/event/handler/init.go
+++ b/src/controller/event/handler/init.go
@@ -42,6 +42,7 @@ func init() {
 	_ = notifier.Subscribe(event.TopicScanningFailed, &scan.Handler{})
 	_ = notifier.Subscribe(event.TopicScanningStopped, &scan.Handler{})
 	_ = notifier.Subscribe(event.TopicScanningCompleted, &scan.Handler{})
+	_ = notifier.Subscribe(event.TopicCreateTag, &artifact.Handler{})
 	_ = notifier.Subscribe(event.TopicReplication, &artifact.ReplicationHandler{})
 	_ = notifier.Subscribe(event.TopicTagRetention, &artifact.RetentionHandler{})
 

--- a/src/controller/event/handler/webhook/artifact/artifact.go
+++ b/src/controller/event/handler/webhook/artifact/artifact.go
@@ -52,6 +52,16 @@ func (a *Handler) Handle(ctx context.Context, value any) error {
 		return a.handle(ctx, v.ArtifactEvent)
 	case *event.DeleteArtifactEvent:
 		return a.handle(ctx, v.ArtifactEvent)
+	case *event.CreateTagEvent:
+		return a.handle(ctx, &event.ArtifactEvent{
+			EventType:  v.EventType,
+			Repository: v.Repository,
+			Artifact:   v.AttachedArtifact,
+			Tags:       []string{v.Tag},
+			Labels:     v.Labels,
+			Operator:   v.Operator,
+			OccurAt:    v.OccurAt,
+		})
 	default:
 		log.Errorf("Can not handler this event type! %#v", v)
 	}

--- a/src/controller/tag/controller.go
+++ b/src/controller/tag/controller.go
@@ -20,7 +20,9 @@ import (
 	"time"
 
 	"github.com/goharbor/harbor/src/common/utils"
+	"github.com/goharbor/harbor/src/controller/event/metadata"
 	"github.com/goharbor/harbor/src/lib/errors"
+	"github.com/goharbor/harbor/src/lib/log"
 	"github.com/goharbor/harbor/src/lib/orm"
 	"github.com/goharbor/harbor/src/lib/q"
 	"github.com/goharbor/harbor/src/lib/selector"
@@ -28,6 +30,7 @@ import (
 	"github.com/goharbor/harbor/src/pkg/artifact"
 	"github.com/goharbor/harbor/src/pkg/immutable/match"
 	"github.com/goharbor/harbor/src/pkg/immutable/match/rule"
+	"github.com/goharbor/harbor/src/pkg/notification"
 	"github.com/goharbor/harbor/src/pkg/tag"
 	model_tag "github.com/goharbor/harbor/src/pkg/tag/model/tag"
 )
@@ -164,7 +167,26 @@ func (c *controller) Create(ctx context.Context, tag *Tag) (id int64, err error)
 	if !isValidTag(tag.Name) {
 		return 0, errors.BadRequestError(errors.Errorf("invalid tag name: %s", tag.Name))
 	}
-	return c.tagMgr.Create(ctx, &(tag.Tag))
+
+	id, err = c.tagMgr.Create(ctx, &(tag.Tag))
+	if err != nil {
+		return 0, err
+	}
+
+	// Fetch the artifact to pass into the event payload
+	art, artErr := c.artMgr.Get(ctx, tag.ArtifactID)
+	if artErr == nil {
+		e := &metadata.CreateTagEventMetadata{
+			Ctx:              ctx,
+			Tag:              tag.Name,
+			AttachedArtifact: art,
+		}
+		notification.AddEvent(ctx, e)
+	} else {
+		log.Warningf("failed to get artifact %d to fire tag creation event: %v", tag.ArtifactID, artErr)
+	}
+
+	return id, nil
 }
 
 func isValidTag(name string) bool {

--- a/src/pkg/notification/notification.go
+++ b/src/pkg/notification/notification.go
@@ -85,6 +85,7 @@ func initSupportedNotifyType() {
 		event.TopicPushArtifact,
 		event.TopicPullArtifact,
 		event.TopicDeleteArtifact,
+		event.TopicCreateTag,
 		event.TopicQuotaExceed,
 		event.TopicQuotaWarning,
 		event.TopicScanningFailed,

--- a/src/pkg/notifier/formats/cloudevents.go
+++ b/src/pkg/notifier/formats/cloudevents.go
@@ -54,6 +54,7 @@ var (
 		event.TopicDeleteArtifact:    eventType("artifact.deleted"),
 		event.TopicPullArtifact:      eventType("artifact.pulled"),
 		event.TopicPushArtifact:      eventType("artifact.pushed"),
+		event.TopicCreateTag:         eventType("tag.created"),
 		event.TopicQuotaExceed:       eventType("quota.exceeded"),
 		event.TopicQuotaWarning:      eventType("quota.warned"),
 		event.TopicReplication:       eventType("replication.status.changed"),

--- a/src/server/v2.0/handler/artifact.go
+++ b/src/server/v2.0/handler/artifact.go
@@ -253,14 +253,6 @@ func (a *artifactAPI) CreateTag(ctx context.Context, params operation.CreateTagP
 		return a.SendError(ctx, err)
 	}
 
-	// fire event
-	notification.AddEvent(ctx, &metadata.CreateTagEventMetadata{
-		Ctx:              ctx,
-		Tag:              tag.Name,
-		Labels:           art.AbstractLabelNames(),
-		AttachedArtifact: &art.Artifact,
-	})
-
 	// as we provide no API for get the single tag, ignore setting the location header here
 	return operation.NewCreateTagCreated()
 }


### PR DESCRIPTION
# Add Webhook Trigger for "Tag Created" Event

## Summary

When a tag is created without pushing a new artifact (e.g. tag promotion `0.403.0` → `0.403.0-prod`), Harbor didn't fire any webhook. This PR adds `CREATE_TAG` as a webhook-supported event so external systems can react to tag creation.

### What changed

- **`controller/tag/controller.go`** — Fire `CreateTagEventMetadata` from `Create()` so the event triggers for all tag creation paths.
- **`server/v2.0/handler/artifact.go`** — Remove the now-duplicate event firing from the API handler.
- **`controller/event/handler/webhook/artifact/artifact.go`** — Handle `CreateTagEvent` by mapping it to `ArtifactEvent` for webhook dispatch.
- **`controller/event/handler/init.go`** — Subscribe `artifact.Handler` to `TopicCreateTag`.
- **`pkg/notification/notification.go`** — Add `TopicCreateTag` to supported event types (makes it available in webhook policy UI).
- **`pkg/notifier/formats/cloudevents.go`** — Map `TopicCreateTag` → `harbor.tag.created`.

## Fixes #22640

- [x] Accepted the DCO
- [x] Tests passing (`go test`, `go vet`, `golangci-lint`, `-race` all clean)
- [ ] Label: `release-note/new-feature`
- [ ] Docs impact considered