### PR TITLE
perf(blob): use batched UNION with LIMIT 1 in FindBlobsShouldUnassociatedWithProject

### DIFF
--- a/src/pkg/blob/dao/dao.go
+++ b/src/pkg/blob/dao/dao.go
@@ -17,6 +17,7 @@ package dao
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/docker/distribution/manifest/schema2"
@@ -246,21 +247,35 @@ func (d *dao) FindBlobsShouldUnassociatedWithProject(ctx context.Context, projec
 		return nil, err
 	}
 
-	sql := `SELECT b.digest_blob FROM artifact a, artifact_blob b WHERE a.digest = b.digest_af AND a.project_id = ? AND b.digest_blob IN (%s)`
-	params := []any{projectID}
-	for _, blob := range blobs {
-		params = append(params, blob.Digest)
-	}
-
-	var digests []string
-	_, err = o.Raw(fmt.Sprintf(sql, orm.ParamPlaceholderForIn(len(blobs))), params...).QueryRows(&digests)
-	if err != nil {
-		return nil, err
-	}
+	// blobBatchSize caps how many blobs are checked per UNION query to avoid
+	// generating excessively large SQL statements.
+	const blobBatchSize = 100
 
 	shouldAssociated := map[string]bool{}
-	for _, digest := range digests {
-		shouldAssociated[digest] = true
+	for i := 0; i < len(blobs); i += blobBatchSize {
+		end := i + blobBatchSize
+		if end > len(blobs) {
+			end = len(blobs)
+		}
+		batch := blobs[i:end]
+
+		// Each subquery uses LIMIT 1 so it short-circuits as soon as one
+		// matching artifact is found, avoiding full scans per blob.
+		var unionParts []string
+		var params []interface{}
+		for _, blob := range batch {
+			unionParts = append(unionParts, `(SELECT b.digest_blob FROM artifact a, artifact_blob b WHERE a.digest = b.digest_af AND a.project_id = ? AND b.digest_blob = ? LIMIT 1)`)
+			params = append(params, projectID, blob.Digest)
+		}
+
+		var digests []string
+		_, err = o.Raw(strings.Join(unionParts, " UNION "), params...).QueryRows(&digests)
+		if err != nil {
+			return nil, err
+		}
+		for _, digest := range digests {
+			shouldAssociated[digest] = true
+		}
 	}
 
 	var results []*models.Blob


### PR DESCRIPTION
## Comprehensive Summary of your change

### Background

We discovered this issue while investigating slow delete API responses in our system. Profiling pointed to \`FindBlobsShouldUnassociatedWithProject\` as the root cause.

Our projects are heavily Go-based, which means most images share a common set of Go runtime/stdlib layers. This high overlap meant that a large number of blobs had many matching artifacts across projects — causing the original \`IN (...)\` query to scan a very large number of rows before completing.

A deeper look at the query execution plan revealed that the original \`IN (...)\` formulation was **not using the available index** on \`digest_blob\`, resulting in a full table scan on \`artifact_blob\` for every call.

**Before this fix:** the query was taking ~4 minutes.
**After this fix:** the same query completes in ~40 milliseconds.

---

### What changed

\`FindBlobsShouldUnassociatedWithProject\` previously used a single \`SELECT ... WHERE digest_blob IN (?, ?, ...)\` query. This has two problems at scale:

1. **Index not used / full table scan:** with a large \`IN\` list and high overlap between blob digests across artifacts (common in Go-heavy environments where many images share runtime layers), the query planner skipped the index and scanned the entire table.
2. **Unbounded query size:** during GC, hundreds or thousands of blobs may be checked in one call, generating a very large \`IN\` list.

This PR replaces that with **batched UNION queries**, each sub-select using \`LIMIT 1\`:

\`\`\`sql
(SELECT b.digest_blob FROM artifact a, artifact_blob b
  WHERE a.digest = b.digest_af AND a.project_id = ? AND b.digest_blob = ? LIMIT 1)
UNION
(SELECT b.digest_blob FROM artifact a, artifact_blob b
  WHERE a.digest = b.digest_af AND a.project_id = ? AND b.digest_blob = ? LIMIT 1)
...
\`\`\`

**Benefits:**
- Each subquery targets a single \`digest_blob\` value, allowing the index to be used effectively.
- \`LIMIT 1\` causes each subquery to short-circuit as soon as one matching artifact is found, avoiding unnecessary row scans.
- Blobs are processed in batches of 100, keeping SQL statement size bounded regardless of how many blobs GC feeds in (e.g. 1000 blobs → 10 queries of 100 each).

## Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [ ] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).