### PR TITLE
perf(blob): fix full table scan in blob unassociation check during GC

### DIFF
--- a/src/pkg/blob/dao/dao.go
+++ b/src/pkg/blob/dao/dao.go
@@ -17,6 +17,7 @@ package dao
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/docker/distribution/manifest/schema2"
@@ -246,21 +247,35 @@ func (d *dao) FindBlobsShouldUnassociatedWithProject(ctx context.Context, projec
 		return nil, err
 	}
 
-	sql := `SELECT b.digest_blob FROM artifact a, artifact_blob b WHERE a.digest = b.digest_af AND a.project_id = ? AND b.digest_blob IN (%s)`
-	params := []any{projectID}
-	for _, blob := range blobs {
-		params = append(params, blob.Digest)
-	}
-
-	var digests []string
-	_, err = o.Raw(fmt.Sprintf(sql, orm.ParamPlaceholderForIn(len(blobs))), params...).QueryRows(&digests)
-	if err != nil {
-		return nil, err
-	}
+	// blobBatchSize caps how many blobs are checked per UNION query to avoid
+	// generating excessively large SQL statements.
+	const blobBatchSize = 100
 
 	shouldAssociated := map[string]bool{}
-	for _, digest := range digests {
-		shouldAssociated[digest] = true
+	for i := 0; i < len(blobs); i += blobBatchSize {
+		end := i + blobBatchSize
+		if end > len(blobs) {
+			end = len(blobs)
+		}
+		batch := blobs[i:end]
+
+		// Each subquery uses LIMIT 1 so it short-circuits as soon as one
+		// matching artifact is found, avoiding full scans per blob.
+		var unionParts []string
+		var params []interface{}
+		for _, blob := range batch {
+			unionParts = append(unionParts, `(SELECT b.digest_blob FROM artifact a, artifact_blob b WHERE a.digest = b.digest_af AND a.project_id = ? AND b.digest_blob = ? LIMIT 1)`)
+			params = append(params, projectID, blob.Digest)
+		}
+
+		var digests []string
+		_, err = o.Raw(strings.Join(unionParts, " UNION "), params...).QueryRows(&digests)
+		if err != nil {
+			return nil, err
+		}
+		for _, digest := range digests {
+			shouldAssociated[digest] = true
+		}
 	}
 
 	var results []*models.Blob

--- a/src/pkg/blob/dao/dao.go
+++ b/src/pkg/blob/dao/dao.go
@@ -247,35 +247,33 @@ func (d *dao) FindBlobsShouldUnassociatedWithProject(ctx context.Context, projec
 		return nil, err
 	}
 
-	// blobBatchSize caps how many blobs are checked per UNION query to avoid
-	// generating excessively large SQL statements.
-	const blobBatchSize = 100
+	// Build a VALUES list for all blob digests and use EXISTS to check
+	// association. EXISTS short-circuits on the first match, and targeting
+	// one digest at a time gives the planner high selectivity to use the index.
+	valueParts := make([]string, len(blobs))
+	params := make([]interface{}, len(blobs)+1)
+	for i, blob := range blobs {
+		valueParts[i] = "(?)"
+		params[i] = blob.Digest
+	}
+	params[len(blobs)] = projectID
+
+	sql := `SELECT v.digest_blob FROM (VALUES ` + strings.Join(valueParts, ", ") + `) AS v(digest_blob)
+WHERE EXISTS (
+  SELECT 1 FROM artifact a
+  JOIN artifact_blob b ON a.digest = b.digest_af
+  WHERE a.project_id = ? AND b.digest_blob = v.digest_blob
+)`
+
+	var digests []string
+	_, err = o.Raw(sql, params...).QueryRows(&digests)
+	if err != nil {
+		return nil, err
+	}
 
 	shouldAssociated := map[string]bool{}
-	for i := 0; i < len(blobs); i += blobBatchSize {
-		end := i + blobBatchSize
-		if end > len(blobs) {
-			end = len(blobs)
-		}
-		batch := blobs[i:end]
-
-		// Each subquery uses LIMIT 1 so it short-circuits as soon as one
-		// matching artifact is found, avoiding full scans per blob.
-		var unionParts []string
-		var params []interface{}
-		for _, blob := range batch {
-			unionParts = append(unionParts, `(SELECT b.digest_blob FROM artifact a, artifact_blob b WHERE a.digest = b.digest_af AND a.project_id = ? AND b.digest_blob = ? LIMIT 1)`)
-			params = append(params, projectID, blob.Digest)
-		}
-
-		var digests []string
-		_, err = o.Raw(strings.Join(unionParts, " UNION "), params...).QueryRows(&digests)
-		if err != nil {
-			return nil, err
-		}
-		for _, digest := range digests {
-			shouldAssociated[digest] = true
-		}
+	for _, digest := range digests {
+		shouldAssociated[digest] = true
 	}
 
 	var results []*models.Blob

--- a/src/pkg/blob/dao/dao_test.go
+++ b/src/pkg/blob/dao/dao_test.go
@@ -324,6 +324,42 @@ func (suite *DaoTestSuite) TestFindBlobsShouldUnassociatedWithProject() {
 
 }
 
+func (suite *DaoTestSuite) TestFindBlobsShouldUnassociatedWithProjectBatching() {
+	ctx := suite.Context()
+
+	suite.WithProject(func(projectID int64, projectName string) {
+		artifact := suite.DigestString()
+		sql := `INSERT INTO artifact ("type", media_type, manifest_media_type, digest, project_id, repository_id, repository_name, artifact_type) VALUES ('image', 'media_type', 'manifest_media_type', ?, ?, ?, 'library/hello-world', 'artifact_type')`
+		suite.ExecSQL(sql, artifact, projectID, 10)
+		defer suite.ExecSQL(`DELETE FROM artifact WHERE project_id = ?`, projectID)
+
+		// Create 110 blobs to exercise batching (batch size is 100).
+		// The first 100 are associated with the artifact; the last 10 are not.
+		const total = 110
+		const associated = 100
+		var ol q.OrList
+		for i := 0; i < total; i++ {
+			digest := suite.DigestString()
+			blobID, err := suite.dao.CreateBlob(ctx, &models.Blob{Digest: digest})
+			if suite.Nil(err) {
+				suite.dao.CreateProjectBlob(ctx, projectID, blobID)
+			}
+			if i < associated {
+				suite.dao.CreateArtifactAndBlob(ctx, artifact, digest)
+			}
+			ol.Values = append(ol.Values, digest)
+		}
+
+		blobs, err := suite.dao.ListBlobs(ctx, q.New(q.KeyWords{"digest": &ol}))
+		suite.Nil(err)
+		suite.Len(blobs, total)
+
+		results, err := suite.dao.FindBlobsShouldUnassociatedWithProject(ctx, projectID, blobs)
+		suite.Nil(err)
+		suite.Len(results, total-associated)
+	})
+}
+
 func (suite *DaoTestSuite) TestCreateProjectBlob() {
 	ctx := suite.Context()
 

--- a/src/pkg/blob/dao/dao_test.go
+++ b/src/pkg/blob/dao/dao_test.go
@@ -333,7 +333,7 @@ func (suite *DaoTestSuite) TestFindBlobsShouldUnassociatedWithProjectBatching() 
 		suite.ExecSQL(sql, artifact, projectID, 10)
 		defer suite.ExecSQL(`DELETE FROM artifact WHERE project_id = ?`, projectID)
 
-		// Create 110 blobs to exercise batching (batch size is 100).
+		// Create blobs with a mix of associated and unassociated.
 		// The first 100 are associated with the artifact; the last 10 are not.
 		const total = 110
 		const associated = 100


### PR DESCRIPTION
## Comprehensive Summary of your change

### Background

We discovered this issue while investigating slow delete API responses in our system. Investigating slow DB queries pointed to `FindBlobsShouldUnassociatedWithProject` as the root cause.

Our projects are heavily Go-based, which means most images share a common set of Go runtime/stdlib layers. These hot blobs end up associated with almost every image in the registry. The query planner's statistics reflect that these digests match a very high fraction of rows in `artifact_blob`, making selectivity too low for an index scan to be considered worthwhile — so the planner opts for a full hash join instead.

**Before this fix:** the query was taking ~4 minutes.
**After this fix:** the same query completes in ~40 milliseconds.

**Evidence (full query plans in issue #22995):**
- Before: Parallel Hash Join, 62M rows scanned, 1.9M buffer hits, ~97s per blob
- After: Nested Loop + Index Only Scan, 59 rows scanned, 11 buffer hits, ~0.1ms per blob

---

### What changed

`FindBlobsShouldUnassociatedWithProject` previously used a single `SELECT ... WHERE digest_blob IN (?, ?, ...)` query. This has two problems:

1. **Full hash join due to low selectivity:** hot blobs shared across many images cause the query planner to bypass the index on `digest_blob` and perform a full hash join on `artifact_blob` instead.
2. **Unbounded query size:** during GC, hundreds or thousands of blobs may be checked in one call, generating a very large `IN` list.

This PR uses a `VALUES + EXISTS` query:

```sql
SELECT v.digest_blob
FROM (VALUES (?), (?), ...) AS v(digest_blob)
WHERE EXISTS (
  SELECT 1 FROM artifact a
  JOIN artifact_blob b ON a.digest = b.digest_af
  WHERE a.project_id = ? AND b.digest_blob = v.digest_blob
)
```

**Benefits:**
- Single round trip for all blobs — no batching overhead
- Near-zero planning time
- `EXISTS` short-circuits on the first match, giving high selectivity per blob and allowing the index to be used
- Simpler, cleaner SQL

Fixes #22995

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).