### PR TITLE
[cherry-pick]fix db scheme migration issue

### DIFF
--- a/make/migrations/postgresql/0171_2.14.1_schema.up.sql
+++ b/make/migrations/postgresql/0171_2.14.1_schema.up.sql
@@ -15,5 +15,3 @@ BEGIN
         INSERT INTO properties (k, v) VALUES ('skip_audit_log_database', 'false');
     END IF;
 END $$;
-
-ALTER TABLE registry ADD COLUMN IF NOT EXISTS ca_certificate TEXT;

--- a/make/migrations/postgresql/0180_2.15.0_schema.up.sql
+++ b/make/migrations/postgresql/0180_2.15.0_schema.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE registry ADD COLUMN IF NOT EXISTS ca_certificate TEXT;


### PR DESCRIPTION
we should not put the changes of v2.15.0 into the v2.14.1, create an 180 db scheme for v2.15.0

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [ ] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [ ] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
