### PR TITLE
fix(about-dialog): format version span indentation

### DIFF
--- a/src/portal/src/app/base/harbor-shell/harbor-shell.component.spec.ts
+++ b/src/portal/src/app/base/harbor-shell/harbor-shell.component.spec.ts
@@ -83,6 +83,7 @@ const fakeAppConfigService = {
     getConfig: function () {
         return {
             with_trivy: true,
+            harbor_version: 'v2.15.0',
         };
     },
 };

--- a/src/portal/src/app/shared/components/about-dialog/about-dialog.component.html
+++ b/src/portal/src/app/shared/components/about-dialog/about-dialog.component.html
@@ -16,7 +16,7 @@
             <div>
                 {{ customName ? customName : ('APP_TITLE.HARBOR' | translate) }}
             </div>
-            <div>
+            <div *ngIf="version">
                 <span class="p5 about-version"
                     >{{ 'ABOUT.VERSION' | translate }} {{ version }}</span
                 >


### PR DESCRIPTION
Thank you for contributing to Harbor!

# Comprehensive Summary of your change
This pull request makes a small improvement to the `about-dialog.component.html` by only displaying the version information if a version is available. This prevents empty or irrelevant version fields from being shown in the dialog.

# Issue being fixed
Fixes https://github.com/goharbor/harbor/issues/23011

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
