### PR TITLE
Fix typos in log messages and build-package workflow

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -42,7 +42,7 @@ jobs:
         if: |
             contains(steps.changed-files.outputs.modified, 'Dockerfile.base') ||
             contains(steps.changed-files.outputs.modified, 'VERSION') ||
-            contains(steps.changed-files.outputs.modified, '.buildbaselog') ||
+            contains(steps.changed-files.outputs.modified, '.github/workflows/build-package.yml') ||
             github.ref == 'refs/heads/main'
         run: |
           set -x

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -42,6 +42,7 @@ jobs:
         if: |
             contains(steps.changed-files.outputs.modified, 'Dockerfile.base') ||
             contains(steps.changed-files.outputs.modified, 'VERSION') ||
+            contains(steps.changed-files.outputs.modified, '.buildbaselog') ||
             contains(steps.changed-files.outputs.modified, '.github/workflows/build-package.yml') ||
             github.ref == 'refs/heads/main'
         run: |

--- a/src/core/main.go
+++ b/src/core/main.go
@@ -398,7 +398,7 @@ func initSkipAuditDBbyEnv(ctx context.Context) error {
 			return err
 		}
 	} else {
-		log.Debugf("key SkipAuditLogDatabase aleady exist in the db with value %v", val)
+		log.Debugf("key SkipAuditLogDatabase already exist in the db with value %v", val)
 	}
 	return nil
 }

--- a/src/pkg/project/models/project.go
+++ b/src/pkg/project/models/project.go
@@ -178,7 +178,7 @@ func (p *Project) MaxUpstreamConnection() int {
 	}
 	cnt, err := strconv.ParseInt(countVal, 10, 32)
 	if err != nil {
-		log.Warningf("failed th parse the max_upstream_conn, val:%s error %v", countVal, err)
+		log.Warningf("failed to parse the max_upstream_conn, val:%s error %v", countVal, err)
 		return 0
 	}
 	return int(cnt)


### PR DESCRIPTION
Thank you for contributing to Harbor!

# Comprehensive Summary of your change
- Fix log message typo in [project.go](cci:7://file:///c:/Users/lovek/OneDrive/Desktop/harbor/harbor/src/pkg/project/models/project.go:0:0-0:0) ('failed th parse' to 'failed to parse')
- Fix log message typo in [main.go](cci:7://file:///c:/Users/lovek/OneDrive/Desktop/harbor/harbor/src/core/main.go:0:0-0:0) ('aleady exist' to 'already exist')
- Fix build-package workflow to check for [.github/workflows/build-package.yml](cci:7://file:///c:/Users/lovek/OneDrive/Desktop/harbor/harbor/.github/workflows/build-package.yml:0:0-0:0) changes instead of the non-existent `.buildbaselog` file

# Issue being fixed
Fixes #22672

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
