### PR TITLE
fix: honor pre-defined secret when creating robot accounts

### DIFF
--- a/src/controller/robot/controller.go
+++ b/src/controller/robot/controller.go
@@ -109,9 +109,19 @@ func (d *controller) Create(ctx context.Context, r *Robot) (int64, string, error
 		expiresAt = time.Now().AddDate(0, 0, duration).Unix()
 	}
 
-	secret, pwd, salt, err := CreateSec()
-	if err != nil {
-		return 0, "", err
+	var secret, pwd, salt string
+	if r.Secret != "" {
+		if !IsValidSec(r.Secret) {
+			return 0, "", errors.New("the secret must be 8-128, inclusively, characters long with at least 1 uppercase letter, 1 lowercase letter and 1 number").WithCode(errors.BadRequestCode)
+		}
+		salt = utils.GenerateRandomString()
+		secret = utils.Encrypt(r.Secret, salt, utils.SHA256)
+	} else {
+		var err error
+		secret, pwd, salt, err = CreateSec()
+		if err != nil {
+			return 0, "", err
+		}
 	}
 
 	name := r.Name

--- a/src/server/v2.0/handler/robot.go
+++ b/src/server/v2.0/handler/robot.go
@@ -71,6 +71,7 @@ func (rAPI *robotAPI) CreateRobot(ctx context.Context, params operation.CreateRo
 			Description: params.Robot.Description,
 			Duration:    params.Robot.Duration,
 			Visible:     true,
+			Secret:      params.Robot.Secret,
 		},
 		Level:           params.Robot.Level,
 		ProjectNameOrID: params.Robot.Permissions[0].Namespace,


### PR DESCRIPTION
# Comprehensive Summary of your change

When creating a robot account via `POST /robots`, the API accepts a `secret`
field in the request body but was silently ignoring it — always generating a
random secret regardless of what the caller supplied.

The fix threads the supplied secret through the handler into [Create()](cci:1://file:///c:/Users/lovek/OneDrive/Desktop/harbor/harbor/src/controller/robot/controller.go:97:0-158:1). If a
secret is provided, it is validated (same rules enforced by [RefreshSec](cci:1://file:///c:/Users/lovek/OneDrive/Desktop/harbor/harbor/src/server/v2.0/handler/robot.go:263:0-300:1)) and
stored as-is; if omitted, behaviour is unchanged and a random secret is
generated as before.

# Issue being fixed
Fixes #22899

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. `release-note/update`
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs
      changes if needed in [website repository](https://github.com/goharbor/website).
