### PR TITLE
feat(referrers): switch to OCI referrers API for signature verificati…

### DIFF
--- a/api/v2.0/swagger.yaml
+++ b/api/v2.0/swagger.yaml
@@ -1403,6 +1403,46 @@ paths:
           $ref: '#/responses/404'
         '500':
           $ref: '#/responses/500'
+  /projects/{project_name}/repositories/{repository_name}/artifacts/{reference}/referrers:
+    get:
+      summary: List referrers
+      description: List referrers of the specific artifact using the OCI referrers API. Returns an OCI Index containing descriptors of all referrers (signatures, SBOMs, etc.) for the given artifact digest. This endpoint uses digest-based querying which supports proxy cache scenarios.
+      tags:
+        - artifact
+      operationId: listReferrers
+      parameters:
+        - $ref: '#/parameters/requestId'
+        - $ref: '#/parameters/projectName'
+        - $ref: '#/parameters/repositoryName'
+        - $ref: '#/parameters/reference'
+        - name: artifactType
+          in: query
+          type: string
+          required: false
+          description: Filter referrers by artifact type
+      responses:
+        '200':
+          description: Success
+          headers:
+            X-Total-Count:
+              description: The total count of referrers
+              type: integer
+            OCI-Filters-Applied:
+              description: Indicates the applied filter
+              type: string
+          schema:
+            type: object
+            description: OCI Index containing referrer descriptors
+        '400':
+          $ref: '#/responses/400'
+        '401':
+          $ref: '#/responses/401'
+        '403':
+          $ref: '#/responses/403'
+        '404':
+          $ref: '#/responses/404'
+        '500':
+          $ref: '#/responses/500'
   /projects/{project_name}/repositories/{repository_name}/artifacts/{reference}/additions/vulnerabilities:
     get:
       summary: Get the vulnerabilities addition of the specific artifact

--- a/src/portal/src/app/base/project/repository/artifact/artifact-list-page/artifact-list/artifact-list-tab/artifact-list-tab.component.ts
+++ b/src/portal/src/app/base/project/repository/artifact/artifact-list-page/artifact-list/artifact-list-tab/artifact-list-tab.component.ts
@@ -54,7 +54,6 @@ import {
     OperationState,
 } from '../../../../../../../shared/components/operation/operate';
 import {
-    AccessoryType,
     artifactDefault,
     ArtifactFilterEvent,
     ArtifactFront as Artifact,
@@ -86,6 +85,7 @@ import { Tag } from '../../../../../../../../../ng-swagger-gen/models/tag';
 import { CopyArtifactComponent } from './copy-artifact/copy-artifact.component';
 import { CopyDigestComponent } from './copy-digest/copy-digest.component';
 import { Scanner } from '../../../../../../left-side-nav/interrogation-services/scanner/scanner';
+import { ReferrerService } from '../../../../../../../shared/services/referrer.service';
 
 export const AVAILABLE_TIME = '0001-01-01T00:00:00.000Z';
 
@@ -217,7 +217,8 @@ export class ArtifactListTabComponent implements OnInit, OnDestroy {
         private activatedRoute: ActivatedRoute,
         private router: Router,
         private appConfigService: AppConfigService,
-        private artifactListPageService: ArtifactListPageService
+        private artifactListPageService: ArtifactListPageService,
+        private referrerService: ReferrerService
     ) {}
     initRouterData() {
         this.projectId =
@@ -1123,46 +1124,35 @@ export class ArtifactListTabComponent implements OnInit, OnDestroy {
         }
     }
     checkCosignAndSbomAsync(artifacts: ArtifactFront[]) {
-        if (artifacts) {
-            if (artifacts.length) {
-                artifacts.forEach(item => {
-                    item.signed = CHECKING;
-                    const sbomOverview = item?.sbom_overview;
-                    item.sbomDigest = sbomOverview?.sbom_digest;
-                    let queryTypes = `${AccessoryType.COSIGN} ${AccessoryType.NOTATION}`;
-                    if (!item.sbomDigest) {
-                        queryTypes = `${queryTypes} ${AccessoryType.SBOM}`;
-                    }
-                    this.newArtifactService
-                        .listAccessories({
-                            projectName: this.projectName,
-                            repositoryName: dbEncodeURIComponent(this.repoName),
-                            reference: item.digest,
-                            page: 1,
-                            pageSize: ACCESSORY_PAGE_SIZE,
-                            q: encodeURIComponent(`type={${queryTypes}}`),
-                        })
-                        .subscribe({
-                            next: res => {
-                                item.signed = res?.filter(
-                                    item => item.type !== AccessoryType.SBOM
-                                )?.length
-                                    ? TRUE
-                                    : FALSE;
-                                if (!item.sbomDigest) {
-                                    item.sbomDigest =
-                                        res?.filter(
-                                            item =>
-                                                item.type === AccessoryType.SBOM
-                                        )?.[0]?.digest ?? undefined;
-                                }
-                            },
-                            error: err => {
-                                item.signed = FALSE;
-                            },
-                        });
-                });
-            }
+        if (artifacts?.length) {
+            artifacts.forEach(item => {
+                item.signed = CHECKING;
+                const sbomOverview = item?.sbom_overview;
+                item.sbomDigest = sbomOverview?.sbom_digest;
+                // Use the OCI referrers API instead of the Harbor-specific accessory API.
+                // The referrers API queries by digest and repository (OCI standard),
+                // which enables proxy cache support.
+                this.referrerService
+                    .listReferrers(
+                        this.projectName,
+                        dbEncodeURIComponent(this.repoName),
+                        item.digest
+                    )
+                    .subscribe({
+                        next: res => {
+                            item.signed = ReferrerService.hasSignatures(res)
+                                ? TRUE
+                                : FALSE;
+                            if (!item.sbomDigest) {
+                                item.sbomDigest =
+                                    ReferrerService.getSbomDigest(res);
+                            }
+                        },
+                        error: err => {
+                            item.signed = FALSE;
+                        },
+                    });
+            });
         }
     }
     // return true if all selected rows are in "running" state

--- a/src/portal/src/app/shared/services/referrer.service.ts
+++ b/src/portal/src/app/shared/services/referrer.service.ts
@@ -1,0 +1,112 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { CURRENT_BASE_HREF } from '../units/utils';
+
+/**
+ * OCI Descriptor from the referrers response
+ */
+export interface OCIDescriptor {
+    mediaType?: string;
+    size?: number;
+    digest?: string;
+    annotations?: { [key: string]: string };
+    artifactType?: string;
+}
+
+/**
+ * OCI Index returned by the referrers API
+ */
+export interface OCIIndex {
+    schemaVersion?: number;
+    mediaType?: string;
+    manifests?: OCIDescriptor[];
+}
+
+// Known signature artifact types
+export const SIGNATURE_ARTIFACT_TYPES = [
+    'application/vnd.dev.cosign.artifact.sig.v1+json',
+    'application/vnd.dev.sigstore.bundle.v0.3+json',
+    'application/vnd.cncf.notary.signature',
+];
+
+// Known SBOM artifact types
+export const SBOM_ARTIFACT_TYPES = [
+    'application/vnd.goharbor.harbor.sbom.v1',
+];
+
+@Injectable({
+    providedIn: 'root',
+})
+export class ReferrerService {
+    constructor(private http: HttpClient) {}
+
+    /**
+     * List referrers for an artifact using the OCI referrers API.
+     * Calls: GET /api/v2.0/projects/{project}/repositories/{repo}/artifacts/{digest}/referrers
+     */
+    listReferrers(
+        projectName: string,
+        repositoryName: string,
+        digest: string,
+        artifactType?: string
+    ): Observable<OCIIndex> {
+        const url = `${CURRENT_BASE_HREF}/projects/${projectName}/repositories/${encodeURIComponent(repositoryName)}/artifacts/${digest}/referrers`;
+        let params = new HttpParams();
+        if (artifactType) {
+            params = params.set('artifactType', artifactType);
+        }
+        return this.http.get<OCIIndex>(url, { params });
+    }
+
+    /**
+     * Check if an OCI Index contains any signature referrers.
+     */
+    static hasSignatures(index: OCIIndex): boolean {
+        if (!index?.manifests?.length) {
+            return false;
+        }
+        return index.manifests.some(desc =>
+            SIGNATURE_ARTIFACT_TYPES.includes(desc.artifactType)
+        );
+    }
+
+    /**
+     * Check if an OCI Index contains any SBOM referrers.
+     */
+    static hasSbom(index: OCIIndex): boolean {
+        if (!index?.manifests?.length) {
+            return false;
+        }
+        return index.manifests.some(desc =>
+            SBOM_ARTIFACT_TYPES.includes(desc.artifactType)
+        );
+    }
+
+    /**
+     * Get the first SBOM digest from the referrers index.
+     */
+    static getSbomDigest(index: OCIIndex): string | undefined {
+        if (!index?.manifests?.length) {
+            return undefined;
+        }
+        const sbom = index.manifests.find(desc =>
+            SBOM_ARTIFACT_TYPES.includes(desc.artifactType)
+        );
+        return sbom?.digest;
+    }
+}

--- a/src/server/v2.0/handler/artifact.go
+++ b/src/server/v2.0/handler/artifact.go
@@ -370,11 +370,21 @@ func (a *artifactAPI) ListAccessories(ctx context.Context, params operation.List
 		return a.SendError(ctx, err)
 	}
 
-	artifact, err := a.artCtl.GetByReference(ctx, fmt.Sprintf("%s/%s", params.ProjectName, params.RepositoryName), params.Reference, nil)
-	if err != nil {
-		return a.SendError(ctx, err)
+	repoName := fmt.Sprintf("%s/%s", params.ProjectName, params.RepositoryName)
+	// Use the referrer approach: query by digest and repository instead of internal artifact ID.
+	// This aligns with the OCI referrers API and enables proxy cache support.
+	if _, err := digest.Parse(params.Reference); err == nil {
+		query.Keywords["SubjectArtifactDigest"] = params.Reference
+		query.Keywords["SubjectArtifactRepo"] = repoName
+	} else {
+		// For tag references, resolve to the artifact digest first
+		art, err := a.artCtl.GetByReference(ctx, repoName, params.Reference, nil)
+		if err != nil {
+			return a.SendError(ctx, err)
+		}
+		query.Keywords["SubjectArtifactDigest"] = art.Digest
+		query.Keywords["SubjectArtifactRepo"] = repoName
 	}
-	query.Keywords["SubjectArtifactID"] = artifact.ID
 
 	// list accessories according to the query
 	total, err := a.accMgr.Count(ctx, query)

--- a/src/server/v2.0/handler/referrers.go
+++ b/src/server/v2.0/handler/referrers.go
@@ -1,0 +1,185 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handler
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/go-openapi/swag"
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"github.com/goharbor/harbor/src/common/rbac"
+	"github.com/goharbor/harbor/src/lib/cache"
+	"github.com/goharbor/harbor/src/lib/config"
+	"github.com/goharbor/harbor/src/lib/errors"
+	lib_http "github.com/goharbor/harbor/src/lib/http"
+	"github.com/goharbor/harbor/src/lib/log"
+	"github.com/goharbor/harbor/src/lib/q"
+	"github.com/goharbor/harbor/src/pkg/accessory"
+	"github.com/goharbor/harbor/src/pkg/artifact"
+	"github.com/goharbor/harbor/src/pkg/cached/manifest/redis"
+	"github.com/goharbor/harbor/src/pkg/registry"
+	"github.com/goharbor/harbor/src/server/router"
+)
+
+const referrersSchemaVersion = 2
+const referrersMediaType = "application/vnd.oci.image.index.v1+json"
+
+// NewReferrersAPIHandler creates a new handler for the OCI referrers API
+// exposed via the Harbor REST API (/api/v2.0/.../referrers).
+func NewReferrersAPIHandler() http.Handler {
+	return &referrersAPIHandler{
+		BaseAPI:          &BaseAPI{},
+		artifactManager:  artifact.NewManager(),
+		accessoryManager: accessory.NewManager(),
+		registryClient:   registry.Cli,
+		maniCacheManager: redis.NewManager(),
+	}
+}
+
+type referrersAPIHandler struct {
+	*BaseAPI
+	artifactManager  artifact.Manager
+	accessoryManager accessory.Manager
+	registryClient   registry.Client
+	maniCacheManager redis.CachedManager
+}
+
+func (r *referrersAPIHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	ctx := req.Context()
+
+	projectName := router.Param(ctx, ":project_name")
+	repoName := router.Param(ctx, ":repo_name")
+	reference := router.Param(ctx, ":reference")
+
+	// Check project-level permission
+	if err := r.RequireProjectAccess(ctx, projectName, rbac.ActionList, rbac.ResourceAccessory); err != nil {
+		lib_http.SendError(w, err)
+		return
+	}
+
+	at := req.URL.Query().Get("artifactType")
+	var filter string
+	if at != "" {
+		filter = "artifactType"
+	}
+
+	// Validate the reference is a valid digest
+	if _, err := digest.Parse(reference); err != nil {
+		lib_http.SendError(w, errors.Wrapf(err, "unsupported digest %s", reference).WithCode(errors.BadRequestCode))
+		return
+	}
+
+	repository := fmt.Sprintf("%s/%s", projectName, repoName)
+
+	// Query accessories by digest and repo (OCI referrer approach)
+	query := q.New(q.KeyWords{"SubjectArtifactDigest": reference, "SubjectArtifactRepo": repository})
+	total, err := r.accessoryManager.Count(ctx, query)
+	if err != nil {
+		lib_http.SendError(w, err)
+		return
+	}
+	accs, err := r.accessoryManager.List(ctx, query)
+	if err != nil {
+		lib_http.SendError(w, err)
+		return
+	}
+
+	// Build OCI index manifest from accessories
+	mfs := make([]ocispec.Descriptor, 0)
+	for _, acc := range accs {
+		accArtDigest := acc.GetData().Digest
+		accArt, err := r.artifactManager.GetByDigest(ctx, repository, accArtDigest)
+		if err != nil {
+			lib_http.SendError(w, err)
+			return
+		}
+
+		fromCache := false
+		writeCache := false
+		var maniContent []byte
+
+		if config.CacheEnabled() {
+			maniContent, err = r.maniCacheManager.Get(req.Context(), accArtDigest)
+			if err == nil {
+				fromCache = true
+			} else {
+				log.Debugf("failed to get manifest %s from cache, will fallback to registry, error: %v", accArtDigest, err)
+				if errors.As(err, &cache.ErrNotFound) {
+					writeCache = true
+				}
+			}
+		}
+		if !fromCache {
+			mani, _, err := r.registryClient.PullManifest(accArt.RepositoryName, accArtDigest)
+			if err != nil {
+				lib_http.SendError(w, err)
+				return
+			}
+			_, maniContent, err = mani.Payload()
+			if err != nil {
+				lib_http.SendError(w, err)
+				return
+			}
+			if writeCache {
+				err = r.maniCacheManager.Save(req.Context(), accArtDigest, maniContent)
+				if err != nil {
+					log.Warningf("failed to save manifest %s to cache, error: %v", accArtDigest, err)
+				}
+			}
+		}
+
+		desc := ocispec.Descriptor{
+			MediaType:    accArt.ManifestMediaType,
+			Size:         int64(len(maniContent)),
+			Digest:       digest.Digest(accArt.Digest),
+			Annotations:  accArt.Annotations,
+			ArtifactType: accArt.ArtifactType,
+		}
+		if at != "" {
+			if accArt.ArtifactType == at {
+				mfs = append(mfs, desc)
+			}
+		} else {
+			mfs = append(mfs, desc)
+		}
+	}
+
+	// Build and return the OCI index
+	result := &ocispec.Index{}
+	result.SchemaVersion = referrersSchemaVersion
+	result.MediaType = referrersMediaType
+	result.Manifests = mfs
+
+	// Write response headers
+	w.Header().Set("Content-Type", referrersMediaType)
+	if filter != "" {
+		w.Header().Set("OCI-Filters-Applied", filter)
+	}
+	xTotalCount := swag.FormatInt64(total)
+	if xTotalCount != "" {
+		w.Header().Set("X-Total-Count", xTotalCount)
+	}
+	w.WriteHeader(http.StatusOK)
+
+	enc := json.NewEncoder(w)
+	if err := enc.Encode(result); err != nil {
+		lib_http.SendError(w, err)
+		return
+	}
+}

--- a/src/server/v2.0/handler/referrers_test.go
+++ b/src/server/v2.0/handler/referrers_test.go
@@ -1,0 +1,285 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	beegocontext "github.com/beego/beego/v2/server/web/context"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/goharbor/harbor/src/common/security"
+	"github.com/goharbor/harbor/src/lib/config"
+	accessorymodel "github.com/goharbor/harbor/src/pkg/accessory/model"
+	basemodel "github.com/goharbor/harbor/src/pkg/accessory/model/base"
+	"github.com/goharbor/harbor/src/pkg/artifact"
+	"github.com/goharbor/harbor/src/pkg/distribution"
+	"github.com/goharbor/harbor/src/server/router"
+	securitytesting "github.com/goharbor/harbor/src/testing/common/security"
+	"github.com/goharbor/harbor/src/testing/mock"
+	accessorytesting "github.com/goharbor/harbor/src/testing/pkg/accessory"
+	arttesting "github.com/goharbor/harbor/src/testing/pkg/artifact"
+	regtesting "github.com/goharbor/harbor/src/testing/pkg/registry"
+)
+
+// newTestRequestContext creates a request context with mock security and beego params
+func newTestRequestContext(req *http.Request, params map[string]string) *http.Request {
+	input := &beegocontext.BeegoInput{}
+	for k, v := range params {
+		input.SetParam(k, v)
+	}
+	ctx := context.WithValue(req.Context(), router.ContextKeyInput{}, input)
+
+	// Set up mock security context with admin access
+	secCtx := &securitytesting.Context{}
+	secCtx.On("IsAuthenticated").Return(true)
+	secCtx.On("IsSysAdmin").Return(true)
+	mock.OnAnything(secCtx, "Can").Return(true)
+	ctx = security.NewContext(ctx, secCtx)
+
+	*req = *(req.WithContext(ctx))
+	return req
+}
+
+var testOCIManifest = `{
+	"schemaVersion": 2,
+	"mediaType": "application/vnd.oci.image.manifest.v1+json",
+	"config": {
+	   "mediaType": "application/vnd.cncf.notary.signature",
+	   "digest": "sha256:5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03",
+	   "size": 123
+	},
+	"layers": [
+	   {
+		  "mediaType": "application/vnd.cncf.notary.signature",
+		  "digest": "sha256:e258d248fda94c63753607f7c4494ee0fcbe92f1a76bfdac795c9d84101eb317",
+		  "size": 1234
+	   }
+	],
+	"annotations": {
+	   "name": "test-signature"
+	}
+}`
+
+func TestReferrersAPIHandlerOK(t *testing.T) {
+	rec := httptest.NewRecorder()
+	digestVal := "sha256:6c3c624b58dbbcd3c0dd82b4c53f04194d1247c6eebdaab7c610cf7d66709b3b"
+	req, err := http.NewRequest("GET",
+		"/api/v2.0/projects/testproject/repositories/testrepo/artifacts/"+digestVal+"/referrers", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req = newTestRequestContext(req, map[string]string{
+		":project_name": "testproject",
+		":repo_name":    "testrepo",
+		":reference":    digestVal,
+	})
+
+	artifactMock := &arttesting.Manager{}
+	accessoryMock := &accessorytesting.Manager{}
+
+	artifactMock.On("GetByDigest", mock.Anything, mock.Anything, mock.Anything).
+		Return(&artifact.Artifact{
+			Digest:            "sha256:4911bb745e19a6b5513755f3d033f10ef10c34b40edc631809e28be8a7c005f6",
+			ManifestMediaType: "application/vnd.oci.image.manifest.v1+json",
+			MediaType:         "application/vnd.cncf.notary.signature",
+			ArtifactType:      "application/vnd.cncf.notary.signature",
+			RepositoryName:    "testproject/testrepo",
+			Size:              1000,
+			Annotations: map[string]string{
+				"name": "test-signature",
+			},
+		}, nil)
+
+	accessoryMock.On("Count", mock.Anything, mock.Anything).
+		Return(int64(1), nil)
+	accessoryMock.On("List", mock.Anything, mock.Anything).
+		Return([]accessorymodel.Accessory{
+			&basemodel.Default{
+				Data: accessorymodel.AccessoryData{
+					ID:                1,
+					ArtifactID:        2,
+					SubArtifactDigest: digestVal,
+					SubArtifactRepo:   "testproject/testrepo",
+					Type:              accessorymodel.TypeNotationSignature,
+					Digest:            "sha256:4911bb745e19a6b5513755f3d033f10ef10c34b40edc631809e28be8a7c005f6",
+				},
+			},
+		}, nil)
+
+	manifest, _, err := distribution.UnmarshalManifest(v1.MediaTypeImageManifest, []byte(testOCIManifest))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	regCliMock := &regtesting.Client{}
+	config.DefaultMgr().Set(context.TODO(), "cache_enabled", false)
+	mock.OnAnything(regCliMock, "PullManifest").Return(manifest, "", nil)
+
+	handler := &referrersAPIHandler{
+		BaseAPI:          &BaseAPI{},
+		artifactManager:  artifactMock,
+		accessoryManager: accessoryMock,
+		registryClient:   regCliMock,
+	}
+
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, referrersMediaType, rec.Header().Get("Content-Type"))
+
+	index := &ocispec.Index{}
+	err = json.Unmarshal(rec.Body.Bytes(), index)
+	assert.NoError(t, err)
+	assert.Equal(t, referrersSchemaVersion, index.SchemaVersion)
+	assert.Len(t, index.Manifests, 1)
+	assert.Equal(t, "application/vnd.cncf.notary.signature", index.Manifests[0].ArtifactType)
+}
+
+func TestReferrersAPIHandlerEmpty(t *testing.T) {
+	rec := httptest.NewRecorder()
+	digestVal := "sha256:6c3c624b58dbbcd3c0dd82b4c53f04194d1247c6eebdaab7c610cf7d66709b3b"
+	req, err := http.NewRequest("GET",
+		"/api/v2.0/projects/testproject/repositories/testrepo/artifacts/"+digestVal+"/referrers", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req = newTestRequestContext(req, map[string]string{
+		":project_name": "testproject",
+		":repo_name":    "testrepo",
+		":reference":    digestVal,
+	})
+
+	accessoryMock := &accessorytesting.Manager{}
+	accessoryMock.On("Count", mock.Anything, mock.Anything).
+		Return(int64(0), nil)
+	accessoryMock.On("List", mock.Anything, mock.Anything).
+		Return([]accessorymodel.Accessory{}, nil)
+
+	handler := &referrersAPIHandler{
+		BaseAPI:          &BaseAPI{},
+		artifactManager:  &arttesting.Manager{},
+		accessoryManager: accessoryMock,
+	}
+
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	index := &ocispec.Index{}
+	err = json.Unmarshal(rec.Body.Bytes(), index)
+	assert.NoError(t, err)
+	assert.Empty(t, index.Manifests)
+}
+
+func TestReferrersAPIHandlerInvalidDigest(t *testing.T) {
+	rec := httptest.NewRecorder()
+	req, err := http.NewRequest("GET",
+		"/api/v2.0/projects/testproject/repositories/testrepo/artifacts/invalid/referrers", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req = newTestRequestContext(req, map[string]string{
+		":project_name": "testproject",
+		":repo_name":    "testrepo",
+		":reference":    "invalid",
+	})
+
+	handler := &referrersAPIHandler{
+		BaseAPI:          &BaseAPI{},
+		artifactManager:  &arttesting.Manager{},
+		accessoryManager: &accessorytesting.Manager{},
+	}
+
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestReferrersAPIHandlerWithArtifactTypeFilter(t *testing.T) {
+	rec := httptest.NewRecorder()
+	digestVal := "sha256:6c3c624b58dbbcd3c0dd82b4c53f04194d1247c6eebdaab7c610cf7d66709b3b"
+	req, err := http.NewRequest("GET",
+		"/api/v2.0/projects/testproject/repositories/testrepo/artifacts/"+digestVal+"/referrers?artifactType=application/vnd.cncf.notary.signature", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req = newTestRequestContext(req, map[string]string{
+		":project_name": "testproject",
+		":repo_name":    "testrepo",
+		":reference":    digestVal,
+	})
+
+	artifactMock := &arttesting.Manager{}
+	accessoryMock := &accessorytesting.Manager{}
+
+	artifactMock.On("GetByDigest", mock.Anything, mock.Anything, mock.Anything).
+		Return(&artifact.Artifact{
+			Digest:            "sha256:4911bb745e19a6b5513755f3d033f10ef10c34b40edc631809e28be8a7c005f6",
+			ManifestMediaType: "application/vnd.oci.image.manifest.v1+json",
+			MediaType:         "application/vnd.cncf.notary.signature",
+			ArtifactType:      "application/vnd.cncf.notary.signature",
+			RepositoryName:    "testproject/testrepo",
+			Size:              1000,
+		}, nil)
+
+	accessoryMock.On("Count", mock.Anything, mock.Anything).
+		Return(int64(1), nil)
+	accessoryMock.On("List", mock.Anything, mock.Anything).
+		Return([]accessorymodel.Accessory{
+			&basemodel.Default{
+				Data: accessorymodel.AccessoryData{
+					ID:                1,
+					ArtifactID:        2,
+					SubArtifactDigest: digestVal,
+					SubArtifactRepo:   "testproject/testrepo",
+					Type:              accessorymodel.TypeNotationSignature,
+					Digest:            "sha256:4911bb745e19a6b5513755f3d033f10ef10c34b40edc631809e28be8a7c005f6",
+				},
+			},
+		}, nil)
+
+	manifest, _, err := distribution.UnmarshalManifest(v1.MediaTypeImageManifest, []byte(testOCIManifest))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	regCliMock := &regtesting.Client{}
+	config.DefaultMgr().Set(context.TODO(), "cache_enabled", false)
+	mock.OnAnything(regCliMock, "PullManifest").Return(manifest, "", nil)
+
+	handler := &referrersAPIHandler{
+		BaseAPI:          &BaseAPI{},
+		artifactManager:  artifactMock,
+		accessoryManager: accessoryMock,
+		registryClient:   regCliMock,
+	}
+
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "artifactType", rec.Header().Get("OCI-Filters-Applied"))
+
+	index := &ocispec.Index{}
+	err = json.Unmarshal(rec.Body.Bytes(), index)
+	assert.NoError(t, err)
+	assert.Len(t, index.Manifests, 1)
+}

--- a/src/server/v2.0/route/route.go
+++ b/src/server/v2.0/route/route.go
@@ -15,6 +15,8 @@
 package route
 
 import (
+	"net/http"
+
 	"github.com/goharbor/harbor/src/server/middleware/apiversion"
 	"github.com/goharbor/harbor/src/server/router"
 	"github.com/goharbor/harbor/src/server/v2.0/handler"
@@ -27,7 +29,16 @@ const (
 
 // RegisterRoutes for Harbor v2.0 APIs
 func RegisterRoutes() {
-	router.NewRoute().Path("/api/" + APIVersion + "/*").
-		Middleware(apiversion.Middleware(APIVersion)).
+	root := router.NewRoute().
+		Middleware(apiversion.Middleware(APIVersion))
+
+	// OCI referrers endpoint via Harbor REST API
+	root.NewRoute().
+		Method(http.MethodGet).
+		Path("/api/" + APIVersion + "/projects/:project_name/repositories/:repo_name/artifacts/:reference/referrers").
+		Handler(handler.NewReferrersAPIHandler())
+
+	// All other Harbor v2.0 APIs (go-swagger)
+	root.NewRoute().Path("/api/" + APIVersion + "/*").
 		Handler(handler.New())
 }


### PR DESCRIPTION
…on (#23024)

Switch from the Harbor-specific accessory API to the OCI standard referrers API for verifying signed artifacts. The accessory API queried by internal artifact ID which is Harbor-specific and cannot be proxy cached. The referrers approach queries by digest and repository, aligning with the OCI distribution spec.

Changes:
- Modify ListAccessories handler to use digest-based querying (referrer approach) instead of internal artifact ID lookup
- Add new REST API endpoint: GET /api/v2.0/projects/{project}/ repositories/{repo}/artifacts/{reference}/referrers
- Create ReferrerService in frontend to call the new referrers endpoint
- Update checkCosignAndSbomAsync to use referrers API with OCI artifact type matching instead of Harbor-specific accessory type filtering
- Update swagger spec with new referrers endpoint definition

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [ ] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [ ] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
