### PR TITLE
(cherry-pick) Pin trivy github action to v0.35.0

### DIFF
--- a/.github/workflows/nightly-trivy-scan.yml
+++ b/.github/workflows/nightly-trivy-scan.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.35.0
         with:
           image-ref: 'docker.io/goharbor/${{ matrix.images }}:${{ matrix.versions }}'
           severity: 'CRITICAL,HIGH'


### PR DESCRIPTION
## Description
Cherry-pick of commit 6765ebd15d293d5bc86fda687bb1ef804ba3d91f into release-2.13.0.

## Related
- Source commit: 6765ebd15d293d5bc86fda687bb1ef804ba3d91f