### PR TITLE
fix: omit sensitive field from scanner registration API response

### DIFF
--- a/src/server/v2.0/handler/model/scanner.go
+++ b/src/server/v2.0/handler/model/scanner.go
@@ -41,7 +41,6 @@ func (s *ScannerRegistration) ToSwagger(_ context.Context) *models.ScannerRegist
 		URL:              strfmt.URI(s.URL),
 		Description:      s.Description,
 		Auth:             s.Auth,
-		AccessCredential: s.AccessCredential,
 		SkipCertVerify:   &s.SkipCertVerify,
 		UseInternalAddr:  &s.UseInternalAddr,
 		IsDefault:        &s.IsDefault,


### PR DESCRIPTION

#  Summary 
Removes a field from the scanner registration response 
model that should not be returned by the API.


Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
