### PR TITLE
fix(dao): use context-aware methods for database operations in MetaDAO

### DIFF
--- a/src/pkg/oidc/dao/meta.go
+++ b/src/pkg/oidc/dao/meta.go
@@ -51,7 +51,7 @@ func (md *metaDAO) DeleteByUserID(ctx context.Context, uid int) error {
 	if err != nil {
 		return err
 	}
-	_, err = ormer.Raw(sql, uid).Exec()
+	_, err = ormer.RawWithCtx(ctx, sql, uid).Exec()
 	return err
 }
 
@@ -65,7 +65,7 @@ func (md *metaDAO) GetByUsername(ctx context.Context, username string) (*models.
 		return nil, err
 	}
 	res := &models.OIDCUser{}
-	if err := ormer.Raw(sql, username).QueryRow(res); err != nil {
+	if err := ormer.RawWithCtx(ctx, sql, username).QueryRow(res); err != nil {
 		if errors.Is(err, orm.ErrNoRows) {
 			return nil, fmt.Errorf("oidc user data with username %s not found", username)
 		}
@@ -79,7 +79,7 @@ func (md *metaDAO) Update(ctx context.Context, oidcUser *models.OIDCUser, props 
 	if err != nil {
 		return err
 	}
-	n, err := ormer.Update(oidcUser, props...)
+	n, err := ormer.UpdateWithCtx(ctx, oidcUser, props...)
 	if err != nil {
 		return err
 	}
@@ -96,7 +96,7 @@ func (md *metaDAO) List(ctx context.Context, query *q.Query) ([]*models.OIDCUser
 	}
 
 	var res []*models.OIDCUser
-	if _, err := qs.All(&res); err != nil {
+	if _, err := qs.AllWithCtx(ctx, &res); err != nil {
 		return nil, err
 	}
 
@@ -108,7 +108,7 @@ func (md *metaDAO) Create(ctx context.Context, oidcUser *models.OIDCUser) (int, 
 	if err != nil {
 		return 0, err
 	}
-	id, err := ormer.Insert(oidcUser)
+	id, err := ormer.InsertWithCtx(ctx, oidcUser)
 	if e := orm.AsConflictError(err, "The OIDC info for user %d exists, subissuer: %s", oidcUser.UserID, oidcUser.SubIss); e != nil {
 		err = e
 	}


### PR DESCRIPTION
Uses the context-aware methods of the ORM so cancel/timeouts can be detected by the underlying ORM provider

Fixes #22653

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
