### PR TITLE
fix(oidc): pass context to database queries in OIDC meta DAO

### DIFF
--- a/src/pkg/oidc/dao/meta.go
+++ b/src/pkg/oidc/dao/meta.go
@@ -51,7 +51,7 @@ func (md *metaDAO) DeleteByUserID(ctx context.Context, uid int) error {
 	if err != nil {
 		return err
 	}
-	_, err = ormer.Raw(sql, uid).Exec()
+	_, err = ormer.RawWithCtx(ctx, sql, uid).Exec()
 	return err
 }
 
@@ -65,7 +65,7 @@ func (md *metaDAO) GetByUsername(ctx context.Context, username string) (*models.
 		return nil, err
 	}
 	res := &models.OIDCUser{}
-	if err := ormer.Raw(sql, username).QueryRow(res); err != nil {
+	if err := ormer.RawWithCtx(ctx, sql, username).QueryRow(res); err != nil {
 		if errors.Is(err, orm.ErrNoRows) {
 			return nil, fmt.Errorf("oidc user data with username %s not found", username)
 		}

--- a/src/pkg/oidc/dao/meta_test.go
+++ b/src/pkg/oidc/dao/meta_test.go
@@ -15,6 +15,7 @@
 package dao
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -109,6 +110,20 @@ func (suite *MetaDaoTestSuite) TestDeleteByUserId() {
 func (suite *MetaDaoTestSuite) appendClearSQL(uid int) {
 	suite.ClearSQLs = append(suite.ClearSQLs, fmt.Sprintf("DELETE FROM oidc_user WHERE user_id = %d", uid))
 	suite.ClearSQLs = append(suite.ClearSQLs, fmt.Sprintf("DELETE FROM harbor_user WHERE user_id = %d", uid))
+}
+
+func (suite *MetaDaoTestSuite) TestGetByUsernameWithCancelledContext() {
+	ctx, cancel := context.WithCancel(orm.Context())
+	cancel() // cancel the context immediately to verify context propagation
+	_, err := suite.dao.GetByUsername(ctx, suite.username)
+	suite.Error(err)
+}
+
+func (suite *MetaDaoTestSuite) TestDeleteByUserIDWithCancelledContext() {
+	ctx, cancel := context.WithCancel(orm.Context())
+	cancel() // cancel the context immediately to verify context propagation
+	err := suite.dao.DeleteByUserID(ctx, suite.deleteUserID)
+	suite.Error(err)
 }
 
 func TestMetaDaoTestSuite(t *testing.T) {


### PR DESCRIPTION
## Summary

The `GetByUsername` and `DeleteByUserID` methods in the OIDC meta DAO (`src/pkg/oidc/dao/meta.go`) use `ormer.Raw()` which does not propagate the context to the underlying database driver. This means context cancellation (e.g., client disconnect, timeout) does not interrupt running queries, potentially causing Postgres connection starvation as described in the issue.

This PR switches both calls to use `ormer.RawWithCtx()` to pass the context through to the database driver, enabling:
- Query cancellation on context cancel
- Timeout enforcement
- Proper resource cleanup

## Changes

- `src/pkg/oidc/dao/meta.go`: Changed `ormer.Raw()` to `ormer.RawWithCtx(ctx, ...)` in `GetByUsername` and `DeleteByUserID`
- `src/pkg/oidc/dao/meta_test.go`: Added tests for context cancellation behavior in both methods

## Test Plan

- [x] Added `TestGetByUsernameWithCancelledContext` to verify `GetByUsername` returns an error when context is cancelled
- [x] Added `TestDeleteByUserIDWithCancelledContext` to verify `DeleteByUserID` returns an error when context is cancelled
- [x] Verified `go vet` passes with no errors
- [ ] Existing integration tests continue to pass (require database environment)

Fixes #22653

Bahtya