### PR TITLE
fix(scan): use created time from annotations in accessory art

### DIFF
--- a/src/pkg/scan/util.go
+++ b/src/pkg/scan/util.go
@@ -16,6 +16,7 @@ package scan
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
@@ -41,12 +42,18 @@ func RemoteOptions() []remote.Option {
 
 // GenAccessoryArt composes the accessory oci object and push it back to harbor core as an accessory of the scanned artifact.
 func GenAccessoryArt(sq v1sq.ScanRequest, accData []byte, accAnnotations map[string]string, mediaType string, robot *model.Robot) (string, error) {
+	createdTime := v1.Time{}
+	if created, ok := accAnnotations["created"]; ok {
+		if t, err := time.Parse(time.RFC3339, created); err == nil {
+			createdTime = v1.Time{Time: t}
+		}
+	}
 	accArt, err := mutate.Append(empty.Image, mutate.Addendum{
 		Layer: static.NewLayer(accData, ocispec.MediaTypeImageLayer),
 		History: v1.History{
 			Author:    "harbor",
 			CreatedBy: "harbor",
-			Created:   v1.Time{}, // static
+			Created:   createdTime,
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
Thank you for contributing to Harbor!

# Comprehensive Summary of your change
This pull request introduces an improvement to the handling of artifact creation times in the `GenAccessoryArt` function within the `package scan`. The function now parses a `created` timestamp from the provided annotations and uses it to set the artifact's creation time, allowing for more accurate metadata.

Enhancement to artifact creation metadata:

* [`src/pkg/scan/util.go`](diffhunk://#diff-6948c472d3598b43775ae4bc998cdeae44f542e3a7b6c202c763c71f44694697R45-R56): Updated the `GenAccessoryArt` function to parse the `created` value from `accAnnotations` and set it as the artifact's creation time, improving accuracy of artifact metadata.
* [`src/pkg/scan/util.go`](diffhunk://#diff-6948c472d3598b43775ae4bc998cdeae44f542e3a7b6c202c763c71f44694697R19): Added import of the `time` package to support parsing RFC3339 timestamps.
# Issue being fixed
Fixes https://github.com/goharbor/harbor/issues/23112

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
