### PR TITLE
ix(blob): refresh update_time on all operations to prevent GC race condition

### DIFF
--- a/src/controller/blob/controller.go
+++ b/src/controller/blob/controller.go
@@ -131,7 +131,20 @@ func (c *controller) AssociateWithArtifact(ctx context.Context, blobDigests []st
 
 func (c *controller) AssociateWithProjectByID(ctx context.Context, blobID int64, projectID int64) error {
 	_, err := c.blobMgr.AssociateWithProject(ctx, blobID, projectID)
-	return err
+	if err != nil {
+		return err
+	}
+	// always touch the blob when it's associated with a project to avoid it being GCed
+	query := &q.Query{
+		Keywords: map[string]any{
+			"id": blobID,
+		},
+	}
+	blobs, err := c.blobMgr.List(ctx, query)
+	if err != nil || len(blobs) == 0 {
+		return err
+	}
+	return c.Touch(ctx, blobs[0])
 }
 
 func (c *controller) AssociateWithProjectByDigest(ctx context.Context, blobDigest string, projectID int64) error {
@@ -141,7 +154,11 @@ func (c *controller) AssociateWithProjectByDigest(ctx context.Context, blobDiges
 	}
 
 	_, err = c.blobMgr.AssociateWithProject(ctx, blob.ID, projectID)
-	return err
+	if err != nil {
+		return err
+	}
+	// always touch the blob when it's associated with a project to avoid it being GCed
+	return c.Touch(ctx, blob)
 }
 
 func (c *controller) CalculateTotalSizeByProject(ctx context.Context, projectID int64, excludeForeign bool) (int64, error) {

--- a/src/server/middleware/blob/head_blob.go
+++ b/src/server/middleware/blob/head_blob.go
@@ -54,12 +54,15 @@ func handleHead(req *http.Request) error {
 		return err
 	}
 
+	// always touch the blob to refresh the update_time to avoid it being GCed
+	if err := blob.Ctl.Touch(req.Context(), bb); err != nil {
+		log.Errorf("failed to update blob: %s status to StatusNone, error:%v", blobInfo.Digest, err)
+		return errors.Wrapf(err, "the request id is: %s", req.Header.Get(requestid.HeaderXRequestID))
+	}
+
 	switch bb.Status {
-	case blob_models.StatusNone, blob_models.StatusDelete:
-		if err := blob.Ctl.Touch(req.Context(), bb); err != nil {
-			log.Errorf("failed to update blob: %s status to StatusNone, error:%v", blobInfo.Digest, err)
-			return errors.Wrapf(err, "the request id is: %s", req.Header.Get(requestid.HeaderXRequestID))
-		}
+	case blob_models.StatusNone, blob_models.StatusDelete, blob_models.StatusDeleteFailed:
+		return nil
 	case blob_models.StatusDeleting:
 		now := time.Now().UTC()
 		// if the deleting exceed 2 hours, marks the blob as StatusDeleteFailed and gives a 404, so client can push it again
@@ -70,10 +73,7 @@ func handleHead(req *http.Request) error {
 			}
 		}
 		return errors.New(nil).WithMessagef("the asking blob is in GC, mark it as non existing, request id: %s", req.Header.Get(requestid.HeaderXRequestID)).WithCode(errors.NotFoundCode)
-	case blob_models.StatusDeleteFailed:
-		return errors.New(nil).WithMessagef("the asking blob is delete failed, mark it as non existing, request id: %s", req.Header.Get(requestid.HeaderXRequestID)).WithCode(errors.NotFoundCode)
 	default:
 		return errors.New(nil).WithMessagef("wrong blob status, %s", bb.Status)
 	}
-	return nil
 }

--- a/src/server/middleware/blob/head_blob_test.go
+++ b/src/server/middleware/blob/head_blob_test.go
@@ -86,6 +86,38 @@ func (suite *HeadBlobUploadMiddlewareTestSuite) TestHeadBlobStatusDeleting() {
 	})
 }
 
+func (suite *HeadBlobUploadMiddlewareTestSuite) TestHeadBlobStatusDeleteFailed() {
+	suite.WithProject(func(projectID int64, projectName string) {
+		digest := suite.DigestString()
+
+		id, err := blob.Ctl.Ensure(suite.Context(), digest, "application/octet-stream", 512)
+		suite.Nil(err)
+
+		// status-none -> status-delete -> status-deleting -> status-deletefailed
+		b := &blob_models.Blob{ID: id, Status: blob_models.StatusDelete}
+		_, err = pkg_blob.Mgr.UpdateBlobStatus(suite.Context(), b)
+		suite.Nil(err)
+		b.Status = blob_models.StatusDeleting
+		_, err = pkg_blob.Mgr.UpdateBlobStatus(suite.Context(), b)
+		suite.Nil(err)
+		b.Status = blob_models.StatusDeleteFailed
+		_, err = pkg_blob.Mgr.UpdateBlobStatus(suite.Context(), b)
+		suite.Nil(err)
+
+		req := suite.makeRequest(projectName, digest)
+		res := httptest.NewRecorder()
+
+		next := suite.NextHandler(http.StatusOK, map[string]string{"Docker-Content-Digest": digest})
+		HeadBlobMiddleware()(next).ServeHTTP(res, req)
+		suite.Equal(http.StatusOK, res.Code)
+
+		blob, err := blob.Ctl.Get(suite.Context(), digest)
+		suite.Nil(err)
+		suite.Equal(digest, blob.Digest)
+		suite.Equal(blob_models.StatusNone, blob.Status)
+	})
+}
+
 func TestHeadBlobUploadMiddlewareTestSuite(t *testing.T) {
 	suite.Run(t, &HeadBlobUploadMiddlewareTestSuite{})
 }

--- a/src/server/middleware/blob/put_manifest.go
+++ b/src/server/middleware/blob/put_manifest.go
@@ -40,10 +40,17 @@ func PutManifestMiddleware() func(http.Handler) http.Handler {
 		}
 
 		contentType := r.Header.Get("Content-Type")
-		_, descriptor, err := distribution.UnmarshalManifest(contentType, body)
+		manifest, descriptor, err := distribution.UnmarshalManifest(contentType, body)
 		if err != nil {
 			logger.Errorf("unmarshal manifest failed, error: %v", err)
 			return errors.Wrapf(err, "unmarshal manifest failed").WithCode(errors.MANIFESTINVALID)
+		}
+
+		// touch all referenced blobs to avoid them being GCed
+		for _, reference := range manifest.References() {
+			if err := probeBlob(r, reference.Digest.String()); err != nil {
+				return err
+			}
 		}
 
 		return probeBlob(r, descriptor.Digest.String())

--- a/src/server/middleware/blob/util.go
+++ b/src/server/middleware/blob/util.go
@@ -39,12 +39,13 @@ func probeBlob(r *http.Request, digest string) error {
 		return err
 	}
 
+	// always touch the blob to refresh the update_time to avoid it being GCed
+	if err := blobController.Touch(r.Context(), bb); err != nil {
+		logger.Errorf("failed to update blob: %s status to StatusNone, error:%v", bb.Digest, err)
+		return errors.Wrapf(err, "the request id is: %s", r.Header.Get(requestid.HeaderXRequestID))
+	}
+
 	switch bb.Status {
-	case models.StatusNone, models.StatusDelete, models.StatusDeleteFailed:
-		if err := blobController.Touch(r.Context(), bb); err != nil {
-			logger.Errorf("failed to update blob: %s status to StatusNone, error:%v", bb.Digest, err)
-			return errors.Wrapf(err, "the request id is: %s", r.Header.Get(requestid.HeaderXRequestID))
-		}
 	case models.StatusDeleting:
 		now := time.Now().UTC()
 		// if the deleting exceed 2 hours, marks the blob as StatusDeleteFailed


### PR DESCRIPTION
# Comprehensive Summary of your change
This PR fixes a critical race condition between online Garbage Collection (GC) and concurrent blob operations. It ensures that all blob accesses refresh the `update_time`, preventing active or recently reused blobs from being mistakenly deleted. It also introduces a recovery path for blobs stuck in `StatusDeleteFailed`, allowing them to be reused safely.

# Issue being fixed
Fixes #23116

## Checklist
- [x] Well Written Title and Summary of the PR  
- [x] Label the PR as needed: `release-note/bug`  
- [x] Accepted the DCO. Commits include Signed-off-by  
- [x] Tests are passing and additional coverage has been added  
- [x] Considered docs impact (no major user-facing changes; docs update not required)