### PR TITLE
feat: add support for mTLS authentication for registries

### DIFF
--- a/src/common/http/transport.go
+++ b/src/common/http/transport.go
@@ -201,8 +201,9 @@ func NewTransport(opts ...func(*http.Transport)) http.RoundTripper {
 
 // TransportConfig is the configuration for http transport
 type TransportConfig struct {
-	Insecure      bool
-	CACertificate string
+	Insecure           bool
+	CACertificate      string
+	ClientCertificates []tls.Certificate
 }
 
 // TransportOption is the option for http transport
@@ -219,6 +220,15 @@ func WithInsecure(skipVerify bool) TransportOption {
 func WithCACert(caCert string) TransportOption {
 	return func(cfg *TransportConfig) {
 		cfg.CACertificate = caCert
+	}
+}
+
+// WithClientCertificates returns a TransportOption that configures mTLS client certificates.
+// The certificates must already be loaded by the caller; any file I/O or parsing errors
+// are the caller's responsibility, which allows proper error propagation before transport creation.
+func WithClientCertificates(certs ...tls.Certificate) TransportOption {
+	return func(cfg *TransportConfig) {
+		cfg.ClientCertificates = append(cfg.ClientCertificates, certs...)
 	}
 }
 
@@ -239,10 +249,26 @@ func GetHTTPTransport(opts ...TransportOption) http.RoundTripper {
 		opt(cfg)
 	}
 
-	if cfg.CACertificate != "" {
-		return NewTransport(
-			WithCustomCACert(cfg.CACertificate),
-		)
+	hasClientCerts := len(cfg.ClientCertificates) > 0
+
+	if cfg.CACertificate != "" || hasClientCerts {
+		var transportOpts []func(*http.Transport)
+		if cfg.CACertificate != "" {
+			transportOpts = append(transportOpts, WithCustomCACert(cfg.CACertificate))
+		}
+		if cfg.Insecure {
+			transportOpts = append(transportOpts, WithInsecureSkipVerify(true))
+		}
+		if hasClientCerts {
+			certs := cfg.ClientCertificates
+			transportOpts = append(transportOpts, func(tr *http.Transport) {
+				if tr.TLSClientConfig == nil {
+					tr.TLSClientConfig = &tls.Config{}
+				}
+				tr.TLSClientConfig.Certificates = append(tr.TLSClientConfig.Certificates, certs...)
+			})
+		}
+		return NewTransport(transportOpts...)
 	}
 
 	if cfg.Insecure {

--- a/src/pkg/reg/adapter/native/adapter.go
+++ b/src/pkg/reg/adapter/native/adapter.go
@@ -15,6 +15,7 @@
 package native
 
 import (
+	"crypto/tls"
 	"fmt"
 
 	"github.com/goharbor/harbor/src/common/utils"
@@ -73,7 +74,17 @@ func NewAdapter(reg *model.Registry) *Adapter {
 		password = reg.Credential.AccessSecret
 	}
 
-	adapter.Client = registry.NewClientWithCACert(reg.URL, username, password, reg.Insecure, reg.CACertificate)
+	var tlsCerts []tls.Certificate
+	if reg.TLSCertPath != "" && reg.TLSKeyPath != "" {
+		cert, err := tls.LoadX509KeyPair(reg.TLSCertPath, reg.TLSKeyPath)
+		if err != nil {
+			log.Errorf("failed to load TLS certs for registry %s: %v", reg.URL, err)
+		} else {
+			tlsCerts = []tls.Certificate{cert}
+		}
+	}
+
+	adapter.Client = registry.NewClientWithTLSConfig(reg.URL, username, password, reg.Insecure, reg.CACertificate, tlsCerts)
 	return adapter
 }
 

--- a/src/pkg/reg/model/registry.go
+++ b/src/pkg/reg/model/registry.go
@@ -101,6 +101,8 @@ type Registry struct {
 	Credential      *Credential `json:"credential"`
 	Insecure        bool        `json:"insecure"`
 	CACertificate   string      `json:"ca_certificate,omitempty"`
+	TLSCertPath     string      `json:"tls_certificate_path,omitempty"`
+	TLSKeyPath      string      `json:"tls_key_path,omitempty"`
 	Status          string      `json:"status"`
 	CreationTime    time.Time   `json:"creation_time"`
 	UpdateTime      time.Time   `json:"update_time"`

--- a/src/pkg/registry/client.go
+++ b/src/pkg/registry/client.go
@@ -16,6 +16,7 @@ package registry
 
 import (
 	"bytes"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -135,10 +136,26 @@ func NewClient(url, username, password string, insecure bool, interceptors ...in
 	return NewClientWithAuthorizer(url, authorizer, insecure, "", interceptors...)
 }
 
-// NewClientWithCACert creates a registry client with custom CA certificate
-func NewClientWithCACert(url, username, password string, insecure bool, caCert string, interceptors ...interceptor.Interceptor) Client {
+// NewClientWithTLSConfig creates a registry client with a fully configured TLS transport.
+// clientCerts are optional mTLS client certificates; pass nil for standard TLS without client auth.
+func NewClientWithTLSConfig(url, username, password string, insecure bool, caCert string, clientCerts []tls.Certificate, interceptors ...interceptor.Interceptor) Client {
 	authorizer := auth.NewAuthorizer(username, password, insecure, caCert)
-	return NewClientWithAuthorizer(url, authorizer, insecure, caCert, interceptors...)
+	transportOpts := []commonhttp.TransportOption{
+		commonhttp.WithInsecure(insecure),
+		commonhttp.WithCACert(caCert),
+	}
+	if len(clientCerts) > 0 {
+		transportOpts = append(transportOpts, commonhttp.WithClientCertificates(clientCerts...))
+	}
+	return &client{
+		url:          url,
+		authorizer:   authorizer,
+		interceptors: interceptors,
+		client: &http.Client{
+			Transport: commonhttp.GetHTTPTransport(transportOpts...),
+			Timeout:   registryHTTPClientTimeout,
+		},
+	}
 }
 
 // NewClientWithAuthorizer creates a registry client with the provided authorizer


### PR DESCRIPTION
# Comprehensive Summary of your change

Harbor is lacking support for mTLS authentication for private registries. In some heavily secured environments it's desired to use TLS authentication against upstream registries.

The current way to do it is using an intermediate sidecar proxy like nginx doing mTLS itself, which is very hacky.

I'm not totally sure about the design we want to pass certificates. I'd say the most common way in Kubernetes would be mounting TLS certs generated by cert-manager, which permits short lifetime certificates, it's the most desirable.

The current PR implementation is incomplete and require to be finished, and i'd like to have some harbor maintainers feedback.
Should we expose the tls_cert/key path through API/UI ? Do we rely on a global ENV_VAR to setup the registry TLS cert ?

# Issue being fixed

Fixes #18624
Fixes #22558

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
