### PR TITLE
feat(gc): use human-readable sizes in GC log messages

### DIFF
--- a/src/jobservice/job/impl/gc/garbage_collection.go
+++ b/src/jobservice/job/impl/gc/garbage_collection.go
@@ -17,6 +17,8 @@ package gc
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"math"
 	"net/url"
 	"os"
 	"sync/atomic"
@@ -278,7 +280,7 @@ func (gc *GarbageCollector) mark(ctx job.Context) error {
 		}
 	}
 	gc.logger.Infof("%d blobs and %d manifests eligible for deletion", blobCt, mfCt)
-	gc.logger.Infof("The GC could free up %d MB space, the size is a rough estimation.", makeSize/1024/1024)
+	gc.logger.Infof("The GC could free up %s space, the size is a rough estimation.", formatSize(makeSize))
 
 	if gc.dryRun {
 		if err := saveGCRes(ctx, makeSize, int64(blobCt), int64(mfCt)); err != nil {
@@ -485,7 +487,7 @@ func (gc *GarbageCollector) sweep(ctx job.Context) error {
 	}
 
 	gc.logger.Infof("%d blobs and %d manifests are actually deleted", blobCnt, mfCnt)
-	gc.logger.Infof("The GC job actual frees up %d MB space.", sweepSize/1024/1024)
+	gc.logger.Infof("The GC job actual frees up %s space.", formatSize(sweepSize))
 
 	if err := saveGCRes(ctx, sweepSize, blobCnt, mfCnt); err != nil {
 		gc.logger.Errorf("failed to save the garbage collection results, errMsg=%v", err)
@@ -749,4 +751,22 @@ func saveGCRes(ctx job.Context, sweepSize, blobs, manifests int64) error {
 	}
 	_ = ctx.Checkin(string(c))
 	return nil
+}
+
+// formatSize formats the size in bytes to a human-readable string with IEC units,
+// keeping exactly 2 decimal places (truncated, not rounded), aligned with the frontend display.
+func formatSize(size int64) string {
+	v := float64(size)
+	switch {
+	case v >= 1024*1024*1024*1024:
+		return fmt.Sprintf("%.2f TiB", math.Trunc(v/(1024*1024*1024*1024)*100)/100)
+	case v >= 1024*1024*1024:
+		return fmt.Sprintf("%.2f GiB", math.Trunc(v/(1024*1024*1024)*100)/100)
+	case v >= 1024*1024:
+		return fmt.Sprintf("%.2f MiB", math.Trunc(v/(1024*1024)*100)/100)
+	case v >= 1024:
+		return fmt.Sprintf("%.2f KiB", math.Trunc(v/1024*100)/100)
+	default:
+		return fmt.Sprintf("%d B", size)
+	}
 }

--- a/src/jobservice/job/impl/gc/garbage_collection_test.go
+++ b/src/jobservice/job/impl/gc/garbage_collection_test.go
@@ -406,6 +406,33 @@ func (suite *gcTestSuite) TestSaveRes() {
 	suite.Nil(saveGCRes(ctx, 123456, 100, 100))
 }
 
+func (suite *gcTestSuite) TestFormatSize() {
+	tests := []struct {
+		name     string
+		size     int64
+		expected string
+	}{
+		{name: "zero bytes", size: 0, expected: "0 B"},
+		{name: "500 bytes", size: 500, expected: "500 B"},
+		{name: "1 KiB", size: 1024, expected: "1.00 KiB"},
+		{name: "1.5 KiB", size: 1536, expected: "1.50 KiB"},
+		{name: "1 MiB", size: 1048576, expected: "1.00 MiB"},
+		{name: "2.5 MiB", size: 2621440, expected: "2.50 MiB"},
+		{name: "1 GiB", size: 1073741824, expected: "1.00 GiB"},
+		{name: "3.5 GiB", size: 3758096384, expected: "3.50 GiB"},
+		{name: "1 TiB", size: 1099511627776, expected: "1.00 TiB"},
+		{name: "2 TiB", size: 2199023255552, expected: "2.00 TiB"},
+		// truncation: 1615981465 / 1024^3 = 1.5049... → should be "1.50 GiB", not "1.51 GiB"
+		{name: "truncation GiB", size: 1615981465, expected: "1.50 GiB"},
+		// truncation: 1579520 / 1024^2 = 1.50625 → should be "1.50 MiB", not "1.51 MiB"
+		{name: "truncation MiB", size: 1579520, expected: "1.50 MiB"},
+	}
+
+	for _, tc := range tests {
+		suite.Equal(tc.expected, formatSize(tc.size), tc.name)
+	}
+}
+
 func TestGCTestSuite(t *testing.T) {
 	t.Setenv("UTTEST", "true")
 	suite.Run(t, &gcTestSuite{})


### PR DESCRIPTION
Thank you for contributing to Harbor!

# Comprehensive Summary of your change

This pull request updates how storage sizes are logged during garbage collection by using human-readable formatting. It introduces the `github.com/dustin/go-humanize` package and replaces previous raw megabyte calculations with more user-friendly size outputs (e.g., "1.2 GB" instead of "1234567890 MB").

**Dependency addition:**

* Added `github.com/dustin/go-humanize` as a dependency in `go.mod` to support human-readable size formatting.

**Logging improvements:**

* Imported `go-humanize` in `garbage_collection.go` to enable usage of its formatting functions.
* Updated logging in the `mark` and `sweep` methods of `GarbageCollector` to use `humanize.IBytes` for displaying freed space in a human-readable format instead of raw MB values. [[1]](diffhunk://#diff-cbef5aff4bbbfa91ab38c259d2c8f22675506c49396ad9fed1a4bca6d79e8971L281-R282) [[2]](diffhunk://#diff-cbef5aff4bbbfa91ab38c259d2c8f22675506c49396ad9fed1a4bca6d79e8971L488-R489)

# Issue being fixed
Fixes https://github.com/goharbor/harbor/issues/23122

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
