### PR TITLE
fix: initial vulnerability prevention for proxy cache projects

### DIFF
--- a/src/controller/proxy/controller.go
+++ b/src/controller/proxy/controller.go
@@ -284,7 +284,7 @@ func (c *controller) GetManifestWithVulnerabilityPrevention(ctx context.Context,
 	if err != nil {
 		return err
 	}
-	msg := fmt.Sprintf(`image is being downloaded from upstream and scanned due to configured policy in 'Prevent images with vulnerability severity of "%s" or higher from running.' `+
+	msg := fmt.Sprintf(`image is being downloaded from upstream and requires scanning due to configured policy in 'Prevent images with vulnerability severity of "%s" or higher from running.' `+
 		`Please try again momentarily.`, severity)
 	return errors.New(nil).WithCode(errors.PROJECTPOLICYVIOLATION).WithMessage(msg)
 }

--- a/src/controller/proxy/controller.go
+++ b/src/controller/proxy/controller.go
@@ -65,6 +65,9 @@ type Controller interface {
 	// ProxyManifest proxy the manifest request to the remote server, p is the proxy project,
 	// art is the ArtifactInfo which includes the tag or digest of the manifest
 	ProxyManifest(ctx context.Context, art lib.ArtifactInfo, remote RemoteInterface) (distribution.Manifest, error)
+	// GetManifestWithVulnerabilityPrevention gets the manifest from the remote server while returning an error
+	// to the client that it's being downloaded when vulnerability prevention is enabled for the proxy project
+	GetManifestWithVulnerabilityPrevention(ctx context.Context, art lib.ArtifactInfo, remote RemoteInterface, severity string) error
 	// HeadManifest send manifest head request to the remote server
 	HeadManifest(ctx context.Context, art lib.ArtifactInfo, remote RemoteInterface) (bool, *distribution.Descriptor, error)
 	// EnsureTag ensure tag for digest
@@ -274,6 +277,16 @@ func (c *controller) ProxyManifest(ctx context.Context, art lib.ArtifactInfo, re
 	}(operator.FromContext(ctx))
 
 	return man, nil
+}
+
+func (c *controller) GetManifestWithVulnerabilityPrevention(ctx context.Context, art lib.ArtifactInfo, remote RemoteInterface, severity string) error {
+	_, err := c.ProxyManifest(ctx, art, remote)
+	if err != nil {
+		return err
+	}
+	msg := fmt.Sprintf(`image is being downloaded from upstream and scanned due to configured policy in 'Prevent images with vulnerability severity of "%s" or higher from running.' `+
+		`Please try again momentarily.`, severity)
+	return errors.New(nil).WithCode(errors.PROJECTPOLICYVIOLATION).WithMessage(msg)
 }
 
 func (c *controller) HeadManifest(_ context.Context, art lib.ArtifactInfo, remote RemoteInterface) (bool, *distribution.Descriptor, error) {

--- a/src/controller/proxy/controller.go
+++ b/src/controller/proxy/controller.go
@@ -285,7 +285,7 @@ func (c *controller) GetManifestWithVulnerabilityPrevention(ctx context.Context,
 		return err
 	}
 	msg := fmt.Sprintf(`image is being downloaded from upstream and requires scanning due to configured policy in 'Prevent images with vulnerability severity of "%s" or higher from running.' `+
-		`Please try again momentarily.`, severity)
+		`This may take a while - please try again later.`, severity)
 	return errors.New(nil).WithCode(errors.PROJECTPOLICYVIOLATION).WithMessage(msg)
 }
 

--- a/src/lib/errors/const.go
+++ b/src/lib/errors/const.go
@@ -119,3 +119,8 @@ func IsChallengesUnsupportedErr(err error) bool {
 func IsRateLimitError(err error) bool {
 	return IsErr(err, RateLimitCode)
 }
+
+// IsProjectPolicyViolationError returns true when the error is PROJECTPOLICYVIOLATION
+func IsProjectPolicyViolationError(err error) bool {
+	return IsErr(err, PROJECTPOLICYVIOLATION)
+}

--- a/src/server/middleware/repoproxy/proxy.go
+++ b/src/server/middleware/repoproxy/proxy.go
@@ -151,7 +151,7 @@ func preCheck(ctx context.Context, withProjectMetadata bool) (art lib.ArtifactIn
 func ManifestMiddleware() func(http.Handler) http.Handler {
 	return middleware.New(func(w http.ResponseWriter, r *http.Request, next http.Handler) {
 		if err := handleManifest(w, r, next); err != nil {
-			if errors.IsNotFoundErr(err) {
+			if errors.IsNotFoundErr(err) || errors.IsProjectPolicyViolationError(err) {
 				httpLib.SendError(w, err)
 				return
 			}
@@ -271,7 +271,7 @@ func handleManifest(w http.ResponseWriter, r *http.Request, next http.Handler) e
 		err = proxyManifestGet(ctx, w, proxyCtl, p, art, remote)
 	}
 	if err != nil {
-		if errors.IsNotFoundErr(err) || errors.IsRateLimitError(err) {
+		if errors.IsNotFoundErr(err) || errors.IsRateLimitError(err) || errors.IsProjectPolicyViolationError(err) {
 			return err
 		}
 		log.Warningf("Proxy to remote failed, fallback to local repo, error: %v", err)
@@ -280,7 +280,10 @@ func handleManifest(w http.ResponseWriter, r *http.Request, next http.Handler) e
 	return nil
 }
 
-func proxyManifestGet(ctx context.Context, w http.ResponseWriter, ctl proxy.Controller, _ *proModels.Project, art lib.ArtifactInfo, remote proxy.RemoteInterface) error {
+func proxyManifestGet(ctx context.Context, w http.ResponseWriter, ctl proxy.Controller, p *proModels.Project, art lib.ArtifactInfo, remote proxy.RemoteInterface) error {
+	if p.VulPrevented() {
+		return ctl.GetManifestWithVulnerabilityPrevention(ctx, art, remote, p.Severity())
+	}
 	man, err := ctl.ProxyManifest(ctx, art, remote)
 	if err != nil {
 		return err

--- a/src/server/middleware/repoproxy/proxy.go
+++ b/src/server/middleware/repoproxy/proxy.go
@@ -206,7 +206,7 @@ func preCheck(ctx context.Context, withProjectMetadata bool) (art lib.ArtifactIn
 func ManifestMiddleware() func(http.Handler) http.Handler {
 	return middleware.New(func(w http.ResponseWriter, r *http.Request, next http.Handler) {
 		if err := handleManifest(w, r, next); err != nil {
-			if errors.IsNotFoundErr(err) {
+			if errors.IsNotFoundErr(err) || errors.IsProjectPolicyViolationError(err) {
 				httpLib.SendError(w, err)
 				return
 			}
@@ -375,7 +375,7 @@ func handleManifest(w http.ResponseWriter, r *http.Request, next http.Handler) e
 		err = proxyManifestGet(ctx, w, proxyCtl, p, art, remote)
 	}
 	if err != nil {
-		if errors.IsNotFoundErr(err) || errors.IsRateLimitError(err) {
+		if errors.IsNotFoundErr(err) || errors.IsRateLimitError(err) || errors.IsProjectPolicyViolationError(err) {
 			return err
 		}
 		log.Warningf("Proxy to remote failed, fallback to local repo, error: %v", err)
@@ -384,7 +384,10 @@ func handleManifest(w http.ResponseWriter, r *http.Request, next http.Handler) e
 	return nil
 }
 
-func proxyManifestGet(ctx context.Context, w http.ResponseWriter, ctl proxy.Controller, _ *proModels.Project, art lib.ArtifactInfo, remote proxy.RemoteInterface) error {
+func proxyManifestGet(ctx context.Context, w http.ResponseWriter, ctl proxy.Controller, p *proModels.Project, art lib.ArtifactInfo, remote proxy.RemoteInterface) error {
+	if p.VulPrevented() {
+		return ctl.GetManifestWithVulnerabilityPrevention(ctx, art, remote, p.Severity())
+	}
 	man, err := ctl.ProxyManifest(ctx, art, remote)
 	if err != nil {
 		return err

--- a/src/server/middleware/repoproxy/proxy_test.go
+++ b/src/server/middleware/repoproxy/proxy_test.go
@@ -16,14 +16,91 @@ package repoproxy
 
 import (
 	"context"
+	"io"
+	"net/http/httptest"
 	"testing"
+
+	"github.com/docker/distribution"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 
 	"github.com/goharbor/harbor/src/common/models"
 	"github.com/goharbor/harbor/src/common/security"
 	"github.com/goharbor/harbor/src/common/security/local"
 	"github.com/goharbor/harbor/src/common/security/proxycachesecret"
 	securitySecret "github.com/goharbor/harbor/src/common/security/secret"
+	"github.com/goharbor/harbor/src/controller/proxy"
+	"github.com/goharbor/harbor/src/lib"
+	"github.com/goharbor/harbor/src/lib/errors"
+	proModels "github.com/goharbor/harbor/src/pkg/project/models"
 )
+
+// mockProxyController implements proxy.Controller for testing proxyManifestGet
+type mockProxyController struct {
+	mock.Mock
+}
+
+func (m *mockProxyController) UseLocalBlob(ctx context.Context, art lib.ArtifactInfo) bool {
+	args := m.Called(ctx, art)
+	return args.Bool(0)
+}
+
+func (m *mockProxyController) UseLocalManifest(ctx context.Context, art lib.ArtifactInfo, remote proxy.RemoteInterface, p *proModels.Project) (bool, *proxy.ManifestList, error) {
+	args := m.Called(ctx, art, remote, p)
+	var ml *proxy.ManifestList
+	if args.Get(1) != nil {
+		ml = args.Get(1).(*proxy.ManifestList)
+	}
+	return args.Bool(0), ml, args.Error(2)
+}
+
+func (m *mockProxyController) ProxyBlob(ctx context.Context, p *proModels.Project, art lib.ArtifactInfo) (int64, io.ReadCloser, error) {
+	args := m.Called(ctx, p, art)
+	var rc io.ReadCloser
+	if args.Get(1) != nil {
+		rc = args.Get(1).(io.ReadCloser)
+	}
+	return args.Get(0).(int64), rc, args.Error(2)
+}
+
+func (m *mockProxyController) ProxyManifest(ctx context.Context, art lib.ArtifactInfo, remote proxy.RemoteInterface) (distribution.Manifest, error) {
+	args := m.Called(ctx, art, remote)
+	var man distribution.Manifest
+	if args.Get(0) != nil {
+		man = args.Get(0).(distribution.Manifest)
+	}
+	return man, args.Error(1)
+}
+
+func (m *mockProxyController) GetManifestWithVulnerabilityPrevention(ctx context.Context, art lib.ArtifactInfo, remote proxy.RemoteInterface, severity string) error {
+	args := m.Called(ctx, art, remote, severity)
+	return args.Error(0)
+}
+
+func (m *mockProxyController) HeadManifest(ctx context.Context, art lib.ArtifactInfo, remote proxy.RemoteInterface) (bool, *distribution.Descriptor, error) {
+	args := m.Called(ctx, art, remote)
+	var desc *distribution.Descriptor
+	if args.Get(1) != nil {
+		desc = args.Get(1).(*distribution.Descriptor)
+	}
+	return args.Bool(0), desc, args.Error(2)
+}
+
+func (m *mockProxyController) EnsureTag(ctx context.Context, art lib.ArtifactInfo, tagName string) error {
+	args := m.Called(ctx, art, tagName)
+	return args.Error(0)
+}
+
+// fakeManifest implements distribution.Manifest for testing
+type fakeManifest struct {
+	mediaType string
+	payload   []byte
+}
+
+func (f *fakeManifest) References() []distribution.Descriptor { return nil }
+func (f *fakeManifest) Payload() (string, []byte, error) {
+	return f.mediaType, f.payload, nil
+}
 
 func TestIsProxySession(t *testing.T) {
 	sc1 := securitySecret.NewSecurityContext("123456789", nil)
@@ -79,4 +156,63 @@ func TestIsProxySession(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestProxyManifestGet_VulnerabilityPrevention(t *testing.T) {
+	ctx := context.Background()
+	w := httptest.NewRecorder()
+	art := lib.ArtifactInfo{
+		Repository:  "library/hello-world",
+		Tag:         "latest",
+		ProjectName: "library",
+	}
+	p := &proModels.Project{
+		RegistryID: 1,
+		Metadata: map[string]string{
+			proModels.ProMetaPreventVul: "true",
+			proModels.ProMetaSeverity:   "critical",
+		},
+	}
+
+	ctl := &mockProxyController{}
+	policyErr := errors.New(nil).WithCode(errors.PROJECTPOLICYVIOLATION).WithMessage(
+		`image is being downloaded from upstream and requires scanning due to configured policy in 'Prevent images with vulnerability severity of "critical" or higher from running.' Please try again momentarily.`,
+	)
+	ctl.On("GetManifestWithVulnerabilityPrevention", mock.Anything, art, mock.Anything, "critical").Return(policyErr)
+
+	err := proxyManifestGet(ctx, w, ctl, p, art, nil)
+
+	assert.NotNil(t, err)
+	assert.True(t, errors.IsProjectPolicyViolationError(err))
+	ctl.AssertExpectations(t)
+	ctl.AssertNotCalled(t, "ProxyManifest")
+}
+
+func TestProxyManifestGet_NormalFlow(t *testing.T) {
+	ctx := context.Background()
+	w := httptest.NewRecorder()
+	art := lib.ArtifactInfo{
+		Repository:  "library/hello-world",
+		Tag:         "latest",
+		ProjectName: "library",
+	}
+	p := &proModels.Project{
+		RegistryID: 1,
+	}
+
+	man := &fakeManifest{
+		mediaType: "application/vnd.docker.distribution.manifest.v2+json",
+		payload:   []byte(`{"schemaVersion":2}`),
+	}
+
+	ctl := &mockProxyController{}
+	ctl.On("ProxyManifest", mock.Anything, art, mock.Anything).Return(man, nil)
+
+	err := proxyManifestGet(ctx, w, ctl, p, art, nil)
+
+	assert.Nil(t, err)
+	ctl.AssertExpectations(t)
+	ctl.AssertNotCalled(t, "GetManifestWithVulnerabilityPrevention")
+	assert.Equal(t, `{"schemaVersion":2}`, w.Body.String())
+	assert.Equal(t, "application/vnd.docker.distribution.manifest.v2+json", w.Header().Get(contentType))
 }

--- a/src/server/middleware/repoproxy/proxy_test.go
+++ b/src/server/middleware/repoproxy/proxy_test.go
@@ -176,7 +176,7 @@ func TestProxyManifestGet_VulnerabilityPrevention(t *testing.T) {
 
 	ctl := &mockProxyController{}
 	policyErr := errors.New(nil).WithCode(errors.PROJECTPOLICYVIOLATION).WithMessage(
-		`image is being downloaded from upstream and requires scanning due to configured policy in 'Prevent images with vulnerability severity of "critical" or higher from running.' Please try again momentarily.`,
+		`image is being downloaded from upstream and requires scanning due to configured policy in 'Prevent images with vulnerability severity of "critical" or higher from running.' This may take a while - please try again later.`,
 	)
 	ctl.On("GetManifestWithVulnerabilityPrevention", mock.Anything, art, mock.Anything, "critical").Return(policyErr)
 

--- a/src/server/middleware/repoproxy/proxy_test.go
+++ b/src/server/middleware/repoproxy/proxy_test.go
@@ -25,7 +25,9 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/docker/distribution"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -35,6 +37,7 @@ import (
 	robotSc "github.com/goharbor/harbor/src/common/security/robot"
 	securitySecret "github.com/goharbor/harbor/src/common/security/secret"
 	"github.com/goharbor/harbor/src/controller/project"
+	"github.com/goharbor/harbor/src/controller/proxy"
 	registryCtl "github.com/goharbor/harbor/src/controller/registry"
 	"github.com/goharbor/harbor/src/controller/robot"
 	"github.com/goharbor/harbor/src/lib"
@@ -975,4 +978,130 @@ func TestTagsListMiddlewareDefaultLibrary(t *testing.T) {
 	if location := rec.Header().Get("Location"); location != expectedLocation {
 		t.Errorf("expected Location header %q, got %q", expectedLocation, location)
 	}
+}
+
+// mockProxyController implements proxy.Controller for testing proxyManifestGet
+type mockProxyController struct {
+	mock.Mock
+}
+
+func (m *mockProxyController) UseLocalBlob(ctx context.Context, art lib.ArtifactInfo) bool {
+	args := m.Called(ctx, art)
+	return args.Bool(0)
+}
+
+func (m *mockProxyController) UseLocalManifest(ctx context.Context, art lib.ArtifactInfo, remote proxy.RemoteInterface, p *proModels.Project) (bool, *proxy.ManifestList, error) {
+	args := m.Called(ctx, art, remote, p)
+	var ml *proxy.ManifestList
+	if args.Get(1) != nil {
+		ml = args.Get(1).(*proxy.ManifestList)
+	}
+	return args.Bool(0), ml, args.Error(2)
+}
+
+func (m *mockProxyController) ProxyBlob(ctx context.Context, p *proModels.Project, art lib.ArtifactInfo) (int64, io.ReadCloser, error) {
+	args := m.Called(ctx, p, art)
+	var rc io.ReadCloser
+	if args.Get(1) != nil {
+		rc = args.Get(1).(io.ReadCloser)
+	}
+	return args.Get(0).(int64), rc, args.Error(2)
+}
+
+func (m *mockProxyController) ProxyManifest(ctx context.Context, art lib.ArtifactInfo, remote proxy.RemoteInterface) (distribution.Manifest, error) {
+	args := m.Called(ctx, art, remote)
+	var man distribution.Manifest
+	if args.Get(0) != nil {
+		man = args.Get(0).(distribution.Manifest)
+	}
+	return man, args.Error(1)
+}
+
+func (m *mockProxyController) GetManifestWithVulnerabilityPrevention(ctx context.Context, art lib.ArtifactInfo, remote proxy.RemoteInterface, severity string) error {
+	args := m.Called(ctx, art, remote, severity)
+	return args.Error(0)
+}
+
+func (m *mockProxyController) HeadManifest(ctx context.Context, art lib.ArtifactInfo, remote proxy.RemoteInterface) (bool, *distribution.Descriptor, error) {
+	args := m.Called(ctx, art, remote)
+	var desc *distribution.Descriptor
+	if args.Get(1) != nil {
+		desc = args.Get(1).(*distribution.Descriptor)
+	}
+	return args.Bool(0), desc, args.Error(2)
+}
+
+func (m *mockProxyController) EnsureTag(ctx context.Context, art lib.ArtifactInfo, tagName string) error {
+	args := m.Called(ctx, art, tagName)
+	return args.Error(0)
+}
+
+// fakeManifest implements distribution.Manifest for testing
+type fakeManifest struct {
+	mediaType string
+	payload   []byte
+}
+
+func (f *fakeManifest) References() []distribution.Descriptor { return nil }
+func (f *fakeManifest) Payload() (string, []byte, error) {
+	return f.mediaType, f.payload, nil
+}
+
+func TestProxyManifestGet_VulnerabilityPrevention(t *testing.T) {
+	ctx := context.Background()
+	w := httptest.NewRecorder()
+	art := lib.ArtifactInfo{
+		Repository:  "library/hello-world",
+		Tag:         "latest",
+		ProjectName: "library",
+	}
+	p := &proModels.Project{
+		RegistryID: 1,
+		Metadata: map[string]string{
+			proModels.ProMetaPreventVul: "true",
+			proModels.ProMetaSeverity:   "critical",
+		},
+	}
+
+	ctl := &mockProxyController{}
+	policyErr := liberrors.New(nil).WithCode(liberrors.PROJECTPOLICYVIOLATION).WithMessage(
+		`image is being downloaded from upstream and requires scanning due to configured policy in 'Prevent images with vulnerability severity of "critical" or higher from running.' Please try again momentarily.`,
+	)
+	ctl.On("GetManifestWithVulnerabilityPrevention", mock.Anything, art, mock.Anything, "critical").Return(policyErr)
+
+	err := proxyManifestGet(ctx, w, ctl, p, art, nil)
+
+	assert.NotNil(t, err)
+	assert.True(t, liberrors.IsProjectPolicyViolationError(err))
+	ctl.AssertExpectations(t)
+	ctl.AssertNotCalled(t, "ProxyManifest")
+}
+
+func TestProxyManifestGet_NormalFlow(t *testing.T) {
+	ctx := context.Background()
+	w := httptest.NewRecorder()
+	art := lib.ArtifactInfo{
+		Repository:  "library/hello-world",
+		Tag:         "latest",
+		ProjectName: "library",
+	}
+	p := &proModels.Project{
+		RegistryID: 1,
+	}
+
+	man := &fakeManifest{
+		mediaType: "application/vnd.docker.distribution.manifest.v2+json",
+		payload:   []byte(`{"schemaVersion":2}`),
+	}
+
+	ctl := &mockProxyController{}
+	ctl.On("ProxyManifest", mock.Anything, art, mock.Anything).Return(man, nil)
+
+	err := proxyManifestGet(ctx, w, ctl, p, art, nil)
+
+	assert.Nil(t, err)
+	ctl.AssertExpectations(t)
+	ctl.AssertNotCalled(t, "GetManifestWithVulnerabilityPrevention")
+	assert.Equal(t, `{"schemaVersion":2}`, w.Body.String())
+	assert.Equal(t, "application/vnd.docker.distribution.manifest.v2+json", w.Header().Get(contentType))
 }

--- a/src/server/middleware/repoproxy/proxy_test.go
+++ b/src/server/middleware/repoproxy/proxy_test.go
@@ -1065,7 +1065,7 @@ func TestProxyManifestGet_VulnerabilityPrevention(t *testing.T) {
 
 	ctl := &mockProxyController{}
 	policyErr := liberrors.New(nil).WithCode(liberrors.PROJECTPOLICYVIOLATION).WithMessage(
-		`image is being downloaded from upstream and requires scanning due to configured policy in 'Prevent images with vulnerability severity of "critical" or higher from running.' Please try again momentarily.`,
+		`image is being downloaded from upstream and requires scanning due to configured policy in 'Prevent images with vulnerability severity of "critical" or higher from running.' This may take a while - please try again later.`,
 	)
 	ctl.On("GetManifestWithVulnerabilityPrevention", mock.Anything, art, mock.Anything, "critical").Return(policyErr)
 


### PR DESCRIPTION
# Summary
When a proxy cache project has the "Prevent vulnerable images from running" policy enabled, the first pull of an artifact bypasses this check. The image is proxied directly back to the client before it has been scanned, violating the configured vulnerability prevention policy.

#### `src/controller/proxy/controller.go`

- Added `GetManifestWithVulnerabilityPrevention` to the `Controller` interface and its implementation.
- This method calls `ProxyManifest` to pull and cache the image from upstream, but instead of returning the manifest to the client, it returns a `PROJECTPOLICYVIOLATION` error informing the user the image is being downloaded and scanned, and to retry momentarily.

#### `src/lib/errors/const.go`

- Added `IsProjectPolicyViolationError()` helper, following the existing pattern of `IsNotFoundErr`, `IsRateLimitError`, etc.

#### `src/server/middleware/repoproxy/proxy.go`

- **`proxyManifestGet`**: Added a guard — if the project has vulnerability prevention enabled (`p.VulPrevented()`), it routes through the new `GetManifestWithVulnerabilityPrevention` path instead of the normal `ProxyManifest` flow.
- **`handleManifest`**: `PROJECTPOLICYVIOLATION` errors are now returned directly to the client (alongside not-found and rate-limit errors) rather than being swallowed with a fallback to the local repo.
- **`ManifestMiddleware`**: Updated the top-level error handler to also send `PROJECTPOLICYVIOLATION` errors as HTTP responses.

# Issues Fixed
Fixes #16218
Fixes #16732
Fixes #22049
