### PR TITLE
fix: do not prevent pulls on artifact rescans

### DIFF
--- a/src/controller/scan/base_controller.go
+++ b/src/controller/scan/base_controller.go
@@ -817,7 +817,7 @@ func (bc *basicController) GetVulnerable(ctx context.Context, artifact *ar.Artif
 			return vulnerable, nil
 		}
 		// Fall through to use the available scan data for vulnerability assessment
-		log.G(ctx).Warningf("artifact %s@%s has scan status %q but previous scan data exists, "+
+		log.G(ctx).Debugf("artifact %s@%s has scan status %q but previous scan data exists, "+
 			"using last successful scan results for vulnerability assessment",
 			artifact.RepositoryName, artifact.Digest, scanStatus)
 		vulnerable.ScanStatus = job.SuccessStatus.String()

--- a/src/controller/scan/base_controller.go
+++ b/src/controller/scan/base_controller.go
@@ -803,7 +803,24 @@ func (bc *basicController) GetVulnerable(ctx context.Context, artifact *ar.Artif
 	}
 
 	if !vulnerable.IsScanSuccess() {
-		return vulnerable, nil
+		// If the scan is not yet successful (e.g., running, pending, or errored)
+		// but there are reports with data from a previous successful scan,
+		// use that data for the vulnerability assessment instead of blocking pulls.
+		hasData := false
+		for _, rp := range reports {
+			if len(rp.Report) > 0 {
+				hasData = true
+				break
+			}
+		}
+		if !hasData {
+			return vulnerable, nil
+		}
+		// Fall through to use the available scan data for vulnerability assessment
+		log.G(ctx).Warningf("artifact %s@%s has scan status %q but previous scan data exists, "+
+			"using last successful scan results for vulnerability assessment",
+			artifact.RepositoryName, artifact.Digest, scanStatus)
+		vulnerable.ScanStatus = job.SuccessStatus.String()
 	}
 
 	raw, err := report.Reports(reports).ResolveData(mimeType)

--- a/src/controller/scan/base_controller_test.go
+++ b/src/controller/scan/base_controller_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/goharbor/harbor/src/lib/orm"
 	"github.com/goharbor/harbor/src/lib/q"
 	accessoryModel "github.com/goharbor/harbor/src/pkg/accessory/model"
+	allowlist "github.com/goharbor/harbor/src/pkg/allowlist/models"
 	art "github.com/goharbor/harbor/src/pkg/artifact"
 	_ "github.com/goharbor/harbor/src/pkg/config/db"
 	_ "github.com/goharbor/harbor/src/pkg/config/inmemory"
@@ -670,6 +671,117 @@ func (suite *ControllerTestSuite) TestStopScanAll() {
 	suite.execMgr.On("Stop", mock.Anything, mockExecID).Return(nil).Once()
 	err = suite.c.StopScanAll(context.TODO(), mockExecID, false)
 	suite.NoError(err)
+}
+
+func (suite *ControllerTestSuite) TestGetVulnerableNonSuccessWithReportData() {
+	// When scan status is non-success (e.g. Running) but report data exists
+	// from a previous scan, GetVulnerable should fall through and evaluate
+	// vulnerabilities instead of blocking the pull.
+	ctx := orm.NewContext(nil, &ormtesting.FakeOrmer{})
+
+	testArt := &artifact.Artifact{Artifact: art.Artifact{
+		ID: 10, ProjectID: 1, Digest: "digest-running",
+		RepositoryName: "library/photon", ManifestMediaType: v1.MimeTypeDockerArtifact,
+	}}
+	testArt.Type = "IMAGE"
+
+	rp := vuln.Report{
+		GeneratedAt: time.Now().UTC().String(),
+		Scanner:     &v1.Scanner{Name: "Trivy", Vendor: "Harbor", Version: "0.1.0"},
+		Severity:    vuln.High,
+		Vulnerabilities: []*vuln.VulnerabilityItem{
+			{ID: "CVE-2024-0001", Package: "openssl", Version: "1.0", FixVersion: "1.1", Severity: vuln.High},
+		},
+	}
+	reportJSON, err := json.Marshal(rp)
+	require.NoError(suite.T(), err)
+
+	// Report has data from a prior scan but the task is currently Running
+	suite.reportMgr.On("GetBy", mock.Anything, "digest-running", "uuid001",
+		[]string{v1.MimeTypeNativeReport}).Return([]*scan.Report{
+		{
+			UUID:             "rp-running-001",
+			Digest:           "digest-running",
+			RegistrationUUID: "uuid001",
+			MimeType:         v1.MimeTypeNativeReport,
+			Report:           string(reportJSON),
+		},
+	}, nil).Once()
+
+	// assembleReports: task lookup returns Running status
+	suite.taskMgr.On("ListScanTasksByReportUUID", mock.Anything, "rp-running-001").Return([]*task.Task{
+		{Status: "Running", ExtraAttrs: suite.makeExtraAttrs(10, "rp-running-001")},
+	}, nil).Once()
+
+	// FromRelationalSchema returns the full report (with vulns inline)
+	suite.c.reportConverter.(*postprocessorstesting.NativeScanReportConverter).On(
+		"FromRelationalSchema", mock.Anything, "rp-running-001", "digest-running", string(reportJSON),
+	).Return(string(reportJSON), nil).Once()
+
+	mock.OnAnything(suite.ar, "HasUnscannableLayer").Return(false, nil).Once()
+	mock.OnAnything(suite.ar, "Walk").Return(nil).Run(func(args mock.Arguments) {
+		walkFn := args.Get(2).(func(*artifact.Artifact) error)
+		walkFn(testArt)
+	}).Once()
+	mock.OnAnything(suite.accessoryMgr, "List").Return(nil, nil).Once()
+
+	v, err := suite.c.GetVulnerable(ctx, testArt, allowlist.CVESet{}, false)
+	require.NoError(suite.T(), err)
+
+	// Should treat as success despite Running status, because report data exists
+	assert.True(suite.T(), v.IsScanSuccess())
+	assert.Equal(suite.T(), 1, v.VulnerabilitiesCount)
+	require.NotNil(suite.T(), v.Severity)
+	assert.Equal(suite.T(), vuln.High, *v.Severity)
+}
+
+func (suite *ControllerTestSuite) TestGetVulnerableNonSuccessNoReportData() {
+	// When scan status is non-success and no report data exists,
+	// GetVulnerable should return early with IsScanSuccess() == false.
+	ctx := orm.NewContext(nil, &ormtesting.FakeOrmer{})
+
+	testArt := &artifact.Artifact{Artifact: art.Artifact{
+		ID: 11, ProjectID: 1, Digest: "digest-empty",
+		RepositoryName: "library/photon", ManifestMediaType: v1.MimeTypeDockerArtifact,
+	}}
+	testArt.Type = "IMAGE"
+
+	// Report exists but has no data (empty placeholder, no prior scan)
+	suite.reportMgr.On("GetBy", mock.Anything, "digest-empty", "uuid001",
+		[]string{v1.MimeTypeNativeReport}).Return([]*scan.Report{
+		{
+			UUID:             "rp-empty-001",
+			Digest:           "digest-empty",
+			RegistrationUUID: "uuid001",
+			MimeType:         v1.MimeTypeNativeReport,
+			Report:           "",
+		},
+	}, nil).Once()
+
+	// assembleReports: task lookup returns Running status
+	suite.taskMgr.On("ListScanTasksByReportUUID", mock.Anything, "rp-empty-001").Return([]*task.Task{
+		{Status: "Running", ExtraAttrs: suite.makeExtraAttrs(11, "rp-empty-001")},
+	}, nil).Once()
+
+	// FromRelationalSchema returns empty (no prior data to reconstruct)
+	suite.c.reportConverter.(*postprocessorstesting.NativeScanReportConverter).On(
+		"FromRelationalSchema", mock.Anything, "rp-empty-001", "digest-empty", "",
+	).Return("", nil).Once()
+
+	mock.OnAnything(suite.ar, "HasUnscannableLayer").Return(false, nil).Once()
+	mock.OnAnything(suite.ar, "Walk").Return(nil).Run(func(args mock.Arguments) {
+		walkFn := args.Get(2).(func(*artifact.Artifact) error)
+		walkFn(testArt)
+	}).Once()
+	mock.OnAnything(suite.accessoryMgr, "List").Return(nil, nil).Once()
+
+	v, err := suite.c.GetVulnerable(ctx, testArt, allowlist.CVESet{}, false)
+	require.NoError(suite.T(), err)
+
+	// Should remain non-success since there's no report data to fall back on
+	assert.False(suite.T(), v.IsScanSuccess())
+	assert.Equal(suite.T(), 0, v.VulnerabilitiesCount)
+	assert.Nil(suite.T(), v.Severity)
 }
 
 func (suite *ControllerTestSuite) makeExtraAttrs(artifactID int64, reportUUIDs ...string) map[string]any {

--- a/src/pkg/scan/vulnerability/vul.go
+++ b/src/pkg/scan/vulnerability/vul.go
@@ -84,6 +84,17 @@ func (h *scanHandler) MakePlaceHolder(ctx context.Context, art *artifact.Artifac
 		}
 	}
 
+	// Preserve the most recent report data per mime type from the old reports.
+	// This data will be copied into the new placeholder so that pulls can
+	// continue using the last successful scan results while the new scan
+	// is in progress.
+	lastReportData := make(map[string]string) // key: mimeType
+	for _, oldReport := range oldReports {
+		if len(oldReport.Report) > 0 {
+			lastReportData[oldReport.MimeType] = oldReport.Report
+		}
+	}
+
 	var reports []*scan.Report
 
 	for _, pm := range r.GetProducesMimeTypes(art.ManifestMediaType, v1.ScanTypeVulnerability) {
@@ -91,6 +102,7 @@ func (h *scanHandler) MakePlaceHolder(ctx context.Context, art *artifact.Artifac
 			Digest:           art.Digest,
 			RegistrationUUID: r.UUID,
 			MimeType:         pm,
+			Report:           lastReportData[pm],
 		}
 
 		create := func(ctx context.Context) error {

--- a/src/pkg/scan/vulnerability/vul_test.go
+++ b/src/pkg/scan/vulnerability/vul_test.go
@@ -136,13 +136,14 @@ func TestScanHandler_RequestProducesMineTypes(t *testing.T) {
 
 type VulHandlerTestSuite struct {
 	htesting.Suite
-	ar             *artifacttesting.Controller
-	accessoryMgr   *accessorytesting.Manager
-	artifact       *artifact.Artifact
-	taskMgr        *tasktesting.Manager
-	reportMgr      *reporttesting.Manager
-	scanController *scanCtlTest.Controller
-	handler        *scanHandler
+	ar              *artifacttesting.Controller
+	accessoryMgr    *accessorytesting.Manager
+	artifact        *artifact.Artifact
+	taskMgr         *tasktesting.Manager
+	reportMgr       *reporttesting.Manager
+	scanController  *scanCtlTest.Controller
+	reportConverter *postprocessorstesting.NativeScanReportConverter
+	handler         *scanHandler
 }
 
 func (suite *VulHandlerTestSuite) SetupSuite() {
@@ -151,6 +152,7 @@ func (suite *VulHandlerTestSuite) SetupSuite() {
 	suite.taskMgr = &tasktesting.Manager{}
 	suite.scanController = &scanCtlTest.Controller{}
 	suite.reportMgr = &reporttesting.Manager{}
+	suite.reportConverter = &postprocessorstesting.NativeScanReportConverter{}
 	suite.artifact = &artifact.Artifact{Artifact: art.Artifact{ID: 1}}
 	suite.artifact.Type = "IMAGE"
 	suite.artifact.ProjectID = 1
@@ -158,7 +160,7 @@ func (suite *VulHandlerTestSuite) SetupSuite() {
 	suite.artifact.Digest = "digest-code"
 	suite.artifact.ManifestMediaType = v1.MimeTypeDockerArtifact
 	suite.handler = &scanHandler{
-		reportConverter:    postprocessors.Converter,
+		reportConverter:    suite.reportConverter,
 		ReportMgrFunc:      func() report.Manager { return suite.reportMgr },
 		TaskMgrFunc:        func() task.Manager { return suite.taskMgr },
 		ScanControllerFunc: func() scanCtl.Controller { return suite.scanController },
@@ -168,6 +170,22 @@ func (suite *VulHandlerTestSuite) SetupSuite() {
 }
 
 func (suite *VulHandlerTestSuite) TearDownSuite() {
+}
+
+func (suite *VulHandlerTestSuite) SetupTest() {
+	suite.ar = &artifacttesting.Controller{}
+	suite.accessoryMgr = &accessorytesting.Manager{}
+	suite.taskMgr = &tasktesting.Manager{}
+	suite.scanController = &scanCtlTest.Controller{}
+	suite.reportMgr = &reporttesting.Manager{}
+	suite.reportConverter = &postprocessorstesting.NativeScanReportConverter{}
+	suite.handler = &scanHandler{
+		reportConverter:    suite.reportConverter,
+		ReportMgrFunc:      func() report.Manager { return suite.reportMgr },
+		TaskMgrFunc:        func() task.Manager { return suite.taskMgr },
+		ScanControllerFunc: func() scanCtl.Controller { return suite.scanController },
+		cloneCtx:           func(ctx context.Context) context.Context { return ctx },
+	}
 }
 
 func TestExampleTestSuite(t *testing.T) {
@@ -213,6 +231,36 @@ func (suite *VulHandlerTestSuite) TestMakeReportPlaceHolder() {
 	rps, err := suite.handler.MakePlaceHolder(ctx, art, r)
 	require.NoError(suite.T(), err)
 	assert.Equal(suite.T(), 1, len(rps))
+}
+
+func (suite *VulHandlerTestSuite) TestMakeReportPlaceHolderCopiesOldReportData() {
+	ctx := orm.NewContext(nil, &ormtesting.FakeOrmer{})
+	art := &artifact.Artifact{Artifact: art.Artifact{ID: 1, Digest: "digest", ManifestMediaType: v1.MimeTypeDockerArtifact}}
+	r := &scanner.Registration{
+		UUID: "uuid",
+		Metadata: &v1.ScannerAdapterMetadata{
+			Capabilities: []*v1.ScannerCapability{
+				{Type: v1.ScanTypeVulnerability, ConsumesMimeTypes: []string{v1.MimeTypeDockerArtifact}, ProducesMimeTypes: []string{v1.MimeTypeGenericVulnerabilityReport}},
+			},
+		},
+	}
+	oldReportData := `{"vulnerabilities":[]}`
+	// Old report has scan data from a previous successful scan.
+	// It should be deleted but its data copied to the new placeholder.
+	mock.OnAnything(suite.reportMgr, "GetBy").Return([]*scan.Report{
+		{ID: 1, UUID: "old-uuid", MimeType: v1.MimeTypeGenericVulnerabilityReport},
+	}, nil).Once()
+	mock.OnAnything(suite.reportMgr, "Delete").Return(nil).Once()
+	mock.OnAnything(suite.reportMgr, "Create").Return("new-uuid", nil).Once()
+	// FromRelationalSchema returns non-empty data, simulating a previously successful scan
+	mock.OnAnything(suite.reportConverter, "FromRelationalSchema").Return(oldReportData, nil)
+	mock.OnAnything(suite.taskMgr, "ListScanTasksByReportUUID").Return([]*task.Task{{Status: "Success"}}, nil)
+
+	rps, err := suite.handler.MakePlaceHolder(ctx, art, r)
+	require.NoError(suite.T(), err)
+	assert.Equal(suite.T(), 1, len(rps))
+	// The new placeholder should carry the old report data as fallback
+	assert.Equal(suite.T(), oldReportData, rps[0].Report)
 }
 
 func (suite *VulHandlerTestSuite) TestGetReportPlaceHolder() {


### PR DESCRIPTION
# Summary
When vulnerability prevention is enabled and an artifact is rescanned (or a scan is stopped/fails), pulls are blocked even though a previous successful scan already produced results. A rescan, stopped scan, or failed scan should not prevent pulling an image that was previously scanned successfully.

#### `src/controller/scan/base_controller.go`

- Modified `GetVulnerable` to no longer immediately return when the current scan status is not "Success".
- When the scan is not yet successful (e.g., running, pending, or errored) but previous scan reports contain data, the method now **falls through** to use that existing data for the vulnerability assessment instead of blocking pulls.
- Logs a warning when falling back to previous scan results.
- Overrides `vulnerable.ScanStatus` to `Success` so downstream logic treats the stale-but-present data as valid.

#### `src/pkg/scan/vulnerability/vul.go`

- Updated `MakePlaceHolder` to **preserve report data from old scan reports** when creating new placeholder reports for a rescan.
- Collects the most recent report data (keyed by MIME type) from old reports before they are deleted.
- Copies that data into the newly created placeholder reports, ensuring that vulnerability assessment can still use the last successful scan results while the new scan is in progress.

#### `src/pkg/scan/vulnerability/vul_test.go`

- Added a `SetupTest` method to reset mocks between tests, ensuring test isolation.
- Added a `reportConverter` mock to the test suite for controlling `FromRelationalSchema` behavior.
- Added `TestMakeReportPlaceHolderCopiesOldReportData` — verifies that when a new scan placeholder is created, the old report data is carried forward into the new placeholder report.
- Reformatted struct field alignment in `VulHandlerTestSuite` to accommodate the new field.

# Issues Fixed
Fixes #15406
Fixes #19385
Fixes #19486