### PR TITLE
fix(gc): redact redis_url_reg from GC extra attrs

### DIFF
--- a/src/server/v2.0/handler/gc.go
+++ b/src/server/v2.0/handler/gc.go
@@ -198,7 +198,7 @@ func (g *gcAPI) GetGCHistory(ctx context.Context, params operation.GetGCHistoryP
 
 	var hs []*model.GCHistory
 	for _, exec := range execs {
-		extraAttrsString, err := json.Marshal(exec.ExtraAttrs)
+		extraAttrsString, err := json.Marshal(model.CleanExtraAttrs(exec.ExtraAttrs))
 		if err != nil {
 			return g.SendError(ctx, err)
 		}
@@ -236,7 +236,7 @@ func (g *gcAPI) GetGC(ctx context.Context, params operation.GetGCParams) middlew
 		return g.SendError(ctx, err)
 	}
 
-	extraAttrsString, err := json.Marshal(exec.ExtraAttrs)
+	extraAttrsString, err := json.Marshal(model.CleanExtraAttrs(exec.ExtraAttrs))
 	if err != nil {
 		return g.SendError(ctx, err)
 	}

--- a/src/server/v2.0/handler/model/gc.go
+++ b/src/server/v2.0/handler/model/gc.go
@@ -83,7 +83,7 @@ func (s *GCSchedule) ToSwagger() *models.GCHistory {
 		return nil
 	}
 
-	e, err := json.Marshal(s.ExtraAttrs)
+	e, err := json.Marshal(CleanExtraAttrs(s.ExtraAttrs))
 	if err != nil {
 		log.Error(err)
 	}
@@ -108,4 +108,17 @@ func (s *GCSchedule) ToSwagger() *models.GCHistory {
 // NewGCSchedule ...
 func NewGCSchedule(s *scheduler.Schedule) *GCSchedule {
 	return &GCSchedule{Schedule: s}
+}
+
+// CleanExtraAttrs removes sensitive information (e.g. redis_url_reg) from
+// extra attributes before returning them to the client.
+func CleanExtraAttrs(attrs map[string]any) map[string]any {
+	cleaned := make(map[string]any, len(attrs))
+	for k, v := range attrs {
+		if k == "redis_url_reg" {
+			continue
+		}
+		cleaned[k] = v
+	}
+	return cleaned
 }


### PR DESCRIPTION
Thank you for contributing to Harbor!

# Comprehensive Summary of your change
This pull request introduces a security improvement to how extra attributes are handled in the GC (Garbage Collection) API. The main change is the addition of a `CleanExtraAttrs` function, which removes sensitive information (specifically, the `redis_url_reg` field) from extra attributes before they are returned to the client. This ensures that sensitive data is not exposed through API responses.

**Security and Data Sanitization Improvements:**

* Added a new function `CleanExtraAttrs` in `model/gc.go` to filter out sensitive fields (like `redis_url_reg`) from extra attributes before returning them to the client.
* Updated all locations where extra attributes are marshaled for API responses (`GetGCHistory`, `GetGC`, and `ToSwagger`) to use `CleanExtraAttrs`, ensuring sensitive data is consistently removed. [[1]](diffhunk://#diff-db97d5dd15fef40be5b2d8bd89ac49f862a1a18ceb147fb230314e394b5fd6e0L201-R201) [[2]](diffhunk://#diff-db97d5dd15fef40be5b2d8bd89ac49f862a1a18ceb147fb230314e394b5fd6e0L239-R239) [[3]](diffhunk://#diff-b9c44bdca85c011cb7d63a90904e77d2ca7e32398cd090e72f6076f5d1d84876L86-R86)
# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
