### PR TITLE
bump go to 1.25.9 and refresh base images

### DIFF
--- a/.buildbaselog
+++ b/.buildbaselog
@@ -8,6 +8,9 @@
 *   Add date here... Add signature here...
 -   Add your reason here...
 
+*   Apr 21 2026 <stone.zhang@broadcom.com>
+-   Refresh base image
+
 *   Apr 15 2026 <yan-yw.wang@broadcom.com>
 -   Refresh base image
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Set up Go 1.25
         uses: actions/setup-go@v5
         with:
-           go-version: 1.25.7
+           go-version: 1.25.9
         id: go
       - uses: actions/checkout@v6
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -169,7 +169,7 @@ Harbor backend is written in [Go](http://golang.org/). If you don't have a Harbo
 | 2.12   | 1.23.2      |
 | 2.13   | 1.23.8      |
 | 2.14   | 1.24.6      |
-| 2.15   | 1.25.7      |
+| 2.15   | 1.25.9      |
 
 
 Ensure your GOPATH and PATH have been configured in accordance with the Go environment instructions.

--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,7 @@ GOINSTALL=$(GOCMD) install
 GOTEST=$(GOCMD) test
 GODEP=$(GOTEST) -i
 GOFMT=gofmt -w
-GOBUILDIMAGE=golang:1.25.7
+GOBUILDIMAGE=golang:1.25.9
 GOBUILDPATHINCONTAINER=/harbor
 
 # go build

--- a/src/go.mod
+++ b/src/go.mod
@@ -1,6 +1,6 @@
 module github.com/goharbor/harbor/src
 
-go 1.25.7
+go 1.25.9
 
 require (
 	github.com/CloudNativeAI/model-spec v0.0.5

--- a/tests/ci/distro_installer.sh
+++ b/tests/ci/distro_installer.sh
@@ -3,5 +3,5 @@ set -x
 
 set -e
 
-sudo make package_online GOBUILDTAGS="include_oss include_gcs" VERSIONTAG=dev-gitaction PKGVERSIONTAG=dev-gitaction UIVERSIONTAG=dev-gitaction GOBUILDIMAGE=golang:1.25.7 COMPILETAG=compile_golangimage TRIVYFLAG=true EXPORTERFLAG=true HTTPPROXY= PULL_BASE_FROM_DOCKERHUB=false
-sudo make package_offline GOBUILDTAGS="include_oss include_gcs" VERSIONTAG=dev-gitaction PKGVERSIONTAG=dev-gitaction UIVERSIONTAG=dev-gitaction GOBUILDIMAGE=golang:1.25.7 COMPILETAG=compile_golangimage TRIVYFLAG=true EXPORTERFLAG=true HTTPPROXY= PULL_BASE_FROM_DOCKERHUB=false
+sudo make package_online GOBUILDTAGS="include_oss include_gcs" VERSIONTAG=dev-gitaction PKGVERSIONTAG=dev-gitaction UIVERSIONTAG=dev-gitaction GOBUILDIMAGE=golang:1.25.9 COMPILETAG=compile_golangimage TRIVYFLAG=true EXPORTERFLAG=true HTTPPROXY= PULL_BASE_FROM_DOCKERHUB=false
+sudo make package_offline GOBUILDTAGS="include_oss include_gcs" VERSIONTAG=dev-gitaction PKGVERSIONTAG=dev-gitaction UIVERSIONTAG=dev-gitaction GOBUILDIMAGE=golang:1.25.9 COMPILETAG=compile_golangimage TRIVYFLAG=true EXPORTERFLAG=true HTTPPROXY= PULL_BASE_FROM_DOCKERHUB=false


### PR DESCRIPTION
Bump the Go toolchain to 1.25.9 in CI, Makefile, go.mod, and distro installer scripts. Update CONTRIBUTING.md accordingly.

Touch .buildbaselog to trigger rebuilding Photon base images from the current Dockerfile.base definitions.


Made-with: Cursor

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [ ] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [ ] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
