### PR TITLE
fix(tag): retry Ensure on conflict so concurrent pushes update the tag

### DIFF
--- a/src/controller/tag/controller.go
+++ b/src/controller/tag/controller.go
@@ -118,8 +118,17 @@ func (c *controller) Ensure(ctx context.Context, repositoryID, artifactID int64,
 		tag.PushTime = time.Now()
 		tagID, err = c.Create(ctx, tag)
 		return err
-	})(orm.SetTransactionOpNameToContext(ctx, "tx-tag-ensure")); err != nil && !errors.IsConflictErr(err) {
-		return 0, err
+	})(orm.SetTransactionOpNameToContext(ctx, "tx-tag-ensure")); err != nil {
+		if !errors.IsConflictErr(err) {
+			return 0, err
+		}
+		// A concurrent request won the unique-constraint race and inserted
+		// the tag first. Re-run Ensure so we fall into the "tag exists"
+		// branch above and update its ArtifactID/PushTime to match this
+		// request. Without this retry we returned (0, nil), which caused
+		// callers such as proxy.controller.EnsureTag to subsequently look
+		// up tag id 0 and fail with NotFoundError (harbor#23118).
+		return c.Ensure(ctx, repositoryID, artifactID, name)
 	}
 
 	return tagID, nil


### PR DESCRIPTION
## Summary

Fixes #23118.

When two clients concurrently push distinct artifacts to the same new tag, both pass the List check and race into the Create path. The unique constraint on `(repository_id, name)` rejects the second insert with a conflict. The current code swallows that conflict via `!errors.IsConflictErr(err)`, keeps `tagID` at its zero-init, and returns `(0, nil)`.

That leads to two concrete failures:

1. `proxy.controller.EnsureTag` receives `tagID=0`, calls `UpdatePullTime(ctx, 0, ...)`, and fails with NotFoundError. Proxy pulls of uncached tags break entirely under concurrency.
2. The tag keeps pointing at the first writer's artifact. The second `docker push` still responds 201 Created but the registry has silently dropped the update.

## Fix

On conflict the tag exists (a concurrent transaction just inserted it). Re-run `Ensure`; the recursive call falls into the existing "tag already exists under the repository" branch and updates `ArtifactID` + `PushTime` to match the current request. One retry is sufficient because the row now exists — subsequent List will return it and we proceed through the update branch, not the create branch.

## Test plan

- [ ] Repro from issue: two concurrent pushes of different multi-arch images to `my-repo:latest` now both converge with the second push's ArtifactID winning (last-push-wins).
- [ ] `proxy.controller.EnsureTag` no longer reports `tag 0 not found` for uncached concurrent pulls.
- [ ] Existing `src/controller/tag/controller_test.go` suite stays green (new path is exercised by the existing conflict path; behaviour on the happy path is unchanged).
