### PR TITLE
refactor(config): centralize registry HTTP client timeout

### DIFF
--- a/src/lib/config/systemconfig.go
+++ b/src/lib/config/systemconfig.go
@@ -19,6 +19,8 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/goharbor/harbor/src/common"
 	"github.com/goharbor/harbor/src/common/models"
@@ -27,6 +29,42 @@ import (
 	"github.com/goharbor/harbor/src/lib/encrypt"
 	"github.com/goharbor/harbor/src/lib/log"
 )
+
+const (
+	// defaultRegistryHTTPClientTimeoutMinutes is the default timeout (in minutes)
+	// for the registry related http clients (backend registry client, registry
+	// auth challenge/token client and reg adapters).
+	defaultRegistryHTTPClientTimeoutMinutes = 30
+)
+
+var (
+	registryHTTPClientTimeoutOnce  sync.Once
+	registryHTTPClientTimeoutValue time.Duration
+)
+
+// RegistryHTTPClientTimeout returns the timeout for registry related HTTP clients.
+// It reads the env variable REGISTRY_HTTP_CLIENT_TIMEOUT (in minutes). When the env
+// is empty, invalid or non-positive, the default value (30 minutes) is used.
+// The value is read once and cached for the lifetime of the process.
+func RegistryHTTPClientTimeout() time.Duration {
+	registryHTTPClientTimeoutOnce.Do(func() {
+		minutes := int64(defaultRegistryHTTPClientTimeoutMinutes)
+		if env := os.Getenv("REGISTRY_HTTP_CLIENT_TIMEOUT"); len(env) > 0 {
+			v, err := strconv.ParseInt(env, 10, 64)
+			if err != nil {
+				log.Errorf("failed to parse REGISTRY_HTTP_CLIENT_TIMEOUT=%q, use default value: %d minutes, error: %v",
+					env, defaultRegistryHTTPClientTimeoutMinutes, err)
+			} else if v <= 0 {
+				log.Errorf("invalid REGISTRY_HTTP_CLIENT_TIMEOUT=%q (must be > 0), use default value: %d minutes",
+					env, defaultRegistryHTTPClientTimeoutMinutes)
+			} else {
+				minutes = v
+			}
+		}
+		registryHTTPClientTimeoutValue = time.Duration(minutes) * time.Minute
+	})
+	return registryHTTPClientTimeoutValue
+}
 
 var (
 	// SecretStore manages secrets

--- a/src/pkg/reg/adapter/awsecr/auth.go
+++ b/src/pkg/reg/adapter/awsecr/auth.go
@@ -31,6 +31,7 @@ import (
 
 	commonhttp "github.com/goharbor/harbor/src/common/http"
 	"github.com/goharbor/harbor/src/common/http/modifier"
+	"github.com/goharbor/harbor/src/lib/config"
 	"github.com/goharbor/harbor/src/lib/log"
 )
 
@@ -111,6 +112,7 @@ func getAwsSvc(region, accessKey, accessSecret string, insecure bool, caCertific
 				commonhttp.WithInsecure(insecure),
 				commonhttp.WithCACert(caCertificate),
 			),
+			Timeout: config.RegistryHTTPClientTimeout(),
 		},
 	}
 	if forceEndpoint != nil {

--- a/src/pkg/reg/adapter/azurecr/auth.go
+++ b/src/pkg/reg/adapter/azurecr/auth.go
@@ -25,6 +25,7 @@ import (
 
 	commonhttp "github.com/goharbor/harbor/src/common/http"
 	"github.com/goharbor/harbor/src/lib"
+	"github.com/goharbor/harbor/src/lib/config"
 	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/pkg/reg/model"
 	"github.com/goharbor/harbor/src/pkg/registry/auth"
@@ -61,10 +62,13 @@ func newAuthorizer(registry *model.Registry) *authorizer {
 	return &authorizer{
 		registry:        registry,
 		innerAuthorizer: auth.NewAuthorizer(username, password, registry.Insecure),
-		client: &http.Client{Transport: commonhttp.GetHTTPTransport(
-			commonhttp.WithInsecure(registry.Insecure),
-			commonhttp.WithCACert(registry.CACertificate),
-		)},
+		client: &http.Client{
+			Transport: commonhttp.GetHTTPTransport(
+				commonhttp.WithInsecure(registry.Insecure),
+				commonhttp.WithCACert(registry.CACertificate),
+			),
+			Timeout: config.RegistryHTTPClientTimeout(),
+		},
 	}
 }
 

--- a/src/pkg/reg/adapter/dockerhub/client.go
+++ b/src/pkg/reg/adapter/dockerhub/client.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	commonhttp "github.com/goharbor/harbor/src/common/http"
+	"github.com/goharbor/harbor/src/lib/config"
 	"github.com/goharbor/harbor/src/lib/log"
 	"github.com/goharbor/harbor/src/pkg/reg/model"
 )
@@ -47,6 +48,7 @@ func NewClient(registry *model.Registry) (*Client, error) {
 				commonhttp.WithInsecure(registry.Insecure),
 				commonhttp.WithCACert(registry.CACertificate),
 			),
+			Timeout: config.RegistryHTTPClientTimeout(),
 		},
 	}
 

--- a/src/pkg/reg/adapter/dtr/client.go
+++ b/src/pkg/reg/adapter/dtr/client.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 
 	common_http "github.com/goharbor/harbor/src/common/http"
+	"github.com/goharbor/harbor/src/lib/config"
 	"github.com/goharbor/harbor/src/lib/log"
 	"github.com/goharbor/harbor/src/pkg/reg/model"
 )
@@ -50,6 +51,7 @@ func NewClient(registry *model.Registry) *Client {
 					common_http.WithInsecure(registry.Insecure),
 					common_http.WithCACert(registry.CACertificate),
 				),
+				Timeout: config.RegistryHTTPClientTimeout(),
 			}),
 	}
 	return client

--- a/src/pkg/reg/adapter/githubcr/adapter.go
+++ b/src/pkg/reg/adapter/githubcr/adapter.go
@@ -22,6 +22,7 @@ import (
 	common_http "github.com/goharbor/harbor/src/common/http"
 	"github.com/goharbor/harbor/src/common/http/modifier"
 	"github.com/goharbor/harbor/src/common/utils"
+	"github.com/goharbor/harbor/src/lib/config"
 	"github.com/goharbor/harbor/src/lib/log"
 	adp "github.com/goharbor/harbor/src/pkg/reg/adapter"
 	"github.com/goharbor/harbor/src/pkg/reg/adapter/native"
@@ -102,6 +103,7 @@ func newAdapter(registry *model.Registry) *adapter {
 		client: common_http.NewClient(
 			&http.Client{
 				Transport: transport,
+				Timeout:   config.RegistryHTTPClientTimeout(),
 			},
 			authorizer,
 		),

--- a/src/pkg/reg/adapter/gitlab/client.go
+++ b/src/pkg/reg/adapter/gitlab/client.go
@@ -24,6 +24,7 @@ import (
 	"reflect"
 
 	common_http "github.com/goharbor/harbor/src/common/http"
+	"github.com/goharbor/harbor/src/lib/config"
 	liberrors "github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/lib/log"
 	"github.com/goharbor/harbor/src/pkg/reg/model"
@@ -61,6 +62,7 @@ func NewClient(registry *model.Registry) (*Client, error) {
 					common_http.WithInsecure(registry.Insecure),
 					common_http.WithCACert(registry.CACertificate),
 				),
+				Timeout: config.RegistryHTTPClientTimeout(),
 			}),
 	}
 	return client, nil

--- a/src/pkg/reg/adapter/harbor/base/adapter.go
+++ b/src/pkg/reg/adapter/harbor/base/adapter.go
@@ -24,6 +24,7 @@ import (
 	common_http "github.com/goharbor/harbor/src/common/http"
 	"github.com/goharbor/harbor/src/common/http/modifier"
 	common_http_auth "github.com/goharbor/harbor/src/common/http/modifier/auth"
+	"github.com/goharbor/harbor/src/lib/config"
 	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/lib/log"
 	"github.com/goharbor/harbor/src/pkg/reg/adapter/native"
@@ -43,6 +44,7 @@ func New(registry *model.Registry) (*Adapter, error) {
 			// If using the secure one, as we'll replace the URL with 127.0.0.1 and this will
 			// cause error "x509: cannot validate certificate for 127.0.0.1 because it doesn't contain any IP SANs"
 			Transport: common_http.GetHTTPTransport(common_http.WithInsecure(true)),
+			Timeout:   config.RegistryHTTPClientTimeout(),
 		}, authorizer)
 		client, err := NewClient(registry.URL, httpClient)
 		if err != nil {
@@ -68,6 +70,7 @@ func New(registry *model.Registry) (*Adapter, error) {
 			common_http.WithInsecure(registry.Insecure),
 			common_http.WithCACert(registry.CACertificate),
 		),
+		Timeout: config.RegistryHTTPClientTimeout(),
 	}, authorizers...)
 	client, err := NewClient(registry.URL, httpClient)
 	if err != nil {

--- a/src/pkg/reg/adapter/huawei/huawei_adapter.go
+++ b/src/pkg/reg/adapter/huawei/huawei_adapter.go
@@ -24,6 +24,7 @@ import (
 
 	common_http "github.com/goharbor/harbor/src/common/http"
 	"github.com/goharbor/harbor/src/common/http/modifier"
+	"github.com/goharbor/harbor/src/lib/config"
 	"github.com/goharbor/harbor/src/lib/log"
 	adp "github.com/goharbor/harbor/src/pkg/reg/adapter"
 	"github.com/goharbor/harbor/src/pkg/reg/adapter/native"
@@ -278,11 +279,13 @@ func newAdapter(registry *model.Registry) (adp.Adapter, error) {
 		client: common_http.NewClient(
 			&http.Client{
 				Transport: transport,
+				Timeout:   config.RegistryHTTPClientTimeout(),
 			},
 			modifiers...,
 		),
 		oriClient: &http.Client{
 			Transport: transport,
+			Timeout:   config.RegistryHTTPClientTimeout(),
 		},
 	}, nil
 }

--- a/src/pkg/reg/adapter/jfrog/client.go
+++ b/src/pkg/reg/adapter/jfrog/client.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 
 	common_http "github.com/goharbor/harbor/src/common/http"
+	"github.com/goharbor/harbor/src/lib/config"
 	"github.com/goharbor/harbor/src/pkg/reg/model"
 	"github.com/goharbor/harbor/src/pkg/registry/auth/basic"
 )
@@ -51,6 +52,7 @@ func newClient(reg *model.Registry) *client {
 					common_http.WithInsecure(reg.Insecure),
 					common_http.WithCACert(reg.CACertificate),
 				),
+				Timeout: config.RegistryHTTPClientTimeout(),
 			},
 			basic.NewAuthorizer(username, password),
 		),

--- a/src/pkg/reg/adapter/quay/adapter.go
+++ b/src/pkg/reg/adapter/quay/adapter.go
@@ -25,6 +25,7 @@ import (
 
 	common_http "github.com/goharbor/harbor/src/common/http"
 	"github.com/goharbor/harbor/src/common/http/modifier"
+	"github.com/goharbor/harbor/src/lib/config"
 	"github.com/goharbor/harbor/src/lib/log"
 	adp "github.com/goharbor/harbor/src/pkg/reg/adapter"
 	"github.com/goharbor/harbor/src/pkg/reg/adapter/native"
@@ -89,6 +90,7 @@ func newAdapter(registry *model.Registry) (*adapter, error) {
 					common_http.WithInsecure(registry.Insecure),
 					common_http.WithCACert(registry.CACertificate),
 				),
+				Timeout: config.RegistryHTTPClientTimeout(),
 			},
 			modifiers...,
 		),

--- a/src/pkg/reg/adapter/tencentcr/adapter.go
+++ b/src/pkg/reg/adapter/tencentcr/adapter.go
@@ -31,6 +31,7 @@ import (
 
 	commonhttp "github.com/goharbor/harbor/src/common/http"
 	"github.com/goharbor/harbor/src/lib"
+	"github.com/goharbor/harbor/src/lib/config"
 	"github.com/goharbor/harbor/src/lib/log"
 	adp "github.com/goharbor/harbor/src/pkg/reg/adapter"
 	"github.com/goharbor/harbor/src/pkg/reg/adapter/native"
@@ -175,6 +176,7 @@ func newAdapter(registry *model.Registry) (a *adapter, err error) {
 		client: commonhttp.NewClient(
 			&http.Client{
 				Transport: transport,
+				Timeout:   config.RegistryHTTPClientTimeout(),
 			},
 			credential,
 		),

--- a/src/pkg/reg/adapter/volcenginecr/helper.go
+++ b/src/pkg/reg/adapter/volcenginecr/helper.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/docker/distribution/registry/client/auth/challenge"
 
+	"github.com/goharbor/harbor/src/lib/config"
 	"github.com/goharbor/harbor/src/lib/log"
 	"github.com/goharbor/harbor/src/pkg/reg/util"
 )
@@ -51,6 +52,7 @@ var resolveHost = func(host string) string { return host }
 func getRealmService(host string, insecure bool, caCert string) (string, string, error) {
 	client := &http.Client{
 		Transport: util.GetHTTPTransport(insecure, caCert),
+		Timeout:   config.RegistryHTTPClientTimeout(),
 	}
 
 	// Allow tests to override the host (e.g., inject mock server URL) via resolveHost

--- a/src/pkg/registry/auth/authorizer.go
+++ b/src/pkg/registry/auth/authorizer.go
@@ -27,6 +27,7 @@ import (
 	"github.com/goharbor/harbor/src/common/http/modifier"
 	"github.com/goharbor/harbor/src/common/utils"
 	"github.com/goharbor/harbor/src/lib"
+	"github.com/goharbor/harbor/src/lib/config"
 	"github.com/goharbor/harbor/src/pkg/registry/auth/basic"
 	"github.com/goharbor/harbor/src/pkg/registry/auth/bearer"
 	"github.com/goharbor/harbor/src/pkg/registry/auth/null"
@@ -49,6 +50,7 @@ func NewAuthorizer(username, password string, insecure bool, caCert ...string) l
 		password: password,
 		client: &http.Client{
 			Transport: transport,
+			Timeout:   config.RegistryHTTPClientTimeout(),
 		},
 	}
 }

--- a/src/pkg/registry/auth/bearer/authorizer.go
+++ b/src/pkg/registry/auth/bearer/authorizer.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/goharbor/harbor/src/common/utils"
 	"github.com/goharbor/harbor/src/lib"
+	"github.com/goharbor/harbor/src/lib/config"
 	"github.com/goharbor/harbor/src/lib/errors"
 )
 
@@ -40,7 +41,10 @@ func NewAuthorizer(realm, service string, a lib.Authorizer, transport http.Round
 		cache:      newCache(cacheCapacity),
 	}
 
-	authorizer.client = &http.Client{Transport: transport}
+	authorizer.client = &http.Client{
+		Transport: transport,
+		Timeout:   config.RegistryHTTPClientTimeout(),
+	}
 	return authorizer
 }
 

--- a/src/pkg/registry/client.go
+++ b/src/pkg/registry/client.go
@@ -21,10 +21,8 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"os"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/docker/distribution"
 	"github.com/docker/distribution/manifest/manifestlist"
@@ -39,7 +37,6 @@ import (
 	"github.com/goharbor/harbor/src/lib"
 	"github.com/goharbor/harbor/src/lib/config"
 	"github.com/goharbor/harbor/src/lib/errors"
-	"github.com/goharbor/harbor/src/lib/log"
 	"github.com/goharbor/harbor/src/pkg/registry/auth"
 	"github.com/goharbor/harbor/src/pkg/registry/interceptor"
 	"github.com/goharbor/harbor/src/pkg/registry/interceptor/readonly"
@@ -62,32 +59,6 @@ var (
 		schema1.MediaTypeManifest,
 	}
 )
-
-// const definition
-const (
-	// DefaultHTTPClientTimeout is the default timeout for registry http client.
-	DefaultHTTPClientTimeout = 30 * time.Minute
-)
-
-var (
-	// registryHTTPClientTimeout is the timeout for registry http client.
-	registryHTTPClientTimeout time.Duration
-)
-
-func init() {
-	registryHTTPClientTimeout = DefaultHTTPClientTimeout
-	// override it if read from environment variable, in minutes
-	if env := os.Getenv("REGISTRY_HTTP_CLIENT_TIMEOUT"); len(env) > 0 {
-		timeout, err := strconv.ParseInt(env, 10, 64)
-		if err != nil {
-			log.Errorf("Failed to parse REGISTRY_HTTP_CLIENT_TIMEOUT: %v, use default value: %v", err, DefaultHTTPClientTimeout)
-		} else {
-			if timeout > 0 {
-				registryHTTPClientTimeout = time.Duration(timeout) * time.Minute
-			}
-		}
-	}
-}
 
 // Client defines the methods that a registry client should implements
 type Client interface {
@@ -155,7 +126,7 @@ func NewClientWithAuthorizer(url string, authorizer lib.Authorizer, insecure boo
 		interceptors: interceptors,
 		client: &http.Client{
 			Transport: transport,
-			Timeout:   registryHTTPClientTimeout,
+			Timeout:   config.RegistryHTTPClientTimeout(),
 		},
 	}
 }


### PR DESCRIPTION
Thank you for contributing to Harbor!

# Comprehensive Summary of your change
A more thorough and complete fix on top of https://github.com/goharbor/harbor/pull/23105.

This pull request introduces a unified and configurable timeout mechanism for all registry-related HTTP clients across the Harbor codebase. The timeout is now controlled via a single environment variable (`REGISTRY_HTTP_CLIENT_TIMEOUT`), with a default value of 30 minutes, and is cached for the process lifetime. This improves maintainability and provides a consistent way to adjust HTTP client timeouts for registry operations.

Key changes:

**Centralized Timeout Configuration**

* Introduced the `RegistryHTTPClientTimeout()` function in `src/lib/config/systemconfig.go` to encapsulate reading, validating, and caching the registry HTTP client timeout from the environment variable, defaulting to 30 minutes if unset or invalid.

**Refactoring and Adoption Across Adapters**

* Updated all registry adapters and authentication modules (AWS ECR, Azure CR, DockerHub, DTR, GitHub CR, GitLab, Harbor, Huawei, JFrog, Quay, Tencent CR, Volcengine CR) to use the new `RegistryHTTPClientTimeout()` function for their HTTP client timeouts, replacing hardcoded or previously scattered logic. [[1]](diffhunk://#diff-6ba7c5c0ad8d4968237ff2ca0a9db4d132f73ec497563ce481680be43ac8f4b8R115) [[2]](diffhunk://#diff-9b2121d8669f124fbbebc37edcd1bd5d5a6eac21247f70a9ff342fac8e3487fdL64-R71) [[3]](diffhunk://#diff-eac44cb832290b4fa8fe10b135e87b60d18b592c56cb9d3932fe7ef04fd6050bR51) [[4]](diffhunk://#diff-7e4bc6b7425fcfa74fdebc56506ce355ec167437489c92a074d29cdde9166b5fR54) [[5]](diffhunk://#diff-1832265e0d448d21c124e48a36597fba74123e6ae59a01a6ca09b580dc9da5d5R106) [[6]](diffhunk://#diff-0c0eac7b825bab34a46ebef340bb92523e22beaad9e890f9f213fe5a15005448R65) [[7]](diffhunk://#diff-6ff9980d9b3153031f746cc543c885879c904c51b9a8db1b719308e5d90fb010R47) [[8]](diffhunk://#diff-6ff9980d9b3153031f746cc543c885879c904c51b9a8db1b719308e5d90fb010R73) [[9]](diffhunk://#diff-1dc0c90d5d11fc90ba5e74c26c022f05b35df19e3868693781707943dde2d15eR282-R288) [[10]](diffhunk://#diff-b1dc5266008ad4af382b9b2065d8491d7db93058cdc5c3852bea8e1b4558042fR55) [[11]](diffhunk://#diff-0d48f2c1f3e559613e236784ae300f000c6588cb4089c5a1aa37a44fd8dd2d85R93) [[12]](diffhunk://#diff-f4a8bc2823455feb8f8dae3df62054e2e5265536992994069fa513c1b671d9bcR179) [[13]](diffhunk://#diff-af6fafe86c9a71e3437841c7bce9d36d3138d1d4746617616c4e232c53d68d61R55) [[14]](diffhunk://#diff-0461f2c6e6f8c1cfd8ced62eccf51ca723010dcfde3afbb9f24256a99d63e4d6R53) [[15]](diffhunk://#diff-ed4ca23a139d8fc14b5101869862a82625dc5fbccdcaa4dea48c2c28af741513L43-R47)

**Code Cleanup and Removal of Redundant Logic**

* Removed legacy timeout handling logic from `src/pkg/registry/client.go`, including the `init()` function and related variables/constants, in favor of the new centralized configuration.

**Dependency Injection and Imports**

* Updated imports across all affected files to include the new `config` package for timeout configuration. [[1]](diffhunk://#diff-e2a1f4a4f2b22209b0ea9607cf55905892a0e95406c389f2022df6a2a54318caR22-R23) [[2]](diffhunk://#diff-6ba7c5c0ad8d4968237ff2ca0a9db4d132f73ec497563ce481680be43ac8f4b8R34) [[3]](diffhunk://#diff-9b2121d8669f124fbbebc37edcd1bd5d5a6eac21247f70a9ff342fac8e3487fdR28) [[4]](diffhunk://#diff-eac44cb832290b4fa8fe10b135e87b60d18b592c56cb9d3932fe7ef04fd6050bR27) [[5]](diffhunk://#diff-7e4bc6b7425fcfa74fdebc56506ce355ec167437489c92a074d29cdde9166b5fR29) [[6]](diffhunk://#diff-1832265e0d448d21c124e48a36597fba74123e6ae59a01a6ca09b580dc9da5d5R25) [[7]](diffhunk://#diff-0c0eac7b825bab34a46ebef340bb92523e22beaad9e890f9f213fe5a15005448R27) [[8]](diffhunk://#diff-6ff9980d9b3153031f746cc543c885879c904c51b9a8db1b719308e5d90fb010R27) [[9]](diffhunk://#diff-1dc0c90d5d11fc90ba5e74c26c022f05b35df19e3868693781707943dde2d15eR27) [[10]](diffhunk://#diff-b1dc5266008ad4af382b9b2065d8491d7db93058cdc5c3852bea8e1b4558042fR25) [[11]](diffhunk://#diff-0d48f2c1f3e559613e236784ae300f000c6588cb4089c5a1aa37a44fd8dd2d85R28) [[12]](diffhunk://#diff-f4a8bc2823455feb8f8dae3df62054e2e5265536992994069fa513c1b671d9bcR34) [[13]](diffhunk://#diff-af6fafe86c9a71e3437841c7bce9d36d3138d1d4746617616c4e232c53d68d61R25) [[14]](diffhunk://#diff-0461f2c6e6f8c1cfd8ced62eccf51ca723010dcfde3afbb9f24256a99d63e4d6R30) [[15]](diffhunk://#diff-ed4ca23a139d8fc14b5101869862a82625dc5fbccdcaa4dea48c2c28af741513R26)

**Consistency and Maintainability**

* Ensured all registry HTTP clients across the codebase now consistently respect the same timeout configuration, improving maintainability and operational flexibility. (All references above)

These changes make it easier to manage and tune HTTP client timeouts for all registry operations in Harbor, reducing duplication and potential for misconfiguration.

# Issue being fixed
Fixes https://github.com/goharbor/harbor/issues/23104

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
