### PR TITLE
fix(log): remove sudo dependency from harbor-log startup

### DIFF
--- a/make/photon/log/logrotate
+++ b/make/photon/log/logrotate
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-# run the logrotate with user 10000, the state file "/var/lib/logrotate/logrotate.status"
-# is specified to avoid the permission error
+# use the explicit state file "/var/lib/logrotate/logrotate.status"
+# to avoid permission issues when rotating logs
 cd /
-sudo -u \#10000 -E /usr/sbin/logrotate -s /var/lib/logrotate/logrotate.status /etc/logrotate.conf
+/usr/sbin/logrotate -s /var/lib/logrotate/logrotate.status /etc/logrotate.conf
 exit 0

--- a/make/photon/log/start.sh
+++ b/make/photon/log/start.sh
@@ -3,5 +3,5 @@ set -e
 chown -R 10000:10000 /var/log/docker
 crond
 rm -f /var/run/rsyslogd.pid
-sudo -u \#10000 -E  'rsyslogd' '-n'
-set +e
+exec rsyslogd -n
+


### PR DESCRIPTION
Thank you for contributing to Harbor!

## Summary

This PR fixes a `harbor-log` crash loop on `v2.15.0` by removing the failing `sudo -u #10000` startup path.

In the current container environment, that `sudo` call can fail with PAM/account-management errors before `rsyslogd` is launched. When that happens, `harbor-log` never becomes healthy and other Harbor services fail because logging is unavailable.

## What changed

* replace `sudo -u #10000 -E rsyslogd -n` with `exec rsyslogd -n` in `make/photon/log/start.sh`
* replace the same `sudo`-based execution path in `make/photon/log/logrotate` with direct execution
* remove the now-dead `set +e` line after `exec`
* update the outdated `logrotate` comment to match the new behavior

## Why

This removes the failing `sudo`/PAM dependency from the `harbor-log` startup path while keeping the existing control flow otherwise unchanged. The issue report also confirmed that bypassing the `sudo` path allows Harbor to start successfully.

## Notes

This changes `rsyslogd` and `logrotate` to run as the container's default user instead of UID `10000`, so there is a behavior change here. However, it is limited to the `harbor-log` container path and avoids the current failure mode where the container cannot start at all.

## Verification

* build the updated `harbor-log` image
* verify `harbor-log` stays up instead of crash-looping
* verify Harbor services start normally once logging is available
* run `/etc/cron.hourly/logrotate` in the container and confirm it completes without `sudo`/PAM errors
* confirm logs under `/var/log/docker` remain writable and rotation still works

# Issue being fixed
Fixes #23156

/label ~"release-note/bug-fix"

Please indicate you've done the following:
* [done] Well Written Title and Summary of the PR
* [done] Label the PR as needed (`release-note/bug-fix`)
* [done] Accepted the DCO (all commits signed with `-s`)
* [done] Made sure tests are passing (no new tests required for this minimal script fix)
* [done] Considered the docs impact (no documentation changes needed for this fix)

