### PR TITLE
ci: disable exporter cache in API tests

### DIFF
--- a/tests/ci/api_common_install.sh
+++ b/tests/ci/api_common_install.sh
@@ -63,6 +63,7 @@ sudo make compile build prepare COMPILETAG=compile_golangimage GOBUILDTAGS="incl
 # set the debugging env
 echo "GC_TIME_WINDOW_HOURS=0" | sudo tee -a ./make/common/config/core/env
 echo "EXECUTION_STATUS_REFRESH_INTERVAL_SECONDS=5" | sudo tee -a ./make/common/config/core/env
+echo "HARBOR_EXPORTER_CACHE_TIME=0" | sudo tee -a ./make/common/config/exporter/env
 sudo make start
 
 # waiting 5 minutes to start


### PR DESCRIPTION
Thank you for contributing to Harbor!

# Comprehensive Summary of your change
This pull request introduces a small configuration change to the test environment setup script. It adds a new environment variable to the exporter configuration to disable caching, likely for testing purposes.

* Added `HARBOR_EXPORTER_CACHE_TIME=0` to the `./make/common/config/exporter/env` file in the test setup script to ensure the exporter does not cache data during CI runs.

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
