### PR TITLE
Make openapi-generator-cli download URL configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,10 @@ HTTPPROXY=
 BUILDREG=true
 BUILDTRIVYADP=true
 NPM_REGISTRY=https://registry.npmjs.org
+# Override when Maven Central returns 429 (rate limit), e.g. a mirror or cached URL:
+#   make swagger_client OPENAPI_GENERATOR_CLI_URL=https://...
+#   export OPENAPI_GENERATOR_CLI_URL=https://... ; make swagger_client
+OPENAPI_GENERATOR_CLI_URL ?= https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/4.3.1/openapi-generator-cli-4.3.1.jar
 BUILDTARGET=build
 GEN_TLS=
 
@@ -561,7 +565,7 @@ restart: down prepare start
 
 swagger_client:
 	@echo "Generate swagger client"
-	wget https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/4.3.1/openapi-generator-cli-4.3.1.jar -O openapi-generator-cli.jar
+	wget "$(OPENAPI_GENERATOR_CLI_URL)" -O openapi-generator-cli.jar
 	rm -rf harborclient
 	mkdir  -p harborclient/harbor_v2_swagger_client
 	java -jar openapi-generator-cli.jar generate -i api/v2.0/swagger.yaml -g python -o harborclient/harbor_v2_swagger_client --package-name v2_swagger_client

--- a/tests/ci/api_common_install.sh
+++ b/tests/ci/api_common_install.sh
@@ -63,7 +63,9 @@ sudo make compile build prepare COMPILETAG=compile_golangimage GOBUILDTAGS="incl
 # set the debugging env
 echo "GC_TIME_WINDOW_HOURS=0" | sudo tee -a ./make/common/config/core/env
 echo "EXECUTION_STATUS_REFRESH_INTERVAL_SECONDS=5" | sudo tee -a ./make/common/config/core/env
-echo "HARBOR_EXPORTER_CACHE_TIME=0" | sudo tee -a ./make/common/config/exporter/env
+# Disable exporter metric cache in API tests. Leading newline avoids merging
+# into the previous line if exporter/env has no trailing newline.
+printf '\nHARBOR_EXPORTER_CACHE_TIME=0\n' | sudo tee -a ./make/common/config/exporter/env
 sudo make start
 
 # waiting 5 minutes to start

--- a/tests/resources/APITest-Util.robot
+++ b/tests/resources/APITest-Util.robot
@@ -3,6 +3,7 @@ ${JFROG_USER}  ${EMPTY}
 ${JFROG_PWD}  ${EMPTY}
 ${JFROG_URL}  ${EMPTY}
 ${JFROG_NAMESPACE}  ${EMPTY}
+${OPENAPI_GENERATOR_CLI_URL_DEFAULT}  https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/4.3.1/openapi-generator-cli-4.3.1.jar
 
 *** Keywords ***
 Make Swagger Client
@@ -10,7 +11,8 @@ Make Swagger Client
     LogAll  ${output}
     ${rc}  ${output}=  Run And Return Rc And Output  pip install -U pip setuptools
     LogAll  ${output}
-    ${rc}  ${output}=  Run And Return Rc And Output  make swagger_client
+    ${openapi_url}=  Get Environment Variable  OPENAPI_GENERATOR_CLI_URL  ${OPENAPI_GENERATOR_CLI_URL_DEFAULT}
+    ${rc}  ${output}=  Run And Return Rc And Output  OPENAPI_GENERATOR_CLI_URL=${openapi_url} make swagger_client
     LogAll  ${output}
     [Return]  ${rc}
 


### PR DESCRIPTION
Add OPENAPI_GENERATOR_CLI_URL (default: Maven Central) so swagger_client can use a mirror or cache when repo1.maven.org returns 429.

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [ ] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [ ] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
