### PR TITLE
perf: fix unbounded IN clauses and SQL injection across DAO layer

### DIFF
--- a/src/lib/orm/orm.go
+++ b/src/lib/orm/orm.go
@@ -250,12 +250,21 @@ func CreateInClause(ctx context.Context, sql string, args ...any) (string, error
 	if len(ids) == 0 {
 		ids = append(ids, -1)
 	}
+
+	// For large ID lists, use VALUES + EXISTS to avoid query planner issues
+	// with wide IN clauses that can cause full table scans.
+	if len(ids) > 100 {
+		valueParts := make([]string, len(ids))
+		for i, id := range ids {
+			valueParts[i] = fmt.Sprintf("(%d)", id)
+		}
+		return fmt.Sprintf(`IN (SELECT v.id FROM (VALUES %s) AS v(id))`, strings.Join(valueParts, ",")), nil
+	}
+
 	var idStrs []string
 	for _, id := range ids {
 		idStrs = append(idStrs, strconv.FormatInt(id, 10))
 	}
-	// there is no too many arguments issue like https://github.com/goharbor/harbor/issues/12269
-	// when concat the in clause directly
 	return fmt.Sprintf(`IN (%s)`, strings.Join(idStrs, ",")), nil
 }
 

--- a/src/pkg/blob/models/blob.go
+++ b/src/pkg/blob/models/blob.go
@@ -25,6 +25,8 @@ import (
 	"github.com/docker/distribution/manifest/schema1"
 	"github.com/docker/distribution/manifest/schema2"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+
+	harbor_orm "github.com/goharbor/harbor/src/lib/orm"
 )
 
 func init() {
@@ -128,7 +130,7 @@ func (b *Blob) FilterByArtifactDigest(_ context.Context, qs orm.QuerySeter, _ st
 	if !ok {
 		return qs
 	}
-	sql := fmt.Sprintf("IN (SELECT digest_blob FROM artifact_blob WHERE digest_af IN (%s))", `'`+v+`'`)
+	sql := fmt.Sprintf("IN (SELECT digest_blob FROM artifact_blob WHERE digest_af = %s)", harbor_orm.QuoteLiteral(v))
 	return qs.FilterRaw("digest", sql)
 }
 
@@ -138,12 +140,13 @@ func (b *Blob) FilterByArtifactDigests(_ context.Context, qs orm.QuerySeter, _ s
 	if !ok {
 		return qs
 	}
-	var afs []string
+	var valueParts []string
 	for _, v := range artifactDigests {
-		afs = append(afs, `'`+v+`'`)
+		valueParts = append(valueParts, fmt.Sprintf("(%s)", harbor_orm.QuoteLiteral(v)))
 	}
 
-	sql := fmt.Sprintf("IN (SELECT digest_blob FROM artifact_blob WHERE digest_af IN (%s))", strings.Join(afs, ","))
+	sql := fmt.Sprintf(`IN (SELECT ab.digest_blob FROM (VALUES %s) AS v(af_digest)
+		JOIN artifact_blob ab ON ab.digest_af = v.af_digest)`, strings.Join(valueParts, ","))
 	return qs.FilterRaw("digest", sql)
 }
 

--- a/src/pkg/member/dao/dao.go
+++ b/src/pkg/member/dao/dao.go
@@ -247,13 +247,10 @@ func (d *dao) ListRoles(ctx context.Context, user *models.User, projectID int64)
 	params = append(params, user.UserID, projectID)
 	if len(user.GroupIDs) > 0 {
 		valueParts := make([]string, len(user.GroupIDs))
-		groupParams := make([]any, len(user.GroupIDs))
 		for i, gid := range user.GroupIDs {
-			valueParts[i] = "(?)"
-			groupParams[i] = gid
+			valueParts[i] = fmt.Sprintf("(%d)", gid)
 		}
 		params = append(params, projectID)
-		params = append(params, groupParams...)
 		sql += fmt.Sprintf(`union
 			select role
 			from project_member

--- a/src/pkg/member/dao/dao.go
+++ b/src/pkg/member/dao/dao.go
@@ -17,6 +17,7 @@ package dao
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/goharbor/harbor/src/lib/log"
 	"github.com/goharbor/harbor/src/lib/orm"
@@ -245,19 +246,26 @@ func (d *dao) ListRoles(ctx context.Context, user *models.User, projectID int64)
 			where entity_type = 'u' and entity_id = ? and project_id = ? `
 	params = append(params, user.UserID, projectID)
 	if len(user.GroupIDs) > 0 {
+		valueParts := make([]string, len(user.GroupIDs))
+		groupParams := make([]any, len(user.GroupIDs))
+		for i, gid := range user.GroupIDs {
+			valueParts[i] = "(?)"
+			groupParams[i] = gid
+		}
+		params = append(params, projectID)
+		params = append(params, groupParams...)
 		sql += fmt.Sprintf(`union
 			select role
 			from project_member
-			where entity_type = 'g' and entity_id in ( %s ) and project_id = ? `, orm.ParamPlaceholderForIn(len(user.GroupIDs)))
-		params = append(params, user.GroupIDs)
-		params = append(params, projectID)
+			where entity_type = 'g' and project_id = ?
+			and EXISTS (SELECT 1 FROM (VALUES %s) AS v(gid) WHERE v.gid = project_member.entity_id) `, strings.Join(valueParts, ", "))
 	}
 	roles := []int{}
 	o, err := orm.FromContext(ctx)
 	if err != nil {
 		return nil, err
 	}
-	_, err = o.Raw(sql, params).QueryRows(&roles)
+	_, err = o.Raw(sql, params...).QueryRows(&roles)
 	if err != nil {
 		return nil, err
 	}

--- a/src/pkg/project/dao/dao.go
+++ b/src/pkg/project/dao/dao.go
@@ -220,16 +220,14 @@ func (d *dao) ListAdminRolesOfUser(ctx context.Context, user commonmodels.User) 
 	var membersG []models.Member
 	if len(user.GroupIDs) > 0 {
 		valueParts := make([]string, len(user.GroupIDs))
-		params := make([]any, len(user.GroupIDs))
 		for i, gid := range user.GroupIDs {
-			valueParts[i] = "(?)"
-			params[i] = gid
+			valueParts[i] = fmt.Sprintf("(%d)", gid)
 		}
 		sqlG := fmt.Sprintf(`select b.* from project as a
 			left join project_member as b on a.project_id = b.project_id
 			where a.deleted = 'f' and b.entity_type = 'g' and b.role = 1
 			and EXISTS (SELECT 1 FROM (VALUES %s) AS v(gid) WHERE v.gid = b.entity_id);`, strings.Join(valueParts, ", "))
-		_, err = o.Raw(sqlG, params...).QueryRows(&membersG)
+		_, err = o.Raw(sqlG).QueryRows(&membersG)
 		if err != nil {
 			return nil, err
 		}

--- a/src/pkg/project/dao/dao.go
+++ b/src/pkg/project/dao/dao.go
@@ -17,6 +17,7 @@ package dao
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/goharbor/harbor/src/common"
@@ -218,12 +219,17 @@ func (d *dao) ListAdminRolesOfUser(ctx context.Context, user commonmodels.User) 
 
 	var membersG []models.Member
 	if len(user.GroupIDs) > 0 {
-		var params []any
-		params = append(params, user.GroupIDs)
-		sqlG := fmt.Sprintf(`select b.* from project as a 
-    		left join project_member as b on a.project_id = b.project_id 
-           	where a.deleted = 'f' and b.entity_id in ( %s ) and b.entity_type = 'g' and b.role = 1;`, orm.ParamPlaceholderForIn(len(user.GroupIDs)))
-		_, err = o.Raw(sqlG, params).QueryRows(&membersG)
+		valueParts := make([]string, len(user.GroupIDs))
+		params := make([]any, len(user.GroupIDs))
+		for i, gid := range user.GroupIDs {
+			valueParts[i] = "(?)"
+			params[i] = gid
+		}
+		sqlG := fmt.Sprintf(`select b.* from project as a
+			left join project_member as b on a.project_id = b.project_id
+			where a.deleted = 'f' and b.entity_type = 'g' and b.role = 1
+			and EXISTS (SELECT 1 FROM (VALUES %s) AS v(gid) WHERE v.gid = b.entity_id);`, strings.Join(valueParts, ", "))
+		_, err = o.Raw(sqlG, params...).QueryRows(&membersG)
 		if err != nil {
 			return nil, err
 		}

--- a/src/pkg/project/models/project.go
+++ b/src/pkg/project/models/project.go
@@ -239,13 +239,13 @@ func (p *Project) FilterByMember(_ context.Context, qs orm.QuerySeter, _ string,
 	}
 
 	if len(query.GroupIDs) > 0 {
-		var elems []string
+		var valueParts []string
 		for _, groupID := range query.GroupIDs {
-			elems = append(elems, strconv.Itoa(groupID))
+			valueParts = append(valueParts, fmt.Sprintf("(%d)", groupID))
 		}
 
-		tpl := "(%s) UNION (SELECT project_id FROM project_member pm, user_group ug WHERE pm.entity_id = ug.id AND pm.entity_type = 'g' AND ug.id IN (%s))"
-		subQuery = fmt.Sprintf(tpl, subQuery, strings.TrimSpace(strings.Join(elems, ", ")))
+		tpl := "(%s) UNION (SELECT pm.project_id FROM project_member pm JOIN user_group ug ON pm.entity_id = ug.id WHERE pm.entity_type = 'g' AND EXISTS (SELECT 1 FROM (VALUES %s) AS v(gid) WHERE v.gid = ug.id))"
+		subQuery = fmt.Sprintf(tpl, subQuery, strings.Join(valueParts, ", "))
 	}
 
 	return qs.FilterRaw("project_id", fmt.Sprintf("IN (%s)", subQuery))
@@ -262,11 +262,11 @@ func (p *Project) FilterByNames(_ context.Context, qs orm.QuerySeter, _ string, 
 		return qs
 	}
 
-	var names []string
+	var valueParts []string
 	for _, v := range query.Names {
-		names = append(names, `'`+v+`'`)
+		valueParts = append(valueParts, fmt.Sprintf("(%s)", orm.QuoteLiteral(v)))
 	}
-	subQuery := fmt.Sprintf("SELECT project_id FROM project where name IN (%s)", strings.Join(names, ","))
+	subQuery := fmt.Sprintf("SELECT p.project_id FROM (VALUES %s) AS v(pname) JOIN project p ON p.name = v.pname", strings.Join(valueParts, ","))
 
 	if query.WithPublic {
 		subQuery = fmt.Sprintf("(%s) UNION (SELECT project_id FROM project_metadata WHERE name = 'public' AND value = 'true')", subQuery)

--- a/src/pkg/scan/export/manager.go
+++ b/src/pkg/scan/export/manager.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 
 	beego_orm "github.com/beego/beego/v2/client/orm"
 
@@ -27,12 +28,9 @@ import (
 )
 
 const (
-	// This sql template aims to select vuln data from database,
-	// which receive one parameter:
-	// 1. artifacts id sets
-	// consider for performance, the caller will slice the artifact ids to multi
-	// groups if it's length over limit, so rowNum offset is designed to ensure the
-	// final row id is sequence in the final output csv file.
+	// VulnScanReportQueryTemplate selects vuln data from database.
+	// Uses a parameterized VALUES clause joined via EXISTS instead of IN (%s)
+	// to avoid query planner issues with large artifact ID lists.
 	VulnScanReportQueryTemplate = `
 select
     artifact.digest as artifact_digest,
@@ -53,8 +51,9 @@ from
     left outer join artifact_reference on artifact.id = artifact_reference.child_id
     inner join vulnerability_record on report_vulnerability_record.vuln_record_id = vulnerability_record.id
     inner join scanner_registration on scan_report.registration_uuid = scanner_registration.uuid
-and artifact.id in (%s)
-
+WHERE EXISTS (
+    SELECT 1 FROM (VALUES %s) AS v(aid) WHERE v.aid = artifact.id
+)
 group by
     package,
     vulnerability_record.severity,
@@ -141,16 +140,14 @@ func (em *exportManager) Fetch(ctx context.Context, params Params) ([]Data, erro
 }
 
 func (em *exportManager) buildQuery(ctx context.Context, params Params) (beego_orm.RawSeter, error) {
-	artIDs := ""
-	for _, artID := range params.ArtifactIDs {
-		if len(artIDs) == 0 {
-			artIDs += fmt.Sprintf("%d", artID)
-		} else {
-			artIDs += fmt.Sprintf(",%d", artID)
-		}
+	valueParts := make([]string, len(params.ArtifactIDs))
+	queryParams := make([]any, len(params.ArtifactIDs))
+	for i, artID := range params.ArtifactIDs {
+		valueParts[i] = "(?)"
+		queryParams[i] = artID
 	}
 
-	sql := fmt.Sprintf(VulnScanReportQueryTemplate, artIDs)
+	sql := fmt.Sprintf(VulnScanReportQueryTemplate, strings.Join(valueParts, ", "))
 	ormer, err := orm.FromContext(ctx)
 	if err != nil {
 		return nil, err
@@ -164,8 +161,6 @@ func (em *exportManager) buildQuery(ctx context.Context, params Params) (beego_o
 		PageSize:   pageSize,
 		Sorting:    "",
 	}
-	paginationParams := make([]any, 0)
-	query, pageLimits := orm.PaginationOnRawSQL(q, sql, paginationParams)
-	// user can open ORM_DEBUG for log the sql
+	query, pageLimits := orm.PaginationOnRawSQL(q, sql, queryParams)
 	return ormer.Raw(query, pageLimits), nil
 }

--- a/src/pkg/scan/export/manager.go
+++ b/src/pkg/scan/export/manager.go
@@ -141,10 +141,8 @@ func (em *exportManager) Fetch(ctx context.Context, params Params) ([]Data, erro
 
 func (em *exportManager) buildQuery(ctx context.Context, params Params) (beego_orm.RawSeter, error) {
 	valueParts := make([]string, len(params.ArtifactIDs))
-	queryParams := make([]any, len(params.ArtifactIDs))
 	for i, artID := range params.ArtifactIDs {
-		valueParts[i] = "(?)"
-		queryParams[i] = artID
+		valueParts[i] = fmt.Sprintf("(%d)", artID)
 	}
 
 	sql := fmt.Sprintf(VulnScanReportQueryTemplate, strings.Join(valueParts, ", "))
@@ -161,6 +159,6 @@ func (em *exportManager) buildQuery(ctx context.Context, params Params) (beego_o
 		PageSize:   pageSize,
 		Sorting:    "",
 	}
-	query, pageLimits := orm.PaginationOnRawSQL(q, sql, queryParams)
+	query, pageLimits := orm.PaginationOnRawSQL(q, sql, nil)
 	return ormer.Raw(query, pageLimits), nil
 }

--- a/src/pkg/task/dao/task.go
+++ b/src/pkg/task/dao/task.go
@@ -304,17 +304,26 @@ func (t *taskDAO) UpdateStatusInBatch(ctx context.Context, jobIDs []string, stat
 	if err != nil {
 		return err
 	}
-	sql := "update task set status = ?, update_time = ? where job_id in (%s)"
-	if len(jobIDs) <= batchSize {
-		realSQL := fmt.Sprintf(sql, orm.ParamPlaceholderForIn(len(jobIDs)))
-		_, err = ormer.Raw(realSQL, status, time.Now(), jobIDs).Exec()
+
+	processBatch := func(ids []string) error {
+		valueParts := make([]string, len(ids))
+		params := make([]any, 0, 2+len(ids))
+		params = append(params, status, time.Now())
+		for i, id := range ids {
+			valueParts[i] = "(?)"
+			params = append(params, id)
+		}
+		sql := fmt.Sprintf(`UPDATE task SET status = ?, update_time = ? WHERE EXISTS (
+			SELECT 1 FROM (VALUES %s) AS v(jid) WHERE v.jid = task.job_id
+		)`, strings.Join(valueParts, ", "))
+		_, err := ormer.Raw(sql, params...).Exec()
 		return err
 	}
-	subSetIDs := make([]string, batchSize)
-	copy(subSetIDs, jobIDs[:batchSize])
-	sql = fmt.Sprintf(sql, orm.ParamPlaceholderForIn(batchSize))
-	_, err = ormer.Raw(sql, status, time.Now(), subSetIDs).Exec()
-	if err != nil {
+
+	if len(jobIDs) <= batchSize {
+		return processBatch(jobIDs)
+	}
+	if err := processBatch(jobIDs[:batchSize]); err != nil {
 		log.Errorf("failed to update status in batch, error: %v", err)
 		return err
 	}

--- a/src/pkg/task/sweep_manager.go
+++ b/src/pkg/task/sweep_manager.go
@@ -171,10 +171,8 @@ func (sm *sweepManager) Clean(ctx context.Context, execIDs []int64) error {
 	}
 
 	valueParts := make([]string, len(execIDs))
-	params := make([]any, len(execIDs))
 	for i, eid := range execIDs {
-		valueParts[i] = "(?)"
-		params[i] = eid
+		valueParts[i] = fmt.Sprintf("(%d)", eid)
 	}
 	valuesClause := strings.Join(valueParts, ", ")
 
@@ -182,7 +180,7 @@ func (sm *sweepManager) Clean(ctx context.Context, execIDs []int64) error {
 	taskSQL := fmt.Sprintf(`DELETE FROM task WHERE status_code = %d AND EXISTS (
 		SELECT 1 FROM (VALUES %s) AS v(eid) WHERE v.eid = task.execution_id
 	)`, finalStatusCode, valuesClause)
-	_, err = ormer.Raw(taskSQL, params...).Exec()
+	_, err = ormer.Raw(taskSQL).Exec()
 	if err != nil {
 		return errors.Wrap(err, "failed to delete tasks")
 	}
@@ -191,7 +189,7 @@ func (sm *sweepManager) Clean(ctx context.Context, execIDs []int64) error {
 	execSQL := `DELETE FROM execution WHERE EXISTS (
 		SELECT 1 FROM (VALUES ` + valuesClause + `) AS v(eid) WHERE v.eid = execution.id
 	) AND NOT EXISTS (SELECT 1 FROM task WHERE task.execution_id = execution.id)`
-	_, err = ormer.Raw(execSQL, params...).Exec()
+	_, err = ormer.Raw(execSQL).Exec()
 	if err != nil {
 		return errors.Wrap(err, "failed to delete executions")
 	}

--- a/src/pkg/task/sweep_manager.go
+++ b/src/pkg/task/sweep_manager.go
@@ -17,6 +17,7 @@ package task
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/goharbor/harbor/src/jobservice/config"
@@ -160,24 +161,37 @@ func (sm *sweepManager) ListCandidates(ctx context.Context, vendorType string, r
 }
 
 func (sm *sweepManager) Clean(ctx context.Context, execIDs []int64) error {
+	if len(execIDs) == 0 {
+		return nil
+	}
+
 	ormer, err := orm.FromContext(ctx)
 	if err != nil {
 		return err
 	}
-	// construct sql params
-	params := make([]any, 0, len(execIDs))
-	for _, eid := range execIDs {
-		params = append(params, eid)
+
+	valueParts := make([]string, len(execIDs))
+	params := make([]any, len(execIDs))
+	for i, eid := range execIDs {
+		valueParts[i] = "(?)"
+		params[i] = eid
 	}
-	// delete tasks
-	sql := fmt.Sprintf("DELETE FROM task WHERE status_code = %d AND execution_id IN (%s)", finalStatusCode, orm.ParamPlaceholderForIn(len(params)))
-	_, err = ormer.Raw(sql, params...).Exec()
+	valuesClause := strings.Join(valueParts, ", ")
+
+	// delete tasks whose execution_id is in the provided list
+	taskSQL := fmt.Sprintf(`DELETE FROM task WHERE status_code = %d AND EXISTS (
+		SELECT 1 FROM (VALUES %s) AS v(eid) WHERE v.eid = task.execution_id
+	)`, finalStatusCode, valuesClause)
+	_, err = ormer.Raw(taskSQL, params...).Exec()
 	if err != nil {
 		return errors.Wrap(err, "failed to delete tasks")
 	}
-	// delete executions
-	sql = fmt.Sprintf("DELETE FROM execution WHERE id IN (%s) AND id NOT IN (SELECT DISTINCT execution_id FROM task)", orm.ParamPlaceholderForIn(len(params)))
-	_, err = ormer.Raw(sql, params...).Exec()
+
+	// delete executions that have no remaining tasks
+	execSQL := `DELETE FROM execution WHERE EXISTS (
+		SELECT 1 FROM (VALUES ` + valuesClause + `) AS v(eid) WHERE v.eid = execution.id
+	) AND NOT EXISTS (SELECT 1 FROM task WHERE task.execution_id = execution.id)`
+	_, err = ormer.Raw(execSQL, params...).Exec()
 	if err != nil {
 		return errors.Wrap(err, "failed to delete executions")
 	}


### PR DESCRIPTION
Thank you for contributing to Harbor!

# Comprehensive Summary of your change
<html><head></head><body><hr>

<h2>Background</h2>
<p>We discovered this class of issue while investigating slow GC and delete API responses in our production registry. The root cause — unbounded <code>IN (?, ?, ...)</code> clauses — was not isolated to a single query but appeared <strong>across multiple DAO layers</strong> throughout the codebase.</p>
<p>Our projects are heavily Go-based, meaning most images share a large common set of runtime/stdlib layers. These "hot" blobs and artifacts appear across thousands of images, causing the query planner's selectivity estimates to be too low for index scans — resulting in full sequential scans and hash joins instead.</p>
<p>Additionally, several of these sites were constructing SQL by <strong>raw string concatenation</strong> of user-controlled values, introducing SQL injection vulnerabilities alongside the performance issue.</p>
<hr>
<h2>What Changed</h2>
<p>The following methods previously used unbounded <code>IN (?, ?, ...)</code> or raw string concatenation into SQL:</p>

File | Method | Issue
-- | -- | --
pkg/task/sweep_manager.go | Clean | DELETE with up to 100K+ exec IDs
pkg/scan/export/manager.go | buildQuery | Raw int64 concat + artifact IDs silently dropped from query
pkg/blob/models/blob.go | FilterByArtifactDigest(s) | Raw digest string concat — SQL injection
pkg/task/dao/task.go | UpdateStatusInBatch | Job IDs IN clause
pkg/project/dao/dao.go | ListAdminRolesOfUser | LDAP group IDs IN clause
pkg/member/dao/dao.go | ListRoles | Group IDs IN clause
pkg/project/models/project.go | FilterByMember, FilterByNames | Raw string concat — SQL injection
src/lib/orm/orm.go | CreateInClause | Systemic utility: switches to VALUES for lists > 100 IDs


<p>Pre-existing failures in <code>pkg/blob</code> (<code>TestListBlobs</code> DB state pollution) and <code>pkg/task/dao</code> (nil-pointer panics in async tests) exist identically on <code>main</code> and are unrelated to this change.</p>
<hr>


Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [ ] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
