### PR TITLE
feat(webhook): add custom payload format with payload template

### DIFF
--- a/api/v2.0/swagger.yaml
+++ b/api/v2.0/swagger.yaml
@@ -8894,7 +8894,7 @@ definitions:
       payload_format:
         $ref: '#/definitions/PayloadFormatType'
         description: The payload format of webhook, by default is Default for http type.
-      payload_transform:
+      custom_payload:
         type: string
         description: Optional Go template to transform the webhook payload before sending, fields are accessible from the payload via dot-notation (e.g. {{.type}}, {{.operator}}).
   WebhookPolicy:

--- a/api/v2.0/swagger.yaml
+++ b/api/v2.0/swagger.yaml
@@ -8894,6 +8894,9 @@ definitions:
       payload_format:
         $ref: '#/definitions/PayloadFormatType'
         description: The payload format of webhook, by default is Default for http type.
+      payload_transform:
+        type: string
+        description: Optional Go template to transform the webhook payload before sending, fields are accessible from the payload via dot-notation (e.g. {{.type}}, {{.operator}}).
   WebhookPolicy:
     type: object
     description: The webhook policy object

--- a/src/jobservice/job/impl/notification/webhook_job.go
+++ b/src/jobservice/job/impl/notification/webhook_job.go
@@ -25,6 +25,7 @@ import (
 	"github.com/goharbor/harbor/src/jobservice/job"
 	"github.com/goharbor/harbor/src/jobservice/logger"
 	"github.com/goharbor/harbor/src/lib/errors"
+	"github.com/goharbor/harbor/src/pkg/notification/transform"
 )
 
 // WebhookJob implements the job interface, which send notification by http or https.
@@ -101,6 +102,14 @@ func (wj *WebhookJob) init(ctx job.Context, params map[string]any) error {
 func (wj *WebhookJob) execute(_ job.Context, params map[string]any) error {
 	payload := params["payload"].(string)
 	address := params["address"].(string)
+
+	if tmpl, ok := params["payload_transform"].(string); ok && tmpl != "" {
+		transformed, err := transform.Apply(tmpl, payload)
+		if err != nil {
+			return errors.Wrap(err, "error applying payload_transform")
+		}
+		payload = transformed
+	}
 
 	req, err := http.NewRequest(http.MethodPost, address, bytes.NewReader([]byte(payload)))
 	if err != nil {

--- a/src/jobservice/job/impl/notification/webhook_job.go
+++ b/src/jobservice/job/impl/notification/webhook_job.go
@@ -25,7 +25,7 @@ import (
 	"github.com/goharbor/harbor/src/jobservice/job"
 	"github.com/goharbor/harbor/src/jobservice/logger"
 	"github.com/goharbor/harbor/src/lib/errors"
-	"github.com/goharbor/harbor/src/pkg/notification/transform"
+	"github.com/goharbor/harbor/src/pkg/notification/custompayload"
 )
 
 // WebhookJob implements the job interface, which send notification by http or https.
@@ -103,10 +103,10 @@ func (wj *WebhookJob) execute(_ job.Context, params map[string]any) error {
 	payload := params["payload"].(string)
 	address := params["address"].(string)
 
-	if tmpl, ok := params["payload_transform"].(string); ok && tmpl != "" {
-		transformed, err := transform.Apply(tmpl, payload)
+	if tmpl, ok := params["custom_payload"].(string); ok && tmpl != "" {
+		transformed, err := custompayload.Apply(tmpl, payload)
 		if err != nil {
-			return errors.Wrap(err, "error applying payload_transform")
+			return errors.Wrap(err, "error applying custom_payload")
 		}
 		payload = transformed
 	}

--- a/src/pkg/notification/custompayload/custompayload.go
+++ b/src/pkg/notification/custompayload/custompayload.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package transform
+package custompayload
 
 import (
 	"bytes"
@@ -21,8 +21,8 @@ import (
 	"text/template"
 )
 
-// maxPayloadTransformSize is the maximum allowed byte size for a payload transform template.
-const maxPayloadTransformSize = 4096
+// maxCustomPayloadSize is the maximum allowed byte size for a custom payload template.
+const maxCustomPayloadSize = 4096
 
 // Apply executes the given template against the JSON payload.
 // If the template is empty, the payload is returned unchanged.
@@ -30,8 +30,8 @@ func Apply(templateString string, rawJSONPayload string) (string, error) {
 	if templateString == "" {
 		return rawJSONPayload, nil
 	}
-	if len(templateString) > maxPayloadTransformSize {
-		return "", fmt.Errorf("payload_transform exceeds max size of %d bytes", maxPayloadTransformSize)
+	if len(templateString) > maxCustomPayloadSize {
+		return "", fmt.Errorf("custom_payload exceeds max size of %d bytes", maxCustomPayloadSize)
 	}
 
 	var eventData map[string]any
@@ -39,16 +39,16 @@ func Apply(templateString string, rawJSONPayload string) (string, error) {
 		return "", fmt.Errorf("invalid payload JSON: %w", err)
 	}
 
-	compiledTemplate, err := template.New("payload_transform").
+	compiledTemplate, err := template.New("custom_payload").
 		Option("missingkey=error"). // reject references to fields that do not exist
 		Parse(templateString)
 	if err != nil {
-		return "", fmt.Errorf("invalid payload_transform template: %w", err)
+		return "", fmt.Errorf("invalid custom_payload template: %w", err)
 	}
 
 	var renderedOutput bytes.Buffer
 	if err := compiledTemplate.Execute(&renderedOutput, eventData); err != nil {
-		return "", fmt.Errorf("failed to execute payload_transform: %w", err)
+		return "", fmt.Errorf("failed to execute custom_payload: %w", err)
 	}
 
 	return renderedOutput.String(), nil
@@ -60,11 +60,11 @@ func Validate(templateString string) error {
 		return nil
 	}
 
-	if len(templateString) > maxPayloadTransformSize {
-		return fmt.Errorf("payload_transform exceeds max size of %d bytes", maxPayloadTransformSize)
+	if len(templateString) > maxCustomPayloadSize {
+		return fmt.Errorf("custom_payload exceeds max size of %d bytes", maxCustomPayloadSize)
 	}
 
-	_, err := template.New("payload_transform").
+	_, err := template.New("custom_payload").
 		Option("missingkey=error").
 		Parse(templateString)
 	return err

--- a/src/pkg/notification/custompayload/custompayload_test.go
+++ b/src/pkg/notification/custompayload/custompayload_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package transform
+package custompayload
 
 import (
 	"testing"
@@ -67,7 +67,7 @@ func TestApply(t *testing.T) {
 		},
 		{
 			name:    "template exceeding max size returns error",
-			tmpl:    string(make([]byte, maxPayloadTransformSize+1)),
+			tmpl:    string(make([]byte, maxCustomPayloadSize+1)),
 			payload: `{"type":"PUSH_ARTIFACT"}`,
 			wantErr: true,
 		},
@@ -90,5 +90,5 @@ func TestValidate(t *testing.T) {
 	assert.NoError(t, Validate(""))
 	assert.NoError(t, Validate(`{"text": "{{.type}} by {{.operator}}"}`))
 	assert.Error(t, Validate(`{{.type`))
-	assert.Error(t, Validate(string(make([]byte, maxPayloadTransformSize+1))))
+	assert.Error(t, Validate(string(make([]byte, maxCustomPayloadSize+1))))
 }

--- a/src/pkg/notification/notification.go
+++ b/src/pkg/notification/notification.go
@@ -102,7 +102,7 @@ func initSupportedNotifyType() {
 		supportedNotifyTypes = append(supportedNotifyTypes, NotifyType(notifyType))
 	}
 
-	payloadFormats := []string{formats.DefaultFormat, formats.CloudEventsFormat}
+	payloadFormats := []string{formats.DefaultFormat, formats.CloudEventsFormat, formats.CustomFormat}
 	for _, payloadFormat := range payloadFormats {
 		supportedPayloadFormatTypes = append(supportedPayloadFormatTypes, PayloadFormatType(payloadFormat))
 	}

--- a/src/pkg/notification/policy/model/model.go
+++ b/src/pkg/notification/policy/model/model.go
@@ -91,9 +91,10 @@ func (w *Policy) ConvertFromDBModel() error {
 
 // EventTarget defines the structure of target a notification send to
 type EventTarget struct {
-	Type           string `json:"type"`
-	Address        string `json:"address"`
-	AuthHeader     string `json:"auth_header,omitempty"`
-	SkipCertVerify bool   `json:"skip_cert_verify"`
-	PayloadFormat  string `json:"payload_format,omitempty"`
+	Type             string `json:"type"`
+	Address          string `json:"address"`
+	AuthHeader       string `json:"auth_header,omitempty"`
+	SkipCertVerify   bool   `json:"skip_cert_verify"`
+	PayloadFormat    string `json:"payload_format,omitempty"`
+	PayloadTransform string `json:"payload_transform,omitempty"`
 }

--- a/src/pkg/notification/policy/model/model.go
+++ b/src/pkg/notification/policy/model/model.go
@@ -91,10 +91,10 @@ func (w *Policy) ConvertFromDBModel() error {
 
 // EventTarget defines the structure of target a notification send to
 type EventTarget struct {
-	Type             string `json:"type"`
-	Address          string `json:"address"`
-	AuthHeader       string `json:"auth_header,omitempty"`
-	SkipCertVerify   bool   `json:"skip_cert_verify"`
-	PayloadFormat    string `json:"payload_format,omitempty"`
-	PayloadTransform string `json:"payload_transform,omitempty"`
+	Type           string `json:"type"`
+	Address        string `json:"address"`
+	AuthHeader     string `json:"auth_header,omitempty"`
+	SkipCertVerify bool   `json:"skip_cert_verify"`
+	PayloadFormat  string `json:"payload_format,omitempty"`
+	CustomPayload  string `json:"custom_payload,omitempty"`
 }

--- a/src/pkg/notification/transform/transform.go
+++ b/src/pkg/notification/transform/transform.go
@@ -1,0 +1,71 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package transform
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"text/template"
+)
+
+// maxPayloadTransformSize is the maximum allowed byte size for a payload transform template.
+const maxPayloadTransformSize = 4096
+
+// Apply executes the given template against the JSON payload.
+// If the template is empty, the payload is returned unchanged.
+func Apply(templateString string, rawJSONPayload string) (string, error) {
+	if templateString == "" {
+		return rawJSONPayload, nil
+	}
+	if len(templateString) > maxPayloadTransformSize {
+		return "", fmt.Errorf("payload_transform exceeds max size of %d bytes", maxPayloadTransformSize)
+	}
+
+	var eventData map[string]any
+	if err := json.Unmarshal([]byte(rawJSONPayload), &eventData); err != nil {
+		return "", fmt.Errorf("invalid payload JSON: %w", err)
+	}
+
+	compiledTemplate, err := template.New("payload_transform").
+		Option("missingkey=error"). // reject references to fields that do not exist
+		Parse(templateString)
+	if err != nil {
+		return "", fmt.Errorf("invalid payload_transform template: %w", err)
+	}
+
+	var renderedOutput bytes.Buffer
+	if err := compiledTemplate.Execute(&renderedOutput, eventData); err != nil {
+		return "", fmt.Errorf("failed to execute payload_transform: %w", err)
+	}
+
+	return renderedOutput.String(), nil
+}
+
+// Validate checks if template is valid
+func Validate(templateString string) error {
+	if templateString == "" {
+		return nil
+	}
+
+	if len(templateString) > maxPayloadTransformSize {
+		return fmt.Errorf("payload_transform exceeds max size of %d bytes", maxPayloadTransformSize)
+	}
+
+	_, err := template.New("payload_transform").
+		Option("missingkey=error").
+		Parse(templateString)
+	return err
+}

--- a/src/pkg/notification/transform/transform_test.go
+++ b/src/pkg/notification/transform/transform_test.go
@@ -1,0 +1,94 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package transform
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApply(t *testing.T) {
+	tests := []struct {
+		name    string
+		tmpl    string
+		payload string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "empty template returns payload unchanged",
+			tmpl:    "",
+			payload: `{"type":"PUSH_ARTIFACT","operator":"admin"}`,
+			want:    `{"type":"PUSH_ARTIFACT","operator":"admin"}`,
+		},
+		{
+			name:    "field access via dot-notation",
+			tmpl:    `{"text": "{{.type}} by {{.operator}}"}`,
+			payload: `{"type":"PUSH_ARTIFACT","operator":"admin"}`,
+			want:    `{"text": "PUSH_ARTIFACT by admin"}`,
+		},
+		{
+			name:    "nested field access",
+			tmpl:    `{"text": "{{.resource.tag}}"}`,
+			payload: `{"resource":{"tag":"latest"}}`,
+			want:    `{"text": "latest"}`,
+		},
+		{
+			name:    "invalid template returns error",
+			tmpl:    `{{.type`,
+			payload: `{"type":"PUSH_ARTIFACT"}`,
+			wantErr: true,
+		},
+		{
+			name:    "missing key returns error",
+			tmpl:    `{{.nonexistent}}`,
+			payload: `{"type":"PUSH_ARTIFACT"}`,
+			wantErr: true,
+		},
+		{
+			name:    "invalid payload JSON returns error",
+			tmpl:    `{"text": "{{.type}}"}`,
+			payload: `not-valid-json`,
+			wantErr: true,
+		},
+		{
+			name:    "template exceeding max size returns error",
+			tmpl:    string(make([]byte, maxPayloadTransformSize+1)),
+			payload: `{"type":"PUSH_ARTIFACT"}`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Apply(tt.tmpl, tt.payload)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestValidate(t *testing.T) {
+	assert.NoError(t, Validate(""))
+	assert.NoError(t, Validate(`{"text": "{{.type}} by {{.operator}}"}`))
+	assert.Error(t, Validate(`{{.type`))
+	assert.Error(t, Validate(string(make([]byte, maxPayloadTransformSize+1))))
+}

--- a/src/pkg/notifier/formats/custom.go
+++ b/src/pkg/notifier/formats/custom.go
@@ -1,0 +1,26 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package formats
+
+func init() {
+	registerFormats(CustomFormat, defaultFormatter)
+}
+
+const (
+	// CustomFormat is the type for custom payload format.
+	// It uses the same Default JSON structure, with an optional
+	// Go template applied by the webhook job via the custom_payload field.
+	CustomFormat = "Custom"
+)

--- a/src/pkg/notifier/formats/custom_test.go
+++ b/src/pkg/notifier/formats/custom_test.go
@@ -1,0 +1,53 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package formats
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/goharbor/harbor/src/pkg/notifier/model"
+)
+
+func TestCustom_Format(t *testing.T) {
+	payload := &model.Payload{
+		Type:     "PUSH_ARTIFACT",
+		OccurAt:  1678082303,
+		Operator: "admin",
+	}
+
+	he := &model.HookEvent{
+		Payload: payload,
+	}
+
+	formatter, err := GetFormatter(CustomFormat)
+	require.NoError(t, err, "Custom formatter should be registered")
+
+	header, data, err := formatter.Format(context.Background(), he)
+	require.NoError(t, err)
+	assert.Equal(t, "application/json", header.Get("Content-Type"))
+	assert.NotEmpty(t, data)
+}
+
+func TestCustom_Format_NilEvent(t *testing.T) {
+	formatter, err := GetFormatter(CustomFormat)
+	require.NoError(t, err)
+
+	_, _, err = formatter.Format(context.Background(), nil)
+	assert.Error(t, err)
+}

--- a/src/pkg/notifier/handler/notification/http_handler.go
+++ b/src/pkg/notifier/handler/notification/http_handler.go
@@ -85,10 +85,11 @@ func (h *HTTPHandler) process(ctx context.Context, event *model.HookEvent) error
 	}
 
 	j.Parameters = map[string]any{
-		"payload":          string(payload),
-		"address":          event.Target.Address,
-		"header":           string(headerBytes),
-		"skip_cert_verify": event.Target.SkipCertVerify,
+		"payload":           string(payload),
+		"address":           event.Target.Address,
+		"header":            string(headerBytes),
+		"skip_cert_verify":  event.Target.SkipCertVerify,
+		"payload_transform": event.Target.PayloadTransform,
 	}
 	return notification.HookManager.StartHook(ctx, event, j)
 }

--- a/src/pkg/notifier/handler/notification/http_handler.go
+++ b/src/pkg/notifier/handler/notification/http_handler.go
@@ -85,11 +85,11 @@ func (h *HTTPHandler) process(ctx context.Context, event *model.HookEvent) error
 	}
 
 	j.Parameters = map[string]any{
-		"payload":           string(payload),
-		"address":           event.Target.Address,
-		"header":            string(headerBytes),
-		"skip_cert_verify":  event.Target.SkipCertVerify,
-		"payload_transform": event.Target.PayloadTransform,
+		"payload":          string(payload),
+		"address":          event.Target.Address,
+		"header":           string(headerBytes),
+		"skip_cert_verify": event.Target.SkipCertVerify,
+		"custom_payload":   event.Target.CustomPayload,
 	}
 	return notification.HookManager.StartHook(ctx, event, j)
 }

--- a/src/portal/src/app/base/project/webhook/add-webhook-form/add-webhook-form.component.html
+++ b/src/portal/src/app/base/project/webhook/add-webhook-form/add-webhook-form.component.html
@@ -235,7 +235,29 @@
                     </div>
                 </div>
             </div>
-
+            <!-- custom payload -->
+            <div class="clr-form-control" *ngIf="showCustomPayload()">
+                <label
+                    for="custom_payload"
+                    class="clr-control-label">
+                    {{ 'WEBHOOK.CUSTOM_PAYLOAD' | translate }}
+                </label>
+                <div class="clr-control-container">
+                    <div class="clr-textarea-wrapper">
+                        <textarea
+                            autocomplete="off"
+                            class="clr-textarea width-238"
+                            id="custom_payload"
+                            [disabled]="checking"
+                            [(ngModel)]="webhook.targets[0].custom_payload"
+                            name="custom_payload"
+                            rows="5"
+                            maxlength="4096"
+                            [placeholder]="customPayloadPlaceholder">
+                        </textarea>
+                    </div>
+                </div>
+            </div>
             <!-- verify remote cert -->
             <div class="clr-form-control">
                 <label for="verify_remote_cert" class="clr-control-label">

--- a/src/portal/src/app/base/project/webhook/add-webhook-form/add-webhook-form.component.ts
+++ b/src/portal/src/app/base/project/webhook/add-webhook-form/add-webhook-form.component.ts
@@ -51,6 +51,7 @@ export class AddWebhookFormComponent implements OnInit, OnDestroy {
     closable: boolean = true;
     checking: boolean = false;
     submitting: boolean = false;
+    customPayloadPlaceholder = '{"text": "{{.type}} by {{.operator}}"}';
     @Input() projectId: number;
     webhook: WebhookPolicy = {
         enabled: true,
@@ -61,6 +62,7 @@ export class AddWebhookFormComponent implements OnInit, OnDestroy {
                 address: '',
                 skip_cert_verify: true,
                 payload_format: PAYLOAD_FORMATS[0],
+                custom_payload: '',
             },
         ],
     };
@@ -255,5 +257,10 @@ export class AddWebhookFormComponent implements OnInit, OnDestroy {
             return PAYLOAD_FORMAT_I18N_MAP[v];
         }
         return v;
+    }
+
+    showCustomPayload(): boolean {
+        const target = this.webhook.targets[0];
+        return target.type === 'http' && target.payload_format === 'Custom';
     }
 }

--- a/src/portal/src/app/base/project/webhook/webhook.service.ts
+++ b/src/portal/src/app/base/project/webhook/webhook.service.ts
@@ -30,11 +30,12 @@ const EVENT_TYPES_TEXT_MAP = {
     TAG_RETENTION: 'Tag retention finished',
 };
 
-export const PAYLOAD_FORMATS: string[] = ['Default', 'CloudEvents'];
+export const PAYLOAD_FORMATS: string[] = ['Default', 'CloudEvents', 'Custom'];
 
 export const PAYLOAD_FORMAT_I18N_MAP = {
     [PAYLOAD_FORMATS[0]]: 'SCANNER.DEFAULT',
     [PAYLOAD_FORMATS[1]]: 'WEBHOOK.CLOUD_EVENT',
+    [PAYLOAD_FORMATS[2]]: 'WEBHOOK.CUSTOM_PAYLOAD',
 };
 
 export enum WebhookType {

--- a/src/portal/src/i18n/lang/de-de-lang.json
+++ b/src/portal/src/i18n/lang/de-de-lang.json
@@ -436,6 +436,7 @@
         "EVENT_TYPE": "Event Typ",
         "EVENT_TYPE_REQUIRED": "Mindestens ein Event Typ ist erforderlich",
         "PAYLOAD_FORMAT": "Payload Format",
+        "CUSTOM_PAYLOAD": "Benutzerdefiniertes Payload",
         "CLOUD_EVENT": "CloudEvents",
         "PAYLOAD_DATA": "Payload Data",
         "SLACK_RATE_LIMIT": "Please be aware of Slack Rate Limits"

--- a/src/portal/src/i18n/lang/en-us-lang.json
+++ b/src/portal/src/i18n/lang/en-us-lang.json
@@ -437,6 +437,7 @@
         "EVENT_TYPE": "Event Type",
         "EVENT_TYPE_REQUIRED": "Require at least one event type",
         "PAYLOAD_FORMAT": "Payload Format",
+        "CUSTOM_PAYLOAD": "Custom Payload",
         "CLOUD_EVENT": "CloudEvents",
         "PAYLOAD_DATA": "Payload Data",
         "SLACK_RATE_LIMIT": "Please be aware of Slack Rate Limits"

--- a/src/portal/src/i18n/lang/es-es-lang.json
+++ b/src/portal/src/i18n/lang/es-es-lang.json
@@ -436,6 +436,7 @@
         "EVENT_TYPE": "Tipo Evento",
         "EVENT_TYPE_REQUIRED": "Requiere al menos un tipo de evento",
         "PAYLOAD_FORMAT": "Formato de Payload",
+        "CUSTOM_PAYLOAD": "Payload Personalizado",
         "CLOUD_EVENT": "CloudEvents",
         "PAYLOAD_DATA": "Data de Payload",
         "SLACK_RATE_LIMIT": "Por favor toma en cuenta los Rate Limits de Slack"

--- a/src/portal/src/i18n/lang/fr-fr-lang.json
+++ b/src/portal/src/i18n/lang/fr-fr-lang.json
@@ -438,6 +438,7 @@
         "EVENT_TYPE": "Types d'évènement",
         "EVENT_TYPE_REQUIRED": "Au moins un type d'évènement est nécessaire",
         "PAYLOAD_FORMAT": "Format du Payload",
+        "CUSTOM_PAYLOAD": "Payload Personnalisé",
         "CLOUD_EVENT": "CloudEvents",
         "PAYLOAD_DATA": "Donnée du Payload",
         "SLACK_RATE_LIMIT": "Attention aux limites de requêtes de Slack"

--- a/src/portal/src/i18n/lang/ko-kr-lang.json
+++ b/src/portal/src/i18n/lang/ko-kr-lang.json
@@ -435,6 +435,7 @@
         "EVENT_TYPE": "유형 입력",
         "EVENT_TYPE_REQUIRED": "하나 이상의 이벤트 유형이 필요합니다.",
         "PAYLOAD_FORMAT": "페이로드 형식",
+        "CUSTOM_PAYLOAD": "커스텀 페이로드",
         "CLOUD_EVENT": "클라우드이벤트",
         "PAYLOAD_DATA": "페이로드 데이터",
         "SLACK_RATE_LIMIT": "Slack 속도 제한에 유의하세요."

--- a/src/portal/src/i18n/lang/pt-br-lang.json
+++ b/src/portal/src/i18n/lang/pt-br-lang.json
@@ -466,6 +466,7 @@
         "EVENT_TYPE": "Tipo de Evento",
         "EVENT_TYPE_REQUIRED": "Pelo menos um tipo de evento é obrigatório",
         "PAYLOAD_FORMAT": "Payload Format",
+        "CUSTOM_PAYLOAD": "Payload Personalizado",
         "CLOUD_EVENT": "CloudEvents",
         "PAYLOAD_DATA": "Payload Data",
         "SLACK_RATE_LIMIT": "Please be aware of Slack Rate Limits"

--- a/src/portal/src/i18n/lang/ru-ru-lang.json
+++ b/src/portal/src/i18n/lang/ru-ru-lang.json
@@ -436,7 +436,8 @@
         "NAME_REQUIRED": "Имя обязательно",
         "NOTIFY_TYPE": "Тип уведомления",
         "EVENT_TYPE": "Тип события",
-        "EVENT_TYPE_REQUIRED": "Требуется хотя бы один тип события"
+        "EVENT_TYPE_REQUIRED": "Требуется хотя бы один тип события",
+        "CUSTOM_PAYLOAD": "Пользовательская нагрузка"
     },
     "GROUP": {
         "GROUP": "Группа",

--- a/src/portal/src/i18n/lang/tr-tr-lang.json
+++ b/src/portal/src/i18n/lang/tr-tr-lang.json
@@ -436,6 +436,7 @@
         "EVENT_TYPE": "Event Type",
         "EVENT_TYPE_REQUIRED": "Require at least one event type",
         "PAYLOAD_FORMAT": "Payload Format",
+        "CUSTOM_PAYLOAD": "Özel Payload",
         "CLOUD_EVENT": "CloudEvents",
         "PAYLOAD_DATA": "Payload Data",
         "SLACK_RATE_LIMIT": "Please be aware of Slack Rate Limits"

--- a/src/portal/src/i18n/lang/zh-cn-lang.json
+++ b/src/portal/src/i18n/lang/zh-cn-lang.json
@@ -435,6 +435,7 @@
         "EVENT_TYPE": "事件类型",
         "EVENT_TYPE_REQUIRED": "请至少选择一种事件类型",
         "PAYLOAD_FORMAT": "载荷形式",
+        "CUSTOM_PAYLOAD": "自定义载荷",
         "CLOUD_EVENT": "CloudEvents",
         "PAYLOAD_DATA": "载荷数据",
         "SLACK_RATE_LIMIT": "请注意 Slack 的速率限制"

--- a/src/portal/src/i18n/lang/zh-tw-lang.json
+++ b/src/portal/src/i18n/lang/zh-tw-lang.json
@@ -435,6 +435,7 @@
         "EVENT_TYPE": "事件類型",
         "EVENT_TYPE_REQUIRED": "至少需要一種事件類型。",
         "PAYLOAD_FORMAT": "Payload 格式",
+        "CUSTOM_PAYLOAD": "自訂 Payload",
         "CLOUD_EVENT": "CloudEvents",
         "PAYLOAD_DATA": "Payload 資料",
         "SLACK_RATE_LIMIT": "請注意 Slack 的速率限制"

--- a/src/server/v2.0/handler/model/webhook_policy.go
+++ b/src/server/v2.0/handler/model/webhook_policy.go
@@ -47,12 +47,12 @@ func (n *WebhookPolicy) ToTargets() []*models.WebhookTargetObject {
 	var results []*models.WebhookTargetObject
 	for _, t := range n.Targets {
 		results = append(results, &models.WebhookTargetObject{
-			Type:             t.Type,
-			Address:          t.Address,
-			AuthHeader:       t.AuthHeader,
-			SkipCertVerify:   t.SkipCertVerify,
-			PayloadFormat:    models.PayloadFormatType(t.PayloadFormat),
-			PayloadTransform: t.PayloadTransform,
+			Type:           t.Type,
+			Address:        t.Address,
+			AuthHeader:     t.AuthHeader,
+			SkipCertVerify: t.SkipCertVerify,
+			PayloadFormat:  models.PayloadFormatType(t.PayloadFormat),
+			CustomPayload:  t.CustomPayload,
 		})
 	}
 	return results

--- a/src/server/v2.0/handler/model/webhook_policy.go
+++ b/src/server/v2.0/handler/model/webhook_policy.go
@@ -47,11 +47,12 @@ func (n *WebhookPolicy) ToTargets() []*models.WebhookTargetObject {
 	var results []*models.WebhookTargetObject
 	for _, t := range n.Targets {
 		results = append(results, &models.WebhookTargetObject{
-			Type:           t.Type,
-			Address:        t.Address,
-			AuthHeader:     t.AuthHeader,
-			SkipCertVerify: t.SkipCertVerify,
-			PayloadFormat:  models.PayloadFormatType(t.PayloadFormat),
+			Type:             t.Type,
+			Address:          t.Address,
+			AuthHeader:       t.AuthHeader,
+			SkipCertVerify:   t.SkipCertVerify,
+			PayloadFormat:    models.PayloadFormatType(t.PayloadFormat),
+			PayloadTransform: t.PayloadTransform,
 		})
 	}
 	return results

--- a/src/server/v2.0/handler/webhook.go
+++ b/src/server/v2.0/handler/webhook.go
@@ -32,8 +32,8 @@ import (
 	"github.com/goharbor/harbor/src/lib/log"
 	"github.com/goharbor/harbor/src/lib/q"
 	"github.com/goharbor/harbor/src/pkg/notification"
+	"github.com/goharbor/harbor/src/pkg/notification/custompayload"
 	policy_model "github.com/goharbor/harbor/src/pkg/notification/policy/model"
-	"github.com/goharbor/harbor/src/pkg/notification/transform"
 	"github.com/goharbor/harbor/src/server/v2.0/handler/model"
 	"github.com/goharbor/harbor/src/server/v2.0/models"
 	"github.com/goharbor/harbor/src/server/v2.0/restapi/operations/webhook"
@@ -431,8 +431,8 @@ func (n *webhookAPI) validateTargets(policy *policy_model.Policy) (bool, error) 
 		if len(target.PayloadFormat) == 0 && target.Type == "http" {
 			policy.Targets[i].PayloadFormat = "Default"
 		}
-		if err := transform.Validate(target.PayloadTransform); err != nil {
-			return false, errors.New(err).WithMessagef("invalid payload_transform template: %v", err).WithCode(errors.BadRequestCode)
+		if err := custompayload.Validate(target.CustomPayload); err != nil {
+			return false, errors.New(err).WithMessagef("invalid custom_payload template: %v", err).WithCode(errors.BadRequestCode)
 		}
 	}
 	return true, nil

--- a/src/server/v2.0/handler/webhook.go
+++ b/src/server/v2.0/handler/webhook.go
@@ -33,6 +33,7 @@ import (
 	"github.com/goharbor/harbor/src/lib/q"
 	"github.com/goharbor/harbor/src/pkg/notification"
 	policy_model "github.com/goharbor/harbor/src/pkg/notification/policy/model"
+	"github.com/goharbor/harbor/src/pkg/notification/transform"
 	"github.com/goharbor/harbor/src/server/v2.0/handler/model"
 	"github.com/goharbor/harbor/src/server/v2.0/models"
 	"github.com/goharbor/harbor/src/server/v2.0/restapi/operations/webhook"
@@ -429,6 +430,9 @@ func (n *webhookAPI) validateTargets(policy *policy_model.Policy) (bool, error) 
 		// set payload format to Default is not specified when the type is http
 		if len(target.PayloadFormat) == 0 && target.Type == "http" {
 			policy.Targets[i].PayloadFormat = "Default"
+		}
+		if err := transform.Validate(target.PayloadTransform); err != nil {
+			return false, errors.New(err).WithMessagef("invalid payload_transform template: %v", err).WithCode(errors.BadRequestCode)
 		}
 	}
 	return true, nil


### PR DESCRIPTION
Thank you for contributing to Harbor!

# Comprehensive Summary of your change
Adds a `Custom` option to the webhook payload format dropdown. When selected,  a textarea appears allowing users to define a template that reshapes the  webhook payload before it is sent. Fields are accessible via dot-notation  (e.g. `{{.type}}`, `{{.operator}}`). This enables Harbor to integrate with  any HTTP webhook target without being limited to the existing formats, as discussed in [#16632](https://github.com/goharbor/harbor/issues/16632).

This feature applies to HTTP webhook type. Template size is capped at 4096 bytes. References to non-existent fields return an error rather than silently rendering empty. If the template execution fails (e.g., due to a missing key), the webhook job will log the error and halt the request, preventing the delivery of malformed payloads.

# Issue being fixed
Fixes #16632

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).