### PR TITLE
chore(ci): add VIS v1 CI workflows for testing

### DIFF
--- a/.github/actions/detect-changes/action.yaml
+++ b/.github/actions/detect-changes/action.yaml
@@ -1,0 +1,36 @@
+name: "Detect Changed Project Folders"
+description: "Finds top-level project folders with changes that contain a specified file"
+inputs:
+    file-pattern:
+        description: "Filename to search for in changed folders (e.g., go.mod, Dockerfile)"
+        required: true
+outputs:
+    modules:
+        description: "JSON array of changed project folder paths"
+        value: ${{ steps.detect.outputs.modules }}
+runs:
+    using: composite
+    steps:
+
+      - name: Detect changes/modules
+        id: detect
+        shell: bash
+        run: |
+          # Get unique top-level folders from changed files
+          folders=$(git diff --name-only origin/main...HEAD | cut -d/ -f1 | sort -u)
+
+          # Filter to folders containing the target file
+          matched=()
+          for folder in $folders; do
+            if [ -d "$folder" ] && find "$folder" -maxdepth 3 -name "${{ inputs.file-pattern }}" | grep -q .; then
+              matched+=("$folder")
+            fi
+          done
+
+          # Output as JSON array
+          if [ ${#matched[@]} -eq 0 ]; then
+            echo "modules=[]" >> "$GITHUB_OUTPUT"
+          else
+            modules=$(printf '%s\n' "${matched[@]}" | jq -R -s -c 'split("\n") | map(select(length > 0))')
+            echo "modules=$modules" >> "$GITHUB_OUTPUT"
+          fi

--- a/.github/workflows/vis-checks.yaml
+++ b/.github/workflows/vis-checks.yaml
@@ -1,0 +1,81 @@
+name: "Checks"
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions: {}
+
+jobs:
+  detect-changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      modules: ${{ steps.detect.outputs.modules }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Detect changed Go modules
+        id: detect
+        uses: ./.github/actions/detect-changes
+        with:
+          file-pattern: 'go.mod'
+
+  go-checks:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.modules != '[]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        directory: ${{ fromJSON(needs.detect-changes.outputs.modules) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup Go
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        with:
+          go-version-file: ${{ matrix.directory }}/go.mod
+          check-latest: false
+
+      - name: Download and verify modules
+        working-directory: ${{ matrix.directory }}
+        run: |
+          go mod download
+          go mod verify
+
+      - name: govulncheck
+        uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1.0.4
+        with:
+          work-dir: ${{ matrix.directory }}
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
+        with:
+          version: v2.8.0
+          working-directory: ${{ matrix.directory }}
+          skip-cache: true
+
+      - name: Run tests
+        working-directory: ${{ matrix.directory }}
+        run: go test ./... -short
+
+      - name: Check formatting and tidiness
+        working-directory: ${{ matrix.directory }}
+        run: |
+          go mod tidy
+          go fmt ./...
+          git restore go.sum
+      - name: Verify no uncommitted changes
+        run: git diff-files --quiet --ignore-submodules

--- a/.github/workflows/vis-codeql.yaml
+++ b/.github/workflows/vis-codeql.yaml
@@ -1,0 +1,48 @@
+name: "CodeQL"
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions: {}
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ["actions", "go", "javascript-typescript", "python"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Setup Go
+        if: ${{ matrix.language == 'go' }}
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        with:
+          go-version: 'stable'
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@16140ae1a102900babc80a33c44059580f687047 # v4.30.9
+        timeout-minutes: 5
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@16140ae1a102900babc80a33c44059580f687047 # v4.30.9
+        timeout-minutes: 10
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@16140ae1a102900babc80a33c44059580f687047 # v4.30.9
+        timeout-minutes: 10
+        with:
+          category: "/language:${{matrix.language}}"

--- a/.github/workflows/vis-dependency-review.yaml
+++ b/.github/workflows/vis-dependency-review.yaml
@@ -1,0 +1,32 @@
+name: "Dependency Review"
+on:
+  pull_request: {}
+
+permissions: {}
+
+jobs:
+  dependency_review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Dependency Review
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
+        with:
+          fail-on-severity: low
+          comment-summary-in-pr: on-failure
+          deny-licenses: >
+            GPL-1.0, GPL-1.0+, GPL-1.0-only, GPL-1.0-or-later,
+            GPL-2.0, GPL-2.0+, GPL-2.0-only, GPL-2.0-or-later,
+            GPL-3.0, GPL-3.0+, GPL-3.0-only, GPL-3.0-or-later,
+            AGPL-1.0, AGPL-1.0-only, AGPL-1.0-or-later,
+            AGPL-3.0, AGPL-3.0-only, AGPL-3.0-or-later,
+            LGPL-2.0, LGPL-2.0+, LGPL-2.0-only, LGPL-2.0-or-later,
+            LGPL-2.1, LGPL-2.1+, LGPL-2.1-only, LGPL-2.1-or-later,
+            LGPL-3.0, LGPL-3.0+, LGPL-3.0-only, LGPL-3.0-or-later

--- a/.github/workflows/vis-pr-checks.yaml
+++ b/.github/workflows/vis-pr-checks.yaml
@@ -1,0 +1,33 @@
+name: "Pull Request Checks"
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - edited
+
+permissions: {}
+
+jobs:
+  title_check:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Conventional commit check
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            fix
+            feat
+            chore
+            refactor
+            revert
+            adr
+          requireScope: false
+          subjectPattern: '^.+$'


### PR DESCRIPTION
Test deployment of integration-studios CI adapted for a public repo. Includes: Go quality gate with dynamic module discovery, CodeQL (actions/go/js-ts/python), conventional commit enforcement, dependency review with license deny-list, and reusable detect-changes composite action.

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [ ] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [ ] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
