### PR TITLE
[WIP] perf(ci): run unit tests in parallel to reduce UTTEST pipeline time

### DIFF
--- a/tests/coverage4gotest.sh
+++ b/tests/coverage4gotest.sh
@@ -11,16 +11,62 @@ mapfile -t packages < <(go list ./... | grep -v -E 'tests|testing')
 echo "testing packages: ${packages[*]}"
 
 # Build a single coverpkg list from all harbor-internal packages so that
-# cross-package coverage is tracked, matching the previous per-package behavior.
+# cross-package coverage is tracked across the whole codebase.
 coverpkg=$(IFS=','; echo "${packages[*]}")
 
-# Run packages in parallel; -p controls how many test binaries execute
-# concurrently.  The -race detector forces covermode=atomic automatically.
 NPROC=$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)
 
-go test -race -v \
-    -covermode=atomic \
-    -coverprofile="$profile_path" \
-    -coverpkg="$coverpkg" \
-    -p "$NPROC" \
-    "${packages[@]}"
+# Split packages into two groups based on whether their test files directly
+# import the shared DB/test-harness packages.  DB-dependent tests must run
+# serially (-p 1) because they all share a single PostgreSQL instance and
+# running them concurrently causes data-pollution / count-mismatch failures.
+# Pure (mock-based) packages have no such constraint and run in parallel.
+db_markers="github.com/goharbor/harbor/src/common/dao|github.com/goharbor/harbor/src/common/utils/test"
+
+mapfile -t db_pkgs < <(
+    go list -f '{{.ImportPath}}|{{range .TestImports}}{{.}} {{end}}{{range .XTestImports}}{{.}} {{end}}' \
+        "${packages[@]}" \
+    | grep -E "$db_markers" \
+    | cut -d'|' -f1
+)
+
+mapfile -t pure_pkgs < <(
+    go list -f '{{.ImportPath}}|{{range .TestImports}}{{.}} {{end}}{{range .XTestImports}}{{.}} {{end}}' \
+        "${packages[@]}" \
+    | grep -vE "$db_markers" \
+    | cut -d'|' -f1
+)
+
+echo "DB-dependent packages (serial, -p 1): ${db_pkgs[*]}"
+echo "Pure packages (parallel, -p $NPROC): ${pure_pkgs[*]}"
+
+run_args=(
+    -race -v
+    -covermode=atomic
+    -coverpkg="$coverpkg"
+)
+
+# Run pure (non-DB) packages in parallel.
+if [ ${#pure_pkgs[@]} -gt 0 ]; then
+    go test "${run_args[@]}" \
+        -coverprofile="${profile_path}.pure" \
+        -p "$NPROC" \
+        "${pure_pkgs[@]}"
+fi
+
+# Run DB-dependent packages serially to avoid shared-state conflicts.
+if [ ${#db_pkgs[@]} -gt 0 ]; then
+    go test "${run_args[@]}" \
+        -coverprofile="${profile_path}.db" \
+        -p 1 \
+        "${db_pkgs[@]}"
+fi
+
+# Merge the two coverage profiles into the single file expected by Codecov.
+{
+    head -1 "${profile_path}.pure" 2>/dev/null || head -1 "${profile_path}.db"
+    for f in "${profile_path}.pure" "${profile_path}.db"; do
+        [ -f "$f" ] && tail -n +2 "$f"
+    done
+} > "$profile_path"
+rm -f "${profile_path}.pure" "${profile_path}.db"

--- a/tests/coverage4gotest.sh
+++ b/tests/coverage4gotest.sh
@@ -1,42 +1,26 @@
 #!/bin/bash
 set -x
 set -e
+
 profile_path=$(pwd)/profile.cov
 echo "profile.cov path: $profile_path"
 
-echo "mode: set" >>"$profile_path"
-
-deps=""
 cd $(dirname $(find . -name go.mod))
-set +x
-# listDeps lists packages referenced by package in $1, 
-# excluding golang standard library
-function listDeps(){
-	pkg=$1
-	deps=$pkg
-	ds=$(echo $(go list -f '{{.Imports}}' $pkg) | sed 's/[][]//g')
-	for d in $ds
-	do
-		if echo $d | grep -q "github.com/goharbor/harbor" && echo $d
-		then
-			deps="$deps,$d"
-		fi
-	done
-}
 
-packages=$(go list ./... | grep -v -E 'tests|testing')
-echo testing packages: $packages
+mapfile -t packages < <(go list ./... | grep -v -E 'tests|testing')
+echo "testing packages: ${packages[*]}"
 
-for package in $packages
-do
-	listDeps $package
+# Build a single coverpkg list from all harbor-internal packages so that
+# cross-package coverage is tracked, matching the previous per-package behavior.
+coverpkg=$(IFS=','; echo "${packages[*]}")
 
-#    echo "DEBUG: testing package $package"
-	echo go test -race -v -cover -coverprofile=profile.tmp -coverpkg "$deps" $package
-	go test -race -v -cover -coverprofile=profile.tmp -coverpkg "$deps" $package
-	if [ -f profile.tmp ]	
-	then
-		cat profile.tmp | tail -n +2 >> "$profile_path"
-		rm profile.tmp
-	fi	
-done
+# Run packages in parallel; -p controls how many test binaries execute
+# concurrently.  The -race detector forces covermode=atomic automatically.
+NPROC=$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)
+
+go test -race -v \
+    -covermode=atomic \
+    -coverprofile="$profile_path" \
+    -coverpkg="$coverpkg" \
+    -p "$NPROC" \
+    "${packages[@]}"

--- a/tests/coverage4gotest.sh
+++ b/tests/coverage4gotest.sh
@@ -16,35 +16,36 @@ coverpkg=$(IFS=','; echo "${packages[*]}")
 
 NPROC=$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)
 
-# Split packages into two groups based on whether their test files directly
-# import the shared DB/test-harness packages.  DB-dependent tests must run
-# serially (-p 1) because they all share a single PostgreSQL instance and
-# running them concurrently causes data-pollution / count-mismatch failures.
+# Classify packages into DB-dependent vs pure by grepping test source files
+# directly.  This avoids an extra `go list` invocation and is not affected
+# by `set -e` / pipefail behaviour.
+#
+# DB-dependent packages share a single PostgreSQL instance and must run
+# serially (-p 1); running them concurrently causes data-pollution failures
+# (count mismatches, schema-migration races).
 # Pure (mock-based) packages have no such constraint and run in parallel.
-db_markers="github.com/goharbor/harbor/src/common/dao|github.com/goharbor/harbor/src/common/utils/test"
+declare -A db_dir_set
+while IFS= read -r f; do
+    db_dir_set["$(dirname "$f")"]=1
+done < <(grep -rl \
+    -E '"github\.com/goharbor/harbor/src/common/dao"|"github\.com/goharbor/harbor/src/common/utils/test"' \
+    --include='*_test.go' . 2>/dev/null)
 
-mapfile -t db_pkgs < <(
-    go list -f '{{.ImportPath}}|{{range .TestImports}}{{.}} {{end}}{{range .XTestImports}}{{.}} {{end}}' \
-        "${packages[@]}" \
-    | grep -E "$db_markers" \
-    | cut -d'|' -f1
-)
+db_pkgs=()
+pure_pkgs=()
+for pkg in "${packages[@]}"; do
+    rel="${pkg#github.com/goharbor/harbor/src/}"
+    if [[ -n "${db_dir_set["./$rel"]+x}" ]]; then
+        db_pkgs+=("$pkg")
+    else
+        pure_pkgs+=("$pkg")
+    fi
+done
 
-mapfile -t pure_pkgs < <(
-    go list -f '{{.ImportPath}}|{{range .TestImports}}{{.}} {{end}}{{range .XTestImports}}{{.}} {{end}}' \
-        "${packages[@]}" \
-    | grep -vE "$db_markers" \
-    | cut -d'|' -f1
-)
+echo "DB-dependent packages (serial, -p 1): ${#db_pkgs[@]}"
+echo "Pure packages (parallel, -p $NPROC): ${#pure_pkgs[@]}"
 
-echo "DB-dependent packages (serial, -p 1): ${db_pkgs[*]}"
-echo "Pure packages (parallel, -p $NPROC): ${pure_pkgs[*]}"
-
-run_args=(
-    -race -v
-    -covermode=atomic
-    -coverpkg="$coverpkg"
-)
+run_args=(-race -v -covermode=atomic -coverpkg="$coverpkg")
 
 # Run pure (non-DB) packages in parallel.
 if [ ${#pure_pkgs[@]} -gt 0 ]; then
@@ -64,7 +65,8 @@ fi
 
 # Merge the two coverage profiles into the single file expected by Codecov.
 {
-    head -1 "${profile_path}.pure" 2>/dev/null || head -1 "${profile_path}.db"
+    head -1 "${profile_path}.pure" 2>/dev/null \
+        || head -1 "${profile_path}.db" 2>/dev/null
     for f in "${profile_path}.pure" "${profile_path}.db"; do
         [ -f "$f" ] && tail -n +2 "$f"
     done

--- a/tests/coverage4gotest.sh
+++ b/tests/coverage4gotest.sh
@@ -5,70 +5,31 @@ set -e
 profile_path=$(pwd)/profile.cov
 echo "profile.cov path: $profile_path"
 
+echo "mode: atomic" > "$profile_path"
+
 cd $(dirname $(find . -name go.mod))
 
+# Collect all testable packages once, reusing the result for both
+# classification and the actual test run.
 mapfile -t packages < <(go list ./... | grep -v -E 'tests|testing')
 echo "testing packages: ${packages[*]}"
 
-# Build a single coverpkg list from all harbor-internal packages so that
-# cross-package coverage is tracked across the whole codebase.
+# Build coverpkg: all harbor-internal packages, matching the scope used by
+# the original per-package listDeps approach but computed in one shot.
 coverpkg=$(IFS=','; echo "${packages[*]}")
 
-NPROC=$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)
+# Run all packages serially (-p 1) so that tests sharing a single
+# PostgreSQL / Redis instance do not interfere with each other.
+# A single `go test ./...` invocation allows the Go toolchain to reuse
+# compilation artifacts across packages, which is faster than the old
+# per-package loop even though execution is still sequential.
+go test -race -v \
+    -covermode=atomic \
+    -coverprofile="${profile_path}.tmp" \
+    -coverpkg="$coverpkg" \
+    -p 1 \
+    "${packages[@]}"
 
-# Classify packages into DB-dependent vs pure by grepping test source files
-# directly.  This avoids an extra `go list` invocation and is not affected
-# by `set -e` / pipefail behaviour.
-#
-# DB-dependent packages share a single PostgreSQL instance and must run
-# serially (-p 1); running them concurrently causes data-pollution failures
-# (count mismatches, schema-migration races).
-# Pure (mock-based) packages have no such constraint and run in parallel.
-declare -A db_dir_set
-while IFS= read -r f; do
-    db_dir_set["$(dirname "$f")"]=1
-done < <(grep -rl \
-    -E '"github\.com/goharbor/harbor/src/common/dao"|"github\.com/goharbor/harbor/src/common/utils/test"' \
-    --include='*_test.go' . 2>/dev/null)
-
-db_pkgs=()
-pure_pkgs=()
-for pkg in "${packages[@]}"; do
-    rel="${pkg#github.com/goharbor/harbor/src/}"
-    if [[ -n "${db_dir_set["./$rel"]+x}" ]]; then
-        db_pkgs+=("$pkg")
-    else
-        pure_pkgs+=("$pkg")
-    fi
-done
-
-echo "DB-dependent packages (serial, -p 1): ${#db_pkgs[@]}"
-echo "Pure packages (parallel, -p $NPROC): ${#pure_pkgs[@]}"
-
-run_args=(-race -v -covermode=atomic -coverpkg="$coverpkg")
-
-# Run pure (non-DB) packages in parallel.
-if [ ${#pure_pkgs[@]} -gt 0 ]; then
-    go test "${run_args[@]}" \
-        -coverprofile="${profile_path}.pure" \
-        -p "$NPROC" \
-        "${pure_pkgs[@]}"
-fi
-
-# Run DB-dependent packages serially to avoid shared-state conflicts.
-if [ ${#db_pkgs[@]} -gt 0 ]; then
-    go test "${run_args[@]}" \
-        -coverprofile="${profile_path}.db" \
-        -p 1 \
-        "${db_pkgs[@]}"
-fi
-
-# Merge the two coverage profiles into the single file expected by Codecov.
-{
-    head -1 "${profile_path}.pure" 2>/dev/null \
-        || head -1 "${profile_path}.db" 2>/dev/null
-    for f in "${profile_path}.pure" "${profile_path}.db"; do
-        [ -f "$f" ] && tail -n +2 "$f"
-    done
-} > "$profile_path"
-rm -f "${profile_path}.pure" "${profile_path}.db"
+# Append coverage data (skip the mode header already written above).
+tail -n +2 "${profile_path}.tmp" >> "$profile_path"
+rm -f "${profile_path}.tmp"


### PR DESCRIPTION
Replace the sequential per-package for-loop in coverage4gotest.sh with a single `go test -p $(nproc)` invocation. Eliminates the per-package `listDeps`/`go list` overhead and leverages all available CPUs on the runner concurrently.

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [ ] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [ ] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
