### PR TITLE
build: add PIP_INDEX_URL variable to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,7 @@ HTTPPROXY=
 BUILDREG=true
 BUILDTRIVYADP=true
 NPM_REGISTRY=https://registry.npmjs.org
+PIP_INDEX_URL=https://pypi.org/simple
 # Override when Maven Central returns 429 (rate limit), e.g. a mirror or cached URL:
 #   make swagger_client OPENAPI_GENERATOR_CLI_URL=https://...
 #   export OPENAPI_GENERATOR_CLI_URL=https://... ; make swagger_client


### PR DESCRIPTION
Thank you for contributing to Harbor!

# Comprehensive Summary of your change
This pull request makes a minor update to the `Makefile` by adding the `PIP_INDEX_URL` variable, which specifies the default Python package index URL. This can help standardize Python dependency installations across environments.

- Configuration update:
  * Added the `PIP_INDEX_URL` variable set to `https://pypi.org/simple` in the `Makefile` to define the default Python package index.
# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
