### PR TITLE
fix: block pull of unsupported artifacts when vulnerability prevention is on

### DIFF
--- a/src/server/middleware/vulnerable/vulnerable.go
+++ b/src/server/middleware/vulnerable/vulnerable.go
@@ -84,7 +84,8 @@ func Middleware() func(http.Handler) http.Handler {
 		vulnerable, err := scanController.GetVulnerable(ctx, art, allowlist, proj.CVEAllowlist.IsExpired())
 		if errors.IsNotFoundErr(err) {
 			// When the scanner is disconnected the artifact will be considered not scannable.
-			// We'll try to check the existing scan report even when it's not scannable, and only if there is no report, we will skip checking the vulnerability.
+			// We'll try to check the existing scan report even when it's not scannable, and if there is no report,
+			// we block the pull for both scannable artifacts (missing report) and unsupported artifacts.
 			checker := scanChecker()
 			scannable, err := checker.IsScannable(ctx, art)
 			if err != nil {
@@ -92,8 +93,9 @@ func Middleware() func(http.Handler) http.Handler {
 				return err
 			}
 			if !scannable {
-				logger.Debugf("artifact %s@%s does not have a scan report, and it is not scannable, skip the checking", art.RepositoryName, art.Digest)
-				return nil
+				msg := fmt.Sprintf(`current image is unsupported for vulnerability scanning and cannot be pulled due to configured policy in 'Prevent images with vulnerability severity of "%s" or higher from running.' `+
+					`To continue with pull, please contact your project administrator for help.`, projectSeverity)
+				return errors.New(nil).WithCode(errors.PROJECTPOLICYVIOLATION).WithMessage(msg)
 			}
 			// If the artifact is scannable but there's no report, it's a violation.
 			msg := fmt.Sprintf(`current image without vulnerability scanning cannot be pulled due to configured policy in 'Prevent images with vulnerability severity of "%s" or higher from running.' `+

--- a/src/server/middleware/vulnerable/vulnerable_test.go
+++ b/src/server/middleware/vulnerable/vulnerable_test.go
@@ -191,7 +191,7 @@ func (suite *MiddlewareTestSuite) TestNonScannerPulling() {
 	rr := httptest.NewRecorder()
 
 	Middleware()(suite.next).ServeHTTP(rr, req)
-	suite.Equal(rr.Code, http.StatusOK)
+	suite.Equal(rr.Code, http.StatusPreconditionFailed)
 }
 
 func (suite *MiddlewareTestSuite) TestScannerPulling() {
@@ -252,7 +252,7 @@ func (suite *MiddlewareTestSuite) TestArtifactIsNotScannableNotScanned() {
 	rr := httptest.NewRecorder()
 
 	Middleware()(suite.next).ServeHTTP(rr, req)
-	suite.Equal(rr.Code, http.StatusOK)
+	suite.Equal(rr.Code, http.StatusPreconditionFailed)
 }
 
 func (suite *MiddlewareTestSuite) TestArtifactNotScanned() {


### PR DESCRIPTION
# Summary
Previously, artifacts that were unsupported for vulnerability scanning (not scannable with no existing scan report) were allowed to be pulled even when the project had "Prevent vulnerable images from running" enabled. This created a security gap where unscanned and unscannable artifacts could bypass the vulnerability prevention policy.

Now, unsupported artifacts are blocked with a `PROJECTPOLICYVIOLATION` error, consistent with how other unscanned artifacts are treated.

#### `src/server/middleware/vulnerable/vulnerable.go`

- When a project has "Prevent vulnerable images from running" enabled, artifacts that are unsupported for vulnerability scanning (not scannable, with no existing scan report) were previously allowed to be pulled, bypassing the policy. Now they are blocked with a `PROJECTPOLICYVIOLATION` error and a message indicating the image is unsupported for scanning. Updated the corresponding comment to reflect the new behavior.

#### `src/server/middleware/vulnerable/vulnerable_test.go`

- Updated `TestNonScannerPulling` and `TestArtifactIsNotScannableNotScanned` to expect `HTTP 412 Precondition Failed` instead of `HTTP 200 OK`, matching the new blocking behavior for unsupported artifacts.

# Issues Fixed
Fixes #16218

# Additional Info
I think this PR should be grouped with (merged at the same time as) #23130.
