### PR TITLE
[release-2.11] Escape repository description in artifact info

### DIFF
--- a/src/server/v2.0/handler/repository.go
+++ b/src/server/v2.0/handler/repository.go
@@ -17,6 +17,7 @@ package handler
 import (
 	"context"
 	"fmt"
+	"html/template"
 
 	"github.com/go-openapi/runtime/middleware"
 
@@ -235,7 +236,7 @@ func (r *repositoryAPI) UpdateRepository(ctx context.Context, params operation.U
 	if err := r.repoCtl.Update(ctx, &repomodel.RepoRecord{
 		RepositoryID: repository.RepositoryID,
 		Name:         repository.Name,
-		Description:  params.Repository.Description,
+		Description:  template.HTMLEscapeString(params.Repository.Description),
 	}, "Description"); err != nil {
 		return r.SendError(ctx, err)
 	}


### PR DESCRIPTION
Backport of the public CVE-2025-32019 fix to `release-2.11.0`.

I cherry-picked `76c2c5f7cfd9` from upstream with `git cherry-pick -x`, so the original author and upstream commit reference are preserved. The change touches `src/server/v2.0/handler/repository.go`.

Upstream commit: https://github.com/goharbor/harbor/commit/76c2c5f7cfd9edb356cbb373889a59cc3217a058
CVE reference: https://nvd.nist.gov/vuln/detail/CVE-2025-32019

This applied cleanly on my local checkout of the target branch. I have not run the full project test suite locally.