### PR TITLE
support configurable PIP_INDEX_URL for swagger client build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,14 @@ PIP_INDEX_URL=https://pypi.org/simple
 #   make swagger_client OPENAPI_GENERATOR_CLI_URL=https://...
 #   export OPENAPI_GENERATOR_CLI_URL=https://... ; make swagger_client
 OPENAPI_GENERATOR_CLI_URL ?= https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/4.3.1/openapi-generator-cli-4.3.1.jar
+# Pass PIP_INDEX_URL to pip only when it is defined in the environment:
+#   export PIP_INDEX_URL=https://pypi.org/simple
+#   make swagger_client
+ifdef PIP_INDEX_URL
+PIP_INDEX_URL_ENV = PIP_INDEX_URL=$(PIP_INDEX_URL)
+else
+PIP_INDEX_URL_ENV =
+endif
 BUILDTARGET=build
 GEN_TLS=
 
@@ -582,8 +590,8 @@ swagger_client:
 	rm -rf harborclient
 	mkdir  -p harborclient/harbor_v2_swagger_client
 	java -jar openapi-generator-cli.jar generate -i api/v2.0/swagger.yaml -g python -o harborclient/harbor_v2_swagger_client --package-name v2_swagger_client
-	cd harborclient/harbor_v2_swagger_client; pip install .
-	pip install docker -q
+	cd harborclient/harbor_v2_swagger_client; $(PIP_INDEX_URL_ENV) pip install .
+	$(PIP_INDEX_URL_ENV) pip install docker -q
 	pip freeze
 
 cleanbinary:

--- a/tests/resources/APITest-Util.robot
+++ b/tests/resources/APITest-Util.robot
@@ -3,7 +3,8 @@ ${JFROG_USER}  ${EMPTY}
 ${JFROG_PWD}  ${EMPTY}
 ${JFROG_URL}  ${EMPTY}
 ${JFROG_NAMESPACE}  ${EMPTY}
-${OPENAPI_GENERATOR_CLI_URL_DEFAULT}  https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/4.3.1/openapi-generator-cli-4.3.1.jar
+${OPENAPI_GENERATOR_CLI_URL}  https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/4.3.1/openapi-generator-cli-4.3.1.jar
+${PIP_INDEX_URL}  https://pypi.org/simple
 
 *** Keywords ***
 Make Swagger Client
@@ -11,8 +12,7 @@ Make Swagger Client
     LogAll  ${output}
     ${rc}  ${output}=  Run And Return Rc And Output  pip install -U pip setuptools
     LogAll  ${output}
-    ${openapi_url}=  Get Environment Variable  OPENAPI_GENERATOR_CLI_URL  ${OPENAPI_GENERATOR_CLI_URL_DEFAULT}
-    ${rc}  ${output}=  Run And Return Rc And Output  OPENAPI_GENERATOR_CLI_URL=${openapi_url} make swagger_client
+    ${rc}  ${output}=  Run And Return Rc And Output  OPENAPI_GENERATOR_CLI_URL=${OPENAPI_GENERATOR_CLI_URL} PIP_INDEX_URL=${PIP_INDEX_URL} make swagger_client
     LogAll  ${output}
     [Return]  ${rc}
 

--- a/tests/robot-cases/Group3-Upgrade/prepare.py
+++ b/tests/robot-cases/Group3-Upgrade/prepare.py
@@ -120,10 +120,18 @@ class HarborAPI:
                 USER_ADMIN=dict(endpoint = "https://"+args.endpoint+"/api/v2.0" , username = "admin", password = "Harbor12345")
                 repo = Repository()
                 for _repo in project["repo"]:
-                    pull_image(args.endpoint+"/"+ project["name"]+"/"+_repo["cache_image_namespace"]+"/"+_repo["cache_image"])
-                    time.sleep(180)
+                    get_image(project["name"], _repo["cache_image_namespace"], _repo["cache_image"], _repo.get("tag", "latest"))
                     repo_name = urllib.parse.quote(_repo["cache_image_namespace"]+"/"+_repo["cache_image"],'utf-8')
-                    repo_data = repo.get_repository(project["name"], repo_name, **USER_ADMIN)
+                    # Retry repository lookup every minute for up to 10 minutes total
+                    deadline = time.time() + 600
+                    while True:
+                        try:
+                            repo_data = repo.get_repository(project["name"], repo_name, **USER_ADMIN)
+                            break
+                        except Exception:
+                            if time.time() >= deadline:
+                                raise
+                            time.sleep(60)
             return
         else:
             raise Exception(r"Error: Feature {} has no branch {}.".format(sys._getframe().f_code.co_name, branch))
@@ -637,6 +645,37 @@ def pull_image(*image):
     for i in image:
         print("docker pulling image: ", i)
         os.system("docker pull "+i)
+
+def get_image(project_name, cache_image_namespace, cache_image, tag, timeout=30, retry=10, interval=10):
+    manifest_url = "https://{}/v2/{}/{}/{}/manifests/{}".format(
+        args.endpoint,
+        project_name,
+        cache_image_namespace,
+        cache_image,
+        tag,
+    )
+    headers = {
+        "Accept": "application/vnd.docker.distribution.manifest.v2+json"
+    }
+    last_error = None
+    for attempt in range(retry):
+        try:
+            print("requesting image manifest: ", manifest_url)
+            resp = requests.get(
+                manifest_url,
+                verify=False,
+                auth=("admin", "Harbor12345"),
+                headers=headers,
+                timeout=timeout,
+            )
+            if resp.status_code < 400:
+                return resp
+            last_error = Exception("status code {}: {}".format(resp.status_code, resp.text))
+        except Exception as e:
+            last_error = e
+        if attempt < retry - 1:
+            time.sleep(interval)
+    raise Exception("failed to GET image manifest {} after {} attempts: {}".format(manifest_url, retry, last_error))
 
 def push_image(image, project):
     os.system("docker tag "+image+" "+args.endpoint+"/"+project+"/"+image)

--- a/tests/robot-cases/Group3-Upgrade/run.sh
+++ b/tests/robot-cases/Group3-Upgrade/run.sh
@@ -6,6 +6,6 @@ DOCKER_PWD=$4
 LOCAL_REGISTRY=$5
 LOCAL_REGISTRY_NAMESPACE=$6
 make swagger_client
-robot -v ip:$IP  -v ip1: -v HARBOR_PASSWORD:Harbor12345 -v DOCKER_USER:$DOCKER_USER -v DOCKER_PWD:$DOCKER_PWD -v HARBOR_ADMIN:admin -v http_get_ca:true /drone/tests/robot-cases/Group1-Nightly/Setup.robot
+robot -v ip:$IP  -v ip1: -v HARBOR_PASSWORD:Harbor12345 -v DOCKER_USER:$DOCKER_USER -v DOCKER_PWD:$DOCKER_PWD -v HARBOR_ADMIN:admin -v http_get_ca:true -v OPENAPI_GENERATOR_CLI_URL:$OPENAPI_GENERATOR_CLI_URL -v PIP_INDEX_URL:$PIP_INDEX_URL /drone/tests/robot-cases/Group1-Nightly/Setup.robot
 cd /drone/tests/robot-cases/Group3-Upgrade
 DOCKER_USER=$DOCKER_USER DOCKER_PWD=$DOCKER_PWD  python ./prepare.py -e $IP -v $HARBOR_VERSION -l /drone/tests/apitests/python/ -g $LOCAL_REGISTRY  -p $LOCAL_REGISTRY_NAMESPACE


### PR DESCRIPTION
Pass PIP_INDEX_URL through Makefile (conditional env injection), APITest-Util.robot (robot variable with public PyPI default), and Group3-Upgrade/run.sh (-v forwarding to robot).

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [ ] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [ ] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
