### PR TITLE
[CHERRY-PICK] support configurable PIP_INDEX_URL for swagger client build (#23241)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,14 @@ NPM_REGISTRY=https://registry.npmjs.org
 #   make swagger_client OPENAPI_GENERATOR_CLI_URL=https://...
 #   export OPENAPI_GENERATOR_CLI_URL=https://... ; make swagger_client
 OPENAPI_GENERATOR_CLI_URL ?= https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/4.3.1/openapi-generator-cli-4.3.1.jar
+# Pass PIP_INDEX_URL to pip only when it is defined in the environment:
+#   export PIP_INDEX_URL=https://pypi.org/simple
+#   make swagger_client
+ifdef PIP_INDEX_URL
+PIP_INDEX_URL_ENV = PIP_INDEX_URL=$(PIP_INDEX_URL)
+else
+PIP_INDEX_URL_ENV =
+endif
 BUILDTARGET=build
 GEN_TLS=
 
@@ -559,8 +567,8 @@ swagger_client:
 	rm -rf harborclient
 	mkdir  -p harborclient/harbor_v2_swagger_client
 	java -jar openapi-generator-cli.jar generate -i api/v2.0/swagger.yaml -g python -o harborclient/harbor_v2_swagger_client --package-name v2_swagger_client
-	cd harborclient/harbor_v2_swagger_client; pip install .
-	pip install docker -q
+	cd harborclient/harbor_v2_swagger_client; $(PIP_INDEX_URL_ENV) pip install .
+	$(PIP_INDEX_URL_ENV) pip install docker -q
 	pip freeze
 
 cleanbinary:

--- a/tests/resources/APITest-Util.robot
+++ b/tests/resources/APITest-Util.robot
@@ -1,5 +1,6 @@
 *** Variables ***
-${OPENAPI_GENERATOR_CLI_URL_DEFAULT}  https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/4.3.1/openapi-generator-cli-4.3.1.jar
+${OPENAPI_GENERATOR_CLI_URL}  https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/4.3.1/openapi-generator-cli-4.3.1.jar
+${PIP_INDEX_URL}  https://pypi.org/simple
 
 *** Keywords ***
 Make Swagger Client
@@ -7,8 +8,7 @@ Make Swagger Client
     LogAll  ${output}
     ${rc}  ${output}=  Run And Return Rc And Output  pip install -U pip setuptools
     LogAll  ${output}
-    ${openapi_url}=  Get Environment Variable  OPENAPI_GENERATOR_CLI_URL  ${OPENAPI_GENERATOR_CLI_URL_DEFAULT}
-    ${rc}  ${output}=  Run And Return Rc And Output  OPENAPI_GENERATOR_CLI_URL=${openapi_url} make swagger_client
+    ${rc}  ${output}=  Run And Return Rc And Output  OPENAPI_GENERATOR_CLI_URL=${OPENAPI_GENERATOR_CLI_URL} PIP_INDEX_URL=${PIP_INDEX_URL} make swagger_client
     LogAll  ${output}
     [Return]  ${rc}
 

--- a/tests/robot-cases/Group3-Upgrade/run.sh
+++ b/tests/robot-cases/Group3-Upgrade/run.sh
@@ -6,6 +6,6 @@ DOCKER_PWD=$4
 LOCAL_REGISTRY=$5
 LOCAL_REGISTRY_NAMESPACE=$6
 make swagger_client
-robot -v ip:$IP  -v ip1: -v HARBOR_PASSWORD:Harbor12345 -v DOCKER_USER:$DOCKER_USER -v DOCKER_PWD:$DOCKER_PWD -v HARBOR_ADMIN:admin -v http_get_ca:true /drone/tests/robot-cases/Group1-Nightly/Setup.robot
+robot -v ip:$IP  -v ip1: -v HARBOR_PASSWORD:Harbor12345 -v DOCKER_USER:$DOCKER_USER -v DOCKER_PWD:$DOCKER_PWD -v HARBOR_ADMIN:admin -v http_get_ca:true -v OPENAPI_GENERATOR_CLI_URL:$OPENAPI_GENERATOR_CLI_URL -v PIP_INDEX_URL:$PIP_INDEX_URL /drone/tests/robot-cases/Group1-Nightly/Setup.robot
 cd /drone/tests/robot-cases/Group3-Upgrade
 DOCKER_USER=$DOCKER_USER DOCKER_PWD=$DOCKER_PWD  python ./prepare.py -e $IP -v $HARBOR_VERSION -l /drone/tests/apitests/python/ -g $LOCAL_REGISTRY  -p $LOCAL_REGISTRY_NAMESPACE


### PR DESCRIPTION
Cherry-pick of #23241 to release-2.15.0.

## What

Pass PIP_INDEX_URL through Makefile (conditional env injection), APITest-Util.robot (robot variable with public PyPI default), and Group3-Upgrade/run.sh (-v forwarding to robot).

## Conflict resolution

In `tests/resources/APITest-Util.robot`, the variable was renamed from `${OPENAPI_GENERATOR_CLI_URL_DEFAULT}` to `${OPENAPI_GENERATOR_CLI_URL}` (to match the already-applied keyword section), and `${PIP_INDEX_URL}` was added. JFROG variables were omitted since they are not present in the release-2.15.0 branch.