### PR TITLE
Switch Dockerfile.base FROM to goharbor/photon:5.0

### DIFF
--- a/make/photon/core/Dockerfile.base
+++ b/make/photon/core/Dockerfile.base
@@ -1,4 +1,4 @@
-FROM photon:5.0
+FROM goharbor/photon:5.0
 
 RUN tdnf install -y tzdata shadow >> /dev/null \
     && tdnf clean all \

--- a/make/photon/db/Dockerfile.base
+++ b/make/photon/db/Dockerfile.base
@@ -1,4 +1,4 @@
-FROM photon:5.0
+FROM goharbor/photon:5.0
 
 ENV PGDATA /var/lib/postgresql/data
 

--- a/make/photon/exporter/Dockerfile.base
+++ b/make/photon/exporter/Dockerfile.base
@@ -1,4 +1,4 @@
-FROM photon:5.0
+FROM goharbor/photon:5.0
 
 RUN tdnf install -y tzdata shadow >> /dev/null \
     && tdnf clean all \

--- a/make/photon/jobservice/Dockerfile.base
+++ b/make/photon/jobservice/Dockerfile.base
@@ -1,4 +1,4 @@
-FROM photon:5.0
+FROM goharbor/photon:5.0
 
 RUN tdnf install -y tzdata shadow >> /dev/null \
     && tdnf clean all \

--- a/make/photon/log/Dockerfile.base
+++ b/make/photon/log/Dockerfile.base
@@ -1,4 +1,4 @@
-FROM photon:5.0
+FROM goharbor/photon:5.0
 
 RUN tdnf install -y cronie rsyslog logrotate shadow tar gzip sudo >> /dev/null\
     && mkdir /var/spool/rsyslog \

--- a/make/photon/nginx/Dockerfile.base
+++ b/make/photon/nginx/Dockerfile.base
@@ -1,4 +1,4 @@
-FROM photon:5.0
+FROM goharbor/photon:5.0
 
 RUN tdnf install -y nginx shadow >> /dev/null \
     && tdnf clean all \

--- a/make/photon/portal/Dockerfile.base
+++ b/make/photon/portal/Dockerfile.base
@@ -1,4 +1,4 @@
-FROM photon:5.0
+FROM goharbor/photon:5.0
 
 RUN tdnf install -y nginx shadow >> /dev/null \
     && tdnf clean all \

--- a/make/photon/prepare/Dockerfile.base
+++ b/make/photon/prepare/Dockerfile.base
@@ -1,4 +1,4 @@
-FROM photon:5.0
+FROM goharbor/photon:5.0
 
 RUN tdnf install -y python3 python3-pip python3-PyYAML python3-jinja2 && tdnf clean all
 ARG pip_index_url=https://pypi.org/simple

--- a/make/photon/registry/Dockerfile.base
+++ b/make/photon/registry/Dockerfile.base
@@ -1,4 +1,4 @@
-FROM photon:5.0
+FROM goharbor/photon:5.0
 
 RUN tdnf install -y shadow >> /dev/null \
     && tdnf clean all \

--- a/make/photon/registryctl/Dockerfile.base
+++ b/make/photon/registryctl/Dockerfile.base
@@ -1,4 +1,4 @@
-FROM photon:5.0
+FROM goharbor/photon:5.0
 
 RUN tdnf install -y shadow >> /dev/null \
     && tdnf clean all \

--- a/make/photon/trivy-adapter/Dockerfile.base
+++ b/make/photon/trivy-adapter/Dockerfile.base
@@ -1,4 +1,4 @@
-FROM photon:5.0
+FROM goharbor/photon:5.0
 
 RUN tdnf install -y rpm shadow >> /dev/null \
     && tdnf clean all \

--- a/make/photon/valkey/Dockerfile.base
+++ b/make/photon/valkey/Dockerfile.base
@@ -1,4 +1,4 @@
-FROM photon:5.0
+FROM goharbor/photon:5.0
 
 RUN tdnf install -y shadow >> /dev/null \
     && groupadd -g 999 valkey \


### PR DESCRIPTION
Use the goharbor-namespaced photon:5.0 base image instead of the generic photon:5.0 across all component base Dockerfiles.

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [ ] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [ ] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
