### PR TITLE
(chore): dockerfile base to refresh Photon packages instead of updating photon image

### DIFF
--- a/make/photon/core/Dockerfile.base
+++ b/make/photon/core/Dockerfile.base
@@ -1,6 +1,7 @@
 FROM photon:5.0
 
-RUN tdnf install -y tzdata shadow >> /dev/null \
+RUN tdnf upgrade -y \
+    && tdnf install -y tzdata shadow >> /dev/null \
     && tdnf clean all \
     && groupadd -r -g 10000 harbor && useradd --no-log-init -r -m -g 10000 -u 10000 harbor \
     && mkdir /harbor/

--- a/make/photon/db/Dockerfile.base
+++ b/make/photon/db/Dockerfile.base
@@ -2,7 +2,8 @@ FROM photon:5.0
 
 ENV PGDATA /var/lib/postgresql/data
 
-RUN tdnf install -y shadow >> /dev/null \
+RUN tdnf upgrade -y \
+    && tdnf install -y shadow >> /dev/null \
     && groupadd -r postgres --gid=999 \
     && useradd -m -r -g postgres --uid=999 postgres
 

--- a/make/photon/exporter/Dockerfile.base
+++ b/make/photon/exporter/Dockerfile.base
@@ -1,6 +1,7 @@
 FROM photon:5.0
 
-RUN tdnf install -y tzdata shadow >> /dev/null \
+RUN tdnf upgrade -y \
+    && tdnf install -y tzdata shadow >> /dev/null \
     && tdnf clean all \
     && groupadd -r -g 10000 harbor && useradd --no-log-init -r -m -g 10000 -u 10000 harbor \
     && mkdir /harbor/

--- a/make/photon/jobservice/Dockerfile.base
+++ b/make/photon/jobservice/Dockerfile.base
@@ -1,5 +1,6 @@
 FROM photon:5.0
 
-RUN tdnf install -y tzdata shadow >> /dev/null \
+RUN tdnf upgrade -y \
+    && tdnf install -y tzdata shadow >> /dev/null \
     && tdnf clean all \
     && groupadd -r -g 10000 harbor && useradd --no-log-init -r -m -g 10000 -u 10000 harbor

--- a/make/photon/log/Dockerfile.base
+++ b/make/photon/log/Dockerfile.base
@@ -1,6 +1,7 @@
 FROM photon:5.0
 
-RUN tdnf install -y cronie rsyslog logrotate shadow tar gzip sudo >> /dev/null\
+RUN tdnf upgrade -y \
+    && tdnf install -y cronie rsyslog logrotate shadow tar gzip sudo >> /dev/null\
     && mkdir /var/spool/rsyslog \
     && groupadd -r -g 10000 syslog && useradd --no-log-init -r -g 10000 -u 10000 syslog \
     && tdnf clean all \

--- a/make/photon/nginx/Dockerfile.base
+++ b/make/photon/nginx/Dockerfile.base
@@ -1,6 +1,7 @@
 FROM photon:5.0
 
-RUN tdnf install -y nginx shadow >> /dev/null \
+RUN tdnf upgrade -y \
+    && tdnf install -y nginx shadow >> /dev/null \
     && tdnf clean all \
     && groupmod -g 10000 nginx && usermod -g 10000 -u 10000 -d /home/nginx -s /bin/bash nginx \
     && ln -sf /dev/stdout /var/log/nginx/access.log \

--- a/make/photon/portal/Dockerfile.base
+++ b/make/photon/portal/Dockerfile.base
@@ -1,6 +1,7 @@
 FROM photon:5.0
 
-RUN tdnf install -y nginx shadow >> /dev/null \
+RUN tdnf upgrade -y \
+    && tdnf install -y nginx shadow >> /dev/null \
     && tdnf clean all \
     && ln -sf /dev/stdout /var/log/nginx/access.log \
     && ln -sf /dev/stderr /var/log/nginx/error.log \

--- a/make/photon/prepare/Dockerfile.base
+++ b/make/photon/prepare/Dockerfile.base
@@ -1,6 +1,7 @@
 FROM photon:5.0
 
-RUN tdnf install -y python3 python3-pip python3-PyYAML python3-jinja2 && tdnf clean all
+RUN tdnf upgrade -y \
+    && tdnf install -y python3 python3-pip python3-PyYAML python3-jinja2 && tdnf clean all
 ARG pip_index_url=https://pypi.org/simple
 RUN pip3 install pipenv==2025.0.3 --index-url ${pip_index_url}
 

--- a/make/photon/registry/Dockerfile.base
+++ b/make/photon/registry/Dockerfile.base
@@ -1,6 +1,7 @@
 FROM photon:5.0
 
-RUN tdnf install -y shadow >> /dev/null \
+RUN tdnf upgrade -y \
+    && tdnf install -y shadow >> /dev/null \
     && tdnf clean all \
     && mkdir -p /etc/registry \
     && groupadd -r -g 10000 harbor && useradd --no-log-init -m -g 10000 -u 10000 harbor

--- a/make/photon/registryctl/Dockerfile.base
+++ b/make/photon/registryctl/Dockerfile.base
@@ -1,6 +1,7 @@
 FROM photon:5.0
 
-RUN tdnf install -y shadow >> /dev/null \
+RUN tdnf upgrade -y \
+    && tdnf install -y shadow >> /dev/null \
     && tdnf clean all \
     && groupadd -r -g 10000 harbor && useradd --no-log-init -m -g 10000 -u 10000 harbor \
     && mkdir -p /etc/registry

--- a/make/photon/trivy-adapter/Dockerfile.base
+++ b/make/photon/trivy-adapter/Dockerfile.base
@@ -1,6 +1,7 @@
 FROM photon:5.0
 
-RUN tdnf install -y rpm shadow >> /dev/null \
+RUN tdnf upgrade -y \
+    && tdnf install -y rpm shadow >> /dev/null \
     && tdnf clean all \
     && groupadd -r -g 10000 scanner \
     && useradd --no-log-init -m -r -g 10000 -u 10000 scanner

--- a/make/photon/valkey/Dockerfile.base
+++ b/make/photon/valkey/Dockerfile.base
@@ -1,6 +1,7 @@
 FROM photon:5.0
 
-RUN tdnf install -y shadow >> /dev/null \
+RUN tdnf upgrade -y \
+    && tdnf install -y shadow >> /dev/null \
     && groupadd -g 999 valkey \
     && useradd -u 999 -g 999 -c "Valkey Database Server" -d /var/lib/redis -s /sbin/nologin -m valkey
 RUN tdnf install -y valkey && tdnf clean all


### PR DESCRIPTION
Thank you for contributing to Harbor!
(welcome)

# Comprehensive Summary of your change

pr to use tdnf to update the packages on its own instead of pulling latest photon image to get  latest packages that include CVE fixes.

(my braindump is [here](https://github.com/1Shubham7/braindump/blob/main/22942.md) )

# Issue being fixed
Fixes #https://github.com/goharbor/harbor/issues/22942

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation" (i dont have perms)
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
