### PR TITLE
(chore): audit log trace for project visiblity update (public/private)

### DIFF
--- a/src/controller/event/handler/auditlog/auditlog.go
+++ b/src/controller/event/handler/auditlog/auditlog.go
@@ -45,7 +45,8 @@ func (h *Handler) Handle(ctx context.Context, value any) error {
 	var addAuditLog bool
 	switch v := value.(type) {
 	case *event.PushArtifactEvent, *event.DeleteArtifactEvent,
-		*event.DeleteRepositoryEvent, *event.CreateProjectEvent, *event.DeleteProjectEvent,
+		*event.DeleteRepositoryEvent,
+		*event.CreateProjectEvent, *event.DeleteProjectEvent, *event.UpdateProjectEvent,
 		*event.DeleteTagEvent, *event.CreateTagEvent,
 		*event.CreateRobotEvent, *event.DeleteRobotEvent, *evtModel.CommonEvent:
 		addAuditLog = true

--- a/src/controller/event/handler/init.go
+++ b/src/controller/event/handler/init.go
@@ -62,6 +62,7 @@ func init() {
 	_ = notifier.Subscribe(event.TopicDeleteArtifact, &auditlog.Handler{})
 	_ = notifier.Subscribe(event.TopicCreateProject, &auditlog.Handler{})
 	_ = notifier.Subscribe(event.TopicDeleteProject, &auditlog.Handler{})
+	_ = notifier.Subscribe(event.TopicUpdateProject, &auditlog.Handler{})
 	_ = notifier.Subscribe(event.TopicDeleteRepository, &auditlog.Handler{})
 	_ = notifier.Subscribe(event.TopicCreateTag, &auditlog.Handler{})
 	_ = notifier.Subscribe(event.TopicDeleteTag, &auditlog.Handler{})

--- a/src/controller/event/metadata/project.go
+++ b/src/controller/event/metadata/project.go
@@ -17,7 +17,7 @@ package metadata
 import (
 	"time"
 
-	event2 "github.com/goharbor/harbor/src/controller/event"
+	controllerevent "github.com/goharbor/harbor/src/controller/event"
 	"github.com/goharbor/harbor/src/pkg/notifier/event"
 )
 
@@ -30,9 +30,9 @@ type CreateProjectEventMetadata struct {
 
 // Resolve to the event from the metadata
 func (c *CreateProjectEventMetadata) Resolve(event *event.Event) error {
-	event.Topic = event2.TopicCreateProject
-	event.Data = &event2.CreateProjectEvent{
-		EventType: event2.TopicCreateProject,
+	event.Topic = controllerevent.TopicCreateProject
+	event.Data = &controllerevent.CreateProjectEvent{
+		EventType: controllerevent.TopicCreateProject,
 		ProjectID: c.ProjectID,
 		Project:   c.Project,
 		Operator:  c.Operator,
@@ -50,13 +50,35 @@ type DeleteProjectEventMetadata struct {
 
 // Resolve to the event from the metadata
 func (d *DeleteProjectEventMetadata) Resolve(event *event.Event) error {
-	event.Topic = event2.TopicDeleteProject
-	event.Data = &event2.DeleteProjectEvent{
-		EventType: event2.TopicDeleteProject,
+	event.Topic = controllerevent.TopicDeleteProject
+	event.Data = &controllerevent.DeleteProjectEvent{
+		EventType: controllerevent.TopicDeleteProject,
 		ProjectID: d.ProjectID,
 		Project:   d.Project,
 		Operator:  d.Operator,
 		OccurAt:   time.Now(),
+	}
+	return nil
+}
+
+// UpdateProjectEventMetadata is the metadata from which the update project visibility event can be resolved
+type UpdateProjectEventMetadata struct {
+	ProjectID int64
+	Project   string
+	Operator  string
+	IsPublic  bool
+}
+
+// Resolve to the event from the metadata
+func (u *UpdateProjectEventMetadata) Resolve(event *event.Event) error {
+	event.Topic = controllerevent.TopicUpdateProject
+	event.Data = &controllerevent.UpdateProjectEvent{
+		EventType: controllerevent.TopicUpdateProject,
+		ProjectID: u.ProjectID,
+		Project:   u.Project,
+		Operator:  u.Operator,
+		OccurAt:   time.Now(),
+		IsPublic:  u.IsPublic,
 	}
 	return nil
 }

--- a/src/controller/event/topic.go
+++ b/src/controller/event/topic.go
@@ -33,6 +33,7 @@ import (
 const (
 	TopicCreateProject     = "CREATE_PROJECT"
 	TopicDeleteProject     = "DELETE_PROJECT"
+	TopicUpdateProject     = "UPDATE_PROJECT"
 	TopicPushArtifact      = "PUSH_ARTIFACT"
 	TopicPullArtifact      = "PULL_ARTIFACT"
 	TopicDeleteArtifact    = "DELETE_ARTIFACT"
@@ -112,6 +113,41 @@ func (d *DeleteProjectEvent) ResolveToAuditLog() (*model.AuditLogExt, error) {
 func (d *DeleteProjectEvent) String() string {
 	return fmt.Sprintf("ID-%d Name-%s Operator-%s OccurAt-%s",
 		d.ProjectID, d.Project, d.Operator, d.OccurAt.Format("2006-01-02 15:04:05"))
+}
+
+// UpdateProjectEvent is the updating project public/private visibility event
+type UpdateProjectEvent struct {
+	EventType string
+	ProjectID int64
+	Project   string
+	Operator  string
+	OccurAt   time.Time
+	IsPublic  bool
+}
+
+// ResolveToAuditLog ...
+func (u *UpdateProjectEvent) ResolveToAuditLog() (*model.AuditLogExt, error) {
+	visibility := "private"
+	if u.IsPublic {
+		visibility = "public"
+	}
+
+	auditLog := &model.AuditLogExt{
+		ProjectID:            u.ProjectID,
+		OpTime:               u.OccurAt,
+		Operation:            rbac.ActionUpdate.String(),
+		Username:             u.Operator,
+		ResourceType:         ResourceTypeProject,
+		IsSuccessful:         true,
+		OperationDescription: fmt.Sprintf("update project %s: set access level to %s", u.Project, visibility),
+		Resource:             u.Project,
+	}
+	return auditLog, nil
+}
+
+func (u *UpdateProjectEvent) String() string {
+	return fmt.Sprintf("ID-%d Name-%s Operator-%s OccurAt-%s",
+		u.ProjectID, u.Project, u.Operator, u.OccurAt.Format("2006-01-02 15:04:05"))
 }
 
 // DeleteRepositoryEvent is the deleting repository event

--- a/src/controller/project/controller.go
+++ b/src/controller/project/controller.go
@@ -207,6 +207,7 @@ func (c *controller) Update(ctx context.Context, p *models.Project) error {
 	// the SQL executed in the allowlist manager will not be in the transaction with metadata manager,
 	// we will update the metadata of the project first so that we can be rollback the operations for the metadata
 	// when set allowlist for the project failed
+	var oldPublic string
 	if len(p.Metadata) > 0 {
 		meta, err := c.metaMgr.Get(ctx, p.ProjectID)
 		if err != nil {
@@ -215,6 +216,7 @@ func (c *controller) Update(ctx context.Context, p *models.Project) error {
 		if meta == nil {
 			meta = map[string]string{}
 		}
+		oldPublic = meta[models.ProMetaPublic]
 
 		metaNeedUpdated := map[string]string{}
 		metaNeedCreated := map[string]string{}
@@ -238,6 +240,16 @@ func (c *controller) Update(ctx context.Context, p *models.Project) error {
 		if err := c.allowlistMgr.Set(ctx, p.ProjectID, p.CVEAllowlist); err != nil {
 			return err
 		}
+	}
+
+	// fire event when public/private visibility changed
+	if newPublic, ok := p.Metadata[models.ProMetaPublic]; ok && newPublic != oldPublic {
+		notification.AddEvent(ctx, &event.UpdateProjectEventMetadata{
+			ProjectID: p.ProjectID,
+			Project:   p.Name,
+			Operator:  operator.FromContext(ctx),
+			IsPublic:  newPublic == "true",
+		})
 	}
 
 	return nil

--- a/src/pkg/auditext/event/login/login.go
+++ b/src/pkg/auditext/event/login/login.go
@@ -42,7 +42,6 @@ func init() {
 const (
 	opLogout       = "logout"
 	opLogin        = "login"
-	logoutSuffix   = "log_out"
 	payloadPattern = `principal=(.*?)&password`
 )
 


### PR DESCRIPTION
Thank you for contributing to Harbor!

# Comprehensive Summary of your change

this pr adds audit logs for the case when someone changes the project visibility (public -> private, vice versa)

braindump: https://github.com/1Shubham7/braindump/blob/main/harbor/23161.md

tested it out locally:
created new proj
<img width="1548" height="553" alt="image" src="https://github.com/user-attachments/assets/48a508ee-8c1f-4ca3-ba12-20c4fba91834" />

made it private 
<img width="1548" height="553" alt="image" src="https://github.com/user-attachments/assets/88b3ac8e-3254-4dff-bf65-53b1414d6e88" />

and I do see audit logs for setting a proj private -> public and public -> private
<img width="1548" height="553" alt="image" src="https://github.com/user-attachments/assets/826cb2e7-c98a-4999-8e0c-30daf36e18ff" />

then I updated other configurations in project:
<img width="1548" height="553" alt="image" src="https://github.com/user-attachments/assets/79a45e39-ed33-45fa-b4e6-8f740367e157" />

it doesnt show up in audit logs as expected.
<img width="1548" height="553" alt="image" src="https://github.com/user-attachments/assets/b6b24f09-c09c-45ef-ac55-c04e60cd6230" />



# Issue being fixed
Fixes #https://github.com/goharbor/harbor/issues/23161

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
