### PR TITLE
[cherry-pick] Rebuild goharbor/photon image before create new harbor base images

### DIFF
--- a/.buildbaselog
+++ b/.buildbaselog
@@ -8,6 +8,9 @@
 *   Add date here... Add signature here...
 -   Add your reason here...
 
+*   May 18 2026 <aaron.an@broadcom.com>
+-   Refresh base image
+
 *   Apr 21 2026 <stone.zhang@broadcom.com>
 -   Refresh base image
 

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -46,6 +46,9 @@ jobs:
             github.ref == 'refs/heads/main'
         run: |
           set -x
+          echo "${{ secrets.DOCKER_HUB_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_HUB_USERNAME }}" --password-stdin
+          docker build -f make/photon/common/Dockerfile -t goharbor/photon:5.0 .
+          docker push goharbor/photon:5.0
           echo "BUILD_BASE=true" >> $GITHUB_ENV
       - name: Build Package
         run: |

--- a/make/photon/common/Dockerfile
+++ b/make/photon/common/Dockerfile
@@ -1,0 +1,14 @@
+FROM photon:5.0
+
+# 1. Install photon-repos package
+RUN tdnf install photon-repos -y
+
+# 2. Enable photon-snapshot repo
+RUN sed -i 's/enabled\s*=.*/enabled=0/g' /etc/yum.repos.d/*.repo
+RUN sed -i 's/enabled\s*=.*/enabled=1/g' /etc/yum.repos.d/photon-snapshot.repo && tdnf clean all
+
+# 2. Use tdnf to disable all default repos, enable only the snapshot, and update/install
+# The --disablerepo="*" flag turns off the mainline public repos
+# The --enablerepo="photon-snapshot" flag explicitly targets your template
+RUN tdnf --disablerepo="*" --enablerepo="photon-snapshot" makecache \
+    && tdnf --disablerepo="*" --enablerepo="photon-snapshot" update -y


### PR DESCRIPTION
Thank you for contributing to Harbor!

# Comprehensive Summary of your change
Motivation:
Currently, the goharbor/photon:5.0 image relies on a fixed snapshot from the photon 91 branch. Keeping this updated requires manual intervention—such as modifying the Dockerfile or running scheduled refreshes—which adds unnecessary maintenance overhead.

What this PR does:
This PR updates the build process to leverage the Photon team's new branching strategy by using the photon-snapshot repository as the source.

Impact:
Whenever we create new Harbor base images, the build will automatically pull the latest upstream changes (whether the Photon team releases a new snapshot or cuts a new branch). This eliminates the need for manual updates and ensures our base images are consistently up-to-date.

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [ ] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [ ] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
