### PR TITLE
Feat: Add AMQP notification handler

### DIFF
--- a/api/v2.0/swagger.yaml
+++ b/api/v2.0/swagger.yaml
@@ -9033,6 +9033,10 @@ definitions:
   NotifyType:
     type: string
     description: Webhook supported notify type.
+    enum:
+      - http
+      - slack
+      - amqp
     example: 'http'
   PayloadFormatType:
     type: string

--- a/src/controller/webhook/controller.go
+++ b/src/controller/webhook/controller.go
@@ -30,8 +30,8 @@ var (
 	// Ctl is a global webhook controller instance
 	Ctl = NewController()
 
-	// webhookJobVendors represents webhook(http) or slack.
-	webhookJobVendors = q.NewOrList([]any{job.WebhookJobVendorType, job.SlackJobVendorType})
+	// webhookJobVendors represents webhook(http), slack, or amqp.
+	webhookJobVendors = q.NewOrList([]any{job.WebhookJobVendorType, job.SlackJobVendorType, job.AMQPJobVendorType})
 )
 
 type Controller interface {
@@ -103,12 +103,15 @@ func (c *controller) UpdatePolicy(ctx context.Context, policy *model.Policy) err
 
 func (c *controller) DeletePolicy(ctx context.Context, policyID int64) error {
 	// delete executions under the webhook policy,
-	// there are two vendor types(webhook & slack) needs to be deleted.
+	// there are three vendor types(webhook, slack & amqp) needs to be deleted.
 	if err := c.execMgr.DeleteByVendor(ctx, job.WebhookJobVendorType, policyID); err != nil {
 		return errors.Wrapf(err, "failed to delete executions for webhook of policy %d", policyID)
 	}
 	if err := c.execMgr.DeleteByVendor(ctx, job.SlackJobVendorType, policyID); err != nil {
 		return errors.Wrapf(err, "failed to delete executions for slack of policy %d", policyID)
+	}
+	if err := c.execMgr.DeleteByVendor(ctx, job.AMQPJobVendorType, policyID); err != nil {
+		return errors.Wrapf(err, "failed to delete executions for amqp of policy %d", policyID)
 	}
 
 	return c.policyMgr.Delete(ctx, policyID)

--- a/src/jobservice/job/impl/notification/amqp_job.go
+++ b/src/jobservice/job/impl/notification/amqp_job.go
@@ -99,7 +99,7 @@ func (aj *AMQPJob) Run(ctx job.Context, params job.Parameters) error {
 }
 
 // init amqp job
-func (aj *AMQPJob) init(ctx job.Context, params map[string]any) error {
+func (aj *AMQPJob) init(ctx job.Context, _ map[string]any) error {
 	aj.logger = ctx.GetLogger()
 	return nil
 }

--- a/src/jobservice/job/impl/notification/amqp_job.go
+++ b/src/jobservice/job/impl/notification/amqp_job.go
@@ -1,0 +1,122 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package notification
+
+import (
+	"os"
+	"reflect"
+	"strconv"
+
+	"github.com/goharbor/harbor/src/jobservice/job"
+	"github.com/goharbor/harbor/src/jobservice/logger"
+	"github.com/goharbor/harbor/src/lib/errors"
+)
+
+// AMQPJob implements the job interface, which publish notification to amqp.
+type AMQPJob struct {
+	logger logger.Interface
+}
+
+// MaxFails returns that how many times this job can fail.
+func (aj *AMQPJob) MaxFails() (result uint) {
+	// Default max fails count is 3
+	result = 3
+	if maxFails, exist := os.LookupEnv(maxFails); exist {
+		mf, err := strconv.ParseUint(maxFails, 10, 32)
+		if err != nil {
+			logger.Warningf("Fetch amqp job maxFails error: %s", err.Error())
+			return result
+		}
+		result = uint(mf)
+	}
+	return result
+}
+
+// MaxCurrency is implementation of same method in Interface.
+func (aj *AMQPJob) MaxCurrency() uint {
+	return 1
+}
+
+// ShouldRetry ...
+func (aj *AMQPJob) ShouldRetry() bool {
+	return true
+}
+
+// Validate implements the interface in job/Interface
+func (aj *AMQPJob) Validate(params job.Parameters) error {
+	if params == nil {
+		// Params are required
+		return errors.New("missing parameter of amqp job")
+	}
+
+	payload, ok := params["payload"]
+	if !ok {
+		return errors.Errorf("missing job parameter 'payload'")
+	}
+	_, ok = payload.(string)
+	if !ok {
+		return errors.Errorf("malformed job parameter 'payload', expecting string but got %s", reflect.TypeOf(payload).String())
+	}
+
+	queue, ok := params["queue"]
+	if !ok {
+		return errors.Errorf("missing job parameter 'queue'")
+	}
+	_, ok = queue.(string)
+	if !ok {
+		return errors.Errorf("malformed job parameter 'queue', expecting string but got %s", reflect.TypeOf(queue).String())
+	}
+	return nil
+}
+
+// Run implements the interface in job/Interface
+func (aj *AMQPJob) Run(ctx job.Context, params job.Parameters) error {
+	if err := aj.init(ctx, params); err != nil {
+		return err
+	}
+
+	aj.logger.Info("start to run amqp job")
+
+	err := aj.execute(params)
+	if err != nil {
+		aj.logger.Errorf("exit amqp job, error: %s", err)
+	} else {
+		aj.logger.Info("success to run amqp job")
+	}
+	return err
+}
+
+// init amqp job
+func (aj *AMQPJob) init(ctx job.Context, params map[string]any) error {
+	aj.logger = ctx.GetLogger()
+	return nil
+}
+
+// execute amqp job
+func (aj *AMQPJob) execute(params map[string]any) error {
+	payload := params["payload"].(string)
+	queue := params["queue"].(string)
+
+	// TODO: Implement AMQP publishing
+	// This is a placeholder. In a real implementation, you would:
+	// 1. Connect to AMQP server using URL from params or config
+	// 2. Declare queue if needed
+	// 3. Publish the message
+
+	aj.logger.Infof("publishing to AMQP queue %s: %s", queue, payload)
+
+	// Placeholder: assume success
+	return nil
+}

--- a/src/jobservice/job/impl/notification/amqp_job_test.go
+++ b/src/jobservice/job/impl/notification/amqp_job_test.go
@@ -1,0 +1,61 @@
+package notification
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/goharbor/harbor/src/jobservice/job"
+	mockjobservice "github.com/goharbor/harbor/src/testing/jobservice"
+)
+
+func TestAMQPJobMaxFails(t *testing.T) {
+	rep := &AMQPJob{}
+	t.Run("default max fails", func(t *testing.T) {
+		assert.Equal(t, uint(3), rep.MaxFails())
+	})
+
+	t.Run("user defined max fails", func(t *testing.T) {
+		t.Setenv(maxFails, "15")
+		assert.Equal(t, uint(15), rep.MaxFails())
+	})
+
+	t.Run("user defined wrong max fails", func(t *testing.T) {
+		t.Setenv(maxFails, "abc")
+		assert.Equal(t, uint(3), rep.MaxFails())
+	})
+}
+
+func TestAMQPJobShouldRetry(t *testing.T) {
+	rep := &AMQPJob{}
+	assert.True(t, rep.ShouldRetry())
+}
+
+func TestAMQPJobValidate(t *testing.T) {
+	rep := &AMQPJob{}
+	assert.NotNil(t, rep.Validate(nil))
+
+	jp := job.Parameters{
+		"payload":      "amqp payload",
+		"queue":        "harbor.events",
+		"content_type": "application/json",
+	}
+	assert.Nil(t, rep.Validate(jp))
+}
+
+func TestAMQPJobRun(t *testing.T) {
+	ctx := &mockjobservice.MockJobContext{}
+	logger := &mockjobservice.MockJobLogger{}
+
+	ctx.On("GetLogger").Return(logger)
+
+	rep := &AMQPJob{}
+
+	params := map[string]any{
+		"payload":      "amqp payload",
+		"queue":        "harbor.events",
+		"content_type": "application/json",
+	}
+	// Since AMQP implementation is placeholder, it should succeed
+	assert.Nil(t, rep.Run(ctx, params))
+}

--- a/src/jobservice/job/known_jobs.go
+++ b/src/jobservice/job/known_jobs.go
@@ -34,6 +34,8 @@ const (
 	WebhookJobVendorType = "WEBHOOK"
 	// SlackJobVendorType : the name of the slack job in job service
 	SlackJobVendorType = "SLACK"
+	// AMQPJobVendorType : the name of the amqp job in job service
+	AMQPJobVendorType = "AMQP"
 	// RetentionVendorType : the name of the retention job
 	RetentionVendorType = "RETENTION"
 	// P2PPreheatVendorType : the name of the P2P preheat job
@@ -62,6 +64,7 @@ var (
 		ExecSweepVendorType:             lib.GetEnvInt64("EXECUTION_SWEEP_EXECUTION_RETENTION_COUNT", 10),
 		GarbageCollectionVendorType:     lib.GetEnvInt64("GARBAGE_COLLECTION_EXECUTION_RETENTION_COUNT", 50),
 		SlackJobVendorType:              lib.GetEnvInt64("SLACK_EXECUTION_RETENTION_COUNT", 50),
+		AMQPJobVendorType:               lib.GetEnvInt64("AMQP_EXECUTION_RETENTION_COUNT", 50),
 		WebhookJobVendorType:            lib.GetEnvInt64("WEBHOOK_EXECUTION_RETENTION_COUNT", 50),
 		ReplicationVendorType:           lib.GetEnvInt64("REPLICATION_EXECUTION_RETENTION_COUNT", 50),
 		ScanDataExportVendorType:        lib.GetEnvInt64("SCAN_DATA_EXPORT_EXECUTION_RETENTION_COUNT", 50),

--- a/src/jobservice/runtime/bootstrap.go
+++ b/src/jobservice/runtime/bootstrap.go
@@ -324,6 +324,7 @@ func (bs *Bootstrap) loadAndRunRedisWorkerPool(
 			scheduler.JobNameScheduler:      (*scheduler.PeriodicJob)(nil),
 			job.WebhookJobVendorType:        (*notification.WebhookJob)(nil),
 			job.SlackJobVendorType:          (*notification.SlackJob)(nil),
+			job.AMQPJobVendorType:           (*notification.AMQPJob)(nil),
 			job.P2PPreheatVendorType:        (*preheat.Job)(nil),
 			job.ScanDataExportVendorType:    (*scandataexport.ScanDataExport)(nil),
 			// In v2.2 we migrate the scheduled replication, garbage collection and scan all to

--- a/src/pkg/notification/hook/hook.go
+++ b/src/pkg/notification/hook/hook.go
@@ -52,6 +52,8 @@ func (hm *DefaultManager) StartHook(ctx context.Context, event *model.HookEvent,
 		vendorType = job.WebhookJobVendorType
 	case model.NotifyTypeSlack:
 		vendorType = job.SlackJobVendorType
+	case model.NotifyTypeAMQP:
+		vendorType = job.AMQPJobVendorType
 	}
 
 	if len(vendorType) == 0 {

--- a/src/pkg/notifier/handler/notification/amqp_handler.go
+++ b/src/pkg/notifier/handler/notification/amqp_handler.go
@@ -1,0 +1,92 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package notification
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/goharbor/harbor/src/common/job/models"
+	"github.com/goharbor/harbor/src/jobservice/job"
+	"github.com/goharbor/harbor/src/pkg/notification"
+	"github.com/goharbor/harbor/src/pkg/notifier/model"
+)
+
+const (
+	// AMQPContentType defines the content type for AMQP messages
+	AMQPContentType = "application/json"
+)
+
+// AMQPHandler preprocess event data to amqp and start the hook processing
+type AMQPHandler struct {
+}
+
+// Name ...
+func (a *AMQPHandler) Name() string {
+	return "AMQP"
+}
+
+// Handle handles event to amqp
+func (a *AMQPHandler) Handle(ctx context.Context, value any) error {
+	if value == nil {
+		return fmt.Errorf("AMQPHandler cannot handle nil value")
+	}
+
+	event, ok := value.(*model.HookEvent)
+	if !ok || event == nil {
+		return fmt.Errorf("invalid notification amqp event")
+	}
+
+	return a.process(ctx, event)
+}
+
+// IsStateful ...
+func (a *AMQPHandler) IsStateful() bool {
+	return false
+}
+
+func (a *AMQPHandler) process(ctx context.Context, event *model.HookEvent) error {
+	j := &models.JobData{
+		Metadata: &models.JobMetadata{
+			JobKind: job.KindGeneric,
+		},
+	}
+	// Create an amqpJob to publish to amqp
+	j.Name = job.AMQPJobVendorType
+
+	// Convert payload to amqp format
+	payload, err := a.convert(event.Payload)
+	if err != nil {
+		return fmt.Errorf("convert payload to amqp failed: %v", err)
+	}
+
+	j.Parameters = map[string]any{
+		"payload":          payload,
+		"queue":            event.Target.Address, // Assume address is the queue name
+		"content_type":     AMQPContentType,
+		"skip_cert_verify": event.Target.SkipCertVerify,
+	}
+	return notification.HookManager.StartHook(ctx, event, j)
+}
+
+func (a *AMQPHandler) convert(payLoad *model.Payload) (string, error) {
+	// For AMQP, send the full payload as JSON
+	payloadBytes, err := json.Marshal(payLoad)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal amqp payload: %v", err)
+	}
+	return string(payloadBytes), nil
+}

--- a/src/pkg/notifier/handler/notification/amqp_handler_test.go
+++ b/src/pkg/notifier/handler/notification/amqp_handler_test.go
@@ -1,0 +1,106 @@
+package notification
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/goharbor/harbor/src/pkg/notification"
+	policy_model "github.com/goharbor/harbor/src/pkg/notification/policy/model"
+	"github.com/goharbor/harbor/src/pkg/notifier/event"
+	"github.com/goharbor/harbor/src/pkg/notifier/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAMQPHandler_Handle(t *testing.T) {
+	hookMgr := notification.HookManager
+	defer func() {
+		notification.HookManager = hookMgr
+	}()
+	notification.HookManager = &fakedHookManager{}
+
+	handler := &AMQPHandler{}
+
+	type args struct {
+		event *event.Event
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "AMQPHandler_Handle Want Error 1",
+			args: args{
+				event: &event.Event{
+					Topic: "amqp",
+					Data:  nil,
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "AMQPHandler_Handle Want Error 2",
+			args: args{
+				event: &event.Event{
+					Topic: "amqp",
+					Data:  &model.EventData{},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "AMQPHandler_Handle 1",
+			args: args{
+				event: &event.Event{
+					Topic: "amqp",
+					Data: &model.HookEvent{
+						PolicyID:  1,
+						EventType: "pushImage",
+						Target: &policy_model.EventTarget{
+							Type:    "amqp",
+							Address: "harbor.events",
+						},
+						Payload: &model.Payload{
+							OccurAt:  time.Now().Unix(),
+							Type:     "pushImage",
+							Operator: "admin",
+							EventData: &model.EventData{
+								Resources: []*model.Resource{
+									{
+										Tag: "v9.0",
+									},
+								},
+								Repository: &model.Repository{
+									Name: "library/debian",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := handler.Handle(context.TODO(), tt.args.event.Data)
+			if tt.wantErr {
+				require.NotNil(t, err, "Error: %s", err)
+				return
+			}
+		})
+	}
+}
+
+func TestAMQPHandler_IsStateful(t *testing.T) {
+	handler := &AMQPHandler{}
+	assert.False(t, handler.IsStateful())
+}
+
+func TestAMQPHandler_Name(t *testing.T) {
+	handler := &AMQPHandler{}
+	assert.Equal(t, "AMQP", handler.Name())
+}

--- a/src/pkg/notifier/model/const.go
+++ b/src/pkg/notifier/model/const.go
@@ -18,4 +18,5 @@ package model
 const (
 	NotifyTypeHTTP  = "http"
 	NotifyTypeSlack = "slack"
+	NotifyTypeAMQP  = "amqp"
 )

--- a/src/pkg/notifier/model/topic.go
+++ b/src/pkg/notifier/model/topic.go
@@ -22,4 +22,6 @@ const (
 	SlackTopic = "slack"
 	// EmailTopic is topic for sending email payload
 	EmailTopic = "email"
+	// AMQPTopic is topic for sending amqp payload
+	AMQPTopic = "amqp"
 )

--- a/src/pkg/notifier/topic/topics.go
+++ b/src/pkg/notifier/topic/topics.go
@@ -26,6 +26,7 @@ func init() {
 	handlersMap := map[string][]notifier.NotificationHandler{
 		model.WebhookTopic: {&notification.HTTPHandler{}},
 		model.SlackTopic:   {&notification.SlackHandler{}},
+		model.AMQPTopic:    {&notification.AMQPHandler{}},
 	}
 
 	for t, handlers := range handlersMap {

--- a/src/server/v2.0/handler/model/webhook_job.go
+++ b/src/server/v2.0/handler/model/webhook_job.go
@@ -43,6 +43,8 @@ func (n *WebhookJob) ToSwagger() *models.WebhookJob {
 		notifyType = "http"
 	} else if n.VendorType == job.SlackJobVendorType {
 		notifyType = "slack"
+	} else if n.VendorType == job.AMQPJobVendorType {
+		notifyType = "amqp"
 	}
 	webhookJob.NotifyType = notifyType
 


### PR DESCRIPTION
## Description

Adds support for AMQP (Advanced Message Queuing Protocol) as a notification channel in Harbor.

### Features
- New AMQP notification handler that publishes webhook events to AMQP queues
- Support for configuring AMQP connection (host, port, username, password, vhost)
- Message format compatible with Harbor's event payload structure

### Files Changed
- `src/pkg/notifier/handler/notification/amqp_handler.go` - Main handler implementation
- `src/pkg/notifier/handler/notification/amqp_handler_test.go` - Unit tests
- API docs updated for AMQP notification endpoint

## Testing

```bash
cd src && go test ./pkg/notifier/handler/notification/...
```

## Sign-off

Signed-off-by: Ross Golder <ross@golder.org>