### PR TITLE
Feat: Add Email notification handler

### DIFF
--- a/api/v2.0/swagger.yaml
+++ b/api/v2.0/swagger.yaml
@@ -9033,6 +9033,10 @@ definitions:
   NotifyType:
     type: string
     description: Webhook supported notify type.
+    enum:
+      - http
+      - slack
+      - email
     example: 'http'
   PayloadFormatType:
     type: string

--- a/src/controller/webhook/controller.go
+++ b/src/controller/webhook/controller.go
@@ -30,8 +30,8 @@ var (
 	// Ctl is a global webhook controller instance
 	Ctl = NewController()
 
-	// webhookJobVendors represents webhook(http) or slack.
-	webhookJobVendors = q.NewOrList([]any{job.WebhookJobVendorType, job.SlackJobVendorType})
+	// webhookJobVendors represents webhook(http), slack, or email.
+	webhookJobVendors = q.NewOrList([]any{job.WebhookJobVendorType, job.SlackJobVendorType, job.EmailJobVendorType})
 )
 
 type Controller interface {
@@ -103,12 +103,15 @@ func (c *controller) UpdatePolicy(ctx context.Context, policy *model.Policy) err
 
 func (c *controller) DeletePolicy(ctx context.Context, policyID int64) error {
 	// delete executions under the webhook policy,
-	// there are two vendor types(webhook & slack) needs to be deleted.
+	// there are three vendor types(webhook, slack & email) needs to be deleted.
 	if err := c.execMgr.DeleteByVendor(ctx, job.WebhookJobVendorType, policyID); err != nil {
 		return errors.Wrapf(err, "failed to delete executions for webhook of policy %d", policyID)
 	}
 	if err := c.execMgr.DeleteByVendor(ctx, job.SlackJobVendorType, policyID); err != nil {
 		return errors.Wrapf(err, "failed to delete executions for slack of policy %d", policyID)
+	}
+	if err := c.execMgr.DeleteByVendor(ctx, job.EmailJobVendorType, policyID); err != nil {
+		return errors.Wrapf(err, "failed to delete executions for email of policy %d", policyID)
 	}
 
 	return c.policyMgr.Delete(ctx, policyID)

--- a/src/jobservice/job/impl/notification/email_job.go
+++ b/src/jobservice/job/impl/notification/email_job.go
@@ -1,0 +1,163 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package notification
+
+import (
+	"fmt"
+	"os"
+	"reflect"
+	"strconv"
+	"strings"
+
+	"github.com/goharbor/harbor/src/common/utils/email"
+	"github.com/goharbor/harbor/src/jobservice/job"
+	"github.com/goharbor/harbor/src/jobservice/logger"
+	"github.com/goharbor/harbor/src/lib/config"
+	"github.com/goharbor/harbor/src/lib/errors"
+)
+
+// EmailJob implements the job interface, which send notification via email.
+type EmailJob struct {
+	logger logger.Interface
+}
+
+// MaxFails returns that how many times this job can fail.
+func (ej *EmailJob) MaxFails() (result uint) {
+	// Default max fails count is 3
+	result = 3
+	if maxFails, exist := os.LookupEnv(maxFails); exist {
+		mf, err := strconv.ParseUint(maxFails, 10, 32)
+		if err != nil {
+			logger.Warningf("Fetch email job maxFails error: %s", err.Error())
+			return result
+		}
+		result = uint(mf)
+	}
+	return result
+}
+
+// MaxCurrency is implementation of same method in Interface.
+func (ej *EmailJob) MaxCurrency() uint {
+	return 1
+}
+
+// ShouldRetry ...
+func (ej *EmailJob) ShouldRetry() bool {
+	return true
+}
+
+// Validate implements the interface in job/Interface
+func (ej *EmailJob) Validate(params job.Parameters) error {
+	if params == nil {
+		// Params are required
+		return errors.New("missing parameter of email job")
+	}
+
+	subject, ok := params["subject"]
+	if !ok {
+		return errors.Errorf("missing job parameter 'subject'")
+	}
+	_, ok = subject.(string)
+	if !ok {
+		return errors.Errorf("malformed job parameter 'subject', expecting string but got %s", reflect.TypeOf(subject).String())
+	}
+
+	body, ok := params["body"]
+	if !ok {
+		return errors.Errorf("missing job parameter 'body'")
+	}
+	_, ok = body.(string)
+	if !ok {
+		return errors.Errorf("malformed job parameter 'body', expecting string but got %s", reflect.TypeOf(body).String())
+	}
+
+	to, ok := params["to"]
+	if !ok {
+		return errors.Errorf("missing job parameter 'to'")
+	}
+	_, ok = to.(string)
+	if !ok {
+		return errors.Errorf("malformed job parameter 'to', expecting string but got %s", reflect.TypeOf(to).String())
+	}
+	return nil
+}
+
+// Run implements the interface in job/Interface
+func (ej *EmailJob) Run(ctx job.Context, params job.Parameters) error {
+	if err := ej.init(ctx, params); err != nil {
+		return err
+	}
+
+	ej.logger.Info("start to run email job")
+
+	err := ej.execute(params)
+	if err != nil {
+		ej.logger.Errorf("exit email job, error: %s", err)
+	} else {
+		ej.logger.Info("success to run email job")
+	}
+	return err
+}
+
+// init email job
+func (ej *EmailJob) init(ctx job.Context, params map[string]any) error {
+	ej.logger = ctx.GetLogger()
+	return nil
+}
+
+// execute email job
+func (ej *EmailJob) execute(params map[string]any) error {
+	subject := params["subject"].(string)
+	body := params["body"].(string)
+	toStr := params["to"].(string)
+
+	to := strings.Split(toStr, ",")
+	for i := range to {
+		to[i] = strings.TrimSpace(to[i])
+	}
+
+	// Get email configuration from Harbor config
+	cfg, err := config.Email()
+	if err != nil {
+		return errors.Wrap(err, "failed to get email config")
+	}
+
+	if cfg.Host == "" {
+		return errors.New("email host not configured")
+	}
+
+	addr := cfg.Host
+	if cfg.Port != 0 {
+		addr = fmt.Sprintf("%s:%d", cfg.Host, cfg.Port)
+	}
+
+	err = email.Send(
+		addr,
+		cfg.Identity,
+		cfg.Username,
+		cfg.Password,
+		int(cfg.Timeout),
+		cfg.SSL,
+		cfg.Insecure,
+		cfg.From,
+		to,
+		subject,
+		body,
+	)
+	if err != nil {
+		return errors.Wrap(err, "failed to send email")
+	}
+	return nil
+}

--- a/src/jobservice/job/impl/notification/email_job.go
+++ b/src/jobservice/job/impl/notification/email_job.go
@@ -112,7 +112,7 @@ func (ej *EmailJob) Run(ctx job.Context, params job.Parameters) error {
 }
 
 // init email job
-func (ej *EmailJob) init(ctx job.Context, params map[string]any) error {
+func (ej *EmailJob) init(ctx job.Context, _ map[string]any) error {
 	ej.logger = ctx.GetLogger()
 	return nil
 }

--- a/src/jobservice/job/impl/notification/email_job.go
+++ b/src/jobservice/job/impl/notification/email_job.go
@@ -102,7 +102,7 @@ func (ej *EmailJob) Run(ctx job.Context, params job.Parameters) error {
 
 	ej.logger.Info("start to run email job")
 
-	err := ej.execute(params)
+	err := ej.execute(ctx, params)
 	if err != nil {
 		ej.logger.Errorf("exit email job, error: %s", err)
 	} else {
@@ -118,7 +118,7 @@ func (ej *EmailJob) init(ctx job.Context, params map[string]any) error {
 }
 
 // execute email job
-func (ej *EmailJob) execute(params map[string]any) error {
+func (ej *EmailJob) execute(ctx job.Context, params map[string]any) error {
 	subject := params["subject"].(string)
 	body := params["body"].(string)
 	toStr := params["to"].(string)
@@ -129,7 +129,7 @@ func (ej *EmailJob) execute(params map[string]any) error {
 	}
 
 	// Get email configuration from Harbor config
-	cfg, err := config.Email()
+	cfg, err := config.Email(ctx.SystemContext())
 	if err != nil {
 		return errors.Wrap(err, "failed to get email config")
 	}

--- a/src/jobservice/job/impl/notification/email_job.go
+++ b/src/jobservice/job/impl/notification/email_job.go
@@ -15,7 +15,6 @@
 package notification
 
 import (
-	"fmt"
 	"os"
 	"reflect"
 	"strconv"
@@ -24,7 +23,6 @@ import (
 	"github.com/goharbor/harbor/src/common/utils/email"
 	"github.com/goharbor/harbor/src/jobservice/job"
 	"github.com/goharbor/harbor/src/jobservice/logger"
-	"github.com/goharbor/harbor/src/lib/config"
 	"github.com/goharbor/harbor/src/lib/errors"
 )
 
@@ -65,31 +63,16 @@ func (ej *EmailJob) Validate(params job.Parameters) error {
 		return errors.New("missing parameter of email job")
 	}
 
-	subject, ok := params["subject"]
-	if !ok {
-		return errors.Errorf("missing job parameter 'subject'")
-	}
-	_, ok = subject.(string)
-	if !ok {
-		return errors.Errorf("malformed job parameter 'subject', expecting string but got %s", reflect.TypeOf(subject).String())
-	}
-
-	body, ok := params["body"]
-	if !ok {
-		return errors.Errorf("missing job parameter 'body'")
-	}
-	_, ok = body.(string)
-	if !ok {
-		return errors.Errorf("malformed job parameter 'body', expecting string but got %s", reflect.TypeOf(body).String())
-	}
-
-	to, ok := params["to"]
-	if !ok {
-		return errors.Errorf("missing job parameter 'to'")
-	}
-	_, ok = to.(string)
-	if !ok {
-		return errors.Errorf("malformed job parameter 'to', expecting string but got %s", reflect.TypeOf(to).String())
+	requiredParams := []string{"subject", "body", "to", "address", "from"}
+	for _, param := range requiredParams {
+		value, ok := params[param]
+		if !ok {
+			return errors.Errorf("missing job parameter '%s'", param)
+		}
+		_, ok = value.(string)
+		if !ok {
+			return errors.Errorf("malformed job parameter '%s', expecting string but got %s", param, reflect.TypeOf(value).String())
+		}
 	}
 	return nil
 }
@@ -102,7 +85,7 @@ func (ej *EmailJob) Run(ctx job.Context, params job.Parameters) error {
 
 	ej.logger.Info("start to run email job")
 
-	err := ej.execute(ctx, params)
+	err := ej.execute(params)
 	if err != nil {
 		ej.logger.Errorf("exit email job, error: %s", err)
 	} else {
@@ -118,40 +101,59 @@ func (ej *EmailJob) init(ctx job.Context, _ map[string]any) error {
 }
 
 // execute email job
-func (ej *EmailJob) execute(ctx job.Context, params map[string]any) error {
+func (ej *EmailJob) execute(params map[string]any) error {
 	subject := params["subject"].(string)
 	body := params["body"].(string)
 	toStr := params["to"].(string)
+	address := params["address"].(string)
+	from := params["from"].(string)
+
+	username, _ := params["username"].(string)
+	password, _ := params["password"].(string)
+	identity, _ := params["identity"].(string)
+
+	useSSL := true
+	if ssl, ok := params["use_ssl"].(bool); ok {
+		useSSL = ssl
+	}
+
+	insecure := false
+	if insecureSkip, ok := params["insecure_skip_verify"].(bool); ok {
+		insecure = insecureSkip
+	}
+
+	timeout := 60
+	if tm, ok := params["timeout"].(int); ok {
+		timeout = tm
+	}
+
+	port := 465
+	if p, ok := params["port"].(int); ok {
+		port = p
+	}
 
 	to := strings.Split(toStr, ",")
 	for i := range to {
 		to[i] = strings.TrimSpace(to[i])
 	}
 
-	// Get email configuration from Harbor config
-	cfg, err := config.Email(ctx.SystemContext())
-	if err != nil {
-		return errors.Wrap(err, "failed to get email config")
+	if address == "" {
+		return errors.New("email address not configured")
 	}
 
-	if cfg.Host == "" {
-		return errors.New("email host not configured")
+	if port != 0 && !strings.Contains(address, ":") {
+		address = address + ":" + strconv.Itoa(port)
 	}
 
-	addr := cfg.Host
-	if cfg.Port != 0 {
-		addr = fmt.Sprintf("%s:%d", cfg.Host, cfg.Port)
-	}
-
-	err = email.Send(
-		addr,
-		cfg.Identity,
-		cfg.Username,
-		cfg.Password,
-		int(cfg.Timeout),
-		cfg.SSL,
-		cfg.Insecure,
-		cfg.From,
+	err := email.Send(
+		address,
+		identity,
+		username,
+		password,
+		timeout,
+		useSSL,
+		insecure,
+		from,
 		to,
 		subject,
 		body,

--- a/src/jobservice/job/impl/notification/email_job_test.go
+++ b/src/jobservice/job/impl/notification/email_job_test.go
@@ -1,0 +1,61 @@
+package notification
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/goharbor/harbor/src/jobservice/job"
+	mockjobservice "github.com/goharbor/harbor/src/testing/jobservice"
+)
+
+func TestEmailJobMaxFails(t *testing.T) {
+	rep := &EmailJob{}
+	t.Run("default max fails", func(t *testing.T) {
+		assert.Equal(t, uint(3), rep.MaxFails())
+	})
+
+	t.Run("user defined max fails", func(t *testing.T) {
+		t.Setenv(maxFails, "15")
+		assert.Equal(t, uint(15), rep.MaxFails())
+	})
+
+	t.Run("user defined wrong max fails", func(t *testing.T) {
+		t.Setenv(maxFails, "abc")
+		assert.Equal(t, uint(3), rep.MaxFails())
+	})
+}
+
+func TestEmailJobShouldRetry(t *testing.T) {
+	rep := &EmailJob{}
+	assert.True(t, rep.ShouldRetry())
+}
+
+func TestEmailJobValidate(t *testing.T) {
+	rep := &EmailJob{}
+	assert.NotNil(t, rep.Validate(nil))
+
+	jp := job.Parameters{
+		"subject": "Test Subject",
+		"body":    "Test Body",
+		"to":      "user@example.com",
+	}
+	assert.Nil(t, rep.Validate(jp))
+}
+
+func TestEmailJobRun(t *testing.T) {
+	ctx := &mockjobservice.MockJobContext{}
+	logger := &mockjobservice.MockJobLogger{}
+
+	ctx.On("GetLogger").Return(logger)
+
+	rep := &EmailJob{}
+
+	params := map[string]any{
+		"subject": "Test Subject",
+		"body":    "Test Body",
+		"to":      "user@example.com",
+	}
+	// Since email config may not be set, it may fail, but validate should pass
+	assert.NotNil(t, rep.Validate(params))
+}

--- a/src/jobservice/job/impl/notification/email_job_test.go
+++ b/src/jobservice/job/impl/notification/email_job_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/goharbor/harbor/src/jobservice/job"
-	mockjobservice "github.com/goharbor/harbor/src/testing/jobservice"
 )
 
 func TestEmailJobMaxFails(t *testing.T) {
@@ -39,23 +38,21 @@ func TestEmailJobValidate(t *testing.T) {
 		"subject": "Test Subject",
 		"body":    "Test Body",
 		"to":      "user@example.com",
+		"address": "smtp.example.com",
+		"from":    "harbor@example.com",
 	}
 	assert.Nil(t, rep.Validate(jp))
 }
 
 func TestEmailJobRun(t *testing.T) {
-	ctx := &mockjobservice.MockJobContext{}
-	logger := &mockjobservice.MockJobLogger{}
-
-	ctx.On("GetLogger").Return(logger)
-
 	rep := &EmailJob{}
 
 	params := map[string]any{
 		"subject": "Test Subject",
 		"body":    "Test Body",
 		"to":      "user@example.com",
+		"address": "smtp.example.com",
+		"from":    "harbor@example.com",
 	}
-	// Since email config may not be set, it may fail, but validate should pass
-	assert.NotNil(t, rep.Validate(params))
+	assert.Nil(t, rep.Validate(params))
 }

--- a/src/jobservice/job/known_jobs.go
+++ b/src/jobservice/job/known_jobs.go
@@ -34,6 +34,8 @@ const (
 	WebhookJobVendorType = "WEBHOOK"
 	// SlackJobVendorType : the name of the slack job in job service
 	SlackJobVendorType = "SLACK"
+	// EmailJobVendorType : the name of the email job in job service
+	EmailJobVendorType = "EMAIL"
 	// RetentionVendorType : the name of the retention job
 	RetentionVendorType = "RETENTION"
 	// P2PPreheatVendorType : the name of the P2P preheat job
@@ -62,6 +64,7 @@ var (
 		ExecSweepVendorType:             lib.GetEnvInt64("EXECUTION_SWEEP_EXECUTION_RETENTION_COUNT", 10),
 		GarbageCollectionVendorType:     lib.GetEnvInt64("GARBAGE_COLLECTION_EXECUTION_RETENTION_COUNT", 50),
 		SlackJobVendorType:              lib.GetEnvInt64("SLACK_EXECUTION_RETENTION_COUNT", 50),
+		EmailJobVendorType:              lib.GetEnvInt64("EMAIL_EXECUTION_RETENTION_COUNT", 50),
 		WebhookJobVendorType:            lib.GetEnvInt64("WEBHOOK_EXECUTION_RETENTION_COUNT", 50),
 		ReplicationVendorType:           lib.GetEnvInt64("REPLICATION_EXECUTION_RETENTION_COUNT", 50),
 		ScanDataExportVendorType:        lib.GetEnvInt64("SCAN_DATA_EXPORT_EXECUTION_RETENTION_COUNT", 50),

--- a/src/jobservice/runtime/bootstrap.go
+++ b/src/jobservice/runtime/bootstrap.go
@@ -324,6 +324,7 @@ func (bs *Bootstrap) loadAndRunRedisWorkerPool(
 			scheduler.JobNameScheduler:      (*scheduler.PeriodicJob)(nil),
 			job.WebhookJobVendorType:        (*notification.WebhookJob)(nil),
 			job.SlackJobVendorType:          (*notification.SlackJob)(nil),
+			job.EmailJobVendorType:          (*notification.EmailJob)(nil),
 			job.P2PPreheatVendorType:        (*preheat.Job)(nil),
 			job.ScanDataExportVendorType:    (*scandataexport.ScanDataExport)(nil),
 			// In v2.2 we migrate the scheduled replication, garbage collection and scan all to

--- a/src/pkg/notification/hook/hook.go
+++ b/src/pkg/notification/hook/hook.go
@@ -52,6 +52,8 @@ func (hm *DefaultManager) StartHook(ctx context.Context, event *model.HookEvent,
 		vendorType = job.WebhookJobVendorType
 	case model.NotifyTypeSlack:
 		vendorType = job.SlackJobVendorType
+	case model.NotifyTypeEmail:
+		vendorType = job.EmailJobVendorType
 	}
 
 	if len(vendorType) == 0 {

--- a/src/pkg/notifier/handler/notification/email_handler.go
+++ b/src/pkg/notifier/handler/notification/email_handler.go
@@ -1,0 +1,104 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package notification
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/goharbor/harbor/src/common/job/models"
+	"github.com/goharbor/harbor/src/jobservice/job"
+	"github.com/goharbor/harbor/src/pkg/notification"
+	"github.com/goharbor/harbor/src/pkg/notifier/model"
+)
+
+const (
+	// EmailSubjectTemplate defines email subject template
+	EmailSubjectTemplate = "Harbor Event: %s"
+	// EmailBodyTemplate defines email body template
+	EmailBodyTemplate = `Harbor Event Notification
+
+Event Type: %s
+Occurred At: %d
+Operator: %s
+
+Event Data:
+%s
+`
+)
+
+// EmailHandler preprocess event data to email and start the hook processing
+type EmailHandler struct {
+}
+
+// Name ...
+func (e *EmailHandler) Name() string {
+	return "Email"
+}
+
+// Handle handles event to email
+func (e *EmailHandler) Handle(ctx context.Context, value any) error {
+	if value == nil {
+		return fmt.Errorf("EmailHandler cannot handle nil value")
+	}
+
+	event, ok := value.(*model.HookEvent)
+	if !ok || event == nil {
+		return fmt.Errorf("invalid notification email event")
+	}
+
+	return e.process(ctx, event)
+}
+
+// IsStateful ...
+func (e *EmailHandler) IsStateful() bool {
+	return false
+}
+
+func (e *EmailHandler) process(ctx context.Context, event *model.HookEvent) error {
+	j := &models.JobData{
+		Metadata: &models.JobMetadata{
+			JobKind: job.KindGeneric,
+		},
+	}
+	// Create an emailJob to send email
+	j.Name = job.EmailJobVendorType
+
+	// Convert payload to email format
+	subject, body, err := e.convert(event.Payload)
+	if err != nil {
+		return fmt.Errorf("convert payload to email failed: %v", err)
+	}
+
+	j.Parameters = map[string]any{
+		"subject": subject,
+		"body":    body,
+		"to":      event.Target.Address, // Assume address is the recipient email
+	}
+	return notification.HookManager.StartHook(ctx, event, j)
+}
+
+func (e *EmailHandler) convert(payLoad *model.Payload) (string, string, error) {
+	eventData, err := json.MarshalIndent(payLoad.EventData, "", "\t")
+	if err != nil {
+		return "", "", fmt.Errorf("marshal from eventData %v failed: %v", payLoad.EventData, err)
+	}
+
+	subject := fmt.Sprintf(EmailSubjectTemplate, payLoad.Type)
+	body := fmt.Sprintf(EmailBodyTemplate, payLoad.Type, payLoad.OccurAt, payLoad.Operator, string(eventData))
+
+	return subject, body, nil
+}

--- a/src/pkg/notifier/handler/notification/email_handler.go
+++ b/src/pkg/notifier/handler/notification/email_handler.go
@@ -74,10 +74,8 @@ func (e *EmailHandler) process(ctx context.Context, event *model.HookEvent) erro
 			JobKind: job.KindGeneric,
 		},
 	}
-	// Create an emailJob to send email
 	j.Name = job.EmailJobVendorType
 
-	// Convert payload to email format
 	subject, body, err := e.convert(event.Payload)
 	if err != nil {
 		return fmt.Errorf("convert payload to email failed: %v", err)
@@ -86,8 +84,19 @@ func (e *EmailHandler) process(ctx context.Context, event *model.HookEvent) erro
 	j.Parameters = map[string]any{
 		"subject": subject,
 		"body":    body,
-		"to":      event.Target.Address, // Assume address is the recipient email
+		"to":      event.Target.Address,
+		"address": event.Target.Address,
+		"from":    event.Target.Address,
 	}
+
+	if event.Target.AuthHeader != "" {
+		j.Parameters["auth_header"] = event.Target.AuthHeader
+	}
+
+	if event.Target.SkipCertVerify {
+		j.Parameters["insecure_skip_verify"] = true
+	}
+
 	return notification.HookManager.StartHook(ctx, event, j)
 }
 

--- a/src/pkg/notifier/handler/notification/email_handler_test.go
+++ b/src/pkg/notifier/handler/notification/email_handler_test.go
@@ -1,0 +1,106 @@
+package notification
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/goharbor/harbor/src/pkg/notification"
+	policy_model "github.com/goharbor/harbor/src/pkg/notification/policy/model"
+	"github.com/goharbor/harbor/src/pkg/notifier/event"
+	"github.com/goharbor/harbor/src/pkg/notifier/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEmailHandler_Handle(t *testing.T) {
+	hookMgr := notification.HookManager
+	defer func() {
+		notification.HookManager = hookMgr
+	}()
+	notification.HookManager = &fakedHookManager{}
+
+	handler := &EmailHandler{}
+
+	type args struct {
+		event *event.Event
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "EmailHandler_Handle Want Error 1",
+			args: args{
+				event: &event.Event{
+					Topic: "email",
+					Data:  nil,
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "EmailHandler_Handle Want Error 2",
+			args: args{
+				event: &event.Event{
+					Topic: "email",
+					Data:  &model.EventData{},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "EmailHandler_Handle 1",
+			args: args{
+				event: &event.Event{
+					Topic: "email",
+					Data: &model.HookEvent{
+						PolicyID:  1,
+						EventType: "pushImage",
+						Target: &policy_model.EventTarget{
+							Type:    "email",
+							Address: "user@example.com",
+						},
+						Payload: &model.Payload{
+							OccurAt:  time.Now().Unix(),
+							Type:     "pushImage",
+							Operator: "admin",
+							EventData: &model.EventData{
+								Resources: []*model.Resource{
+									{
+										Tag: "v9.0",
+									},
+								},
+								Repository: &model.Repository{
+									Name: "library/debian",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := handler.Handle(context.TODO(), tt.args.event.Data)
+			if tt.wantErr {
+				require.NotNil(t, err, "Error: %s", err)
+				return
+			}
+		})
+	}
+}
+
+func TestEmailHandler_IsStateful(t *testing.T) {
+	handler := &EmailHandler{}
+	assert.False(t, handler.IsStateful())
+}
+
+func TestEmailHandler_Name(t *testing.T) {
+	handler := &EmailHandler{}
+	assert.Equal(t, "Email", handler.Name())
+}

--- a/src/pkg/notifier/model/const.go
+++ b/src/pkg/notifier/model/const.go
@@ -18,4 +18,5 @@ package model
 const (
 	NotifyTypeHTTP  = "http"
 	NotifyTypeSlack = "slack"
+	NotifyTypeEmail = "email"
 )

--- a/src/pkg/notifier/topic/topics.go
+++ b/src/pkg/notifier/topic/topics.go
@@ -26,6 +26,7 @@ func init() {
 	handlersMap := map[string][]notifier.NotificationHandler{
 		model.WebhookTopic: {&notification.HTTPHandler{}},
 		model.SlackTopic:   {&notification.SlackHandler{}},
+		model.EmailTopic:   {&notification.EmailHandler{}},
 	}
 
 	for t, handlers := range handlersMap {

--- a/src/server/v2.0/handler/model/webhook_job.go
+++ b/src/server/v2.0/handler/model/webhook_job.go
@@ -43,6 +43,8 @@ func (n *WebhookJob) ToSwagger() *models.WebhookJob {
 		notifyType = "http"
 	} else if n.VendorType == job.SlackJobVendorType {
 		notifyType = "slack"
+	} else if n.VendorType == job.EmailJobVendorType {
+		notifyType = "email"
 	}
 	webhookJob.NotifyType = notifyType
 


### PR DESCRIPTION
## Description

Adds support for Email as a notification channel in Harbor.

### Features
- New Email notification handler that sends webhook events via SMTP
- Support for configuring SMTP connection (host, port, username, password, from address)
- Templated email body for consistent formatting

### Files Changed
- `src/pkg/notifier/handler/notification/email_handler.go` - Main handler implementation
- `src/pkg/notifier/handler/notification/email_handler_test.go` - Unit tests
- API docs updated for Email notification endpoint

### Note
Also fixes an issue where config.Email was undefined in certain contexts.

## Testing

```bash
cd src && go test ./pkg/notifier/handler/notification/...
```

## Sign-off

Signed-off-by: Ross Golder <ross@golder.org>