### PR TITLE
[cherry-pick]remove install net-tools from db dockerfile as photon removed it

### DIFF
--- a/make/photon/db/Dockerfile.base
+++ b/make/photon/db/Dockerfile.base
@@ -17,4 +17,4 @@ RUN tdnf install -y gzip postgresql15-server findutils bc >> /dev/null \
     && sed -i "s|#unix_socket_directories = '/tmp'.*|unix_socket_directories = '/run/postgresql'|g" /usr/pgsql/15/share/postgresql/postgresql.conf.sample \
     && tdnf clean all
 
-RUN tdnf erase -y toybox && tdnf install -y util-linux net-tools
+RUN tdnf install -y util-linux


### PR DESCRIPTION
…266)

remove install net-tools from db dockerfile as photon removed it from repo already

Thank you for contributing to Harbor!

# Comprehensive Summary of your change
remove install net-tools from db dockerfile.base as photon removed it from repo in recently. the failed installation of the package breaks build db base image and git workflow.
Tested in my local desktop to build the db image and run container locally. Checked the psql commands and no error hit.

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [ ] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [ ] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
