### PR TITLE
fix(security): validate blob-mount source project and reject tokens missing iat

### DIFF
--- a/src/server/middleware/security/v2_token.go
+++ b/src/server/middleware/security/v2_token.go
@@ -79,22 +79,40 @@ func (vt *v2Token) Generate(req *http.Request) security.Context {
 }
 
 // tokenIssuedAfterProjectCreation prevents tokens from a deleted project
-// granting access to a new project recreated with the same name.
+// granting access to a new project recreated with the same name. It validates
+// every project the request is authorized against, including the source
+// project of a cross-repository blob mount.
 func tokenIssuedAfterProjectCreation(ctx context.Context, logger *log.Logger, claims *v2TokenClaims) bool {
-	info := lib.GetArtifactInfo(ctx)
-	if info.ProjectName == "" {
-		return true
-	}
-	p, err := project_ctl.Ctl.GetByName(ctx, info.ProjectName)
-	if err != nil {
-		logger.Warningf("failed to get project %q for token validation: %v", info.ProjectName, err)
+	// Fail closed: a token without an iat claim cannot be validated against the
+	// project creation time, and claims.IssuedAt is a pointer that would panic
+	// on dereference below.
+	if claims.IssuedAt == nil {
+		logger.Warningf("bearer token missing iat claim, rejecting")
 		return false
 	}
 	iat := claims.IssuedAt.Time
-	if iat.Add(common.JwtLeeway).Before(p.CreationTime) {
-		logger.Warningf("bearer token issued at %v is before project %q creation time %v, rejecting",
-			iat, info.ProjectName, p.CreationTime)
-		return false
+
+	info := lib.GetArtifactInfo(ctx)
+	// A blob mount (POST .../blobs/uploads/?from=<repo>) also requires pull
+	// access to the source project, so its creation time must be checked too.
+	names := []string{info.ProjectName}
+	if info.BlobMountProjectName != "" && info.BlobMountProjectName != info.ProjectName {
+		names = append(names, info.BlobMountProjectName)
+	}
+	for _, projectName := range names {
+		if projectName == "" {
+			continue
+		}
+		p, err := project_ctl.Ctl.GetByName(ctx, projectName)
+		if err != nil {
+			logger.Warningf("failed to get project %q for token validation: %v", projectName, err)
+			return false
+		}
+		if iat.Add(common.JwtLeeway).Before(p.CreationTime) {
+			logger.Warningf("bearer token issued at %v is before project %q creation time %v, rejecting",
+				iat, projectName, p.CreationTime)
+			return false
+		}
 	}
 	return true
 }

--- a/src/server/middleware/security/v2_token_test.go
+++ b/src/server/middleware/security/v2_token_test.go
@@ -101,3 +101,39 @@ func TestTokenIssuedAfterProjectCreation(t *testing.T) {
 		})
 	}
 }
+
+func TestTokenIssuedAfterProjectCreation_NilIAT(t *testing.T) {
+	logger := log.DefaultLogger()
+	origCtl := project_ctl.Ctl
+	defer func() { project_ctl.Ctl = origCtl }()
+	project_ctl.Ctl = &projecttesting.Controller{}
+
+	ctx := lib.WithArtifactInfo(context.Background(), lib.ArtifactInfo{ProjectName: "myproject"})
+	claims := &v2TokenClaims{} // no iat
+
+	assert.False(t, tokenIssuedAfterProjectCreation(ctx, logger, claims))
+}
+
+func TestTokenIssuedAfterProjectCreation_BlobMountSource(t *testing.T) {
+	logger := log.DefaultLogger()
+	created := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	iat := time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC) // after dest creation
+
+	// Destination created before iat (ok); source recreated after iat (must reject).
+	dest := &proModels.Project{Name: "dest", CreationTime: created}
+	src := &proModels.Project{Name: "src", CreationTime: iat.Add(24 * time.Hour)}
+
+	origCtl := project_ctl.Ctl
+	defer func() { project_ctl.Ctl = origCtl }()
+	mockCtl := &projecttesting.Controller{}
+	project_ctl.Ctl = mockCtl
+	mockCtl.On("GetByName", mock.Anything, "dest").Return(dest, nil)
+	mockCtl.On("GetByName", mock.Anything, "src").Return(src, nil)
+
+	ctx := lib.WithArtifactInfo(context.Background(), lib.ArtifactInfo{
+		ProjectName:          "dest",
+		BlobMountProjectName: "src",
+	})
+
+	assert.False(t, tokenIssuedAfterProjectCreation(ctx, logger, makeClaimsWithIAT(iat)))
+}


### PR DESCRIPTION
Follow-up to #22900, which added `tokenIssuedAfterProjectCreation` to reject bearer tokens issued before the named project's `creation_time` (preventing an authorization bypass when a project is deleted and recreated with the same name). Two gaps remained in that check:

### 1. Blob-mount source project is not validated
The check only looked at `info.ProjectName`. A cross-repository blob mount — `POST /v2/<repo>/blobs/uploads/?from=<src>` — additionally requires **pull** access to the source repository (`accessList` in `server/middleware/v2auth/access.go`), and `artifactinfo` middleware populates `ArtifactInfo.BlobMountProjectName`. Because the source project's creation time was never checked, a token issued before the *source* project was deleted and recreated with the same name was still accepted — re-opening, for the source project, exactly the hole the function closes for the destination.

Fix: validate `iat` against both `ProjectName` and (when set and different) `BlobMountProjectName`.

### 2. Missing `iat` claim panics the request handler
`claims.IssuedAt` is a `*jwt.NumericDate` and was dereferenced unconditionally (`claims.IssuedAt.Time`). The validator does not require `iat` (jwt/v5 `verifyIat` is off and `WithIssuedAt` is not used), so a signed token without `iat` reached the dereference and panicked. Fail closed: reject tokens without `iat`.

### Tests
- `TestTokenIssuedAfterProjectCreation_NilIAT` — token without `iat` is rejected, no panic.
- `TestTokenIssuedAfterProjectCreation_BlobMountSource` — destination created before `iat`, source recreated after `iat` ⇒ rejected.

Both new tests fail on the pre-fix code (the nil-`iat` case panics) and pass after the change. Existing `TestTokenIssuedAfterProjectCreation` cases are unchanged.

# Issue being fixed
Follow-up to #22900.

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
