### PR TITLE
test(cosign): disable tlog for signing checks

### DIFF
--- a/tests/resources/Cosign_Util.robot
+++ b/tests/resources/Cosign_Util.robot
@@ -24,12 +24,12 @@ Cosign Generate Key Pair
 
 Cosign Sign
     [Arguments]  ${artifact}
-    Wait Unitl Command Success  cosign sign -y --allow-insecure-registry --key cosign.key ${artifact}
+    Wait Unitl Command Success  cosign sign -y --allow-insecure-registry --key cosign.key --tlog-upload=false ${artifact}
 
 Cosign Verify
     [Arguments]  ${artifact}  ${signed}
     Run Keyword If  ${signed}==${true}  Wait Unitl Command Success  cosign verify --key cosign.pub ${artifact}
-    ...  ELSE  Command Should be Failed  cosign verify --key cosign.pub ${artifact}
+    ...  ELSE  Command Should be Failed  cosign verify --key cosign.pub --insecure-ignore-tlog=true ${artifact}
 
 Cosign Push Sbom
     [Arguments]  ${artifact}  ${sbom_path}=${files_directory}/sbom_test.json  ${type}=spdx


### PR DESCRIPTION
Thank you for contributing to Harbor!

# Comprehensive Summary of your change
This pull request updates the `Cosign_Util.robot` test resource to improve the reliability of signing and verification commands by modifying how transparency log interactions are handled.

**Cosign signing and verification command updates:**

* The `cosign sign` command now disables transparency log upload by default using the `--tlog-upload=false` flag, preventing external network calls during signing.
* The `cosign verify` command in negative test cases now ignores the transparency log using the `--insecure-ignore-tlog=true` flag, ensuring verification failures are not blocked by tlog lookup errors.

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
