### PR TITLE
fix: build valkey from source to support arm64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,6 +133,10 @@ PREPARE_VERSION_NAME=versions
 REGISTRYVERSION=v2.8.3-patch-redis
 TRIVYVERSION=v0.69.3
 TRIVYADAPTERVERSION=v0.35.1
+# VALKEYVERSION and VALKEYSHA256 are only used for the arm64 source build.
+# On amd64 the Photon tdnf package version is used directly.
+VALKEYVERSION=9.0.3
+VALKEYSHA256=e220f4b0143292ee6ea6d705aa40d45a0c8a77759b3e94c201cb5c25dbdca42f
 NODEBUILDIMAGE=node:16.18.0
 
 # version of registry for pulling the source code
@@ -432,6 +436,7 @@ build:
 	make -f $(MAKEFILEPATH_PHOTON)/Makefile $(BUILDTARGET) -e DEVFLAG=$(DEVFLAG) -e GOBUILDIMAGE=$(GOBUILDIMAGE) -e NODEBUILDIMAGE=$(NODEBUILDIMAGE) \
 	 -e REGISTRYVERSION=$(REGISTRYVERSION) -e REGISTRY_SRC_TAG=$(REGISTRY_SRC_TAG)  -e DISTRIBUTION_SRC=$(DISTRIBUTION_SRC)\
 	 -e TRIVYVERSION=$(TRIVYVERSION) -e TRIVYADAPTERVERSION=$(TRIVYADAPTERVERSION) \
+	 -e VALKEYVERSION=$(VALKEYVERSION) -e VALKEYSHA256=$(VALKEYSHA256) \
 	 -e VERSIONTAG=$(VERSIONTAG) \
 	 -e DOCKERNETWORK=$(DOCKERNETWORK) \
 	 -e BUILDREG=$(BUILDREG) -e BUILDTRIVYADP=$(BUILDTRIVYADP) \
@@ -457,7 +462,11 @@ build_base_docker:
 	@for name in $(BUILDBASETARGET); do \
 		echo $$name ; \
 		sleep 30 ; \
-		$(DOCKERBUILD) --pull --no-cache -f $(MAKEFILEPATH_PHOTON)/$$name/Dockerfile.base -t $(BASEIMAGENAMESPACE)/harbor-$$name-base:$(BASEIMAGETAG) --label base-build-date=$(date +"%Y%m%d") . ; \
+		valkey_args="" ; \
+		if [ "$$name" = "valkey" ]; then \
+			valkey_args="--build-arg VALKEY_VERSION=$(VALKEYVERSION) --build-arg VALKEY_SHA256=$(VALKEYSHA256)" ; \
+		fi ; \
+		$(DOCKERBUILD) --pull --no-cache -f $(MAKEFILEPATH_PHOTON)/$$name/Dockerfile.base $$valkey_args -t $(BASEIMAGENAMESPACE)/harbor-$$name-base:$(BASEIMAGETAG) --label base-build-date=$(date +"%Y%m%d") . ; \
 		if [ "$(PUSHBASEIMAGE)" != "false" ] ; then \
 			$(PUSHSCRIPTPATH)/$(PUSHSCRIPTNAME) $(BASEIMAGENAMESPACE)/harbor-$$name-base:$(BASEIMAGETAG) $(REGISTRYUSER) $(REGISTRYPASSWORD) || exit 1; \
 		fi ; \

--- a/make/photon/Makefile
+++ b/make/photon/Makefile
@@ -202,7 +202,7 @@ _build_registryctl:
 	@echo "Done."
 
 _build_valkey:
-	@$(call _build_base,$(VALKEY),$(DOCKERFILEPATH_VALKEY))
+	@$(call _build_base,$(VALKEY),$(DOCKERFILEPATH_VALKEY),--build-arg VALKEY_VERSION=$(VALKEYVERSION) --build-arg VALKEY_SHA256=$(VALKEYSHA256))
 	@echo "building valkey container for photon..."
 	@$(DOCKERBUILD_WITH_PULL_PARA) --build-arg harbor_base_image_version=$(BASEIMAGETAG) --build-arg harbor_base_namespace=$(BASEIMAGENAMESPACE) -f $(DOCKERFILEPATH_VALKEY)/$(DOCKERFILENAME_VALKEY) -t $(DOCKERIMAGENAME_VALKEY):$(VERSIONTAG) .
 	@echo "Done."
@@ -236,7 +236,7 @@ define _build_base
 		else \
 			echo "No docker credentials provided, please be aware of privileges to access docker hub!" ; \
 		fi ;\
-		$(DOCKERBUILD) -f $(2)/Dockerfile.base --build-arg pip_index_url=$(PIP_INDEX_URL) -t $(BASEIMAGENAMESPACE)/harbor-$(1)-base:$(BASEIMAGETAG) --label base-build-date=$(TIMESTAMP) . ;\
+			$(DOCKERBUILD) -f $(2)/Dockerfile.base --build-arg pip_index_url=$(PIP_INDEX_URL) $(3) -t $(BASEIMAGENAMESPACE)/harbor-$(1)-base:$(BASEIMAGETAG) --label base-build-date=$(TIMESTAMP) . ;\
 		if [ "$(PUSHBASEIMAGE)" = "true" ] ; then \
 			$(PUSHSCRIPTPATH)/$(PUSHSCRIPTNAME) $(BASEIMAGENAMESPACE)/harbor-$(1)-base:$(BASEIMAGETAG) $(REGISTRYUSER) $(REGISTRYPASSWORD) docker.io $(PULL_BASE_FROM_DOCKERHUB) || exit 1; \
 		fi ; \

--- a/make/photon/valkey/Dockerfile.base
+++ b/make/photon/valkey/Dockerfile.base
@@ -1,6 +1,47 @@
-FROM goharbor/photon:5.0
+# TARGETARCH is auto-populated by BuildKit via --platform; default ensures
+# graceful fallback to amd64 if built without explicit platform flag.
+ARG TARGETARCH=amd64
+# VALKEY_VERSION and VALKEY_SHA256 are only used by the arm64 source-build path.
+# On amd64 the Photon tdnf package is installed directly (version managed by Photon).
+ARG VALKEY_VERSION
+ARG VALKEY_SHA256
 
+# ---- amd64: use tdnf package (unchanged from original) ----
+FROM goharbor/photon:5.0 AS amd64-base
 RUN tdnf install -y shadow >> /dev/null \
     && groupadd -g 999 valkey \
     && useradd -u 999 -g 999 -c "Valkey Database Server" -d /var/lib/redis -s /sbin/nologin -m valkey
 RUN tdnf install -y valkey && tdnf clean all
+
+# ---- arm64: build from source (Photon OS has no valkey package for aarch64) ----
+FROM goharbor/photon:5.0 AS arm64-builder
+ARG VALKEY_VERSION
+ARG VALKEY_SHA256
+RUN tdnf install -y gcc make coreutils gawk glibc-devel linux-api-headers \
+    binutils tar gzip ca-certificates curl openssl-devel >> /dev/null \
+    && tdnf clean all
+WORKDIR /tmp
+RUN curl -fsSL -o valkey.tar.gz \
+    "https://github.com/valkey-io/valkey/archive/refs/tags/${VALKEY_VERSION}.tar.gz" \
+    && echo "${VALKEY_SHA256}  valkey.tar.gz" | sha256sum -c - \
+    && tar -xzf valkey.tar.gz \
+    && cd "valkey-${VALKEY_VERSION}" \
+    && make -j"$(nproc)" BUILD_TLS=yes \
+    && make PREFIX=/usr/local install
+RUN strip /usr/local/bin/valkey-* || true
+
+FROM goharbor/photon:5.0 AS arm64-base
+RUN tdnf install -y shadow openssl >> /dev/null \
+    && groupadd -g 999 valkey \
+    && useradd -u 999 -g 999 -c "Valkey Database Server" -d /var/lib/redis -s /sbin/nologin -m valkey \
+    && tdnf clean all
+COPY --from=arm64-builder /usr/local/bin/valkey-server /usr/local/bin/valkey-server
+COPY --from=arm64-builder /usr/local/bin/valkey-cli /usr/local/bin/valkey-cli
+COPY --from=arm64-builder /usr/local/bin/valkey-check-aof /usr/local/bin/valkey-check-aof
+COPY --from=arm64-builder /usr/local/bin/valkey-check-rdb /usr/local/bin/valkey-check-rdb
+COPY --from=arm64-builder /usr/local/bin/valkey-benchmark /usr/local/bin/valkey-benchmark
+RUN ln -sf /usr/local/bin/valkey-server /usr/local/bin/redis-server \
+    && ln -sf /usr/local/bin/valkey-cli /usr/local/bin/redis-cli
+
+# ---- Select final image based on target architecture ----
+FROM ${TARGETARCH}-base


### PR DESCRIPTION
The Photon OS repos dont ship a valkey package for aarch64, which breaks arm64 builds. This replaces the `tdnf install valkey` approach with a multi-stage build that compiles valkey from the upstream release tarball.

The same Dockerfile now produces working images on both amd64 and arm64 without any Makefile changes, the existing `_build_base` macro already handles multi-stage builds via BuildKit.
No changes to CI pipelines,image names, or downstream Dockerfiles are needed.

What changed:
- Multi-stage builder compiles valkey 9.1.0 with TLS support
- Only the final binaries are copied into the runtime image (~99MB)
- Added redis-server/redis-cli symlinks for backward compat
- Reverted Makefile to main (no changes needed there)

Tested on arm64:
- valkey-server 9.1.0 starts cleanly (jemalloc-5.3.0, 64-bit)
- SET/GET operations work
- No regressions on amd64