### PR TITLE
perf(replication): filter event policies in query

### DIFF
--- a/src/controller/event/handler/replication/event/handler.go
+++ b/src/controller/event/handler/replication/event/handler.go
@@ -23,6 +23,7 @@ import (
 	"github.com/goharbor/harbor/src/controller/replication"
 	repctlmodel "github.com/goharbor/harbor/src/controller/replication/model"
 	"github.com/goharbor/harbor/src/lib/log"
+	"github.com/goharbor/harbor/src/lib/q"
 	"github.com/goharbor/harbor/src/pkg/reg/filter"
 	"github.com/goharbor/harbor/src/pkg/reg/model"
 	"github.com/goharbor/harbor/src/pkg/task"
@@ -67,27 +68,20 @@ func Handle(ctx context.Context, event *Event) error {
 }
 
 func getRelatedPolicies(ctx context.Context, resource *model.Resource) ([]*repctlmodel.Policy, error) {
-	policies, err := replication.Ctl.ListPolicies(ctx, nil)
+	// Only query enabled event-based replication policies here, so the loop below
+	// doesn't need to check policy.Enabled or policy.Trigger.Type again.
+	policies, err := replication.Ctl.ListPolicies(ctx, q.New(q.KeyWords{
+		"Enabled":            true,
+		"Trigger__icontains": fmt.Sprintf("\"type\":\"%s\"", model.TriggerTypeEventBased),
+	}))
 	if err != nil {
 		return nil, err
 	}
 	result := []*repctlmodel.Policy{}
 	for _, policy := range policies {
-		// disabled
-		if !policy.Enabled {
-			continue
-		}
 		// currently, the events are produced only by local Harbor,
 		// so they should only apply to the policies whose source registry is local Harbor
 		if !(policy.SrcRegistry == nil || policy.SrcRegistry.ID == 0) {
-			continue
-		}
-		// has no trigger
-		if policy.Trigger == nil {
-			continue
-		}
-		// trigger type isn't event based
-		if policy.Trigger.Type != model.TriggerTypeEventBased {
 			continue
 		}
 		// doesn't replicate deletion


### PR DESCRIPTION
Thank you for contributing to Harbor!

# Comprehensive Summary of your change
This pull request improves the efficiency and clarity of the replication event handler by refactoring how related replication policies are queried and filtered. The main change is to move filtering logic for enabled, event-based policies into the query itself, reducing unnecessary in-memory checks.

**Replication policy filtering improvements:**

* Updated `getRelatedPolicies` in `handler.go` to query only enabled, event-based replication policies directly using the `ListPolicies` method with a constructed query, removing redundant in-memory checks for policy status and trigger type.
* Added an import for the `q` package to support the new query construction.
# Issue being fixed
Fixes https://github.com/goharbor/harbor/issues/23277

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
