### PR TITLE
[CHERRY-PICK] fix: Bump repository update_time on tag and artifact changes (#23225)

### DIFF
--- a/src/controller/artifact/controller.go
+++ b/src/controller/artifact/controller.go
@@ -262,7 +262,20 @@ func (c *controller) ensureArtifact(ctx context.Context, repository, digest stri
 		}
 	}
 
+	if created {
+		c.touchRepo(ctx, repo.RepositoryID)
+	}
+
 	return created, artifact, nil
+}
+
+// touchRepo bumps update_time on the parent repository so the "last modified"
+// timestamp reflects artifact create/delete events. Errors are logged only;
+// the caller's operation has already succeeded.
+func (c *controller) touchRepo(ctx context.Context, repositoryID int64) {
+	if err := c.repoMgr.Touch(ctx, repositoryID); err != nil {
+		log.G(ctx).Warningf("failed to touch repository %d update_time: %v", repositoryID, err)
+	}
 }
 
 func (c *controller) Count(ctx context.Context, query *q.Query) (int64, error) {
@@ -438,6 +451,9 @@ func (c *controller) deleteDeeply(ctx context.Context, id int64, isRoot, isAcces
 			return nil
 		}
 		return err
+	}
+	if isRoot {
+		c.touchRepo(ctx, art.RepositoryID)
 	}
 
 	blobs, err := c.blobMgr.List(ctx, q.New(q.KeyWords{"artifactDigest": art.Digest}))

--- a/src/controller/artifact/controller_test.go
+++ b/src/controller/artifact/controller_test.go
@@ -234,8 +234,10 @@ func (c *controllerTestSuite) TestEnsureArtifact() {
 
 	// the artifact doesn't exist
 	c.repoMgr.On("GetByName", mock.Anything, mock.Anything).Return(&repomodel.RepoRecord{
-		ProjectID: 1,
+		RepositoryID: 1,
+		ProjectID:    1,
 	}, nil)
+	c.repoMgr.On("Touch", mock.Anything, int64(1)).Return(nil)
 	c.artMgr.On("GetByDigest", mock.Anything, mock.Anything, mock.Anything).Return(nil, errors.NotFoundError(nil))
 	c.artMgr.On("Create", mock.Anything, mock.Anything).Return(int64(1), nil)
 	c.abstractor.On("AbstractMetadata").Return(nil)
@@ -265,8 +267,10 @@ func (c *controllerTestSuite) TestEnsure() {
 
 	// both the artifact and the tag don't exist
 	c.repoMgr.On("GetByName", mock.Anything, mock.Anything).Return(&repomodel.RepoRecord{
-		ProjectID: 1,
+		RepositoryID: 1,
+		ProjectID:    1,
 	}, nil)
+	c.repoMgr.On("Touch", mock.Anything, int64(1)).Return(nil)
 	c.artMgr.On("GetByDigest", mock.Anything, mock.Anything, mock.Anything).Return(nil, errors.NotFoundError(nil))
 	c.artMgr.On("Create", mock.Anything, mock.Anything).Return(int64(1), nil)
 	c.abstractor.On("AbstractMetadata").Return(nil)
@@ -566,7 +570,7 @@ func (c *controllerTestSuite) TestDeleteDeeply() {
 	c.SetupTest()
 
 	// accessory contains tag
-	c.artMgr.On("Get", mock.Anything, mock.Anything).Return(&artifact.Artifact{ID: 1}, nil)
+	c.artMgr.On("Get", mock.Anything, mock.Anything).Return(&artifact.Artifact{ID: 1, RepositoryID: 1}, nil)
 	c.artMgr.On("Delete", mock.Anything, mock.Anything).Return(nil)
 	c.tagCtl.On("List").Return([]*tag.Tag{
 		{
@@ -583,6 +587,7 @@ func (c *controllerTestSuite) TestDeleteDeeply() {
 	c.blobMgr.On("List", mock.Anything, mock.Anything).Return(nil, nil)
 	c.blobMgr.On("CleanupAssociationsForProject", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	c.repoMgr.On("Get", mock.Anything, mock.Anything).Return(&repomodel.RepoRecord{}, nil)
+	c.repoMgr.On("Touch", mock.Anything, int64(1)).Return(nil)
 	c.artrashMgr.On("Create", mock.Anything, mock.Anything).Return(int64(0), nil)
 	c.labelMgr.On("ListByArtifact", mock.Anything, mock.Anything).Return([]*model.Label{}, nil)
 	err = c.ctl.deleteDeeply(orm.NewContext(nil, &ormtesting.FakeOrmer{}), 1, true, true)
@@ -600,6 +605,7 @@ func (c *controllerTestSuite) TestCopy() {
 		RepositoryID: 1,
 		Name:         "library/hello-world",
 	}, nil)
+	c.repoMgr.On("Touch", mock.Anything, mock.Anything).Return(nil)
 	c.artMgr.On("Count", mock.Anything, mock.Anything).Return(int64(0), nil)
 	c.artMgr.On("GetByDigest", mock.Anything, mock.Anything, mock.Anything).Return(nil, errors.NotFoundError(nil))
 	c.tagCtl.On("List").Return([]*tag.Tag{

--- a/src/controller/tag/controller.go
+++ b/src/controller/tag/controller.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/goharbor/harbor/src/common/utils"
 	"github.com/goharbor/harbor/src/lib/errors"
+	"github.com/goharbor/harbor/src/lib/log"
 	"github.com/goharbor/harbor/src/lib/orm"
 	"github.com/goharbor/harbor/src/lib/q"
 	"github.com/goharbor/harbor/src/lib/selector"
@@ -28,6 +29,7 @@ import (
 	"github.com/goharbor/harbor/src/pkg/artifact"
 	"github.com/goharbor/harbor/src/pkg/immutable/match"
 	"github.com/goharbor/harbor/src/pkg/immutable/match/rule"
+	"github.com/goharbor/harbor/src/pkg/repository"
 	"github.com/goharbor/harbor/src/pkg/tag"
 	model_tag "github.com/goharbor/harbor/src/pkg/tag/model/tag"
 )
@@ -63,6 +65,7 @@ func NewController() Controller {
 	return &controller{
 		tagMgr:       tag.Mgr,
 		artMgr:       pkg.ArtifactMgr,
+		repoMgr:      pkg.RepositoryMgr,
 		immutableMtr: rule.NewRuleMatcher(),
 	}
 }
@@ -70,6 +73,7 @@ func NewController() Controller {
 type controller struct {
 	tagMgr       tag.Manager
 	artMgr       artifact.Manager
+	repoMgr      repository.Manager
 	immutableMtr match.ImmutableTagMatcher
 }
 
@@ -103,7 +107,11 @@ func (c *controller) Ensure(ctx context.Context, repositoryID, artifactID int64,
 		// update it to point to the provided artifact
 		tag.ArtifactID = artifactID
 		tag.PushTime = time.Now()
-		return tag.ID, c.Update(ctx, tag, "ArtifactID", "PushTime")
+		if err := c.Update(ctx, tag, "ArtifactID", "PushTime"); err != nil {
+			return 0, err
+		}
+		c.touchRepo(ctx, repositoryID)
+		return tag.ID, nil
 	}
 
 	// the tag doesn't exist under the repository, create it
@@ -118,11 +126,23 @@ func (c *controller) Ensure(ctx context.Context, repositoryID, artifactID int64,
 		tag.PushTime = time.Now()
 		tagID, err = c.Create(ctx, tag)
 		return err
-	})(orm.SetTransactionOpNameToContext(ctx, "tx-tag-ensure")); err != nil && !errors.IsConflictErr(err) {
+	})(orm.SetTransactionOpNameToContext(ctx, "tx-tag-ensure")); err != nil {
+		if errors.IsConflictErr(err) {
+			return tagID, nil
+		}
 		return 0, err
 	}
 
 	return tagID, nil
+}
+
+// touchRepo bumps update_time on the parent repository so the "last modified"
+// timestamp reflects tag push/delete events. Errors are logged only; the tag
+// operation has already succeeded.
+func (c *controller) touchRepo(ctx context.Context, repositoryID int64) {
+	if err := c.repoMgr.Touch(ctx, repositoryID); err != nil {
+		log.G(ctx).Warningf("failed to touch repository %d update_time: %v", repositoryID, err)
+	}
 }
 
 // Count ...
@@ -164,7 +184,12 @@ func (c *controller) Create(ctx context.Context, tag *Tag) (id int64, err error)
 	if !isValidTag(tag.Name) {
 		return 0, errors.BadRequestError(errors.Errorf("invalid tag name: %s", tag.Name))
 	}
-	return c.tagMgr.Create(ctx, &(tag.Tag))
+	id, err = c.tagMgr.Create(ctx, &(tag.Tag))
+	if err != nil {
+		return 0, err
+	}
+	c.touchRepo(ctx, tag.RepositoryID)
+	return id, nil
 }
 
 func isValidTag(name string) bool {
@@ -191,7 +216,11 @@ func (c *controller) Delete(ctx context.Context, id int64) (err error) {
 		return errors.New(nil).WithCode(errors.PreconditionCode).
 			WithMessagef("the tag %s configured as immutable, cannot be deleted", tag.Name)
 	}
-	return c.tagMgr.Delete(ctx, id)
+	if err := c.tagMgr.Delete(ctx, id); err != nil {
+		return err
+	}
+	c.touchRepo(ctx, tag.RepositoryID)
+	return nil
 }
 
 // DeleteTags ...

--- a/src/controller/tag/controller_test.go
+++ b/src/controller/tag/controller_test.go
@@ -50,6 +50,7 @@ func (c *controllerTestSuite) SetupTest() {
 	c.ctl = &controller{
 		tagMgr:       c.tagMgr,
 		artMgr:       c.artMgr,
+		repoMgr:      c.repoMgr,
 		immutableMtr: c.immutableMtr,
 	}
 }
@@ -88,10 +89,12 @@ func (c *controllerTestSuite) TestEnsureTag() {
 	c.artMgr.On("Get", mock.Anything, mock.Anything).Return(&pkg_artifact.Artifact{
 		ID: 1,
 	}, nil)
+	c.repoMgr.On("Touch", mock.Anything, int64(1)).Return(nil).Once()
 	mock.OnAnything(c.immutableMtr, "Match").Return(false, nil)
 	_, err = c.ctl.Ensure(orm.NewContext(nil, &ormtesting.FakeOrmer{}), 1, 1, "latest")
 	c.Require().Nil(err)
 	c.tagMgr.AssertExpectations(c.T())
+	c.repoMgr.AssertExpectations(c.T())
 
 	// reset the mock
 	c.SetupTest()
@@ -99,10 +102,18 @@ func (c *controllerTestSuite) TestEnsureTag() {
 	// the tag doesn't exist under the repository, create it
 	c.tagMgr.On("List", mock.Anything, mock.Anything).Return([]*tag.Tag{}, nil)
 	c.tagMgr.On("Create", mock.Anything, mock.Anything).Return(int64(1), nil)
-	c.artMgr.On("Get", mock.Anything, mock.Anything).Return(&pkg_artifact.Artifact{
-		ID: 1,
-	}, nil)
-	mock.OnAnything(c.immutableMtr, "Match").Return(false, nil)
+	c.repoMgr.On("Touch", mock.Anything, int64(1)).Return(nil).Once()
+	_, err = c.ctl.Ensure(orm.NewContext(nil, &ormtesting.FakeOrmer{}), 1, 1, "latest")
+	c.Require().Nil(err)
+	c.tagMgr.AssertExpectations(c.T())
+	c.repoMgr.AssertExpectations(c.T())
+
+	// reset the mock
+	c.SetupTest()
+
+	// a concurrent create conflict means this request did not change tag state
+	c.tagMgr.On("List", mock.Anything, mock.Anything).Return([]*tag.Tag{}, nil)
+	c.tagMgr.On("Create", mock.Anything, mock.Anything).Return(int64(0), errors.ConflictError(nil))
 	_, err = c.ctl.Ensure(orm.NewContext(nil, &ormtesting.FakeOrmer{}), 1, 1, "latest")
 	c.Require().Nil(err)
 	c.tagMgr.AssertExpectations(c.T())
@@ -142,18 +153,30 @@ func (c *controllerTestSuite) TestGet() {
 	c.Equal(false, tag.Immutable)
 }
 
+func (c *controllerTestSuite) TestCreate() {
+	c.tagMgr.On("Create", mock.Anything, mock.Anything).Return(int64(1), nil)
+	c.repoMgr.On("Touch", mock.Anything, int64(1)).Return(nil).Once()
+	id, err := c.ctl.Create(nil, &Tag{Tag: tag.Tag{RepositoryID: 1, Name: "v1"}})
+	c.Require().Nil(err)
+	c.Equal(int64(1), id)
+	c.repoMgr.AssertExpectations(c.T())
+}
+
 func (c *controllerTestSuite) TestDelete() {
 	c.tagMgr.On("Get", mock.Anything, mock.Anything).Return(&tag.Tag{
 		RepositoryID: 1,
+		ArtifactID:   1,
 		Name:         "test",
 	}, nil)
 	c.artMgr.On("Get", mock.Anything, mock.Anything).Return(&pkg_artifact.Artifact{
 		ID: 1,
 	}, nil)
+	c.repoMgr.On("Touch", mock.Anything, int64(1)).Return(nil).Once()
 	mock.OnAnything(c.immutableMtr, "Match").Return(false, nil)
 	c.tagMgr.On("Delete", mock.Anything, mock.Anything).Return(nil)
 	err := c.ctl.Delete(nil, 1)
 	c.Require().Nil(err)
+	c.repoMgr.AssertExpectations(c.T())
 }
 
 func (c *controllerTestSuite) TestDeleteImmutable() {
@@ -186,15 +209,18 @@ func (c *controllerTestSuite) TestUpdate() {
 func (c *controllerTestSuite) TestDeleteTags() {
 	c.tagMgr.On("Get", mock.Anything, mock.Anything).Return(&tag.Tag{
 		RepositoryID: 1,
+		ArtifactID:   1,
 	}, nil)
 	c.artMgr.On("Get", mock.Anything, mock.Anything).Return(&pkg_artifact.Artifact{
 		ID: 1,
 	}, nil)
+	c.repoMgr.On("Touch", mock.Anything, int64(1)).Return(nil).Times(4)
 	mock.OnAnything(c.immutableMtr, "Match").Return(false, nil)
 	c.tagMgr.On("Delete", mock.Anything, mock.Anything).Return(nil)
 	ids := []int64{1, 2, 3, 4}
 	err := c.ctl.DeleteTags(nil, ids)
 	c.Require().Nil(err)
+	c.repoMgr.AssertExpectations(c.T())
 }
 
 func (c *controllerTestSuite) TestAssembleTag() {

--- a/src/pkg/cached/repository/redis/manager.go
+++ b/src/pkg/cached/repository/redis/manager.go
@@ -162,6 +162,18 @@ func (m *Manager) AddPullCount(ctx context.Context, id int64, count uint64) erro
 	return nil
 }
 
+func (m *Manager) Touch(ctx context.Context, id int64) error {
+	repo, err := m.Get(ctx, id)
+	if err != nil {
+		return err
+	}
+	if err = m.delegator.Touch(ctx, id); err != nil {
+		return err
+	}
+	m.cleanUp(ctx, repo)
+	return nil
+}
+
 // cleanUp cleans up data in cache.
 func (m *Manager) cleanUp(ctx context.Context, repo *model.RepoRecord) {
 	// clean index by id

--- a/src/pkg/repository/dao/dao.go
+++ b/src/pkg/repository/dao/dao.go
@@ -42,6 +42,8 @@ type DAO interface {
 	Update(ctx context.Context, repository *model.RepoRecord, props ...string) (err error)
 	// AddPullCount increase pull count for the specified repository
 	AddPullCount(ctx context.Context, id int64, count uint64) error
+	// Touch bumps the repository's update_time to now
+	Touch(ctx context.Context, id int64) error
 	// NonEmptyRepos returns the repositories without any artifact or all the artifacts are untagged.
 	NonEmptyRepos(ctx context.Context) ([]*model.RepoRecord, error)
 }
@@ -148,6 +150,22 @@ func (d *dao) AddPullCount(ctx context.Context, id int64, count uint64) error {
 	}
 	if num == 0 {
 		return errors.New(nil).WithMessagef("failed to increase repository pull count: %d", id)
+	}
+	return nil
+}
+
+func (d *dao) Touch(ctx context.Context, id int64) error {
+	ormer, err := orm.FromContext(ctx)
+	if err != nil {
+		return err
+	}
+	num, err := ormer.QueryTable(new(model.RepoRecord)).Filter("RepositoryID", id).Update(
+		o.Params{"update_time": time.Now()})
+	if err != nil {
+		return err
+	}
+	if num == 0 {
+		return errors.NotFoundError(nil).WithMessagef("repository %d not found", id)
 	}
 	return nil
 }

--- a/src/pkg/repository/manager.go
+++ b/src/pkg/repository/manager.go
@@ -41,6 +41,8 @@ type Manager interface {
 	Update(ctx context.Context, repository *model.RepoRecord, props ...string) (err error)
 	// AddPullCount increase pull count for the specified repository
 	AddPullCount(ctx context.Context, id int64, count uint64) error
+	// Touch bumps the repository's update_time to now
+	Touch(ctx context.Context, id int64) error
 	// NonEmptyRepos returns the repositories without any artifact or all the artifacts are untagged.
 	NonEmptyRepos(ctx context.Context) ([]*model.RepoRecord, error)
 }
@@ -101,6 +103,10 @@ func (m *manager) Update(ctx context.Context, repository *model.RepoRecord, prop
 
 func (m *manager) AddPullCount(ctx context.Context, id int64, count uint64) error {
 	return m.dao.AddPullCount(ctx, id, count)
+}
+
+func (m *manager) Touch(ctx context.Context, id int64) error {
+	return m.dao.Touch(ctx, id)
 }
 
 func (m *manager) NonEmptyRepos(ctx context.Context) ([]*model.RepoRecord, error) {

--- a/src/testing/pkg/repository/dao/dao.go
+++ b/src/testing/pkg/repository/dao/dao.go
@@ -197,6 +197,24 @@ func (_m *DAO) NonEmptyRepos(ctx context.Context) ([]*model.RepoRecord, error) {
 	return r0, r1
 }
 
+// Touch provides a mock function with given fields: ctx, id
+func (_m *DAO) Touch(ctx context.Context, id int64) error {
+	ret := _m.Called(ctx, id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Touch")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, int64) error); ok {
+		r0 = rf(ctx, id)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // Update provides a mock function with given fields: ctx, repository, props
 func (_m *DAO) Update(ctx context.Context, repository *model.RepoRecord, props ...string) error {
 	_va := make([]interface{}, len(props))

--- a/src/testing/pkg/repository/manager.go
+++ b/src/testing/pkg/repository/manager.go
@@ -227,6 +227,24 @@ func (_m *Manager) NonEmptyRepos(ctx context.Context) ([]*model.RepoRecord, erro
 	return r0, r1
 }
 
+// Touch provides a mock function with given fields: ctx, id
+func (_m *Manager) Touch(ctx context.Context, id int64) error {
+	ret := _m.Called(ctx, id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Touch")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, int64) error); ok {
+		r0 = rf(ctx, id)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // Update provides a mock function with given fields: ctx, _a1, props
 func (_m *Manager) Update(ctx context.Context, _a1 *model.RepoRecord, props ...string) error {
 	_va := make([]interface{}, len(props))


### PR DESCRIPTION
fix: bump repository update_time on tag and artifact changes

Fixes #23149.

The "Last Modified Time" column on the repository list only moved when an image was pushed. Adding or deleting a tag from the UI, or deleting an artifact, left the timestamp stale.

This wires update_time bumps into:

- Tag create, delete, and retag (both UI and registry push)
- Artifact create and delete

A new repository.Manager.Touch method does the actual update and invalidates the redis cache. It's skipped on tag-create conflicts so a duplicate push doesn't falsely advance the timestamp.

The change is repo-only on purpose: artifacts are addressed by their immutable digest, so an artifact update_time has no use.

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
