### PR TITLE
fix(registryctl): avoid fatal log on graceful shutdown

### DIFF
--- a/src/registryctl/main.go
+++ b/src/registryctl/main.go
@@ -17,6 +17,7 @@ package main
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"flag"
 	"net/http"
 	"os"
@@ -86,7 +87,7 @@ func (s *RegistryCtl) Start() {
 		err = regCtl.ListenAndServe()
 	}
 	<-shutdown
-	if err != nil {
+	if err != nil && !errors.Is(err, http.ErrServerClosed) {
 		log.Fatal(err)
 	}
 }


### PR DESCRIPTION
## Comprehensive Summary of your change

This PR fixes a misleading fatal log emitted by registryctl during graceful shutdown.

Previously, http.ErrServerClosed returned from ListenAndServe() was treated as a fatal error and logged as:

 [FATAL] http: Server closed 

This behavior occurs during normal graceful shutdown and should not be considered a fatal error.

The fix explicitly ignores http.ErrServerClosed before calling log.Fatal.

# Issue being fixed

Fixes #23294