### PR TITLE
build(registry): update source tag to rc.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,7 @@ TRIVYADAPTERVERSION=v0.35.1
 NODEBUILDIMAGE=node:16.18.0
 
 # version of registry for pulling the source code
-REGISTRY_SRC_TAG=v2.8.3-harbor.1-rc.2
+REGISTRY_SRC_TAG=v2.8.3-harbor.1-rc.4
 # source of upstream distribution code
 DISTRIBUTION_SRC=https://github.com/goharbor/distribution.git
 


### PR DESCRIPTION
Thank you for contributing to Harbor!

# Comprehensive Summary of your change
This pull request updates the `REGISTRY_SRC_TAG` version in the `Makefile` to use a newer release candidate for the Harbor registry source.

Version update:

* Updated `REGISTRY_SRC_TAG` from `v2.8.3-harbor.1-rc.2` to `v2.8.3-harbor.1-rc.3` in the `Makefile` to pull the latest Harbor registry source code.
# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
