### PR TITLE
Refresh Photon packages in component base images

### DIFF
--- a/make/photon/core/Dockerfile.base
+++ b/make/photon/core/Dockerfile.base
@@ -1,5 +1,7 @@
 FROM goharbor/photon:5.0
 
+RUN tdnf update -y && tdnf clean all
+
 RUN tdnf install -y tzdata shadow >> /dev/null \
     && tdnf clean all \
     && groupadd -r -g 10000 harbor && useradd --no-log-init -r -m -g 10000 -u 10000 harbor \

--- a/make/photon/db/Dockerfile.base
+++ b/make/photon/db/Dockerfile.base
@@ -2,6 +2,8 @@ FROM goharbor/photon:5.0
 
 ENV PGDATA /var/lib/postgresql/data
 
+RUN tdnf update -y && tdnf clean all
+
 RUN tdnf install -y shadow >> /dev/null \
     && groupadd -r postgres --gid=999 \
     && useradd -m -r -g postgres --uid=999 postgres

--- a/make/photon/exporter/Dockerfile.base
+++ b/make/photon/exporter/Dockerfile.base
@@ -1,5 +1,7 @@
 FROM goharbor/photon:5.0
 
+RUN tdnf update -y && tdnf clean all
+
 RUN tdnf install -y tzdata shadow >> /dev/null \
     && tdnf clean all \
     && groupadd -r -g 10000 harbor && useradd --no-log-init -r -m -g 10000 -u 10000 harbor \

--- a/make/photon/jobservice/Dockerfile.base
+++ b/make/photon/jobservice/Dockerfile.base
@@ -1,5 +1,7 @@
 FROM goharbor/photon:5.0
 
+RUN tdnf update -y && tdnf clean all
+
 RUN tdnf install -y tzdata shadow >> /dev/null \
     && tdnf clean all \
     && groupadd -r -g 10000 harbor && useradd --no-log-init -r -m -g 10000 -u 10000 harbor

--- a/make/photon/log/Dockerfile.base
+++ b/make/photon/log/Dockerfile.base
@@ -1,5 +1,7 @@
 FROM goharbor/photon:5.0
 
+RUN tdnf update -y && tdnf clean all
+
 RUN tdnf install -y cronie rsyslog logrotate shadow tar gzip sudo >> /dev/null\
     && mkdir /var/spool/rsyslog \
     && groupadd -r -g 10000 syslog && useradd --no-log-init -r -g 10000 -u 10000 syslog \

--- a/make/photon/nginx/Dockerfile.base
+++ b/make/photon/nginx/Dockerfile.base
@@ -1,5 +1,7 @@
 FROM goharbor/photon:5.0
 
+RUN tdnf update -y && tdnf clean all
+
 RUN tdnf install -y nginx shadow >> /dev/null \
     && tdnf clean all \
     && groupmod -g 10000 nginx && usermod -g 10000 -u 10000 -d /home/nginx -s /bin/bash nginx \

--- a/make/photon/portal/Dockerfile.base
+++ b/make/photon/portal/Dockerfile.base
@@ -1,5 +1,7 @@
 FROM goharbor/photon:5.0
 
+RUN tdnf update -y && tdnf clean all
+
 RUN tdnf install -y nginx shadow >> /dev/null \
     && tdnf clean all \
     && ln -sf /dev/stdout /var/log/nginx/access.log \

--- a/make/photon/prepare/Dockerfile.base
+++ b/make/photon/prepare/Dockerfile.base
@@ -1,5 +1,7 @@
 FROM goharbor/photon:5.0
 
+RUN tdnf update -y && tdnf clean all
+
 RUN tdnf install -y python3 python3-pip python3-PyYAML python3-jinja2 && tdnf clean all
 RUN pip3 install pipenv==2025.0.3
 

--- a/make/photon/redis/Dockerfile.base
+++ b/make/photon/redis/Dockerfile.base
@@ -1,5 +1,7 @@
 FROM goharbor/photon:5.0
 
+RUN tdnf update -y && tdnf clean all
+
 RUN tdnf install -y shadow >> /dev/null \
     && groupadd -g 999 redis \
     && useradd -u 999 -g 999 -c "Redis Database Server" -d /var/lib/redis -s /sbin/nologin -m redis

--- a/make/photon/registry/Dockerfile.base
+++ b/make/photon/registry/Dockerfile.base
@@ -1,5 +1,7 @@
 FROM goharbor/photon:5.0
 
+RUN tdnf update -y && tdnf clean all
+
 RUN tdnf install -y shadow >> /dev/null \
     && tdnf clean all \
     && mkdir -p /etc/registry \

--- a/make/photon/registryctl/Dockerfile.base
+++ b/make/photon/registryctl/Dockerfile.base
@@ -1,5 +1,7 @@
 FROM goharbor/photon:5.0
 
+RUN tdnf update -y && tdnf clean all
+
 RUN tdnf install -y shadow >> /dev/null \
     && tdnf clean all \
     && groupadd -r -g 10000 harbor && useradd --no-log-init -m -g 10000 -u 10000 harbor \

--- a/make/photon/trivy-adapter/Dockerfile.base
+++ b/make/photon/trivy-adapter/Dockerfile.base
@@ -1,5 +1,7 @@
 FROM goharbor/photon:5.0
 
+RUN tdnf update -y && tdnf clean all
+
 RUN tdnf install -y rpm shadow >> /dev/null \
     && tdnf clean all \
     && groupadd -r -g 10000 scanner \

--- a/make/photon/valkey/Dockerfile.base
+++ b/make/photon/valkey/Dockerfile.base
@@ -1,5 +1,7 @@
 FROM goharbor/photon:5.0
 
+RUN tdnf update -y && tdnf clean all
+
 RUN tdnf install -y shadow >> /dev/null \
     && groupadd -g 999 valkey \
     && useradd -u 999 -g 999 -c "Valkey Database Server" -d /var/lib/redis -s /sbin/nologin -m valkey


### PR DESCRIPTION
## Summary
- Run `tdnf update -y` in each Photon component base image before installing component-specific packages.
- Keep the existing package installs and user/group setup unchanged.
- Make patched `2.15.x` rebuilds less dependent on whether the inherited `goharbor/photon:5.0` tag or local build cache already contains the latest Photon packages.

## Motivation
A container security scan of the official `v2.15.1` image set showed fixable reachable findings in common Photon package families such as `glibc`, `curl-libs`, `libssh2`, `ncurses-libs`, and `expat-libs`. The release branch already refreshes the shared Photon base, but the component base images can also refresh packages directly at build time to reduce stale-package risk in rebuilt images.

Addresses #23311.

## Testing
- `git diff --check`
- Built representative base image:
  `docker build --platform linux/amd64 -f make/photon/core/Dockerfile.base -t harbor-core-base-security-refresh-test .`

The local Docker environment emitted a platform warning because the host is arm64, but the Dockerfile parsed and the `tdnf update` step completed successfully.
