### PR TITLE
fix(db): select newest available Postgres major per arch to unblock arm64 build

### DIFF
--- a/make/photon/db/Dockerfile
+++ b/make/photon/db/Dockerfile
@@ -13,7 +13,15 @@ RUN chown -R postgres:postgres /docker-entrypoint.sh /initdb.sh /upgrade.sh \
     /docker-healthcheck.sh /docker-entrypoint-initdb.d \
     && chmod u+x /initdb.sh /upgrade.sh /docker-entrypoint.sh /docker-healthcheck.sh
 
-ENTRYPOINT ["/docker-entrypoint.sh", "15", "18"]
+# Exec-form ENTRYPOINT can't expand the per-arch PG major that harbor-db-base
+# records in /etc/harbor-pg-new-version, so a shim injects it (15 = upgrade-from
+# version). See goharbor/harbor#23317.
+RUN printf '#!/bin/bash\nexec /docker-entrypoint.sh 15 "$(cat /etc/harbor-pg-new-version 2>/dev/null || echo 18)" "$@"\n' \
+        > /docker-entrypoint-shim.sh \
+    && chmod u+x /docker-entrypoint-shim.sh \
+    && chown postgres:postgres /docker-entrypoint-shim.sh
+
+ENTRYPOINT ["/docker-entrypoint-shim.sh"]
 HEALTHCHECK CMD ["/docker-healthcheck.sh"]
 
 USER postgres

--- a/make/photon/db/Dockerfile.base
+++ b/make/photon/db/Dockerfile.base
@@ -1,5 +1,9 @@
 FROM goharbor/photon:5.0
 
+# No default: a default value shadows BuildKit's --platform auto-population of
+# TARGETARCH, breaking the per-arch selection below. See goharbor/harbor#23317.
+ARG TARGETARCH
+
 ENV PGDATA /var/lib/postgresql/data
 
 RUN tdnf install -y shadow >> /dev/null \
@@ -7,14 +11,18 @@ RUN tdnf install -y shadow >> /dev/null \
     && useradd -m -r -g postgres --uid=999 postgres
 
 RUN tdnf install -y postgresql15-server >> /dev/null
-RUN tdnf install -y gzip postgresql18-server findutils bc >> /dev/null \
+# Photon 5.0 has no postgresql18 for aarch64 (newest is pg17), so pick the newest
+# major available per arch. See goharbor/harbor#23317.
+RUN if [ "$TARGETARCH" = "arm64" ] || [ "$(uname -m)" = "aarch64" ]; then PG_NEW=17; else PG_NEW=18; fi \
+    && tdnf install -y gzip postgresql${PG_NEW}-server findutils bc >> /dev/null \
     && mkdir -p /docker-entrypoint-initdb.d \
     && mkdir -p /run/postgresql \
     && chown -R postgres:postgres /run/postgresql \
     && chmod 2777 /run/postgresql \
     && mkdir -p "$PGDATA" && chown -R postgres:postgres "$PGDATA" && chmod 777 "$PGDATA" \
-    && sed -i "s|#listen_addresses = 'localhost'.*|listen_addresses = '*'|g" /usr/pgsql/18/share/postgresql/postgresql.conf.sample \
-    && sed -i "s|#unix_socket_directories = '/tmp'.*|unix_socket_directories = '/run/postgresql'|g" /usr/pgsql/18/share/postgresql/postgresql.conf.sample \
+    && sed -i "s|#listen_addresses = 'localhost'.*|listen_addresses = '*'|g" /usr/pgsql/${PG_NEW}/share/postgresql/postgresql.conf.sample \
+    && sed -i "s|#unix_socket_directories = '/tmp'.*|unix_socket_directories = '/run/postgresql'|g" /usr/pgsql/${PG_NEW}/share/postgresql/postgresql.conf.sample \
+    && echo "$PG_NEW" > /etc/harbor-pg-new-version \
     && tdnf clean all
 
 RUN tdnf install -y util-linux


### PR DESCRIPTION

The arm64 leg of `Build Package Workflow` fails while amd64 passes ([failing run](https://github.com/goharbor/harbor/actions/runs/26807434260/job/79028428755)):

```
#7 postgresql18-server package not found or not installed
#7 Error(1011) : No matching packages
make[1]: *** [make/photon/Makefile:127: _build_db] Error 1
make: *** [Makefile:431: build] Error 2
```

The recent valkey arm64 fix (#23282) was one step in the right way. The build now gets past valkey and fails at the **next** arm64-incompatible step, the database image.

## Root cause

**Photon OS 5.0 packages `postgresql18` for `x86_64` but only up to `postgresql17` for `aarch64`.** Since the DB image was bumped to PostgreSQL 18 in #23184, `make/photon/db/Dockerfile.base` installs `postgresql18-server`, which cannot resolve on aarch64.

Verified against `goharbor/photon:5.0`:

```
$ docker run --rm --platform linux/arm64 goharbor/photon:5.0 \
    sh -c "tdnf list available 2>/dev/null | grep -i postgresql.*server"
postgresql15-server.aarch64   15.17-1.1.ph5   photon-snapshot
postgresql16-server.aarch64   16.13-1.1.ph5   photon-snapshot
postgresql17-server.aarch64   17.9-1.1.ph5    photon-snapshot
# postgresql18-server -> Error(1011): No matching packages
```

# Issue being fixed

Make the DB image's target Postgres major **architecture-aware**, keeping amd64 unchanged:

- **amd64** → PostgreSQL **18** (unchanged)
- **arm64** → PostgreSQL **17** (newest package available for aarch64)

## Follow-up

This is a deliberate stopgap (amd64 on pg18, arm64 on pg17). Converging both architectures on the same major  and the related base-image tag race between the parallel arch builds is tracked in #23318.




Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
