### PR TITLE
fix(ecr): use amazonaws.com.cn domain for AWS China region endpoints

### DIFF
--- a/src/pkg/reg/adapter/awsecr/adapter.go
+++ b/src/pkg/reg/adapter/awsecr/adapter.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsecrapi "github.com/aws/aws-sdk-go-v2/service/ecr"
@@ -162,9 +163,14 @@ func getAdapterInfo() *model.AdapterPattern {
 		"us-gov-east-1",
 		"us-gov-west-1",
 	} {
+		// AWS China regions (aws-cn partition) use amazonaws.com.cn.
+		domain := "amazonaws.com"
+		if strings.HasPrefix(e, "cn-") {
+			domain = "amazonaws.com.cn"
+		}
 		endpoints = append(endpoints, &model.Endpoint{
 			Key:   e,
-			Value: fmt.Sprintf("https://api.ecr.%s.amazonaws.com", e),
+			Value: fmt.Sprintf("https://api.ecr.%s.%s", e, domain),
 		})
 	}
 	info := &model.AdapterPattern{

--- a/src/pkg/reg/adapter/awsecr/adapter_test.go
+++ b/src/pkg/reg/adapter/awsecr/adapter_test.go
@@ -393,6 +393,24 @@ func TestAwsAuthCredential_Modify(t *testing.T) {
 	require.Nil(t, err)
 }
 
+func TestGetAdapterInfo_ChinaRegionEndpoints(t *testing.T) {
+	info := getAdapterInfo()
+	endpoints := info.EndpointPattern.Endpoints
+	endpointMap := make(map[string]string, len(endpoints))
+	for _, ep := range endpoints {
+		endpointMap[ep.Key] = ep.Value
+	}
+
+	// China regions must use amazonaws.com.cn
+	assert.Equal(t, "https://api.ecr.cn-north-1.amazonaws.com.cn", endpointMap["cn-north-1"])
+	assert.Equal(t, "https://api.ecr.cn-northwest-1.amazonaws.com.cn", endpointMap["cn-northwest-1"])
+
+	// Standard regions must use amazonaws.com
+	assert.Equal(t, "https://api.ecr.us-east-1.amazonaws.com", endpointMap["us-east-1"])
+	assert.Equal(t, "https://api.ecr.ap-southeast-1.amazonaws.com", endpointMap["ap-southeast-1"])
+	assert.Equal(t, "https://api.ecr.eu-west-1.amazonaws.com", endpointMap["eu-west-1"])
+}
+
 var urlForBenchmark = []string{
 	"https://1234.dkr.ecr.test-region.amazonaws.com/v2/",
 	"https://api.ecr.test-region.amazonaws.com",


### PR DESCRIPTION
## Comprehensive Summary

The ECR adapter's `getAdapterInfo()` function builds the UI endpoint dropdown for all AWS regions using a hardcoded `amazonaws.com` domain suffix — regardless of whether the region belongs to the standard `aws` partition or the China `aws-cn` partition. This means users selecting `cn-north-1` or `cn-northwest-1` from the Harbor UI receive a pre-filled endpoint of:

```
https://api.ecr.cn-north-1.amazonaws.com   # wrong
```

when the correct endpoint is:

```
https://api.ecr.cn-north-1.amazonaws.com.cn
```

The connection attempt fails silently and there is no obvious indication in the UI that the domain is wrong.

**Root cause:** A single-line format string `fmt.Sprintf("https://api.ecr.%s.amazonaws.com", e)` was applied uniformly across all regions in the loop.

**Fix:** Added a domain suffix check — any region prefixed with `cn-` (AWS China partition) gets `amazonaws.com.cn`; all other regions retain `amazonaws.com`. The existing `ecrPattern` regex already handles `.cn` correctly for URL parsing; only the endpoint generator was wrong.

**Test added:** `TestGetAdapterInfo_ChinaRegionEndpoints` asserts China regions produce `.com.cn` URLs and sampled standard regions produce `.com` URLs.

## Issue being fixed

Fixes #23325

## Discovery

While reviewing the region list introduced by PR #22941 (fix: add missing AWS regions to ECR adapter, contributed by @nicknikolakakis closing my earlier issue #22860), I noticed that `cn-north-1` and `cn-northwest-1` were added to the loop but the domain suffix was never adjusted for the China partition. The regex pattern in the same file already accounts for `.cn` — the endpoint builder just didn't.

## Checklist

- [x] Well Written Title and Summary of the PR
- [x] Label the PR: `release-note/fix`
- [x] Accepted the DCO — commits include `Signed-off-by: Amaan Ul Haq Siddiqui <amaanulhaq.s@outlook.com>`
- [x] Tests passing — `TestGetAdapterInfo_ChinaRegionEndpoints` added and passes alongside the full `awsecr` suite
- [ ] Docs impact — no user-facing documentation change needed; this is a URL generation fix for an existing UI dropdown