### PR TITLE
fix: build PostgreSQL 18 from source to support arm64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,6 +137,10 @@ TRIVYADAPTERVERSION=v0.35.1
 # On amd64 the Photon tdnf package version is used directly.
 VALKEYVERSION=9.0.3
 VALKEYSHA256=e220f4b0143292ee6ea6d705aa40d45a0c8a77759b3e94c201cb5c25dbdca42f
+# PG18VERSION and PG18SHA256 are only used for the arm64 source build.
+# On amd64 the Photon tdnf postgresql18-server package is used directly.
+PG18VERSION=18.4
+PG18SHA256=81a81ec695fb0c7901407defaa1d2f7973617154cf27ba74e3a7ab8e64436094
 NODEBUILDIMAGE=node:16.18.0
 
 # version of registry for pulling the source code
@@ -437,6 +441,7 @@ build:
 	 -e REGISTRYVERSION=$(REGISTRYVERSION) -e REGISTRY_SRC_TAG=$(REGISTRY_SRC_TAG)  -e DISTRIBUTION_SRC=$(DISTRIBUTION_SRC)\
 	 -e TRIVYVERSION=$(TRIVYVERSION) -e TRIVYADAPTERVERSION=$(TRIVYADAPTERVERSION) \
 	 -e VALKEYVERSION=$(VALKEYVERSION) -e VALKEYSHA256=$(VALKEYSHA256) \
+	 -e PG18VERSION=$(PG18VERSION) -e PG18SHA256=$(PG18SHA256) \
 	 -e VERSIONTAG=$(VERSIONTAG) \
 	 -e DOCKERNETWORK=$(DOCKERNETWORK) \
 	 -e BUILDREG=$(BUILDREG) -e BUILDTRIVYADP=$(BUILDTRIVYADP) \
@@ -462,11 +467,14 @@ build_base_docker:
 	@for name in $(BUILDBASETARGET); do \
 		echo $$name ; \
 		sleep 30 ; \
-		valkey_args="" ; \
+		extra_args="" ; \
 		if [ "$$name" = "valkey" ]; then \
-			valkey_args="--build-arg VALKEY_VERSION=$(VALKEYVERSION) --build-arg VALKEY_SHA256=$(VALKEYSHA256)" ; \
+			extra_args="--build-arg VALKEY_VERSION=$(VALKEYVERSION) --build-arg VALKEY_SHA256=$(VALKEYSHA256) --target $(ARCH)-base" ; \
 		fi ; \
-		$(DOCKERBUILD) --pull --no-cache -f $(MAKEFILEPATH_PHOTON)/$$name/Dockerfile.base $$valkey_args -t $(BASEIMAGENAMESPACE)/harbor-$$name-base:$(BASEIMAGETAG) --label base-build-date=$(date +"%Y%m%d") . ; \
+		if [ "$$name" = "db" ]; then \
+			extra_args="--build-arg PG18_VERSION=$(PG18VERSION) --build-arg PG18_SHA256=$(PG18SHA256) --target $(ARCH)-base" ; \
+		fi ; \
+		$(DOCKERBUILD) --pull --no-cache -f $(MAKEFILEPATH_PHOTON)/$$name/Dockerfile.base $$extra_args -t $(BASEIMAGENAMESPACE)/harbor-$$name-base:$(BASEIMAGETAG) --label base-build-date=$(date +"%Y%m%d") . ; \
 		if [ "$(PUSHBASEIMAGE)" != "false" ] ; then \
 			$(PUSHSCRIPTPATH)/$(PUSHSCRIPTNAME) $(BASEIMAGENAMESPACE)/harbor-$$name-base:$(BASEIMAGETAG) $(REGISTRYUSER) $(REGISTRYPASSWORD) || exit 1; \
 		fi ; \

--- a/make/photon/Makefile
+++ b/make/photon/Makefile
@@ -124,7 +124,7 @@ _build_prepare:
 	@echo "Done."
 
 _build_db:
-	@$(call _build_base,$(DB),$(DOCKERFILEPATH_DB))
+	@$(call _build_base,$(DB),$(DOCKERFILEPATH_DB),--build-arg PG18_VERSION=$(PG18VERSION) --build-arg PG18_SHA256=$(PG18SHA256) --target $(TARGETARCH)-base)
 	@echo "building db container for photon..."
 	@$(DOCKERBUILD_WITH_PULL_PARA) --build-arg harbor_base_image_version=$(BASEIMAGETAG) --build-arg harbor_base_namespace=$(BASEIMAGENAMESPACE) -f $(DOCKERFILEPATH_DB)/$(DOCKERFILENAME_DB) -t $(DOCKERIMAGENAME_DB):$(VERSIONTAG) .
 	@echo "Done."
@@ -202,7 +202,7 @@ _build_registryctl:
 	@echo "Done."
 
 _build_valkey:
-	@$(call _build_base,$(VALKEY),$(DOCKERFILEPATH_VALKEY),--build-arg VALKEY_VERSION=$(VALKEYVERSION) --build-arg VALKEY_SHA256=$(VALKEYSHA256))
+	@$(call _build_base,$(VALKEY),$(DOCKERFILEPATH_VALKEY),--build-arg VALKEY_VERSION=$(VALKEYVERSION) --build-arg VALKEY_SHA256=$(VALKEYSHA256) --target $(TARGETARCH)-base)
 	@echo "building valkey container for photon..."
 	@$(DOCKERBUILD_WITH_PULL_PARA) --build-arg harbor_base_image_version=$(BASEIMAGETAG) --build-arg harbor_base_namespace=$(BASEIMAGENAMESPACE) -f $(DOCKERFILEPATH_VALKEY)/$(DOCKERFILENAME_VALKEY) -t $(DOCKERIMAGENAME_VALKEY):$(VERSIONTAG) .
 	@echo "Done."

--- a/make/photon/db/Dockerfile.base
+++ b/make/photon/db/Dockerfile.base
@@ -1,4 +1,13 @@
-FROM goharbor/photon:5.0
+# TARGETARCH is auto-populated by BuildKit via --platform; default ensures
+# graceful fallback to amd64 if built without explicit platform flag.
+ARG TARGETARCH=amd64
+# PG18_VERSION and PG18_SHA256 are only used by the arm64 source-build path.
+# On amd64 the Photon tdnf package is installed directly.
+ARG PG18_VERSION
+ARG PG18_SHA256
+
+# ---- amd64: use tdnf packages (unchanged from original) ----
+FROM goharbor/photon:5.0 AS amd64-base
 
 ENV PGDATA /var/lib/postgresql/data
 
@@ -18,3 +27,48 @@ RUN tdnf install -y gzip postgresql18-server findutils bc >> /dev/null \
     && tdnf clean all
 
 RUN tdnf install -y util-linux
+
+# ---- arm64: build PostgreSQL 18 from source (Photon has no postgresql18-server for aarch64) ----
+FROM goharbor/photon:5.0 AS arm64-builder
+ARG PG18_VERSION
+ARG PG18_SHA256
+RUN tdnf install -y gcc make binutils glibc-devel linux-api-headers \
+    readline-devel zlib-devel openssl-devel icu-devel \
+    coreutils diffutils gawk bison flex perl \
+    bzip2 tar ca-certificates curl >> /dev/null \
+    && tdnf clean all
+WORKDIR /tmp
+RUN curl -fsSL -o postgresql.tar.bz2 \
+    "https://ftp.postgresql.org/pub/source/v${PG18_VERSION}/postgresql-${PG18_VERSION}.tar.bz2" \
+    && echo "${PG18_SHA256}  postgresql.tar.bz2" | sha256sum -c - \
+    && tar -xjf postgresql.tar.bz2 \
+    && cd "postgresql-${PG18_VERSION}" \
+    && ./configure --prefix=/usr --datadir=/usr/pgsql/18/share/postgresql \
+       --with-openssl --with-icu --with-system-tzdata=/usr/share/zoneinfo \
+    && make -j"$(nproc)" world-bin \
+    && make DESTDIR=/tmp/pg18-install install-world-bin
+RUN strip /tmp/pg18-install/usr/bin/* 2>/dev/null || true \
+    && strip /tmp/pg18-install/usr/lib/*.so* 2>/dev/null || true \
+    && strip /tmp/pg18-install/usr/lib/postgresql/*.so 2>/dev/null || true
+
+FROM goharbor/photon:5.0 AS arm64-base
+ENV PGDATA=/var/lib/postgresql/data
+RUN tdnf install -y shadow gzip findutils bc util-linux \
+    readline zlib openssl icu >> /dev/null \
+    && groupadd -r postgres --gid=999 \
+    && useradd -m -r -g postgres --uid=999 postgres \
+    && tdnf clean all
+RUN tdnf install -y postgresql15-server >> /dev/null
+COPY --from=arm64-builder /tmp/pg18-install/usr/bin/ /usr/bin/
+COPY --from=arm64-builder /tmp/pg18-install/usr/lib/ /usr/lib/
+COPY --from=arm64-builder /tmp/pg18-install/usr/pgsql/ /usr/pgsql/
+RUN mkdir -p /docker-entrypoint-initdb.d \
+    && mkdir -p /run/postgresql \
+    && chown -R postgres:postgres /run/postgresql \
+    && chmod 2777 /run/postgresql \
+    && mkdir -p "$PGDATA" && chown -R postgres:postgres "$PGDATA" && chmod 777 "$PGDATA" \
+    && sed -i "s|#listen_addresses = 'localhost'.*|listen_addresses = '*'|g" /usr/pgsql/18/share/postgresql/postgresql.conf.sample \
+    && sed -i "s|#unix_socket_directories = '/tmp'.*|unix_socket_directories = '/run/postgresql'|g" /usr/pgsql/18/share/postgresql/postgresql.conf.sample
+
+# ---- Select final image based on target architecture ----
+FROM ${TARGETARCH}-base


### PR DESCRIPTION

This applies the same multi-stage build approach used for valkey (#23282):
the amd64 path is completely unchanged (tdnf package install), while arm64
compiles PostgreSQL 18 from the upstream release tarball.

### What changed

- `make/photon/db/Dockerfile.base`: multi-stage build with `amd64-base` (tdnf,
  unchanged) and `arm64-builder` + `arm64-base` (source compile). Final stage
  selected via `FROM ${TARGETARCH}-base`.
- `Makefile`: added `PG18VERSION` and `PG18SHA256` variables, threaded as
  build-args to the photon sub-make.
- `make/photon/Makefile`: pass `--build-arg PG18_VERSION/PG18_SHA256` and
  `--target $(TARGETARCH)-base` to `_build_db`.

### Validation (aarch64 — Graviton)

- ✅ Image builds successfully on arm64
- ✅ `postgres --version` → PostgreSQL 18.4 on aarch64
- ✅ `initdb` succeeds
- ✅ Server starts and accepts connections (`pg_isready`)
- ✅ SQL operations (CREATE TABLE, INSERT, SELECT) work
- ✅ Harbor entrypoint (`/docker-entrypoint.sh 15 18`) runs init, creates
  `registry` DB, applies `initial-registry.sql`
- ✅ Harbor healthcheck (`/docker-healthcheck.sh`) passes — container reports healthy
- ✅ PostgreSQL 15 present for upgrade path (`pg_upgrade`)
- ✅ No regressions on amd64 (path unchanged)

### Related

- Fixes the arm64 leg of Build Package Workflow
  (https://github.com/goharbor/harbor/actions/runs/26807434260/job/79028428755)
- Root cause: #23184 (pg18 bump)
- Same approach as: #23282 (valkey arm64 fix)
- Photon issue for missing package: https://github.com/vmware/photon/issues/1655