### PR TITLE
fix: use postgres 18 in db base image

### DIFF
--- a/make/photon/db/Dockerfile.base
+++ b/make/photon/db/Dockerfile.base
@@ -8,7 +8,6 @@ RUN tdnf install -y shadow >> /dev/null \
     && groupadd -r postgres --gid=999 \
     && useradd -m -r -g postgres --uid=999 postgres
 
-RUN tdnf install -y postgresql15-server >> /dev/null
 RUN if [ "${TARGETARCH:-amd64}" = "arm64" ]; then \
         cp /etc/yum.repos.d/photon-snapshot.repo /etc/yum.repos.d/photon-snapshot.repo.bak \
         && sed -i '/^snapshot/d' /etc/yum.repos.d/photon-snapshot.repo \


### PR DESCRIPTION
## Summary
- remove the remaining `postgresql15-server` install from the DB base image
- install `postgresql18-server` directly as the only PostgreSQL server package
- keep the change limited to `make/photon/db/Dockerfile.base`


Failing job reference: https://github.com/goharbor/harbor/actions/runs/27182030877/job/80243049233