### PR TITLE
[WIP]fix postgres15 removed from photon snapshot issue

### DIFF
--- a/.buildbaselog
+++ b/.buildbaselog
@@ -8,6 +8,9 @@
 *   Add date here... Add signature here...
 -   Add your reason here...
 
+*   Jun 09 2026 <aaron.an@broadcom.com>
+-   Refresh base image
+
 *   May 18 2026 <aaron.an@broadcom.com>
 -   Refresh base image
 

--- a/make/photon/db/Dockerfile.base
+++ b/make/photon/db/Dockerfile.base
@@ -8,7 +8,19 @@ RUN tdnf install -y shadow >> /dev/null \
     && groupadd -r postgres --gid=999 \
     && useradd -m -r -g postgres --uid=999 postgres
 
-RUN tdnf install -y postgresql15-server >> /dev/null
+RUN if [ "${TARGETARCH:-amd64}" = "amd64" ]; then \
+        cp /etc/yum.repos.d/photon-snapshot.repo /etc/yum.repos.d/photon-snapshot.repo.bak \
+        && sed -i '/^snapshot/d' /etc/yum.repos.d/photon-snapshot.repo \
+        && tdnf clean all \
+        && tdnf makecache \
+        && tdnf install -y postgresql15-server >> /dev/null \
+        && mv /etc/yum.repos.d/photon-snapshot.repo.bak /etc/yum.repos.d/photon-snapshot.repo \
+        && tdnf clean all \
+        && tdnf makecache; \
+    else \
+        tdnf install -y postgresql15-server >> /dev/null; \
+    fi
+
 RUN if [ "${TARGETARCH:-amd64}" = "arm64" ]; then \
         cp /etc/yum.repos.d/photon-snapshot.repo /etc/yum.repos.d/photon-snapshot.repo.bak \
         && sed -i '/^snapshot/d' /etc/yum.repos.d/photon-snapshot.repo \


### PR DESCRIPTION
Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)
Photon modified their snapshot in recently, Postgres15 releases were removed from snapshot, we need to install it from main repo and switch back to snapshot repo after the installation. This change implement the mentioned fix. 

Please indicate you've done the following:
- [ ] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [ ] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
