### PR TITLE
fix: publish goharbor/photon:5.0 as a multi-arch manifest (#23324)

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -8,7 +8,47 @@ on:
       - main
       - release-*
 jobs:
+  BUILD_BASE_IMAGE:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      build_base: ${{ steps.decide.outputs.build_base || 'false' }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: jitterbit/get-changed-files@v1
+        id: changed-files
+        continue-on-error: true
+        with:
+          format: space-delimited
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Decide whether to (re)build the base image
+        id: decide
+        if: |
+            steps.changed-files.outcome != 'success' ||
+            contains(steps.changed-files.outputs.modified, 'common/Dockerfile') ||
+            contains(steps.changed-files.outputs.modified, 'Dockerfile.base') ||
+            contains(steps.changed-files.outputs.modified, 'VERSION') ||
+            contains(steps.changed-files.outputs.modified, '.buildbaselog') ||
+            github.ref == 'refs/heads/main'
+        run: echo "build_base=true" >> "$GITHUB_OUTPUT"
+      - name: Set up QEMU
+        if: steps.decide.outputs.build_base == 'true'
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        if: steps.decide.outputs.build_base == 'true'
+        uses: docker/setup-buildx-action@v3
+      - name: Build and push goharbor/photon:5.0 multi-arch manifest
+        if: steps.decide.outputs.build_base == 'true'
+        run: |
+          set -x
+          echo "${{ secrets.DOCKER_HUB_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_HUB_USERNAME }}" --password-stdin
+          docker buildx build --platform linux/amd64,linux/arm64 \
+            -f make/photon/common/Dockerfile -t goharbor/photon:5.0 --push .
+          docker logout
+
   BUILD_PACKAGE:
+    needs: [BUILD_BASE_IMAGE]
     strategy:
       fail-fast: false
       matrix:
@@ -16,6 +56,7 @@ jobs:
     env:
         BUILD_PACKAGE: true
         ARCH: ${{ matrix.arch }}
+        BUILD_BASE: ${{ needs.BUILD_BASE_IMAGE.outputs.build_base }}
     runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     steps:
       - name: Configure AWS credentials
@@ -35,26 +76,9 @@ jobs:
           docker_version: 20.10
           docker_channel: stable
       - uses: actions/checkout@v6
-      - uses: jitterbit/get-changed-files@v1
-        id: changed-files
-        with:
-          format: space-delimited
-          token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@v6
         with:
           path: src/github.com/goharbor/harbor
-      - name: Build Base Image
-        if: |
-            contains(steps.changed-files.outputs.modified, 'Dockerfile.base') ||
-            contains(steps.changed-files.outputs.modified, 'VERSION') ||
-            contains(steps.changed-files.outputs.modified, '.buildbaselog') ||
-            github.ref == 'refs/heads/main'
-        run: |
-          set -x
-          echo "${{ secrets.DOCKER_HUB_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_HUB_USERNAME }}" --password-stdin
-          docker build -f make/photon/common/Dockerfile -t goharbor/photon:5.0 .
-          docker push goharbor/photon:5.0
-          echo "BUILD_BASE=true" >> $GITHUB_ENV
       - name: Build Package
         run: |
           set -x
@@ -125,7 +149,7 @@ jobs:
           publishImage $target_branch $Harbor_Assets_Version "${{ secrets.DOCKER_HUB_USERNAME }}" "${{ secrets.DOCKER_HUB_PASSWORD }}" ${ARCH}
       - name: Save repo list
         run: |
-          docker images --format '{{.Repository}}' | grep '^goharbor/' | grep -v '\-base' | sort -u > "$GITHUB_WORKSPACE/_repos_${ARCH}.txt"
+          docker images --format '{{.Repository}}' | grep '^goharbor/' | grep -v '\-base' | grep -v '^goharbor/photon$' | sort -u > "$GITHUB_WORKSPACE/_repos_${ARCH}.txt"
       - name: Upload repo list
         uses: actions/upload-artifact@v4
         with:

--- a/make/photon/common/Dockerfile
+++ b/make/photon/common/Dockerfile
@@ -1,14 +1,9 @@
 FROM photon:5.0
 
-# 1. Install photon-repos package
-RUN tdnf install photon-repos -y
-
-# 2. Enable photon-snapshot repo
-RUN sed -i 's/enabled\s*=.*/enabled=0/g' /etc/yum.repos.d/*.repo
-RUN sed -i 's/enabled\s*=.*/enabled=1/g' /etc/yum.repos.d/photon-snapshot.repo && tdnf clean all
-
-# 2. Use tdnf to disable all default repos, enable only the snapshot, and update/install
-# The --disablerepo="*" flag turns off the mainline public repos
-# The --enablerepo="photon-snapshot" flag explicitly targets your template
-RUN tdnf --disablerepo="*" --enablerepo="photon-snapshot" makecache \
-    && tdnf --disablerepo="*" --enablerepo="photon-snapshot" update -y
+RUN tdnf install photon-repos -y \
+    && sed -i 's/enabled\s*=.*/enabled=0/g' /etc/yum.repos.d/*.repo \
+    && sed -i 's/enabled\s*=.*/enabled=1/g' /etc/yum.repos.d/photon-snapshot.repo \
+    && tdnf clean all \
+    && tdnf --disablerepo="*" --enablerepo="photon-snapshot" makecache \
+    && tdnf --disablerepo="*" --enablerepo="photon-snapshot" update -y \
+    && tdnf clean all

--- a/make/photon/db/Dockerfile.base
+++ b/make/photon/db/Dockerfile.base
@@ -8,7 +8,19 @@ RUN tdnf install -y shadow >> /dev/null \
     && groupadd -r postgres --gid=999 \
     && useradd -m -r -g postgres --uid=999 postgres
 
-RUN tdnf install -y postgresql15-server >> /dev/null
+RUN if [ "${TARGETARCH:-amd64}" = "amd64" ]; then \
+        cp /etc/yum.repos.d/photon-snapshot.repo /etc/yum.repos.d/photon-snapshot.repo.bak \
+        && sed -i '/^snapshot/d' /etc/yum.repos.d/photon-snapshot.repo \
+        && tdnf clean all \
+        && tdnf makecache \
+        && tdnf install -y postgresql15-server >> /dev/null \
+        && mv /etc/yum.repos.d/photon-snapshot.repo.bak /etc/yum.repos.d/photon-snapshot.repo \
+        && tdnf clean all \
+        && tdnf makecache; \
+    else \
+        tdnf install -y postgresql15-server >> /dev/null; \
+    fi
+
 RUN if [ "${TARGETARCH:-amd64}" = "arm64" ]; then \
         cp /etc/yum.repos.d/photon-snapshot.repo /etc/yum.repos.d/photon-snapshot.repo.bak \
         && sed -i '/^snapshot/d' /etc/yum.repos.d/photon-snapshot.repo \


### PR DESCRIPTION
# Comprehensive Summary of your change

`goharbor/photon:5.0` was built and pushed independently by **both** the `amd64` and `arm64` `BUILD_PACKAGE` matrix jobs to the **same tag**, so whichever job finished last overwrote the other and the published tag ended up single-arch — "sometimes amd64, sometimes arm64" (#23324).

### Changes

- **`.github/workflows/build-package.yml`** (the #23324 fix) — build and push `goharbor/photon:5.0` **once** as a multi-arch (amd64+arm64) manifest list in a dedicated `BUILD_BASE_IMAGE` job that `BUILD_PACKAGE` depends on, instead of each per-arch job overwriting the tag. `goharbor/photon` is excluded from the component manifest list in `CREATE_MANIFEST` (it is published here and stays at tag `5.0`). The base-rebuild decision is made fail-safe (rebuild when the changed-files lookup is unavailable, e.g. on a new branch).
- **`make/photon/db/Dockerfile.base`** — apply the Photon-team workaround (per @wy65701436 / @jUDASmILE review, same as #23332): keep the stable `photon-snapshot` repo, but temporarily un-pin it (`sed '/^snapshot/d'`) to install the postgresql major that Photon has deprecated out of the current snapshot — `postgresql15-server` on amd64, `postgresql18-server` on arm64 — then restore the snapshot. Both majors are kept: pg15 supplies the old binaries at `/usr/pgsql/15/bin` required by `pg_upgrade`, pg18 is the runtime.
- **`make/photon/common/Dockerfile`** — keep the `photon-snapshot` repo (the stable Photon source) and merge its setup into a single `RUN`.

### Why keep both pg15 and pg18

`make/photon/db/Dockerfile`'s entrypoint is `["/docker-entrypoint.sh", "15", "18"]`. For an existing install, `docker-entrypoint.sh` runs `pg_upgrade` from the old pg15 cluster (`/usr/pgsql/15/bin`) to pg18 (`/usr/bin`) — so the pg15 binaries must be present. Fresh installs init pg18 directly. This is why dropping pg15 (#23331) is not viable.

### Verification

Built locally with BuildKit for **both** `linux/amd64` and `linux/arm64`:
- `goharbor/photon:5.0` (snapshot base) builds on both arches.
- `harbor-db-base` builds on both arches; `/usr/bin/postgres` → `/usr/pgsql/18/bin/postgres` = **PostgreSQL 18.3** (runtime), `/usr/pgsql/15/bin/postgres` = 15.17 (upgrade), `/usr/bin/pg_upgrade` present, and the `postgresql.conf.sample` edits applied.

# Issue being fixed

Fixes #23324
Relates to #23309. The pg15/pg18 install workaround matches #23332.

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. `release-note/infra`
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).

```release-note
Publish the goharbor/photon:5.0 base image as a proper multi-arch (amd64+arm64) manifest instead of overwriting the tag per architecture.
```
