### PR TITLE
fix: publish harbor-*-base images as multi-arch manifests

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -150,14 +150,19 @@ jobs:
       - name: Save repo list
         run: |
           docker images --format '{{.Repository}}' | grep '^goharbor/' | grep -v '\-base' | grep -v '^goharbor/photon$' | grep -v '^goharbor/spectral$' | grep -v '^goharbor/swagger$' | grep -v '^goharbor/mockery$' | sort -u > "$GITHUB_WORKSPACE/_repos_${ARCH}.txt"
+          # base images are pushed arch-suffixed by the _build_base make macro
+          # and combined into multi-arch manifests by CREATE_MANIFEST
+          docker images --format '{{.Repository}}' | grep '^goharbor/.*-base$' | sort -u > "$GITHUB_WORKSPACE/_base_repos_${ARCH}.txt"
       - name: Upload repo list
         uses: actions/upload-artifact@v4
         with:
           name: repos-${{ matrix.arch }}
-          path: ${{ github.workspace }}/_repos_${{ matrix.arch }}.txt
+          path: |
+            ${{ github.workspace }}/_repos_${{ matrix.arch }}.txt
+            ${{ github.workspace }}/_base_repos_${{ matrix.arch }}.txt
 
   CREATE_MANIFEST:
-    needs: [BUILD_PACKAGE]
+    needs: [BUILD_BASE_IMAGE, BUILD_PACKAGE]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -181,6 +186,13 @@ jobs:
           else
             echo "image_tag=${version}" >> $GITHUB_OUTPUT
           fi
+          # base images use BASEIMAGETAG (see Harbor_Build_Base_Tag in BUILD_PACKAGE):
+          # "dev" on main, the release version on release-* branches
+          if [[ $target_branch == "release-"* ]]; then
+            echo "base_tag=${version}" >> $GITHUB_OUTPUT
+          else
+            echo "base_tag=dev" >> $GITHUB_OUTPUT
+          fi
       - name: Login to Docker Hub
         run: echo "${{ secrets.DOCKER_HUB_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_HUB_USERNAME }}" --password-stdin
       - name: Create multi-arch manifests
@@ -194,4 +206,17 @@ jobs:
               "${repo}:${image_tag}-amd64" \
               "${repo}:${image_tag}-arm64"
           done
+          # The harbor-*-base images are only (re)built and pushed (arch-suffixed)
+          # when BUILD_BASE_IMAGE decided to rebuild the base; otherwise the
+          # suffixed tags from this run don't exist and there is nothing to combine.
+          if [ "${{ needs.BUILD_BASE_IMAGE.outputs.build_base }}" = "true" ]; then
+            base_tag="${{ steps.tag.outputs.base_tag }}"
+            cat _base_repos_*.txt | sort -u | while IFS= read -r repo; do
+              [ -z "$repo" ] && continue
+              echo "Creating manifest ${repo}:${base_tag}"
+              docker buildx imagetools create -t "${repo}:${base_tag}" \
+                "${repo}:${base_tag}-amd64" \
+                "${repo}:${base_tag}-arm64"
+            done
+          fi
           docker logout

--- a/make/photon/Makefile
+++ b/make/photon/Makefile
@@ -238,7 +238,8 @@ define _build_base
 		fi ;\
 			$(DOCKERBUILD) -f $(2)/Dockerfile.base --build-arg pip_index_url=$(PIP_INDEX_URL) --build-arg TARGETARCH=$(TARGETARCH) $(3) -t $(BASEIMAGENAMESPACE)/harbor-$(1)-base:$(BASEIMAGETAG) --label base-build-date=$(TIMESTAMP) . ;\
 		if [ "$(PUSHBASEIMAGE)" = "true" ] ; then \
-			$(PUSHSCRIPTPATH)/$(PUSHSCRIPTNAME) $(BASEIMAGENAMESPACE)/harbor-$(1)-base:$(BASEIMAGETAG) $(REGISTRYUSER) $(REGISTRYPASSWORD) docker.io $(PULL_BASE_FROM_DOCKERHUB) || exit 1; \
+			$(DOCKERCMD) tag $(BASEIMAGENAMESPACE)/harbor-$(1)-base:$(BASEIMAGETAG) $(BASEIMAGENAMESPACE)/harbor-$(1)-base:$(BASEIMAGETAG)-$(TARGETARCH) ; \
+			$(PUSHSCRIPTPATH)/$(PUSHSCRIPTNAME) $(BASEIMAGENAMESPACE)/harbor-$(1)-base:$(BASEIMAGETAG)-$(TARGETARCH) $(REGISTRYUSER) $(REGISTRYPASSWORD) docker.io $(PULL_BASE_FROM_DOCKERHUB) || exit 1; \
 		fi ; \
 	fi
 endef


### PR DESCRIPTION
After #23334 fixed `goharbor/photon:5.0`, an audit of every image push path in the pipeline found one remaining last-writer-wins overwrite: the **12 per-component base images** (`goharbor/harbor-core-base`, `harbor-db-base`, `harbor-portal-base`, `harbor-nginx-base`, `harbor-registry-base`, `harbor-registryctl-base`, `harbor-jobservice-base`, `harbor-log-base`, `harbor-prepare-base`, `harbor-exporter-base`, `harbor-trivy-adapter-base`, `harbor-valkey-base`).

`_build_base` in `make/photon/Makefile` pushes `goharbor/harbor-<name>-base:dev` via a plain `docker push` from **both** `BUILD_PACKAGE` matrix jobs — whichever architecture finishes last overwrites the tag. Verified on Docker Hub right now:

| tag | architectures |
|---|---|
| `harbor-portal-base:dev` | **arm64 only** (last push 2026-06-10 09:19) |
| `harbor-core-base:dev` | **arm64 only** (last push 2026-06-10 09:21) |
| `harbor-*-base:v2.x` (release tags) | **amd64 only** |

This breaks any consumer that pulls the bases from Docker Hub (`PULL_BASE_FROM_DOCKERHUB=true` with `BUILD_BASE=false`) on the architecture that lost the race.

### Changes — same pattern as the component images

- **`make/photon/Makefile`** — `_build_base` still builds the local **unsuffixed** tag (component Dockerfiles `FROM harbor-<name>-base:<tag>` keep working unchanged), but now pushes an **arch-suffixed** tag: `harbor-<name>-base:<tag>-amd64` / `-arm64`.
- **`.github/workflows/build-package.yml`** — each matrix job saves the list of `goharbor/*-base` repos; `CREATE_MANIFEST` combines `<tag>-amd64` + `<tag>-arm64` into the unsuffixed `<tag>` multi-arch manifest with `docker buildx imagetools create`. The base tag scheme matches `Harbor_Build_Base_Tag` (`dev` on main, the release version on `release-*`). The base-manifest step is gated on `BUILD_BASE_IMAGE.outputs.build_base` since suffixed tags only exist in runs that rebuilt bases.

After this, pulling `harbor-*-base:dev` resolves the correct architecture via the manifest list on both amd64 and arm64.

### Relation to #23347

#23347 proposes `max-parallel: 1` for the same symptom. Serializing the matrix makes the overwrite deterministic (the tag would always end up arm64-only, since arm64 runs last) but still publishes a single-arch tag and roughly doubles workflow wall-clock. This PR removes the overwrite instead: both arches publish suffixed tags concurrently and the manifest list serves both.

### Verification

- `make -n` dry-run of `_build_base` for `ARCH=amd64` and `ARCH=arm64` confirms: local build tag stays `harbor-db-base:dev`, push becomes `harbor-db-base:dev-amd64` / `dev-arm64`, and the component image build still consumes the local unsuffixed tag.
- The `CREATE_MANIFEST` `imagetools create` pattern is the one already in production for the component images (e.g. `harbor-core:dev` is amd64+arm64 today).
- The full push flow validates post-merge on `main` (the workflow is push-only and needs the Docker Hub secrets).

# Issue being fixed

Follow-up to #23324 / #23334. Alternative to #23347.

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. `release-note/infra`
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).

```release-note
Publish the goharbor/harbor-*-base images as multi-arch (amd64+arm64) manifests instead of overwriting the tag per architecture.
```
