### PR TITLE
fix(build): pin Photon base to stable multi-arch digest

### DIFF
--- a/make/photon/common/Dockerfile
+++ b/make/photon/common/Dockerfile
@@ -1,4 +1,4 @@
-FROM photon:5.0
+FROM photon:5.0-20260214
 
 RUN tdnf install photon-repos -y \
     && sed -i 's/enabled\s*=.*/enabled=0/g' /etc/yum.repos.d/*.repo \


### PR DESCRIPTION
The latest upstream photon:5.0 arm64 image currently has an empty rootfs, which fails during the multi-arch base build with "/bin/sh: no such file or directory". Pin the Photon base to a known-good stable digest to keep the amd64 and arm64 builds reproducible.

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [ ] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [ ] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
