### PR TITLE
fix: stabilize build base image workflow

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -129,7 +129,7 @@ jobs:
           if [ -z "$BUILD_BASE"  ] || [ "$BUILD_BASE" != "true"  ]; then
             echo "Do not need to build base images!"
           else
-            build_base_params=" BUILD_BASE=true PULL_BASE_FROM_DOCKERHUB=true PUSHBASEIMAGE=true REGISTRYUSER=\"${{ secrets.DOCKER_HUB_USERNAME }}\" REGISTRYPASSWORD=\"${{ secrets.DOCKER_HUB_PASSWORD }}\""
+            build_base_params=" BUILD_BASE=true PULL_BASE_FROM_DOCKERHUB=false PUSHBASEIMAGE=true REGISTRYUSER=\"${{ secrets.DOCKER_HUB_USERNAME }}\" REGISTRYPASSWORD=\"${{ secrets.DOCKER_HUB_PASSWORD }}\""
           fi
 
           sudo make package_offline ARCH=${ARCH} GOBUILDTAGS="include_oss include_gcs" BASEIMAGETAG=${Harbor_Build_Base_Tag} VERSIONTAG=${Harbor_Assets_Version} PKGVERSIONTAG=${Harbor_Package_Version} TRIVYFLAG=true EXPORTERFLAG=true HTTPPROXY= ${build_base_params}

--- a/make/photon/common/Dockerfile
+++ b/make/photon/common/Dockerfile
@@ -1,4 +1,4 @@
-FROM photon:5.0
+FROM photon:5.0-20260214
 
 RUN tdnf install photon-repos -y \
     && sed -i 's/enabled\s*=.*/enabled=0/g' /etc/yum.repos.d/*.repo \


### PR DESCRIPTION
Thank you for contributing to Harbor!

# Comprehensive Summary of your change

This PR stabilizes the build package workflow base-image rebuild path with the smallest possible change:

- Pin Harbor's `goharbor/photon:5.0` wrapper build input to `photon:5.0-20260214`, a known-good upstream Photon tag. The current floating `photon:5.0` tag has a `linux/arm64/v8` manifest entry, but that image is only 127B and lacks `/bin/sh`, causing `BUILD_BASE_IMAGE` to fail before Harbor can publish `goharbor/photon:5.0`.
- Use `PULL_BASE_FROM_DOCKERHUB=false` when `BUILD_BASE=true` in `BUILD_PACKAGE`, so component image builds consume the freshly rebuilt local `harbor-*-base:<tag>` images instead of pulling stale unsuffixed base manifests before `CREATE_MANIFEST` publishes the new multi-arch manifests.

Verification performed:

- `regctl manifest get photon:5.0-20260214 --platform linux/amd64`
- `regctl manifest get photon:5.0-20260214 --platform linux/arm64`
- `make -n -f make/photon/Makefile _build_db ARCH=amd64 BUILD_BASE=true PULL_BASE_FROM_DOCKERHUB=false PUSHBASEIMAGE=true REGISTRYUSER=user REGISTRYPASSWORD=pass BASEIMAGETAG=dev VERSIONTAG=test DOCKERNETWORK=host`
- `make -n -f make/photon/Makefile _build_db ARCH=arm64 BUILD_BASE=true PULL_BASE_FROM_DOCKERHUB=false PUSHBASEIMAGE=true REGISTRYUSER=user REGISTRYPASSWORD=pass BASEIMAGETAG=dev VERSIONTAG=test DOCKERNETWORK=host`
- `act push -W .github/workflows/build-package.yml -j BUILD_BASE_IMAGE -n -P ubuntu-latest=catthehacker/ubuntu:act-latest`

# Issue being fixed

Fixes #23354

Upstream Photon issue: vmware/photon#1660

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. `release-note/infra`
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).

```release-note
Fix the build package workflow base image rebuild path after the upstream photon:5.0 arm64 image became unusable.
```
