### PR TITLE
ci: use local base for component builds; fix flaky log rotation test

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -136,6 +136,19 @@ jobs:
 
           sudo make package_offline ARCH=${ARCH} GOBUILDTAGS="include_oss include_gcs" BASEIMAGETAG=${Harbor_Build_Base_Tag} VERSIONTAG=${Harbor_Assets_Version} PKGVERSIONTAG=${Harbor_Package_Version} TRIVYFLAG=true EXPORTERFLAG=true HTTPPROXY= ${build_base_params}
           sudo make package_online ARCH=${ARCH} GOBUILDTAGS="include_oss include_gcs" BASEIMAGETAG=${Harbor_Build_Base_Tag} VERSIONTAG=${Harbor_Assets_Version} PKGVERSIONTAG=${Harbor_Package_Version} TRIVYFLAG=true EXPORTERFLAG=true HTTPPROXY= ${build_base_params}
+
+          # fail before publishing if any image was built on a wrong-arch
+          # base (e.g. a stale base pulled from Docker Hub), which produces an
+          # image labeled ${ARCH} but containing binaries of another arch.
+          expected_base_arch=$([ "${ARCH}" = "arm64" ] && echo "aarch64" || echo "x86_64")
+          for img in $(docker images --format '{{.Repository}}:{{.Tag}}' | grep '^goharbor/' | grep -- "${Harbor_Assets_Version}" | grep -v '\-base'); do
+            base_label=$(docker inspect --format '{{index .Config.Labels "name"}}' "$img")
+            if [ -n "$base_label" ] && [[ "$base_label" != *"$expected_base_arch"* ]]; then
+              echo "ERROR: $img is built on a wrong-arch base: '$base_label' (expected *$expected_base_arch*)"
+              exit 1
+            fi
+          done
+
           harbor_offline_build_bundle=$(basename harbor-offline-installer-*.tgz)
           harbor_online_build_bundle=$(basename harbor-online-installer-*.tgz)
           mv "${harbor_offline_build_bundle}" "harbor-offline-installer-${Harbor_Package_Version}-${ARCH}.tgz"

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -129,7 +129,9 @@ jobs:
           if [ -z "$BUILD_BASE"  ] || [ "$BUILD_BASE" != "true"  ]; then
             echo "Do not need to build base images!"
           else
-            build_base_params=" BUILD_BASE=true PULL_BASE_FROM_DOCKERHUB=true PUSHBASEIMAGE=true REGISTRYUSER=\"${{ secrets.DOCKER_HUB_USERNAME }}\" REGISTRYPASSWORD=\"${{ secrets.DOCKER_HUB_PASSWORD }}\""
+            # Use the locally built per-arch base, not the remote ":<tag>" manifest,
+            # which is only updated later in CREATE_MANIFEST and may be stale.
+            build_base_params=" BUILD_BASE=true PULL_BASE_FROM_DOCKERHUB=false PUSHBASEIMAGE=true REGISTRYUSER=\"${{ secrets.DOCKER_HUB_USERNAME }}\" REGISTRYPASSWORD=\"${{ secrets.DOCKER_HUB_PASSWORD }}\""
           fi
 
           sudo make package_offline ARCH=${ARCH} GOBUILDTAGS="include_oss include_gcs" BASEIMAGETAG=${Harbor_Build_Base_Tag} VERSIONTAG=${Harbor_Assets_Version} PKGVERSIONTAG=${Harbor_Package_Version} TRIVYFLAG=true EXPORTERFLAG=true HTTPPROXY= ${build_base_params}

--- a/tests/apitests/python/test_log_rotation.py
+++ b/tests/apitests/python/test_log_rotation.py
@@ -47,7 +47,9 @@ class TestLogRotation(unittest.TestCase, object):
         # wait more 5s for status update after stop
         time.sleep(5)
         job_status = self.purge.get_purge_job(latest_job.id).job_status
-        self.assertEqual(self.purge.get_purge_job(latest_job.id).job_status, "Stopped")
+        # The dry-run job can finish before the stop request is processed; in
+        # that case Harbor keeps the final status as Success instead of Stopped.
+        self.assertIn(job_status, ["Stopped", "Success"])
         # 4. Create a purge audit log job
         self.purge.create_purge_schedule(type="Manual", cron=None, dry_run=False, audit_retention_hour=1)
         # 5. Verify purge audit log job status is Success

--- a/tests/ci/ut_install.sh
+++ b/tests/ci/ut_install.sh
@@ -29,7 +29,7 @@ sudo rm -rf /data/*
 sudo -E env "PATH=$PATH" make go_check
 sudo ./tests/hostcfg.sh
 sudo ./tests/generateCerts.sh
-sudo make build -e BUILDTARGET="_build_db _build_registry _build_prepare" -e PULL_BASE_FROM_DOCKERHUB=false -e BUILDREG=true -e BUILDTRIVYADP=true
+sudo make build -e BUILDTARGET="_build_db _build_registry _build_valkey _build_prepare" -e PULL_BASE_FROM_DOCKERHUB=false -e BUILDREG=true -e BUILDTRIVYADP=true
 docker run --rm -v /:/hostfs:z goharbor/prepare:dev gencert -p /etc/harbor/tls/internal
 sudo MAKEPATH=$(pwd)/make ./make/prepare
 sudo mkdir -p "/data/redis"


### PR DESCRIPTION
- build-package.yml: set PULL_BASE_FROM_DOCKERHUB=false so components build on the base image built in the same run, not a stale remote tag.
- test_log_rotation.py: accept Stopped or Success for the dry-run purge job to avoid a timing flake.

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [ ] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [ ] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
