### PR TITLE
test(api_db): support dynamic OpenAPI generator and PyPI URLs via env vars

### DIFF
--- a/tests/resources/APITest-Util.robot
+++ b/tests/resources/APITest-Util.robot
@@ -3,14 +3,14 @@ ${JFROG_USER}  ${EMPTY}
 ${JFROG_PWD}  ${EMPTY}
 ${JFROG_URL}  ${EMPTY}
 ${JFROG_NAMESPACE}  ${EMPTY}
-${OPENAPI_GENERATOR_CLI_URL}  https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/4.3.1/openapi-generator-cli-4.3.1.jar
-${PIP_INDEX_URL}  https://pypi.org/simple
+${OPENAPI_GENERATOR_CLI_URL}  %{OPENAPI_GENERATOR_CLI_URL=https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/4.3.1/openapi-generator-cli-4.3.1.jar}
+${PIP_INDEX_URL}              %{PIP_INDEX_URL=https://pypi.org/simple}
 
 *** Keywords ***
 Make Swagger Client
     ${rc}  ${output}=  Run And Return Rc And Output  pip uninstall setuptools -y
     LogAll  ${output}
-    ${rc}  ${output}=  Run And Return Rc And Output  pip install -U pip setuptools
+    ${rc}  ${output}=  Run And Return Rc And Output  pip install -U pip setuptools --index-url ${PIP_INDEX_URL}
     LogAll  ${output}
     ${rc}  ${output}=  Run And Return Rc And Output  OPENAPI_GENERATOR_CLI_URL=${OPENAPI_GENERATOR_CLI_URL} PIP_INDEX_URL=${PIP_INDEX_URL} make swagger_client
     LogAll  ${output}


### PR DESCRIPTION
Thank you for contributing to Harbor!

# Comprehensive Summary of your change

Hardcoded URLs for openapi-generator-cli and PyPI in APITest-Util.robot frequently cause 429 rate limit errors in busy environments.
The current hardcoded URLs in APITest-Util.robot prevent users from overriding them with reliable internal mirrors or S3 buckets.


Testing Steps:

1.Manually start a container on the JUMPER with below commands
```
docker run -i --privileged --network host -v /root/mirrors_github_harbor:/drone -v /root/mirrors_github_harbor/tests/:/ca -e https_proxy=http://10.162.237.53:3128/ -e HTTP_PROXY=http://10.162.237.53:3128/ -e HTTPS_PROXY=http://10.162.237.53:3128/ -e NETWORKTYPE=public -e PIP_INDEX_URL=https://packages.vcfd.broadcom.net/artifactory/api/pypi/upstream-pypi-virtual/simple -e OPENAPI_GENERATOR_CLI_URL=https://harbor-releases.s3.us-west-1.amazonaws.com/ci-artifacts/openapi-generator-cli-4.3.1.jar -w /drone registry.goharbor.io/harbor-ci/goharbor/harbor-e2e-engine:latest-api robot --xunit ./junit --exclude proxy_cache --exclude metrics --exclude push_cnab --exclude gc --exclude robot_account --exclude replic_dockerhub --exclude view_logs -v OPENAPI_GENERATOR_CLI_URL_DEFAULT:https://harbor-releases.s3.us-west-1.amazonaws.com/ci-artifacts/openapi-generator-cli-4.3.1.jar -v DOCKER_USER:yminer -v DOCKER_PWD: -v ip:harbor.192.168.130.4.nip.io -v HARBOR_ADMIN:admin -v ip1: -v network_type:public -v http_get_ca:true -v HARBOR_PASSWORD:Harbor12345 /drone/tests/robot-cases/Group1-Nightly/Setup.robot /drone/tests/robot-cases/Group0-BAT/API_DB.robot
```
2. Exec into the container and check the env

```
root [ /drone ]# env
HOSTNAME=corgi-jumper
PWD=/drone
HELM_EXPERIMENTAL_OCI=1
HOME=/root
LANG=C.UTF-8
NETWORKTYPE=public
https_proxy=http://10.162.237.53:3128
OPENAPI_GENERATOR_CLI_URL=https://harbor-releases.s3.us-west-1.amazonaws.com/ci-artifacts/openapi-generator-cli-4.3.1.jar
COSIGN_OCI_EXPERIMENTAL=1
TERM=linux
PIP_INDEX_URL=https://packages.vcfd.broadcom.net/artifactory/api/pypi/upstream-pypi-virtual/simple
SHLVL=1
HTTPS_PROXY=http://10.162.237.53:3128
COSIGN_PASSWORD=Harbor12345
HTTP_PROXY=http://10.162.237.53:3128
NOTATION_EXPERIMENTAL=1
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
COSIGN_EXPERIMENTAL=1
_=/usr/bin/env
```

3. Robot cases can be run with correct OPENAPI_GENERATOR_CLI_URL




# Issue being fixed
Fixes #(issue)
-  Pass these environment variables explicitly into the `Run And Return Rc And Output` subprocess context for `make swagger_client`.

Please indicate you've done the following:
- [ ] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [ ] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
