### PR TITLE
docs: fix contributing fork setup instructions to cd before git clone

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,6 @@ mkdir -p $GOPATH/src/github.com/goharbor
 cd $GOPATH/src/github.com/goharbor/harbor
 git clone git@github.com:goharbor/harbor.git
 
-
 #Track repository under your personal account
 git config push.default nothing # Anything to avoid pushing to goharbor/harbor by default
 git remote rename origin goharbor

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,8 +31,9 @@ export GOPATH=$HOME/go
 mkdir -p $GOPATH/src/github.com/goharbor
 
 #Get code
-git clone git@github.com:goharbor/harbor.git
 cd $GOPATH/src/github.com/goharbor/harbor
+git clone git@github.com:goharbor/harbor.git
+
 
 #Track repository under your personal account
 git config push.default nothing # Anything to avoid pushing to goharbor/harbor by default


### PR DESCRIPTION
Thank you for contributing to Harbor!

# Comprehensive Summary of your change
The forking setup instructions does not cd into the newly created directory before git cloning, causing the repo to be cloned into the user's home directory instead. 

Added a cd $GOPATH/src/github.com/goharbor step between mkdir and git clone to ensure the clone lands in the correct location.

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).

Label suggestion: release-note/docs