### PR TITLE
fix(proxy-cache): redirect tags/list for Docker Hub library images

### DIFF
--- a/src/server/middleware/repoproxy/proxy.go
+++ b/src/server/middleware/repoproxy/proxy.go
@@ -165,7 +165,7 @@ func ManifestMiddleware() func(http.Handler) http.Handler {
 	})
 }
 
-func defaultLibrary(ctx context.Context, registryID int64, a lib.ArtifactInfo) (bool, string, error) {
+var defaultLibrary = func(ctx context.Context, registryID int64, a lib.ArtifactInfo) (bool, string, error) {
 	if registryID <= 0 {
 		return false, "", nil
 	}
@@ -191,6 +191,18 @@ func defaultManifestURL(projectName string, name string, a lib.ArtifactInfo) str
 // defaultBlobURL return the real url for request with default project
 func defaultBlobURL(projectName string, name string, digest string) string {
 	return fmt.Sprintf("/v2/%s/library/%s/blobs/%s", projectName, name, digest)
+}
+
+// defaultTagsListURL return the real url for the tags list request with default
+// project. The original query string (e.g. the n and last pagination
+// parameters) is preserved so that paginated requests keep working after the
+// redirect.
+func defaultTagsListURL(projectName string, name string, rawQuery string) string {
+	u := fmt.Sprintf("/v2/%s/library/%s/tags/list", projectName, name)
+	if rawQuery != "" {
+		u += "?" + rawQuery
+	}
+	return u
 }
 
 // upstreamRegistryConnectionKey get upstream registry connection key

--- a/src/server/middleware/repoproxy/tag.go
+++ b/src/server/middleware/repoproxy/tag.go
@@ -41,6 +41,22 @@ func TagsListMiddleware() func(http.Handler) http.Handler {
 			return
 		}
 
+		// Handle dockerhub request without library prefix.
+		// Docker Hub official images live under the implicit "library/" namespace,
+		// which the docker client expands transparently. The registry tags/list
+		// API does not, so a request for a single-segment repository returns an
+		// empty tag list. Redirect it to the library/-prefixed path, mirroring the
+		// manifest and blob middlewares.
+		isDefault, name, err := defaultLibrary(ctx, p.RegistryID, art)
+		if err != nil {
+			libhttp.SendError(w, err)
+			return
+		}
+		if isDefault {
+			http.Redirect(w, r, defaultTagsListURL(p.Name, name, r.URL.RawQuery), http.StatusMovedPermanently)
+			return
+		}
+
 		if !canProxy(ctx, p) {
 			next.ServeHTTP(w, r)
 			return

--- a/src/server/middleware/repoproxy/tag_test.go
+++ b/src/server/middleware/repoproxy/tag_test.go
@@ -1,0 +1,144 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package repoproxy
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/goharbor/harbor/src/controller/project"
+	"github.com/goharbor/harbor/src/lib"
+	proModels "github.com/goharbor/harbor/src/pkg/project/models"
+	projecttesting "github.com/goharbor/harbor/src/testing/controller/project"
+	"github.com/goharbor/harbor/src/testing/mock"
+)
+
+func TestDefaultTagsListURL(t *testing.T) {
+	cases := []struct {
+		name     string
+		project  string
+		repo     string
+		rawQuery string
+		want     string
+	}{
+		{
+			name:    "no query",
+			project: "proxy",
+			repo:    "busybox",
+			want:    "/v2/proxy/library/busybox/tags/list",
+		},
+		{
+			name:     "preserves pagination query",
+			project:  "proxy",
+			repo:     "alpine",
+			rawQuery: "n=50&last=1.0",
+			want:     "/v2/proxy/library/alpine/tags/list?n=50&last=1.0",
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := defaultTagsListURL(tt.project, tt.repo, tt.rawQuery); got != tt.want {
+				t.Errorf("defaultTagsListURL() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+type TagsListMiddlewareTestSuite struct {
+	suite.Suite
+
+	originalProjectController project.Controller
+	projectController         *projecttesting.Controller
+
+	originalDefaultLibrary func(context.Context, int64, lib.ArtifactInfo) (bool, string, error)
+
+	next http.Handler
+}
+
+func (suite *TagsListMiddlewareTestSuite) SetupTest() {
+	suite.originalProjectController = project.Ctl
+	suite.projectController = &projecttesting.Controller{}
+	project.Ctl = suite.projectController
+
+	suite.originalDefaultLibrary = defaultLibrary
+
+	suite.next = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+}
+
+func (suite *TagsListMiddlewareTestSuite) TearDownTest() {
+	project.Ctl = suite.originalProjectController
+	defaultLibrary = suite.originalDefaultLibrary
+}
+
+func (suite *TagsListMiddlewareTestSuite) makeRequest(target, repository string) *http.Request {
+	req := httptest.NewRequest(http.MethodGet, target, nil)
+	info := lib.ArtifactInfo{
+		ProjectName: "proxy",
+		Repository:  repository,
+	}
+	return req.WithContext(lib.WithArtifactInfo(req.Context(), info))
+}
+
+// A single-segment Docker Hub official image must be redirected to the
+// library/-prefixed tags/list path, preserving the pagination query string.
+func (suite *TagsListMiddlewareTestSuite) TestRedirectsDockerHubLibraryImage() {
+	mock.OnAnything(suite.projectController, "GetByName").Return(&proModels.Project{
+		ProjectID:  1,
+		Name:       "proxy",
+		RegistryID: 1,
+	}, nil)
+	defaultLibrary = func(context.Context, int64, lib.ArtifactInfo) (bool, string, error) {
+		return true, "busybox", nil
+	}
+
+	req := suite.makeRequest("/v2/proxy/busybox/tags/list?n=50&last=1.0", "proxy/busybox")
+	rr := httptest.NewRecorder()
+
+	TagsListMiddleware()(suite.next).ServeHTTP(rr, req)
+
+	suite.Equal(http.StatusMovedPermanently, rr.Code)
+	suite.Equal("/v2/proxy/library/busybox/tags/list?n=50&last=1.0", rr.Header().Get("Location"))
+}
+
+// A multi-segment repository is not a default-library image and must not be
+// redirected; the request falls through to the next handler.
+func (suite *TagsListMiddlewareTestSuite) TestNoRedirectForNamespacedImage() {
+	mock.OnAnything(suite.projectController, "GetByName").Return(&proModels.Project{
+		ProjectID:  1,
+		Name:       "proxy",
+		RegistryID: 0,
+	}, nil)
+	defaultLibrary = func(context.Context, int64, lib.ArtifactInfo) (bool, string, error) {
+		return false, "", nil
+	}
+
+	req := suite.makeRequest("/v2/proxy/goharbor/harbor/tags/list", "proxy/goharbor/harbor")
+	rr := httptest.NewRecorder()
+
+	TagsListMiddleware()(suite.next).ServeHTTP(rr, req)
+
+	suite.Equal(http.StatusOK, rr.Code)
+	suite.Empty(rr.Header().Get("Location"))
+}
+
+func TestTagsListMiddlewareTestSuite(t *testing.T) {
+	suite.Run(t, &TagsListMiddlewareTestSuite{})
+}


### PR DESCRIPTION
## Problem

Listing tags for a Docker Hub official ("library") image through a proxy cache
returns an empty list:

    GET /v2/<proxy>/busybox/tags/list  ->  {"name":"...","tags":[]}

while the same repository with the explicit `library/` prefix works:

    GET /v2/<proxy>/library/busybox/tags/list  ->  full upstream tag list

This breaks every tool that discovers versions through the registry tags/list
API. For example, Renovate can no longer propose image updates for any official
image pulled through the proxy cache (busybox, postgres, nginx, mariadb, redis,
…), because it sees zero tags.

## Root cause

Docker Hub official images live under the implicit `library/` namespace. The
docker client expands `busybox` -> `library/busybox` transparently, but the
registry tags/list API does not.

`ManifestMiddleware` and `BlobGetMiddleware` already handle this: for a
single-segment repository on a Docker Hub registry they detect the
default-library case (`defaultLibrary`) and issue a 301 redirect to the
`library/`-prefixed path (`defaultManifestURL` / `defaultBlobURL`).
`TagsListMiddleware` was missing the equivalent handling, so the request was
proxied upstream as `busybox` (which Docker Hub does not resolve) and an empty
tag list was returned.

The asymmetry is observable today on a Docker Hub proxy-cache project:

    GET /v2/<proxy>/busybox/manifests/<tag>  ->  301 Location: /v2/<proxy>/library/busybox/manifests/<tag>
    GET /v2/<proxy>/busybox/tags/list        ->  200 {"tags":[]}

## Fix

Add the same `defaultLibrary` redirect to `TagsListMiddleware`, pointing at a
new `defaultTagsListURL` helper. The original query string is preserved so the
`n` / `last` pagination parameters keep working after the redirect.

## Tests

- `TestDefaultTagsListURL` — unit test for the URL builder, including query-string preservation.
- `TagsListMiddlewareTestSuite` — verifies that a single-segment Docker Hub image
  is redirected (301 + `Location`, query preserved) and that a multi-segment
  image is not.

Relates to #21454.