### PR TITLE
[Backport 2.15.0] test(api_db): support dynamic OpenAPI generator and PyPI URLs via env vars

### DIFF
--- a/tests/resources/APITest-Util.robot
+++ b/tests/resources/APITest-Util.robot
@@ -1,12 +1,16 @@
 *** Variables ***
-${OPENAPI_GENERATOR_CLI_URL}  https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/4.3.1/openapi-generator-cli-4.3.1.jar
-${PIP_INDEX_URL}  https://pypi.org/simple
+${JFROG_USER}  ${EMPTY}
+${JFROG_PWD}  ${EMPTY}
+${JFROG_URL}  ${EMPTY}
+${JFROG_NAMESPACE}  ${EMPTY}
+${OPENAPI_GENERATOR_CLI_URL}  %{OPENAPI_GENERATOR_CLI_URL=https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/4.3.1/openapi-generator-cli-4.3.1.jar}
+${PIP_INDEX_URL}              %{PIP_INDEX_URL=https://pypi.org/simple}
 
 *** Keywords ***
 Make Swagger Client
     ${rc}  ${output}=  Run And Return Rc And Output  pip uninstall setuptools -y
     LogAll  ${output}
-    ${rc}  ${output}=  Run And Return Rc And Output  pip install -U pip setuptools
+    ${rc}  ${output}=  Run And Return Rc And Output  pip install -U pip setuptools --index-url ${PIP_INDEX_URL}
     LogAll  ${output}
     ${rc}  ${output}=  Run And Return Rc And Output  OPENAPI_GENERATOR_CLI_URL=${OPENAPI_GENERATOR_CLI_URL} PIP_INDEX_URL=${PIP_INDEX_URL} make swagger_client
     LogAll  ${output}


### PR DESCRIPTION
Thank you for contributing to Harbor!

# Comprehensive Summary of your change

Backporting the support dynamic OpenAPI generator and PyPI URLs via env vars to release-2.15.0 branch.
This corresponds to the original main branch PR #<23361>.

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [ ] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [ ] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
