### PR TITLE
feat(acr): add artifact to supported resource types

### DIFF
--- a/src/pkg/reg/adapter/azurecr/adapter.go
+++ b/src/pkg/reg/adapter/azurecr/adapter.go
@@ -69,6 +69,7 @@ func (a *adapter) Info() (*model.RegistryInfo, error) {
 		Type: model.RegistryTypeAzureAcr,
 		SupportedResourceTypes: []string{
 			model.ResourceTypeImage,
+			model.ResourceTypeArtifact,
 		},
 		SupportedResourceFilters: []*model.FilterStyle{
 			{

--- a/src/pkg/reg/adapter/azurecr/adapter_test.go
+++ b/src/pkg/reg/adapter/azurecr/adapter_test.go
@@ -37,8 +37,9 @@ func TestInfo(t *testing.T) {
 	info, err := a.Info()
 	assert.Nil(t, err)
 	assert.NotNil(t, info)
-	assert.EqualValues(t, 1, len(info.SupportedResourceTypes))
+	assert.EqualValues(t, 2, len(info.SupportedResourceTypes))
 	assert.EqualValues(t, model.ResourceTypeImage, info.SupportedResourceTypes[0])
+	assert.EqualValues(t, model.ResourceTypeArtifact, info.SupportedResourceTypes[1])
 	assert.True(t, info.SupportedCopyByChunk)
 }
 


### PR DESCRIPTION

# Comprehensive Summary of your change
This PR resolves an issue where Harbor was unable to replicate non-image artifacts (e.g., Helm charts, CNAB bundles) from an Azure Container Registry (ACR). Previously, the Azure ACR adapter only registered `model.ResourceTypeImage` as supported. Since the ACR adapter internally wraps the native registry adapter and already satisfies the `ArtifactRegistry` interface, adding `model.ResourceTypeArtifact` to the `SupportedResourceTypes` list in `Info()` enables full OCI artifact replication natively.

# Issue being fixed
Fixes #23175

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).