### PR TITLE
fix: prevent nil pointer dereference on invalid retention policies

### DIFF
--- a/src/server/v2.0/handler/retention.go
+++ b/src/server/v2.0/handler/retention.go
@@ -159,7 +159,11 @@ func (r *retentionAPI) GetRetention(ctx context.Context, params operation.GetRet
 }
 
 func (r *retentionAPI) CreateRetention(ctx context.Context, params operation.CreateRetentionParams) middleware.Responder {
-	p := model.NewRetentionPolicyFromSwagger(params.Policy).Metadata
+	rp := model.NewRetentionPolicyFromSwagger(params.Policy)
+	if rp == nil {
+		return r.SendError(ctx, errors.BadRequestError(fmt.Errorf("invalid retention policy")))
+	}
+	p := rp.Metadata
 	if len(p.Rules) > 15 {
 		return r.SendError(ctx, errors.BadRequestError(fmt.Errorf("only 15 rules are allowed at most")))
 	}
@@ -210,7 +214,11 @@ func (r *retentionAPI) CreateRetention(ctx context.Context, params operation.Cre
 }
 
 func (r *retentionAPI) UpdateRetention(ctx context.Context, params operation.UpdateRetentionParams) middleware.Responder {
-	p := model.NewRetentionPolicyFromSwagger(params.Policy).Metadata
+	rp := model.NewRetentionPolicyFromSwagger(params.Policy)
+	if rp == nil {
+		return r.SendError(ctx, errors.BadRequestError(fmt.Errorf("invalid retention policy")))
+	}
+	p := rp.Metadata
 	p.ID = params.ID
 	if len(p.Rules) > 15 {
 		return r.SendError(ctx, errors.BadRequestError(fmt.Errorf("only 15 rules are allowed at most")))

--- a/src/server/v2.0/handler/retention.go
+++ b/src/server/v2.0/handler/retention.go
@@ -215,7 +215,7 @@ func (r *retentionAPI) CreateRetention(ctx context.Context, params operation.Cre
 
 func (r *retentionAPI) UpdateRetention(ctx context.Context, params operation.UpdateRetentionParams) middleware.Responder {
 	rp := model.NewRetentionPolicyFromSwagger(params.Policy)
-	if rp == nil {
+	if rp == nil || rp.Metadata == nil || rp.Metadata.Scope == nil || rp.Metadata.Trigger == nil {
 		return r.SendError(ctx, errors.BadRequestError(fmt.Errorf("invalid retention policy")))
 	}
 	p := rp.Metadata

--- a/src/server/v2.0/handler/retention.go
+++ b/src/server/v2.0/handler/retention.go
@@ -160,7 +160,7 @@ func (r *retentionAPI) GetRetention(ctx context.Context, params operation.GetRet
 
 func (r *retentionAPI) CreateRetention(ctx context.Context, params operation.CreateRetentionParams) middleware.Responder {
 	rp := model.NewRetentionPolicyFromSwagger(params.Policy)
-	if rp == nil {
+	if rp == nil || rp.Metadata == nil || rp.Metadata.Scope == nil || rp.Metadata.Trigger == nil {
 		return r.SendError(ctx, errors.BadRequestError(fmt.Errorf("invalid retention policy")))
 	}
 	p := rp.Metadata


### PR DESCRIPTION
## SUMMARY

This PR prevents nil pointer dereferences in Harbor's retention policy handlers by validating the result of `NewRetentionPolicyFromSwagger()` before accessing its metadata. The change affects the retention API handlers in `src/server/v2.0/handler/retention.go`, specifically the create and update retention policy flows.

## FIX

```go
// Before
p := model.NewRetentionPolicyFromSwagger(params.Policy).Metadata

// After
rp := model.NewRetentionPolicyFromSwagger(params.Policy)
if rp == nil {
    return r.SendError(ctx,
        errors.BadRequestError(fmt.Errorf("invalid retention policy")))
}

p := rp.Metadata
```
