### PR TITLE
(cherry-pick) fix UI issues across portal components

### DIFF
--- a/src/portal/src/app/base/global-confirmation-dialog/global-confirmation-dialog.component.html
+++ b/src/portal/src/app/base/global-confirmation-dialog/global-confirmation-dialog.component.html
@@ -6,7 +6,7 @@
     <div class="modal-body">
         @if (buttons !== 2) {
         <div class="confirmation-icon-inline">
-            <clr-icon shape="warning" class="is-warning" size="64"></clr-icon>
+            <clr-icon shape="warning" status="warning" size="64"></clr-icon>
         </div>
         }
         <div class="confirmation-content">{{ dialogContent }}</div>

--- a/src/portal/src/app/base/left-side-nav/distribution/distribution-instances/distribution-instances.component.html
+++ b/src/portal/src/app/base/left-side-nav/distribution/distribution-instances/distribution-instances.component.html
@@ -207,7 +207,8 @@
                             <clr-icon
                                 shape="check-circle"
                                 size="20"
-                                class="is-success enabled-icon"></clr-icon>
+                                status="success"
+                                class="enabled-icon"></clr-icon>
                             <span class="margin-left-5px">{{
                                 'WEBHOOK.ENABLED' | translate
                             }}</span>
@@ -217,7 +218,7 @@
                             <clr-icon
                                 shape="exclamation-triangle"
                                 size="20"
-                                class="is-warning"></clr-icon>
+                                status="warning"></clr-icon>
                             <span class="margin-left-5px">{{
                                 'WEBHOOK.DISABLED' | translate
                             }}</span>

--- a/src/portal/src/app/base/left-side-nav/interrogation-services/scanner/config-scanner.component.html
+++ b/src/portal/src/app/base/left-side-nav/interrogation-services/scanner/config-scanner.component.html
@@ -178,7 +178,8 @@
                         <clr-icon
                             shape="check-circle"
                             size="20"
-                            class="is-success enabled-icon"></clr-icon>
+                            status="success"
+                            class="enabled-icon"></clr-icon>
                         <span class="margin-left-5px">{{
                             'WEBHOOK.ENABLED' | translate
                         }}</span>
@@ -188,7 +189,7 @@
                         <clr-icon
                             shape="exclamation-triangle"
                             size="20"
-                            class="is-warning"></clr-icon>
+                            status="warning"></clr-icon>
                         <span class="margin-left-5px">{{
                             'WEBHOOK.DISABLED' | translate
                         }}</span>

--- a/src/portal/src/app/base/left-side-nav/projects/list-project/export-cve/export-cve.component.html
+++ b/src/portal/src/app/base/left-side-nav/projects/list-project/export-cve/export-cve.component.html
@@ -149,18 +149,15 @@
                                         } @if (!allLabels?.length) {
                                         <button
                                             type="button"
-                                            class="dropdown-item space-between no-labels">
+                                            class="dropdown-item space-between no-labels"
+                                            (click)="goToLabels()">
                                             <span class="alert-label">{{
                                                 'REPLICATION.NO_LABEL_INFO'
                                                     | translate
                                             }}</span>
-                                            <span
-                                                class="alert-label go-link"
-                                                routerLink="/harbor/labels"
-                                                >{{
-                                                    'CONFIG.LABEL' | translate
-                                                }}</span
-                                            >
+                                            <span class="alert-label go-link">{{
+                                                'CONFIG.LABEL' | translate
+                                            }}</span>
                                         </button>
                                         } }
                                     </clr-dropdown-menu>

--- a/src/portal/src/app/base/left-side-nav/projects/list-project/export-cve/export-cve.component.spec.ts
+++ b/src/portal/src/app/base/left-side-nav/projects/list-project/export-cve/export-cve.component.spec.ts
@@ -14,6 +14,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ExportCveComponent } from './export-cve.component';
 import { SharedTestingModule } from '../../../../../shared/shared.module';
+import { Router } from '@angular/router';
 
 describe('ExportCveComponent', () => {
     let component: ExportCveComponent;
@@ -34,5 +35,18 @@ describe('ExportCveComponent', () => {
 
     it('should create', () => {
         expect(component).toBeTruthy();
+    });
+
+    it('goToLabels should close the modal and navigate to /harbor/labels', () => {
+        const router = TestBed.inject(Router);
+        const navigateSpy = spyOn(router, 'navigate');
+        const closeSpy = spyOn(component, 'close').and.callThrough();
+
+        component.opened = true;
+        component.goToLabels();
+
+        expect(closeSpy).toHaveBeenCalled();
+        expect(component.opened).toBeFalse();
+        expect(navigateSpy).toHaveBeenCalledOnceWith(['/harbor/labels']);
     });
 });

--- a/src/portal/src/app/base/left-side-nav/projects/list-project/export-cve/export-cve.component.ts
+++ b/src/portal/src/app/base/left-side-nav/projects/list-project/export-cve/export-cve.component.ts
@@ -18,6 +18,7 @@ import {
     Output,
     ViewChild,
 } from '@angular/core';
+import { Router } from '@angular/router';
 import { Label } from 'ng-swagger-gen/models/label';
 import { finalize } from 'rxjs/operators';
 import { Project } from 'src/app/base/project/project';
@@ -61,7 +62,8 @@ export class ExportCveComponent {
         private labelService: LabelService,
         private scanDataExportService: ScanDataExportService,
         private msgHandler: MessageHandlerService,
-        private event: EventService
+        private event: EventService,
+        private router: Router
     ) {}
     reset() {
         this.inlineAlertComponent?.close();
@@ -86,6 +88,11 @@ export class ExportCveComponent {
 
     cancel() {
         this.close();
+    }
+
+    goToLabels() {
+        this.close();
+        this.router.navigate(['/harbor/labels']);
     }
 
     save() {

--- a/src/portal/src/app/base/left-side-nav/replication/replication/create-edit-rule/create-edit-rule.component.html
+++ b/src/portal/src/app/base/left-side-nav/replication/replication/create-edit-rule/create-edit-rule.component.html
@@ -313,14 +313,14 @@
                                             !supportedFilterLabels?.length ) {
                                             <button
                                                 type="button"
-                                                class="dropdown-item space-between no-labels">
+                                                class="dropdown-item space-between no-labels"
+                                                (click)="goToLabels()">
                                                 <span class="alert-label">{{
                                                     'REPLICATION.NO_LABEL_INFO'
                                                         | translate
                                                 }}</span>
                                                 <span
                                                     class="alert-label go-link"
-                                                    routerLink="/harbor/labels"
                                                     >{{
                                                         'CONFIG.LABEL'
                                                             | translate

--- a/src/portal/src/app/base/left-side-nav/replication/replication/create-edit-rule/create-edit-rule.component.spec.ts
+++ b/src/portal/src/app/base/left-side-nav/replication/replication/create-edit-rule/create-edit-rule.component.spec.ts
@@ -34,6 +34,7 @@ import { RegistryService } from '../../../../../../../ng-swagger-gen/services/re
 import { Registry } from '../../../../../../../ng-swagger-gen/models/registry';
 import { ReplicationPolicy } from '../../../../../../../ng-swagger-gen/models/replication-policy';
 import { ReplicationExecution } from '../../../../../../../ng-swagger-gen/models/replication-execution';
+import { Router } from '@angular/router';
 
 describe('CreateEditRuleComponent (inline template)', () => {
     let mockRules: ReplicationPolicy[] = [
@@ -303,4 +304,17 @@ describe('CreateEditRuleComponent (inline template)', () => {
         tick(5000);
         expect(comp.targetList.length).toBe(4);
     }));
+
+    it('goToLabels should close the modal and navigate to /harbor/labels', () => {
+        const router = TestBed.inject(Router);
+        const navigateSpy = spyOn(router, 'navigate');
+        const closeSpy = spyOn(comp, 'close').and.callThrough();
+
+        comp.createEditRuleOpened = true;
+        comp.goToLabels();
+
+        expect(closeSpy).toHaveBeenCalled();
+        expect(comp.createEditRuleOpened).toBeFalse();
+        expect(navigateSpy).toHaveBeenCalledOnceWith(['/harbor/labels']);
+    });
 });

--- a/src/portal/src/app/base/left-side-nav/replication/replication/create-edit-rule/create-edit-rule.component.ts
+++ b/src/portal/src/app/base/left-side-nav/replication/replication/create-edit-rule/create-edit-rule.component.ts
@@ -46,6 +46,7 @@ import { RegistryService } from '../../../../../../../ng-swagger-gen/services/re
 import { Registry } from '../../../../../../../ng-swagger-gen/models/registry';
 import { Label } from '../../../../../../../ng-swagger-gen/models/label';
 import { LabelService } from '../../../../../../../ng-swagger-gen/services/label.service';
+import { Router } from '@angular/router';
 import {
     BandwidthUnit,
     Decoration,
@@ -129,7 +130,8 @@ export class CreateEditRuleComponent implements OnInit, OnDestroy {
         private errorHandler: ErrorHandler,
         private translateService: TranslateService,
         private jobServiceService: JobserviceService,
-        private labelService: LabelService
+        private labelService: LabelService,
+        private router: Router
     ) {
         this.createForm();
     }
@@ -677,6 +679,11 @@ export class CreateEditRuleComponent implements OnInit, OnDestroy {
     }
     close(): void {
         this.createEditRuleOpened = false;
+    }
+
+    goToLabels(): void {
+        this.close();
+        this.router.navigate(['/harbor/labels']);
     }
 
     confirmCancel(confirmed: boolean) {

--- a/src/portal/src/app/base/left-side-nav/replication/replication/list-replication-rule/list-replication-rule.component.html
+++ b/src/portal/src/app/base/left-side-nav/replication/replication/list-replication-rule/list-replication-rule.component.html
@@ -151,7 +151,8 @@
                     <div>
                         <clr-icon
                             shape="exclamation-triangle"
-                            class="is-warning text-alignment"
+                            status="warning"
+                            class="text-alignment"
                             size="18"></clr-icon>
                         {{ 'WEBHOOK.DISABLED' | translate }}
                     </div>
@@ -159,7 +160,8 @@
                     <div>
                         <clr-icon
                             shape="success-standard"
-                            class="is-success text-alignment"
+                            status="success"
+                            class="text-alignment"
                             size="18"></clr-icon>
                         {{ 'WEBHOOK.ENABLED' | translate }}
                     </div>

--- a/src/portal/src/app/base/left-side-nav/system-robot-accounts/new-robot/new-robot.component.html
+++ b/src/portal/src/app/base/left-side-nav/system-robot-accounts/new-robot/new-robot.component.html
@@ -40,11 +40,16 @@
         <ng-template clrPageTitle>{{
             'ROBOT_ACCOUNT.BASIC_INFO' | translate
         }}</ng-template>
-        <form clrForm #robotForm="ngForm" class="clr-form clr-form-horizontal">
+        <form
+            clrForm
+            #robotForm="ngForm"
+            class="clr-form clr-form-horizontal"
+            clrLabelSize="4">
             @if (addRobotOpened) {
             <section class="form-block">
-                <div class="clr-form-control">
-                    <label for="name" class="clr-control-label required"
+                <!-- Name -->
+                <clr-input-container>
+                    <label for="name" class="required"
                         >{{ 'P2P_PROVIDER.NAME' | translate }}
                         @if (!isEditMode) {
                         <clr-tooltip>
@@ -64,53 +69,46 @@
                         </clr-tooltip>
                         }
                     </label>
-                    <div
-                        class="clr-control-container"
-                        [class.clr-error]="
+                    <input
+                        clrInput
+                        [disabled]="loading || isEditMode"
+                        type="text"
+                        id="name"
+                        [(ngModel)]="systemRobot.name"
+                        required
+                        pattern="^[a-z0-9]+(?:[._\-][a-z0-9]+)*$"
+                        maxLengthExt="255"
+                        autocomplete="off"
+                        size="30"
+                        name="name"
+                        #name="ngModel"
+                        (keyup)="inputName()" />
+
+                    <clr-control-error
+                        *ngIf="
                             ((name.dirty || name.touched) && name.invalid) ||
                             isNameExisting
                         ">
-                        <div class="clr-input-wrapper">
-                            <input
-                                class="clr-input input-width"
-                                [disabled]="loading || isEditMode"
-                                type="text"
-                                id="name"
-                                [(ngModel)]="systemRobot.name"
-                                required
-                                pattern="^[a-z0-9]+(?:[._\-][a-z0-9]+)*$"
-                                maxLengthExt="255"
-                                autocomplete="off"
-                                size="30"
-                                name="name"
-                                #name="ngModel"
-                                (keyup)="inputName()" />
-                            <clr-icon
-                                class="clr-validate-icon"
-                                shape="exclamation-circle"></clr-icon>
-                            <span
-                                class="spinner spinner-inline"
-                                [hidden]="!checkNameOnGoing"></span>
-                        </div>
-                        @if ( ((name.dirty || name.touched) && name.invalid) ||
-                        isNameExisting ) {
-                        <clr-control-error>
-                            @if ( !( (name.dirty || name.touched) &&
-                            name.invalid ) && isNameExisting ) {
-                            <span>{{
+                        <span
+                            *ngIf="
+                                !(
+                                    (name.dirty || name.touched) &&
+                                    name.invalid
+                                ) && isNameExisting
+                            "
+                            >{{
                                 'ROBOT_ACCOUNT.ACCOUNT_EXISTING' | translate
-                            }}</span>
-                            } @if ( (name.dirty || name.touched) && name.invalid
-                            ) {
-                            <span>{{
-                                'SYSTEM_ROBOT.NAME_TOOLTIP' | translate
-                            }}</span>
-                            }
-                        </clr-control-error>
-                        }
-                    </div>
-                </div>
-                <clr-textarea-container class="mt-2">
+                            }}</span
+                        >
+                        <span
+                            *ngIf="(name.dirty || name.touched) && name.invalid"
+                            >{{ 'SYSTEM_ROBOT.NAME_TOOLTIP' | translate }}</span
+                        >
+                    </clr-control-error>
+                </clr-input-container>
+
+                <!-- Description -->
+                <clr-textarea-container class="">
                     <label>{{ 'DISTRIBUTION.DESCRIPTION' | translate }}</label>
                     <textarea
                         class="input-width"
@@ -121,7 +119,9 @@
                         [ngModelOptions]="{ standalone: true }"
                         [(ngModel)]="systemRobot.description"></textarea>
                 </clr-textarea-container>
-                <div class="clr-form-control mt-2">
+
+                <!-- Expiration Time -->
+                <div class="clr-form-control clr-row">
                     <label class="clr-control-label required"
                         >{{ 'SYSTEM_ROBOT.EXPIRATION_TIME' | translate }}
                         <clr-tooltip>

--- a/src/portal/src/app/base/project/p2p-provider/policy/policy.component.html
+++ b/src/portal/src/app/base/project/p2p-provider/policy/policy.component.html
@@ -184,7 +184,8 @@
                     <clr-icon
                         shape="check-circle"
                         size="20"
-                        class="is-success enabled-icon"></clr-icon>
+                        status="success"
+                        class="enabled-icon"></clr-icon>
                     <span class="margin-left-5px">{{
                         'WEBHOOK.ENABLED' | translate
                     }}</span>
@@ -194,7 +195,7 @@
                     <clr-icon
                         shape="exclamation-triangle"
                         size="20"
-                        class="is-warning"></clr-icon>
+                        status="warning"></clr-icon>
                     <span class="margin-left-5px">{{
                         'WEBHOOK.DISABLED' | translate
                     }}</span>

--- a/src/portal/src/app/base/project/repository/artifact/artifact-additions/artifact-vulnerabilities/artifact-vulnerabilities.component.html
+++ b/src/portal/src/app/base/project/repository/artifact/artifact-additions/artifact-vulnerabilities/artifact-vulnerabilities.component.html
@@ -164,7 +164,7 @@
                     <div *ngIf="res.fix_version; else elseBlock">
                         <clr-icon
                             shape="wrench"
-                            class="is-success"
+                            status="success"
                             size="20"></clr-icon
                         >&nbsp;<span class="font-color-green">{{
                             res.fix_version

--- a/src/portal/src/app/base/project/repository/artifact/sbom-scanning/scanning.scss
+++ b/src/portal/src/app/base/project/repository/artifact/sbom-scanning/scanning.scss
@@ -1,9 +1,6 @@
-.bar-wrapper {
-    width: 210px;
-}
-
 hbr-sbom-bar {
-    .label,.not-scan {
+    .label,
+    .not-scan {
         width: 90%;
     }
 }
@@ -14,8 +11,7 @@ hbr-sbom-bar {
     }
 
     .label {
-        max-width: 60%;
-        min-width: 50%;
+        padding: 0 1rem;
     }
 }
 

--- a/src/portal/src/app/base/project/repository/artifact/vulnerability-scanning/result-tip-histogram/result-tip-histogram.component.html
+++ b/src/portal/src/app/base/project/repository/artifact/vulnerability-scanning/result-tip-histogram/result-tip-histogram.component.html
@@ -102,7 +102,7 @@
                 } @if (noVulnerability) {
                 <clr-icon
                     shape="check-circle"
-                    class="is-success"
+                    status="success"
                     size="32"></clr-icon>
                 <span>{{ 'VULNERABILITY.NO_VULNERABILITY' | translate }}</span>
                 }
@@ -142,7 +142,7 @@
             <clr-icon
                 shape="exclamation-triangle"
                 size="20"
-                class="is-warning"></clr-icon>
+                status="warning"></clr-icon>
         </div>
         <clr-tooltip-content [clrSize]="'lg'" *clrIfOpen>
             <div class="font-weight-600">

--- a/src/portal/src/app/base/project/repository/repository-gridview.component.html
+++ b/src/portal/src/app/base/project/repository/repository-gridview.component.html
@@ -157,7 +157,7 @@
         [withAdmiral]="withAdmiral"
         (loadNextPageEvent)="loadNextPage()">
         <ng-template let-item="item">
-            <a class="card clickable" [routerLink]="getLink(item)">
+            <div class="card clickable">
                 <div class="card-header">
                     <div
                         [ngClass]="{
@@ -184,24 +184,33 @@
                                 ('REPOSITORY.NO_INFO' | translate)
                         }}
                     </div>
-                    <div class="form-group">
-                        <label>{{
-                            'REPOSITORY.ARTIFACTS_COUNT' | translate
-                        }}</label>
-                        <div>{{ item.artifact_count }}</div>
-                    </div>
-                    <div class="form-group">
-                        <label>{{ 'REPOSITORY.PULL_COUNT' | translate }}</label>
-                        <div>{{ item.pull_count }}</div>
-                    </div>
-                    <div class="form-group">
-                        <label>{{
-                            'REPOSITORY.LAST_MODIFIED' | translate
-                        }}</label>
-                        <div>
-                            {{ item.update_time | harborDatetime : 'short' }}
+                    <a
+                        class="nav-link"
+                        href="javascript:void(0)"
+                        [routerLink]="getLink(item)">
+                        <div class="form-group">
+                            <label>{{
+                                'REPOSITORY.ARTIFACTS_COUNT' | translate
+                            }}</label>
+                            <div>{{ item.artifact_count }}</div>
                         </div>
-                    </div>
+                        <div class="form-group">
+                            <label>{{
+                                'REPOSITORY.PULL_COUNT' | translate
+                            }}</label>
+                            <div>{{ item.pull_count }}</div>
+                        </div>
+                        <div class="form-group">
+                            <label>{{
+                                'REPOSITORY.LAST_MODIFIED' | translate
+                            }}</label>
+                            <div>
+                                {{
+                                    item.update_time | harborDatetime : 'short'
+                                }}
+                            </div>
+                        </div>
+                    </a>
                 </div>
                 <div class="card-footer">
                     <clr-dropdown [clrCloseMenuOnItemClick]="true">
@@ -247,7 +256,7 @@
                         </clr-dropdown-menu>
                     </clr-dropdown>
                 </div>
-            </a>
+            </div>
         </ng-template>
     </hbr-gridview>
     } @if (isFirstLoadingGridView && isCardView) {

--- a/src/portal/src/app/base/project/webhook/add-webhook-form/add-webhook-form.component.html
+++ b/src/portal/src/app/base/project/webhook/add-webhook-form/add-webhook-form.component.html
@@ -130,7 +130,7 @@
                     class="clr-control-container clr-control-inline"
                     [class.clr-error]="!hasEventType()">
                     @for (item of metadata?.event_type; track item) {
-                    <div class="clr-checkbox-wrapper width-8rem">
+                    <div class="clr-checkbox-wrapper width-12rem">
                         <input
                             type="checkbox"
                             id="{{ item }}"

--- a/src/portal/src/app/base/project/webhook/add-webhook-form/add-webhook-form.component.scss
+++ b/src/portal/src/app/base/project/webhook/add-webhook-form/add-webhook-form.component.scss
@@ -1,23 +1,23 @@
 .icon-tooltip {
-  margin-top: 4px;
+    margin-top: 4px;
 }
 
 .padding-top-3 {
-  padding-top: 3px;
+    padding-top: 3px;
 }
 
 .bottom-btn {
-  text-align: right;
+    text-align: right;
 }
 
 .width-238 {
-  width: 238px;
+    width: 238px;
 }
 
-.width-8rem {
-  width: 8rem;
+.width-12rem {
+    width: 12rem;
 }
 
 .clr-control-label {
-  width: 10rem !important;
+    width: 10rem !important;
 }

--- a/src/portal/src/app/base/project/webhook/excutions/executions.component.scss
+++ b/src/portal/src/app/base/project/webhook/excutions/executions.component.scss
@@ -1,48 +1,55 @@
 .link-normal {
-  text-overflow: ellipsis;
-  overflow: hidden;
-  white-space: nowrap;
-  max-width: 10rem;
-  text-transform: unset;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
+    display: inline-block;
+    padding: 0;
+    text-transform: unset;
+    width: 100%;
 }
 
 .flex {
-  display: flex;
+    display: flex;
+
+    clr-signpost {
+        display: inline-flex;
+        width: 100%;
+    }
 }
 
 .pre {
-  min-width: 25rem;
-  max-width: 40rem;
+    min-width: 25rem;
+    max-width: 40rem;
 }
 
 .flex-end {
-  display: flex;
-  justify-content: space-between;
+    display: flex;
+    justify-content: space-between;
 }
 
 .refresh-btn {
-  margin-right: 1rem;
-  margin-bottom: 0.5rem;
-  cursor: pointer;
+    margin-right: 1rem;
+    margin-bottom: 0.5rem;
+    cursor: pointer;
 }
 
 .refresh-btn:hover {
-  color: #007CBB;
+    color: #007cbb;
 }
 
 pre {
-  border: none;
+    border: none;
 }
 
 .label-flex {
-  width: 9.5rem;
-  letter-spacing: 0;
-  display: block;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-  overflow: hidden;
-  border: 1px solid;
-  border-radius: 9px;
-  padding: 0 7px 0 10px;
-  text-align: center;
+    width: 9.5rem;
+    letter-spacing: 0;
+    display: block;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    border: 1px solid;
+    border-radius: 9px;
+    padding: 0 7px 0 10px;
+    text-align: center;
 }

--- a/src/portal/src/app/base/project/webhook/webhook.component.html
+++ b/src/portal/src/app/base/project/webhook/webhook.component.html
@@ -121,7 +121,7 @@
         <clr-dg-column [clrDgField]="'name'">{{
             'WEBHOOK.NAME' | translate
         }}</clr-dg-column>
-        <clr-dg-column class="width-120">{{
+        <clr-dg-column class="width-140">{{
             'WEBHOOK.ENABLED' | translate
         }}</clr-dg-column>
         <clr-dg-column>{{ 'WEBHOOK.NOTIFY_TYPE' | translate }}</clr-dg-column>
@@ -148,15 +148,16 @@
                     <clr-icon
                         shape="check-circle"
                         size="20"
-                        class="is-success enabled-icon"></clr-icon>
+                        status="success"
+                        class="enabled-icon"></clr-icon>
                     <span>{{ 'WEBHOOK.ENABLED' | translate }}</span>
                 </div>
                 } @case (false) {
                 <div class="icon-wrap">
                     <clr-icon
                         shape="exclamation-triangle"
-                        size="20"
-                        class="is-warning"></clr-icon>
+                        size="18"
+                        status="warning"></clr-icon>
                     <span>{{ 'WEBHOOK.DISABLED' | translate }}</span>
                 </div>
                 } }

--- a/src/portal/src/app/base/project/webhook/webhook.component.scss
+++ b/src/portal/src/app/base/project/webhook/webhook.component.scss
@@ -4,11 +4,14 @@
 
 .icon-wrap {
     height: 14px;
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
 }
 
 .webhook-form-wrap {
     width: 19rem;
-    margin: 0 ;
+    margin: 0;
 }
 
 .create-text {
@@ -61,7 +64,7 @@
 }
 
 .min-width-340 {
-    min-width: 340px!important;
+    min-width: 340px !important;
 }
 
 .margin-left-10 {
@@ -70,10 +73,6 @@
 
 .event-types {
     padding-right: 14px;
-}
-
-.bar-state {
-    width: 100%;
 }
 
 .label-flex {
@@ -85,7 +84,7 @@
     overflow: hidden;
     border: 1px solid;
     border-radius: 9px;
-    padding: 0 7px 0 10px;
+    padding: 0 1rem;
     text-align: center;
 }
 
@@ -96,8 +95,8 @@
     margin-top: -0.4rem;
 }
 
-.width-120 {
-    width: 120px;
+.width-140 {
+    width: 140px;
 }
 
 .refresh-btn {
@@ -105,5 +104,5 @@
 }
 
 .refresh-btn:hover {
-    color: #007CBB;
+    color: #007cbb;
 }

--- a/src/portal/src/app/not-found/not-found.component.html
+++ b/src/portal/src/app/not-found/not-found.component.html
@@ -1,6 +1,6 @@
 <div class="wrapper-back">
     <div>
-        <clr-icon shape="warning" class="is-warning" size="96"></clr-icon>
+        <clr-icon shape="warning" status="warning" size="96"></clr-icon>
         <span class="status-code">404</span>
         <span class="status-text">{{
             'PAGE_NOT_FOUND.MAIN_TITLE' | translate

--- a/src/portal/src/app/shared/components/confirmation-dialog/confirmation-dialog.component.html
+++ b/src/portal/src/app/shared/components/confirmation-dialog/confirmation-dialog.component.html
@@ -5,7 +5,7 @@
     <h3 class="modal-title confirmation-title">{{ dialogTitle }}</h3>
     <div class="modal-body">
         <div class="confirmation-icon-inline">
-            <clr-icon shape="warning" class="is-warning" size="64"></clr-icon>
+            <clr-icon shape="warning" status="warning" size="64"></clr-icon>
         </div>
         <div class="confirmation-content">{{ dialogContent }}</div>
     </div>

--- a/src/portal/src/app/shared/components/navigator/navigator.component.html
+++ b/src/portal/src/app/shared/components/navigator/navigator.component.html
@@ -16,7 +16,7 @@
         </a>
     </div>
 
-    <global-search></global-search>
+    <global-search class="global-search"></global-search>
     <div class="header-actions">
         @if (!isSessionValid) {
         <clr-dropdown class="dropdown-lang dropdown bottom-left">

--- a/src/portal/src/app/shared/components/navigator/navigator.component.scss
+++ b/src/portal/src/app/shared/components/navigator/navigator.component.scss
@@ -76,3 +76,11 @@
 .user-down {
     right: 1rem !important;
 }
+
+.global-search {
+    flex: 1;
+}
+
+.header-actions {
+    flex: 0;
+}


### PR DESCRIPTION
Backport of #23393 to `release-2.15.0`.

Source commit: goharbor/harbor@4e30db31aa94b4d798ec4e615ac8785c911646ad
Backport commit: stonezdj/harbor@f55551194cad1c855f4a65ce26807498fef74348

Notes:
- Resolved release-2.15.0 conflicts by keeping Angular 16-compatible template syntax (`*ngIf` / `*ngFor`) while preserving the UI behavior fixes.
- Omitted the `global-search.component.scss` portion because that stylesheet is not present on `release-2.15.0`.

