### PR TITLE
docs: fix broken installation guide link in contrib doc

### DIFF
--- a/contrib/deploying_using_docker_machine.md
+++ b/contrib/deploying_using_docker_machine.md
@@ -16,7 +16,7 @@ You can get this IP address using:
 $ docker-machine ip harbor.mydomain.com
 ```
 
-Copy `Deploy/harbor.yml.tmp` to `Deploy/harbor.yml` and make sure to change the `hostname` in `Deploy/harbor.yml` to `harbor.mydomain.com`, configure everything else according to the [Harbor Installation Guide](../docs/installation_guide.md) and run `prepare`.
+Copy `Deploy/harbor.yml.tmp` to `Deploy/harbor.yml` and make sure to change the `hostname` in `Deploy/harbor.yml` to `harbor.mydomain.com`, configure everything else according to the [Harbor Installation Guide](https://goharbor.io/docs/latest/install-config/) and run `prepare`.
 
 Now, activate the created Docker Machine instance:
 


### PR DESCRIPTION
The docker-machine contrib guide linked to `../docs/installation_guide.md`, which no longer exists (Harbor docs moved to goharbor.io/docs, per docs/README.md). Pointed it at the current install-config docs.
