### PR TITLE
fix: map internal errors to HTTP 4xx on Admin API endpoints

### DIFF
--- a/src/controller/scanner/base_controller.go
+++ b/src/controller/scanner/base_controller.go
@@ -312,7 +312,7 @@ func (bc *basicController) Ping(ctx context.Context, registration *scanner.Regis
 	if registration.URL != "" {
 		_, err := url.ParseRequestURI(registration.URL)
 		if err != nil {
-			return nil, errors.BadRequestError(err).WithMessagef("invalid scanner URL: %v", err)
+			return nil, errors.BadRequestError(err).WithMessage("invalid scanner URL")
 		}
 	}
 
@@ -330,7 +330,7 @@ func (bc *basicController) Ping(ctx context.Context, registration *scanner.Regis
 	if err != nil {
 		log.G(ctx).WithField("error", err).Error("failed to ping scanner")
 
-		return nil, errors.BadRequestError(err).WithMessagef("scanner controller: ping: %v", err)
+		return nil, errors.BadRequestError(err).WithMessage("scanner controller: ping failed")
 	}
 
 	if err := meta.Validate(); err != nil {

--- a/src/controller/scanner/base_controller.go
+++ b/src/controller/scanner/base_controller.go
@@ -17,6 +17,7 @@ package scanner // nolint:revive
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"slices"
 	"sync"
 	"time"
@@ -308,6 +309,13 @@ func (bc *basicController) Ping(ctx context.Context, registration *scanner.Regis
 		return nil, errors.New("nil registration to ping")
 	}
 
+	if registration.URL != "" {
+		_, err := url.ParseRequestURI(registration.URL)
+		if err != nil {
+			return nil, errors.BadRequestError(err).WithMessagef("invalid scanner URL: %v", err)
+		}
+	}
+
 	var (
 		err  error
 		meta *v1.ScannerAdapterMetadata
@@ -322,7 +330,7 @@ func (bc *basicController) Ping(ctx context.Context, registration *scanner.Regis
 	if err != nil {
 		log.G(ctx).WithField("error", err).Error("failed to ping scanner")
 
-		return nil, errors.Wrap(err, "scanner controller: ping")
+		return nil, errors.BadRequestError(err).WithMessagef("scanner controller: ping: %v", err)
 	}
 
 	if err := meta.Validate(); err != nil {

--- a/src/controller/scanner/base_controller_test.go
+++ b/src/controller/scanner/base_controller_test.go
@@ -263,6 +263,38 @@ func (suite *ControllerTestSuite) TestPing() {
 	suite.NotNil(meta)
 }
 
+// TestPingInvalidURL tests ping for scanner with invalid URL
+func (suite *ControllerTestSuite) TestPingInvalidURL() {
+	reg := &scanner.Registration{
+		Name:        "invalidURL",
+		Description: "sample registration",
+		URL:         "://invalid.url",
+	}
+	meta, err := suite.c.Ping(context.TODO(), reg)
+	require.Error(suite.T(), err)
+	suite.Nil(meta)
+	require.Contains(suite.T(), err.Error(), "invalid scanner URL")
+}
+
+// TestPingAdapterFailure tests ping for scanner with adapter failure
+func (suite *ControllerTestSuite) TestPingAdapterFailure() {
+	mc := &v1testing.Client{}
+	mc.On("GetMetadata").Return(nil, fmt.Errorf("dial timeout"))
+
+	mcp := &v1testing.ClientPool{}
+	mocktesting.OnAnything(mcp, "Get").Return(mc, nil)
+	c := &basicController{
+		manager:    suite.mMgr,
+		proMetaMgr: suite.mMeta,
+		clientPool: mcp,
+	}
+
+	meta, err := c.Ping(context.TODO(), suite.sample)
+	require.Error(suite.T(), err)
+	suite.Nil(meta)
+	require.Contains(suite.T(), err.Error(), "scanner controller: ping failed")
+}
+
 // TestPingWithGenericMimeType tests ping for scanners supporting MIME type MimeTypeGenericVulnerabilityReport
 func (suite *ControllerTestSuite) TestPingWithGenericMimeType() {
 	m := &v1.ScannerAdapterMetadata{

--- a/src/server/v2.0/handler/jobservice.go
+++ b/src/server/v2.0/handler/jobservice.go
@@ -203,7 +203,7 @@ func (j *jobServiceAPI) ActionGetJobLog(ctx context.Context, params jobservice.A
 	}
 	log, err := j.jobCtr.GetJobLog(ctx, params.JobID)
 	if err != nil {
-		if strings.Contains(err.Error(), "10009") || strings.Contains(err.Error(), "invalid length of log identify") {
+		if strings.Contains(err.Error(), `"code":10009`) && strings.Contains(err.Error(), "invalid length of log identify") {
 			return j.SendError(ctx, errors.BadRequestError(err))
 		}
 		return j.SendError(ctx, err)

--- a/src/server/v2.0/handler/jobservice.go
+++ b/src/server/v2.0/handler/jobservice.go
@@ -203,6 +203,9 @@ func (j *jobServiceAPI) ActionGetJobLog(ctx context.Context, params jobservice.A
 	}
 	log, err := j.jobCtr.GetJobLog(ctx, params.JobID)
 	if err != nil {
+		if strings.Contains(err.Error(), "10009") || strings.Contains(err.Error(), "invalid length of log identify") {
+			return j.SendError(ctx, errors.BadRequestError(err))
+		}
 		return j.SendError(ctx, err)
 	}
 	return jobservice.NewActionGetJobLogOK().WithContentType("text/plain").WithPayload(string(log))

--- a/src/server/v2.0/handler/ldap.go
+++ b/src/server/v2.0/handler/ldap.go
@@ -20,8 +20,10 @@ import (
 
 	"github.com/go-openapi/runtime/middleware"
 
+	"github.com/goharbor/harbor/src/common"
 	"github.com/goharbor/harbor/src/common/rbac"
 	"github.com/goharbor/harbor/src/controller/ldap"
+	"github.com/goharbor/harbor/src/lib/config"
 	cfgModels "github.com/goharbor/harbor/src/lib/config/models"
 	"github.com/goharbor/harbor/src/lib/errors"
 	ldapModel "github.com/goharbor/harbor/src/pkg/ldap/model"
@@ -118,6 +120,13 @@ func toFailedListResp(users []ldapModel.FailedImportUser) []*models.LdapFailedIm
 func (l *ldapAPI) SearchLdapGroup(ctx context.Context, params operation.SearchLdapGroupParams) middleware.Responder {
 	if err := l.RequireSystemAccess(ctx, rbac.ActionList, rbac.ResourceLdapUser); err != nil {
 		return l.SendError(ctx, err)
+	}
+	mode, err := config.AuthMode(ctx)
+	if err != nil {
+		return l.SendError(ctx, err)
+	}
+	if mode != common.LDAPAuth {
+		return l.SendError(ctx, errors.PreconditionFailedError(nil).WithMessage("LDAP is not configured"))
 	}
 	var groupName, groupDN string
 	if params.Groupname != nil && len(*params.Groupname) > 0 {

--- a/src/server/v2.0/handler/retention.go
+++ b/src/server/v2.0/handler/retention.go
@@ -160,6 +160,9 @@ func (r *retentionAPI) GetRetention(ctx context.Context, params operation.GetRet
 
 func (r *retentionAPI) CreateRetention(ctx context.Context, params operation.CreateRetentionParams) middleware.Responder {
 	p := model.NewRetentionPolicyFromSwagger(params.Policy).Metadata
+	if p == nil || p.Scope == nil || p.Trigger == nil {
+		return r.SendError(ctx, errors.BadRequestError(fmt.Errorf("missing required fields in retention policy: scope, trigger")))
+	}
 	if len(p.Rules) > 15 {
 		return r.SendError(ctx, errors.BadRequestError(fmt.Errorf("only 15 rules are allowed at most")))
 	}


### PR DESCRIPTION


# Comprehensive Summary of your change
This PR addresses robustness issues across several Admin API endpoints where missing prerequisites or malformed data resulted in unhandled HTTP 500 (`UNKNOWN`) internal server errors instead of the appropriate HTTP 4xx responses.

Specifically, the following endpoint handlers and controllers were updated:
- **Retention API (`handler/retention.go`)**: Added nil-pointer validation in `CreateRetention` to reject requests missing `Scope` or `Trigger` with an `errors.BadRequestError`.
- **Scanner Registration (`scanner/base_controller.go`)**: Added explicit `url.ParseRequestURI` validation in `Ping()` to catch invalid URLs. Any subsequent ping or dial failures are now wrapped as an `errors.BadRequestError`.
- **LDAP Group Search (`handler/ldap.go`)**: Added a precondition check using `config.AuthMode(ctx)` to immediately return an `errors.PreconditionFailedError` if the authentication mode is not set to LDAP, preventing unnecessary attempts to dial `:389`.
- **Job Service (`handler/jobservice.go`)**: Updated `ActionGetJobLog` to explicitly catch the core job service error code `10009` ("invalid length of log identify") and translate it to an `errors.BadRequestError`.

# Issue being fixed
Fixes #23345

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).