### PR TITLE
fix: use validated scan type in StopScanArtifact

### DIFF
--- a/src/server/v2.0/handler/scan.go
+++ b/src/server/v2.0/handler/scan.go
@@ -69,7 +69,7 @@ func (s *scanAPI) StopScanArtifact(ctx context.Context, params operation.StopSca
 		return s.SendError(ctx, err)
 	}
 
-	if err := s.scanCtl.Stop(ctx, curArtifact, params.ScanType.ScanType); err != nil {
+	if err := s.scanCtl.Stop(ctx, curArtifact, scanType); err != nil {
 		return s.SendError(ctx, err)
 	}
 


### PR DESCRIPTION
## SUMMARY

This PR fixes `StopScanArtifact()` to use the already validated and defaulted `scanType` value when stopping a scan. The change affects the scan API handler in `src/server/v2.0/handler/scan.go` and aligns its behavior with the existing `ScanArtifact()` implementation.

## FIX

```go i
// Before
if err := s.scanCtl.Stop(ctx, curArtifact, params.ScanType.ScanType); err != nil {
    return s.SendError(ctx, err)
}

// After
if err := s.scanCtl.Stop(ctx, curArtifact, scanType); err != nil {
    return s.SendError(ctx, err)
}
```

