### PR TITLE
fix: increase access_key column length to 4096

### DIFF
--- a/make/migrations/postgresql/0190_2.16.0_schema.up.sql
+++ b/make/migrations/postgresql/0190_2.16.0_schema.up.sql
@@ -1,1 +1,10 @@
 ALTER TABLE artifact_accessory ADD COLUMN IF NOT EXISTS source varchar(50) DEFAULT 'local';
+
+/*
+Increase the length of the registry access_key column so it can store long-form credentials.
+
+This keeps access_key consistent with access_secret, which is already varchar(4096).
+
+See: https://github.com/goharbor/harbor/issues/23303
+*/
+ALTER TABLE registry ALTER COLUMN access_key TYPE varchar(4096);


### PR DESCRIPTION
# Comprehensive Summary of Your Change

Currently, the `access_key` column has a maximum length of `255` characters. However, this is not sufficient because some registries store the full JWT token in this field rather than only the username, which was the original intent. Therefore, we should increase the maximum length to `4096` characters to accommodate these use cases and keep it consistent with the corresponding credential storage requirements.

# Issue Being Fixed

Fixes #23303

Please indicate you've done the following:
- [X] Well Written Title and Summary of the PR
- [X] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [X] Accepted the DCO. Commits without the DCO will delay acceptance.
- [X]  Made sure tests are passing and test coverage is added if needed.
- [X] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
