### PR TITLE
fix: allow database authentication when OIDC is enabled for non-OIDC users

### DIFF
--- a/src/core/auth/auth_test.go
+++ b/src/core/auth/auth_test.go
@@ -15,13 +15,16 @@ package auth
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/goharbor/harbor/src/common/models"
+	"github.com/goharbor/harbor/src/pkg/user"
 	"github.com/goharbor/harbor/src/pkg/usergroup/model"
+	testinguserpkg "github.com/goharbor/harbor/src/testing/pkg/user"
 )
 
 var l = NewUserLock(2 * time.Second)
@@ -85,4 +88,132 @@ func TestErrAuth(t *testing.T) {
 	e := NewErrAuth("test")
 	expectedStr := "Failed to authenticate user, due to error 'test'"
 	assert.Equal(expectedStr, e.Error())
+}
+
+func TestCanUseOIDCAuth(t *testing.T) {
+	// Test all code paths of canUseOIDCAuth with mocked user manager.
+	// Saves and restores the original user.Mgr to avoid side effects.
+	tests := []struct {
+		name        string
+		username    string
+		mockUser    *models.User
+		mockErr     error
+		expected    bool
+		description string
+	}{
+		{
+			name:        "DBLookupError",
+			username:    "alice",
+			mockUser:    nil,
+			mockErr:     fmt.Errorf("database connection failed"),
+			expected:    false,
+			description: "User lookup error should return false (fallback to DB auth)",
+		},
+		{
+			name:        "UserNotFound",
+			username:    "bob",
+			mockUser:    nil,
+			mockErr:     nil,
+			expected:    false,
+			description: "User not found (nil return, no error) should return false",
+		},
+		{
+			name:     "UserWithoutOIDCMetadata",
+			username: "charlie",
+			mockUser: &models.User{
+				UserID:       2,
+				Username:    "charlie",
+				OIDCUserMeta: nil,
+			},
+			mockErr:     nil,
+			expected:    false,
+			description: "User without OIDC metadata should return false (fallback to DB auth)",
+		},
+		{
+			name:     "UserWithOIDCMetadata",
+			username: "dave",
+			mockUser: &models.User{
+				UserID:       3,
+				Username:    "dave",
+				OIDCUserMeta: &models.OIDCUser{ID: 1, UserID: 3},
+			},
+			mockErr:     nil,
+			expected:    true,
+			description: "User with OIDC metadata should return true (use OIDC auth)",
+		},
+	}
+
+	ctx := context.Background()
+	orig := user.Mgr
+	defer func() { user.Mgr = orig }()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockMgr := &testinguserpkg.Manager{}
+			user.Mgr = mockMgr
+
+			mockMgr.On("GetByName", ctx, tt.username).Return(tt.mockUser, tt.mockErr)
+
+			result := canUseOIDCAuth(ctx, tt.username)
+			assert.Equal(t, tt.expected, result, tt.description)
+			mockMgr.AssertExpectations(t)
+		})
+	}
+}
+
+func TestIsSuperUser_WithMockedUserManager(t *testing.T) {
+	// Test IsSuperUser with mocked user.Mgr to exercise the user lookup path.
+	// This also exercises the same GetByName call used by canUseOIDCAuth during Login flow.
+
+	orig := user.Mgr
+	defer func() { user.Mgr = orig }()
+
+	ctx := context.Background()
+
+	tests := []struct {
+		name        string
+		username    string
+		mockUser    *models.User
+		mockErr     error
+		expected    bool
+		description string
+	}{
+		{
+			name:        "SuperUserIsAdmin",
+			username:    "admin",
+			mockUser:    &models.User{UserID: 1, Username: "admin"},
+			mockErr:     nil,
+			expected:    true,
+			description: "User with UserID=1 should be super user",
+		},
+		{
+			name:        "NonSuperUser",
+			username:    "regular",
+			mockUser:    &models.User{UserID: 2, Username: "regular"},
+			mockErr:     nil,
+			expected:    false,
+			description: "User with UserID != 1 should not be super user",
+		},
+		{
+			name:        "UserLookupError",
+			username:    "unknown",
+			mockUser:    nil,
+			mockErr:     fmt.Errorf("db error"),
+			expected:    false,
+			description: "User lookup error should return false (not super user)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockMgr := &testinguserpkg.Manager{}
+			user.Mgr = mockMgr
+
+			mockMgr.On("GetByName", ctx, tt.username).Return(tt.mockUser, tt.mockErr)
+
+			result := IsSuperUser(ctx, tt.username)
+			assert.Equal(t, tt.expected, result, tt.description)
+			mockMgr.AssertExpectations(t)
+		})
+	}
 }

--- a/src/core/auth/authenticator.go
+++ b/src/core/auth/authenticator.go
@@ -141,6 +141,12 @@ func Login(ctx context.Context, m models.AuthModel) (*models.User, error) {
 	}
 	if authMode == "" || IsSuperUser(ctx, m.Principal) {
 		authMode = common.DBAuth
+	} else if authMode == common.OIDCAuth && !canUseOIDCAuth(ctx, m.Principal) {
+		// OIDC migration support: allow local database users (e.g., admin) without OIDC metadata
+		// to authenticate using DB credentials when OIDC is enabled. This prevents lockout
+		// when switching authentication modes while maintaining OIDC-first for users with metadata.
+		log.Debugf("User %s lacks OIDC metadata, falling back to database authentication", m.Principal)
+		authMode = common.DBAuth
 	}
 	log.Debug("Current AUTH_MODE is ", authMode)
 
@@ -264,4 +270,25 @@ func IsSuperUser(ctx context.Context, username string) bool {
 		return false
 	}
 	return u.UserID == 1
+}
+
+// canUseOIDCAuth checks if a user has OIDC metadata linked to their account.
+// Returns true only if the user exists and has OIDC metadata, allowing OIDC authentication.
+// Returns false if the user doesn't exist or doesn't have OIDC metadata, allowing fallback to DB auth.
+func canUseOIDCAuth(ctx context.Context, username string) bool {
+	u, err := user.Mgr.GetByName(ctx, username)
+	if err != nil {
+		log.Debugf("Could not retrieve user %s from database, will fall back to DB auth: %v", username, err)
+		return false
+	}
+	if u == nil {
+		log.Debugf("User %s not found in database, will fall back to DB auth", username)
+		return false
+	}
+	// Check if user has OIDC metadata
+	if u.OIDCUserMeta != nil {
+		return true
+	}
+	log.Debugf("User %s has no OIDC metadata, will fall back to DB auth", username)
+	return false
 }


### PR DESCRIPTION
## Summary
When OIDC is enabled, local database users without OIDC metadata linked can now authenticate using their database credentials. This allows admin users created in the database to continue logging in after switching to OIDC authentication.

## Changes
- Adds `canUseOIDCAuth()` to check if a user has OIDC metadata
- Routes users without OIDC metadata to DB authenticator even when OIDC is enabled
- Preserves OIDC-first behavior for users with OIDC metadata linked

## Motivation
Currently, enabling OIDC blocks all local database authentication. This prevents admin users from logging in after auth mode switch, creating a lock-out situation.

## Testing
- Integration tests needed to verify OIDC + DB auth fallback works end-to-end
- The fix allows existing database users to maintain access while OIDC users work normally