### PR TITLE
Bump Trivy adapter version to v0.37.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ PREPARE_VERSION_NAME=versions
 #versions
 REGISTRYVERSION=v2.8.3-patch-redis
 TRIVYVERSION=v0.71.1
-TRIVYADAPTERVERSION=v0.37.1-rc.1
+TRIVYADAPTERVERSION=v0.37.1
 NODEBUILDIMAGE=node:22.22.3
 
 # version of registry for pulling the source code


### PR DESCRIPTION
Update TRIVYADAPTERVERSION from v0.37.1-rc.1 to v0.37.1 in Makefile.

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [ ] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [ ] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
