### PR TITLE
cherry-pick: fix(ui): use selected tag for pull command copy (#23240) to release-2.15.0

### DIFF
--- a/src/portal/src/app/base/project/repository/artifact/artifact-list-page/artifact-list/artifact-list-tab/pull-command/pull-command.component.spec.ts
+++ b/src/portal/src/app/base/project/repository/artifact/artifact-list-page/artifact-list/artifact-list-tab/pull-command/pull-command.component.spec.ts
@@ -29,6 +29,9 @@ describe('PullCommandComponent', () => {
 
         fixture = TestBed.createComponent(PullCommandComponent);
         component = fixture.componentInstance;
+        component.registryUrl = 'demo.goharbor.io';
+        component.projectName = 'library';
+        component.repoName = 'hello-world';
 
         component.artifact = {
             type: ArtifactType.CHART,
@@ -151,5 +154,52 @@ describe('PullCommandComponent', () => {
         const modal =
             fixture.nativeElement.querySelector(`#pullCommandForCNAB`);
         expect(modal).toBeTruthy();
+    });
+
+    [
+        { tagNumber: 1, tags: [{ name: '1.0.0' }] },
+        { tagNumber: 2, tags: [{ name: '1.0.0' }, { name: 'latest' }] },
+        { tagNumber: 0, tags: [] },
+        { tagNumber: undefined, tags: undefined },
+    ].forEach(({ tagNumber, tags }) => {
+        it(`should use selected tag for image tag pull command when artifact tag number is ${tagNumber}`, () => {
+            component.selectedTag = '2.0.0';
+
+            const pullCommand = component.getPullCommandForRuntimeByTag({
+                type: ArtifactType.IMAGE,
+                tagNumber,
+                tags,
+            });
+
+            expect(pullCommand).toEqual(
+                'docker pull demo.goharbor.io/library/hello-world:2.0.0'
+            );
+        });
+    });
+
+    it('should use selected tag for chart tag pull command even when artifact tags are unavailable', () => {
+        component.selectedTag = '2.0.0';
+
+        const pullCommand = component.getPullCommandForChartByTag({
+            type: ArtifactType.CHART,
+            tagNumber: undefined,
+            tags: undefined,
+        });
+
+        expect(pullCommand).toEqual(
+            'helm pull oci://demo.goharbor.io/library/hello-world --version 2.0.0'
+        );
+    });
+
+    it('should not build a tag pull command without selected tag', () => {
+        component.selectedTag = '';
+
+        const pullCommand = component.getPullCommandForRuntimeByTag({
+            type: ArtifactType.IMAGE,
+            tagNumber: 1,
+            tags: [{ name: '1.0.0' }],
+        });
+
+        expect(pullCommand).toEqual('');
     });
 });

--- a/src/portal/src/app/base/project/repository/artifact/artifact-list-page/artifact-list/artifact-list-tab/pull-command/pull-command.component.ts
+++ b/src/portal/src/app/base/project/repository/artifact/artifact-list-page/artifact-list/artifact-list-tab/pull-command/pull-command.component.ts
@@ -128,8 +128,7 @@ export class PullCommandComponent {
     }
 
     getPullCommandForRuntimeByTag(artifact: Artifact): string {
-        // early return if artifact has no tags
-        if (!this.isArtifactTagValid(artifact)) {
+        if (!this.isSelectedTagValid()) {
             return '';
         }
         return getPullCommandByTag(
@@ -143,8 +142,7 @@ export class PullCommandComponent {
     }
 
     getPullCommandForCNABByTag(artifact: Artifact): string {
-        // early return if artifact has no tags
-        if (!this.isArtifactTagValid(artifact)) {
+        if (!this.isSelectedTagValid()) {
             return '';
         }
         return getPullCommandByTag(
@@ -158,8 +156,7 @@ export class PullCommandComponent {
     }
 
     getPullCommandForChartByTag(artifact: Artifact): string {
-        // early return if artifact has no tags
-        if (!this.isArtifactTagValid(artifact)) {
+        if (!this.isSelectedTagValid()) {
             return '';
         }
         return getPullCommandByTag(
@@ -180,6 +177,10 @@ export class PullCommandComponent {
             artifact.tags.length > 0 &&
             typeof artifact.tags[0]?.name === 'string'
         );
+    }
+
+    private isSelectedTagValid(): boolean {
+        return typeof this.selectedTag === 'string' && this.selectedTag !== '';
     }
 
     onCpSuccess(copied: string): void {


### PR DESCRIPTION
## Summary
- Cherry-pick of #23240 to release-2.15.0.
- Fixes artifact tag copy-pull commands to use the selected tag row instead of validating against artifact-level tag metadata.
- Adds coverage for single-tag, multi-tag, empty-tag, and missing-tag artifact metadata cases.

