### PR TITLE
fix(ui): fix UI issues #48–#54 across portal components

### DIFF
--- a/src/portal/src/app/account/sign-in/sign-in.component.html
+++ b/src/portal/src/app/account/sign-in/sign-in.component.html
@@ -89,31 +89,34 @@
                                 (passwordInput.dirty || passwordInput.touched)
                             ">
                             <div class="clr-input-wrapper">
-                                <input
-                                    class="clr-input pwd-input"
-                                    [type]="showPwd ? 'text' : 'password'"
-                                    required
-                                    [(ngModel)]="signInCredential.password"
-                                    name="login_password"
-                                    id="login_password"
-                                    placeholder="{{
-                                        'PLACEHOLDER.SIGN_IN_PWD' | translate
-                                    }}"
-                                    #passwordInput="ngModel" />
-                                @if (!showPwd) {
-                                <clr-icon
-                                    shape="eye"
-                                    class="pw-eye"
-                                    (click)="showPwd = !showPwd"></clr-icon>
-                                } @if (showPwd) {
-                                <clr-icon
-                                    shape="eye-hide"
-                                    class="pw-eye"
-                                    (click)="showPwd = !showPwd"></clr-icon>
-                                }
-                                <clr-icon
-                                    class="clr-validate-icon"
-                                    shape="exclamation-circle"></clr-icon>
+                                <div class="clr-input-group">
+                                    <input
+                                        class="clr-input pwd-input"
+                                        [type]="showPwd ? 'text' : 'password'"
+                                        required
+                                        [(ngModel)]="signInCredential.password"
+                                        name="login_password"
+                                        id="login_password"
+                                        placeholder="{{
+                                            'PLACEHOLDER.SIGN_IN_PWD'
+                                                | translate
+                                        }}"
+                                        #passwordInput="ngModel" />
+                                    @if (!showPwd) {
+                                    <clr-icon
+                                        shape="eye"
+                                        class="pw-eye"
+                                        (click)="showPwd = !showPwd"></clr-icon>
+                                    } @if (showPwd) {
+                                    <clr-icon
+                                        shape="eye-hide"
+                                        class="pw-eye"
+                                        (click)="showPwd = !showPwd"></clr-icon>
+                                    }
+                                    <clr-icon
+                                        class="clr-validate-icon"
+                                        shape="exclamation-circle"></clr-icon>
+                                </div>
                             </div>
                             @if ( passwordInput.invalid && (passwordInput.dirty
                             || passwordInput.touched) ) {

--- a/src/portal/src/app/base/account-settings/account-settings-modal.component.html
+++ b/src/portal/src/app/base/account-settings/account-settings-modal.component.html
@@ -68,31 +68,36 @@
                         !getValidationState('account_settings_email')
                     ">
                     <div class="clr-input-wrapper">
-                        <input
-                            name="account_settings_email"
-                            type="text"
-                            #eamilInput="ngModel"
-                            class="clr-input"
-                            [(ngModel)]="account.email"
-                            required
-                            email
-                            id="account_settings_email"
-                            size="30"
-                            (input)="
-                                handleValidation(
-                                    'account_settings_email',
-                                    false
-                                )
-                            "
-                            (blur)="
-                                handleValidation('account_settings_email', true)
-                            " />
-                        <clr-icon
-                            class="clr-validate-icon"
-                            shape="exclamation-circle"></clr-icon>
-                        <span
-                            class="spinner spinner-inline"
-                            [hidden]="!checkProgress"></span>
+                        <div class="clr-input-group">
+                            <input
+                                name="account_settings_email"
+                                type="text"
+                                #eamilInput="ngModel"
+                                class="clr-input"
+                                [(ngModel)]="account.email"
+                                required
+                                email
+                                id="account_settings_email"
+                                size="30"
+                                (input)="
+                                    handleValidation(
+                                        'account_settings_email',
+                                        false
+                                    )
+                                "
+                                (blur)="
+                                    handleValidation(
+                                        'account_settings_email',
+                                        true
+                                    )
+                                " />
+                            <clr-icon
+                                class="clr-validate-icon"
+                                shape="exclamation-circle"></clr-icon>
+                            <span
+                                class="spinner spinner-inline"
+                                [hidden]="!checkProgress"></span>
+                        </div>
                     </div>
                     @if (!getValidationState('account_settings_email')) {
                     <clr-control-error>

--- a/src/portal/src/app/base/left-side-nav/config/security/security.component.html
+++ b/src/portal/src/app/base/left-side-nav/config/security/security.component.html
@@ -109,7 +109,8 @@
                                     readonly
                                     type="date"
                                     [(clrDate)]="expiresDate"
-                                    newFormLayout="true" />
+                                    newFormLayout="true"
+                                    class="expire-date-input" />
                             </div>
                         </div>
                         <div class="clr-row">

--- a/src/portal/src/app/base/left-side-nav/config/security/security.component.scss
+++ b/src/portal/src/app/base/left-side-nav/config/security/security.component.scss
@@ -1,104 +1,109 @@
 .clr-form-horizontal {
-  .clr-form-control {
-    & >.clr-control-label {
-      width: 14rem;
-    }
-  }
+    .clr-form-control {
+        & > .clr-control-label {
+            width: 14rem;
+        }
 
-  .flex-direction-column {
-    flex-direction: column;
-  }
+        .expire-date-input {
+            border-bottom: var(--cds-alias-object-border-width-100) solid
+                var(--clr-forms-border-color);
+        }
+    }
+
+    .flex-direction-column {
+        flex-direction: column;
+    }
 }
 
 .bottom-line {
-  display: flex;
-  flex-direction: column-reverse;
+    display: flex;
+    flex-direction: column-reverse;
 }
 
 .expire-data {
-  min-width: 12.5rem;
-  margin-top: -1rem;
+    min-width: 12.5rem;
+    margin-top: -1rem;
 }
 
 .position-relative {
-  position: relative;
+    position: relative;
 }
 
 .pl-05 {
-  padding-left: 0.5rem;
+    padding-left: 0.5rem;
 }
 
 .mt-1 {
-  margin-top: 1rem;
+    margin-top: 1rem;
 }
 
 .d-f {
-  display: flex;
+    display: flex;
 }
 
 .font-size-13 {
-  font-size: 13px;
+    font-size: 13px;
 }
 
 .mt-05 {
-  margin-bottom: 0.5rem;
+    margin-bottom: 0.5rem;
 }
 
 .title {
-  font-weight: bold;
+    font-weight: bold;
 }
 
 .margin-top-4 {
-  margin-top: 4px;
+    margin-top: 4px;
 }
 
 .allowlist-window {
-  border: 1px solid #ccc;
-  border-radius: 3px;
-  padding: 12px;
-  height: 224px;
-  width: 222px;
-  overflow-y: auto;
+    border: 1px solid #ccc;
+    border-radius: 3px;
+    padding: 12px;
+    height: 224px;
+    width: 222px;
+    overflow-y: auto;
 
-  li {
-    height: 24px;
-    line-height: 24px;
-    list-style-type: none;
-  }
+    li {
+        height: 24px;
+        line-height: 24px;
+        list-style-type: none;
+    }
 }
 
 .width-90per {
-  width: 90%;
+    width: 90%;
 }
 
 .none {
-  color: #ccc;
+    color: #ccc;
 }
 
 .color-0079bb {
-  color: #0079bb;
+    color: #0079bb;
 }
 
 .padding-top-8 {
-  padding-top: 8px;
+    padding-top: 8px;
 }
 
 .padding-left-80 {
-  padding-left: 80px;
+    padding-left: 80px;
 }
 
 .add-modal {
-  position: absolute;
-  padding: 0 8px;
-  background-color: rgb(238 238 238);
-  z-index: 1000;
+    position: absolute;
+    padding: 0 8px;
+    background-color: rgb(238 238 238);
+    z-index: 1000;
 
-  input {
-    width: 100%;
-    border: 1px solid;
-  }
+    input {
+        width: 100%;
+        border: 1px solid;
+    }
 
-  button {
-    float: right;
-  }
+    button {
+        float: right;
+    }
 }

--- a/src/portal/src/app/base/left-side-nav/projects/create-project/create-project.component.html
+++ b/src/portal/src/app/base/left-side-nav/projects/create-project/create-project.component.html
@@ -14,22 +14,24 @@
                     class="clr-control-container"
                     [class.clr-error]="!isNameValid">
                     <div class="clr-input-wrapper">
-                        <input
-                            type="text"
-                            id="create_project_name"
-                            [(ngModel)]="project.name"
-                            name="create_project_name"
-                            class="clr-input input-width"
-                            required
-                            pattern="^[a-z0-9]+(?:[._\-][a-z0-9]+)*$"
-                            #projectName
-                            autocomplete="off" />
-                        <clr-icon
-                            class="clr-validate-icon"
-                            shape="exclamation-circle"></clr-icon>
-                        <span
-                            class="spinner spinner-inline"
-                            [hidden]="!checkOnGoing"></span>
+                        <div class="clr-input-group">
+                            <input
+                                type="text"
+                                id="create_project_name"
+                                [(ngModel)]="project.name"
+                                name="create_project_name"
+                                class="clr-input input-width"
+                                required
+                                pattern="^[a-z0-9]+(?:[._\-][a-z0-9]+)*$"
+                                #projectName
+                                autocomplete="off" />
+                            <clr-icon
+                                class="clr-validate-icon"
+                                shape="exclamation-circle"></clr-icon>
+                            <span
+                                class="spinner spinner-inline"
+                                [hidden]="!checkOnGoing"></span>
+                        </div>
                     </div>
                     @if (!isNameValid) {
                     <clr-control-error class="tooltip-content">
@@ -208,17 +210,20 @@
                     class="clr-control-label"></label>
                 <div class="clr-control-container">
                     <div class="clr-input-wrapper">
-                        <label class="clr-control-label endpoint required">{{
-                            'PROJECT.ENDPOINT' | translate
-                        }}</label>
-                        <input
-                            placeholder="http(s)://192.168.1.1"
-                            [value]="getEndpoint()"
-                            readonly
-                            class="clr-input"
-                            type="text"
-                            id="endpoint"
-                            autocomplete="off" />
+                        <div class="clr-input-group">
+                            <label
+                                class="clr-control-label endpoint required"
+                                >{{ 'PROJECT.ENDPOINT' | translate }}</label
+                            >
+                            <input
+                                placeholder="http(s)://192.168.1.1"
+                                [value]="getEndpoint()"
+                                readonly
+                                class="clr-input"
+                                type="text"
+                                id="endpoint"
+                                autocomplete="off" />
+                        </div>
                     </div>
                 </div>
             </div>

--- a/src/portal/src/app/base/left-side-nav/registries/create-edit-endpoint/create-edit-endpoint.component.html
+++ b/src/portal/src/app/base/left-side-nav/registries/create-edit-endpoint/create-edit-endpoint.component.html
@@ -15,7 +15,7 @@
                 </span>
             </div>
         </div>
-        }
+        } @if (createEditDestinationOpened) {
         <form #targetForm="ngForm" class="clr-form clr-form-horizontal">
             <!-- provider -->
             <clr-select-container>
@@ -267,6 +267,7 @@
                 </clr-control-helper>
             </clr-textarea-container>
         </form>
+        }
     </div>
     <div class="modal-footer">
         <button
@@ -274,7 +275,7 @@
             type="button"
             class="btn btn-outline"
             (click)="testConnection()"
-            [disabled]="inProgress || targetEndpoint?.errors">
+            [disabled]="inProgress || isEndpointInvalid">
             {{ 'DESTINATION.TEST_CONNECTION' | translate }}
         </button>
         <button

--- a/src/portal/src/app/base/left-side-nav/registries/create-edit-endpoint/create-edit-endpoint.component.ts
+++ b/src/portal/src/app/base/left-side-nav/registries/create-edit-endpoint/create-edit-endpoint.component.ts
@@ -149,6 +149,10 @@ export class CreateEditEndpointComponent
         return this.onGoing || this.testOngoing;
     }
 
+    public get isEndpointInvalid(): boolean {
+        return !!this.targetForm?.controls?.['endpointUrl']?.errors;
+    }
+
     setInsecureValue($event: any) {
         this.target.insecure = !$event;
     }

--- a/src/portal/src/app/base/project/repository/artifact/sbom-scanning/sbom-scan-component.html
+++ b/src/portal/src/app/base/project/repository/artifact/sbom-scanning/sbom-scan-component.html
@@ -12,7 +12,7 @@
             class="error-text"
             target="_blank"
             [href]="viewLog()">
-            <clr-icon shape="error" class="is-error" size="24"></clr-icon>
+            <clr-icon shape="error" status="danger" size="24"></clr-icon>
             {{ 'SBOM.STATE.ERROR' | translate }}
         </a>
     </div>

--- a/src/portal/src/app/base/project/repository/artifact/vulnerability-scanning/result-bar-chart-component.html
+++ b/src/portal/src/app/base/project/repository/artifact/vulnerability-scanning/result-bar-chart-component.html
@@ -12,7 +12,7 @@
             class="error-text"
             target="_blank"
             [href]="viewLog()">
-            <clr-icon shape="error" class="is-error" size="24"></clr-icon>
+            <clr-icon shape="error" status="danger" size="24"></clr-icon>
             {{ 'VULNERABILITY.STATE.ERROR' | translate }}
         </a>
     </div>

--- a/src/portal/src/app/shared/components/new-user-form/new-user-form.component.html
+++ b/src/portal/src/app/shared/components/new-user-form/new-user-form.component.html
@@ -1,32 +1,35 @@
 <div>
-    <form #newUserFrom="ngForm" class="clr-form clr-form-horizontal">
-        <div class="clr-form-control">
+    <form clrForm #newUserFrom="ngForm" clrLayout="horizontal" clrLabelSize="4">
+        <!-- Name -->
+        <div class="clr-form-control clr-row">
             <label class="required clr-control-label">{{
                 'PROFILE.USER_NAME' | translate
             }}</label>
             <div
-                class="clr-control-container"
+                class="clr-control-container clr-col-md-8 clr-col-12"
                 [class.clr-error]="getValidationState('username')">
                 <div class="clr-input-wrapper">
-                    <input
-                        type="text"
-                        class="clr-input"
-                        required
-                        pattern='[^,"~#$%]+'
-                        maxLengthExt="255"
-                        #usernameInput="ngModel"
-                        name="username"
-                        [(ngModel)]="newUser.username"
-                        id="username"
-                        size="30"
-                        (input)="handleValidation('username', false)"
-                        (blur)="handleValidation('username', true)" />
-                    <clr-icon
-                        class="clr-validate-icon"
-                        shape="exclamation-circle"></clr-icon>
-                    <span
-                        class="spinner spinner-inline spinner-pos"
-                        [hidden]="isChecking('username')"></span>
+                    <div class="clr-input-group">
+                        <input
+                            type="text"
+                            class="clr-input"
+                            required
+                            pattern='[^,"~#$%]+'
+                            maxLengthExt="255"
+                            #usernameInput="ngModel"
+                            name="username"
+                            [(ngModel)]="newUser.username"
+                            id="username"
+                            size="30"
+                            (input)="handleValidation('username', false)"
+                            (blur)="handleValidation('username', true)" />
+                        <clr-icon
+                            class="clr-validate-icon"
+                            shape="exclamation-circle"></clr-icon>
+                        <span
+                            class="spinner spinner-inline spinner-pos"
+                            [hidden]="isChecking('username')"></span>
+                    </div>
                 </div>
                 @if (getValidationState('username')) {
                 <clr-control-error>
@@ -35,44 +38,48 @@
                 }
             </div>
         </div>
-        <div class="clr-form-control">
+        <div class="clr-form-control clr-row">
             <label class="required clr-control-label">{{
                 'PROFILE.EMAIL' | translate
             }}</label>
             <div
-                class="clr-control-container"
+                class="clr-control-container clr-col-md-8 clr-col-12"
                 [class.clr-error]="getValidationState('email')">
                 <div class="clr-input-wrapper">
-                    <input
-                        name="email"
-                        type="text"
-                        #eamilInput="ngModel"
-                        [(ngModel)]="newUser.email"
-                        required
-                        email
-                        id="email"
-                        size="30"
-                        (input)="handleValidation('email', false)"
-                        (blur)="handleValidation('email', true)"
-                        class="clr-input" />
-                    <clr-icon
-                        class="clr-validate-icon"
-                        shape="exclamation-circle"></clr-icon>
-                    <span
-                        class="spinner spinner-inline spinner-pos"
-                        [hidden]="isChecking('email')"></span>
-                    @if (isSelfRegistration) {
-                    <clr-control-helper>{{
-                        'TOOLTIP.SIGN_UP_MAIL' | translate
-                    }}</clr-control-helper>
-                    } @if (getValidationState('email')) {
-                    <clr-control-error>
-                        {{ emailTooltip | translate }}
-                    </clr-control-error>
-                    }
+                    <div class="clr-input-group">
+                        <input
+                            name="email"
+                            type="text"
+                            #eamilInput="ngModel"
+                            [(ngModel)]="newUser.email"
+                            required
+                            email
+                            id="email"
+                            size="30"
+                            (input)="handleValidation('email', false)"
+                            (blur)="handleValidation('email', true)"
+                            class="clr-input" />
+                        <clr-icon
+                            class="clr-validate-icon"
+                            shape="exclamation-circle"></clr-icon>
+                        <span
+                            class="spinner spinner-inline spinner-pos"
+                            [hidden]="isChecking('email')"></span>
+                    </div>
                 </div>
+                @if (isSelfRegistration) {
+                <clr-control-helper>{{
+                    'TOOLTIP.SIGN_UP_MAIL' | translate
+                }}</clr-control-helper>
+                } @if (getValidationState('email')) {
+                <clr-control-error>
+                    {{ emailTooltip | translate }}
+                </clr-control-error>
+                }
             </div>
         </div>
+
+        <!-- Full Name -->
         <clr-input-container>
             <label class="required">{{
                 'PROFILE.FULL_NAME' | translate
@@ -95,41 +102,45 @@
             </clr-control-error>
             }
         </clr-input-container>
-        <div class="clr-form-control">
+
+        <!-- Password -->
+        <div class="clr-form-control clr-row">
             <label for="newPassword" class="clr-control-label required">{{
                 'PROFILE.PASSWORD' | translate
             }}</label>
             <div
-                class="clr-control-container"
+                class="clr-control-container clr-col-md-8 clr-col-12"
                 [class.clr-error]="getValidationState('newPassword')">
                 <div class="clr-input-wrapper">
-                    <input
-                        class="clr-input pwd-input"
-                        [type]="showNewPwd ? 'text' : 'password'"
-                        id="newPassword"
-                        required
-                        pattern="^(?=.*\d)(?=.*[a-z])(?=.*[A-Z]).{8,128}$"
-                        name="newPassword"
-                        [(ngModel)]="newUser.password"
-                        #newPassInput="ngModel"
-                        size="30"
-                        maxLength="128"
-                        (input)="handleValidation('newPassword', false)"
-                        (blur)="handleValidation('newPassword', true)" />
-                    @if (!showNewPwd) {
-                    <clr-icon
-                        shape="eye"
-                        class="pw-eye"
-                        (click)="showNewPwd = !showNewPwd"></clr-icon>
-                    } @if (showNewPwd) {
-                    <clr-icon
-                        shape="eye-hide"
-                        class="pw-eye"
-                        (click)="showNewPwd = !showNewPwd"></clr-icon>
-                    }
-                    <clr-icon
-                        class="clr-validate-icon"
-                        shape="exclamation-circle"></clr-icon>
+                    <div class="clr-input-group">
+                        <input
+                            class="clr-input pwd-input"
+                            [type]="showNewPwd ? 'text' : 'password'"
+                            id="newPassword"
+                            required
+                            pattern="^(?=.*\d)(?=.*[a-z])(?=.*[A-Z]).{8,128}$"
+                            name="newPassword"
+                            [(ngModel)]="newUser.password"
+                            #newPassInput="ngModel"
+                            size="30"
+                            maxLength="128"
+                            (input)="handleValidation('newPassword', false)"
+                            (blur)="handleValidation('newPassword', true)" />
+                        @if (!showNewPwd) {
+                        <clr-icon
+                            shape="eye"
+                            class="pw-eye"
+                            (click)="showNewPwd = !showNewPwd"></clr-icon>
+                        } @if (showNewPwd) {
+                        <clr-icon
+                            shape="eye-hide"
+                            class="pw-eye"
+                            (click)="showNewPwd = !showNewPwd"></clr-icon>
+                        }
+                        <clr-icon
+                            class="clr-validate-icon"
+                            shape="exclamation-circle"></clr-icon>
+                    </div>
                 </div>
                 @if (isSelfRegistration) {
                 <clr-control-helper>{{
@@ -142,41 +153,51 @@
                 }
             </div>
         </div>
-        <div class="clr-form-control">
+
+        <!-- Confirm Password -->
+        <div class="clr-form-control clr-row">
             <label for="confirmPassword" class="clr-control-label required">{{
                 'CHANGE_PWD.CONFIRM_PWD' | translate
             }}</label>
             <div
-                class="clr-control-container"
+                class="clr-control-container clr-col-md-8 clr-col-12"
                 [class.clr-error]="getValidationState('confirmPassword')">
                 <div class="clr-input-wrapper">
-                    <input
-                        class="clr-input pwd-input"
-                        [type]="showConfirmPwd ? 'text' : 'password'"
-                        id="confirmPassword"
-                        required
-                        pattern="^(?=.*\d)(?=.*[a-z])(?=.*[A-Z]).{8,128}$"
-                        name="confirmPassword"
-                        [(ngModel)]="confirmedPwd"
-                        #confirmPassInput="ngModel"
-                        size="30"
-                        maxLength="128"
-                        (input)="handleValidation('confirmPassword', false)"
-                        (blur)="handleValidation('confirmPassword', true)" />
-                    @if (!showConfirmPwd) {
-                    <clr-icon
-                        shape="eye"
-                        class="pw-eye"
-                        (click)="showConfirmPwd = !showConfirmPwd"></clr-icon>
-                    } @if (showConfirmPwd) {
-                    <clr-icon
-                        shape="eye-hide"
-                        class="pw-eye"
-                        (click)="showConfirmPwd = !showConfirmPwd"></clr-icon>
-                    }
-                    <clr-icon
-                        class="clr-validate-icon"
-                        shape="exclamation-circle"></clr-icon>
+                    <div class="clr-input-group">
+                        <input
+                            class="clr-input pwd-input"
+                            [type]="showConfirmPwd ? 'text' : 'password'"
+                            id="confirmPassword"
+                            required
+                            pattern="^(?=.*\d)(?=.*[a-z])(?=.*[A-Z]).{8,128}$"
+                            name="confirmPassword"
+                            [(ngModel)]="confirmedPwd"
+                            #confirmPassInput="ngModel"
+                            size="30"
+                            maxLength="128"
+                            (input)="handleValidation('confirmPassword', false)"
+                            (blur)="
+                                handleValidation('confirmPassword', true)
+                            " />
+                        @if (!showConfirmPwd) {
+                        <clr-icon
+                            shape="eye"
+                            class="pw-eye"
+                            (click)="
+                                showConfirmPwd = !showConfirmPwd
+                            "></clr-icon>
+                        } @if (showConfirmPwd) {
+                        <clr-icon
+                            shape="eye-hide"
+                            class="pw-eye"
+                            (click)="
+                                showConfirmPwd = !showConfirmPwd
+                            "></clr-icon>
+                        }
+                        <clr-icon
+                            class="clr-validate-icon"
+                            shape="exclamation-circle"></clr-icon>
+                    </div>
                 </div>
                 @if (getValidationState('confirmPassword')) {
                 <clr-control-error>
@@ -185,6 +206,8 @@
                 }
             </div>
         </div>
+
+        <!-- Comment -->
         <clr-input-container>
             <label>{{ 'PROFILE.COMMENT' | translate }}</label>
             <input

--- a/src/portal/src/app/shared/components/push-image/copy-input.coponent.html
+++ b/src/portal/src/app/shared/components/push-image/copy-input.coponent.html
@@ -25,8 +25,7 @@
         <span>
             <clr-icon
                 shape="copy"
-                [class.is-success]="isCopied"
-                [class.is-error]="hasCopyError"
+                [status]="isCopied ? 'success' : hasCopyError ? 'danger' : null"
                 class="info-tips-icon"
                 size="24"
                 [ngxClipboard]="inputTarget1"

--- a/src/portal/src/global.scss
+++ b/src/portal/src/global.scss
@@ -1,448 +1,453 @@
 body {
     overflow-y: hidden;
-  }
+}
 
-a {
-  text-decoration: none;
+:root,
+[cds-theme] {
+    --clr-link-active-color: var(--clr-link-color);
 }
 
 .app-loading {
-  position: absolute !important;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  margin: auto !important;
-  width: 108px !important;
-  height: 108px !important;
+    position: absolute !important;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    margin: auto !important;
+    width: 108px !important;
+    height: 108px !important;
 }
 
 .tooltip-content {
-  white-space: normal;
-  word-wrap: break-word;
+    white-space: normal;
+    word-wrap: break-word;
 }
 
 .modal-header {
-  padding: 0;
+    padding: 0;
 }
 
 .rotate-90 {
-  transform: rotate(-90deg);
+    transform: rotate(-90deg);
 }
 
 /* set overflow bar style */
 ::-webkit-scrollbar {
-  width: 8px;
-  background: transparent;
+    width: 8px;
+    background: transparent;
 }
 
 ::-webkit-scrollbar-track {
-  box-shadow: inset 0 0 2px rgb(0 0 0 / 30%);
-  border-radius: 4px;
+    box-shadow: inset 0 0 2px rgb(0 0 0 / 30%);
+    border-radius: 4px;
 }
 
 ::-webkit-scrollbar-thumb {
-  border-radius: 4px;
-  background: #ccc;
-  box-shadow: inset 0 0 2px rgb(0 0 0 / 50%);
+    border-radius: 4px;
+    background: #ccc;
+    box-shadow: inset 0 0 2px rgb(0 0 0 / 50%);
 }
 
 ::-webkit-scrollbar-thumb:window-inactive {
-  background: rgb(255 0 0 / 40%);
+    background: rgb(255 0 0 / 40%);
 }
 
 .custom-h2 {
-  line-height: 24px;
+    line-height: 24px;
 }
 
 .datagrid-header {
-  z-index: 0 !important;
+    z-index: 0 !important;
 }
 
 .color-green {
-  color: #00d40f;
+    color: #00d40f;
 }
 
 .color-red {
-  color: red;
-  margin-left: 2px;
+    color: red;
+    margin-left: 2px;
 }
 
 .datagrid-table,
 .datagrid-header {
-  position: inherit !important;
+    position: inherit !important;
 }
 
 .required::after {
-  content: "*";
-  font-size: 0.5848rem;
-  line-height: 0.5rem;
-  color: #c92100;
-  margin-left: 0.25rem;
+    content: '*';
+    font-size: 0.5848rem;
+    line-height: 0.5rem;
+    color: #c92100;
+    margin-left: 0.25rem;
 }
 
 .flex-items-xs-right {
-  justify-content: flex-end;
+    justify-content: flex-end;
 }
 
 .clr-vertical-nav .nav-link {
-  border-radius: 5px;
+    border-radius: 5px;
 }
 
 clr-dropdown {
-  div:focus {
-    outline: none;
-  }
+    div:focus {
+        outline: none;
+    }
 }
 
-
 .w-100 {
-  width: 100% !important;
+    width: 100% !important;
 }
 
 .h-100 {
-  height: 100% !important;
+    height: 100% !important;
 }
 
 .mx-auto {
-  margin-right: auto !important;
-  margin-left: auto !important;
+    margin-right: auto !important;
+    margin-left: auto !important;
 }
 
 .m-0 {
-  margin: 0 !important;
+    margin: 0 !important;
 }
 
 .mt-0 {
-  margin-top: 0 !important;
+    margin-top: 0 !important;
 }
 
 .mr-0 {
-  margin-right: 0 !important;
+    margin-right: 0 !important;
 }
 
 .mb-0 {
-  margin-bottom: 0 !important;
+    margin-bottom: 0 !important;
 }
 
 .ml-0 {
-  margin-left: 0 !important;
+    margin-left: 0 !important;
 }
 
 .mx-0 {
-  margin-right: 0 !important;
-  margin-left: 0 !important;
+    margin-right: 0 !important;
+    margin-left: 0 !important;
 }
 
 .my-0 {
-  margin-top: 0 !important;
-  margin-bottom: 0 !important;
+    margin-top: 0 !important;
+    margin-bottom: 0 !important;
 }
 
 .m-1 {
-  margin: 1rem !important;
+    margin: 1rem !important;
 }
 
 .mt-1 {
-  margin-top: 1rem !important;
+    margin-top: 1rem !important;
 }
 
 .mr-1 {
-  margin-right: 1rem !important;
+    margin-right: 1rem !important;
 }
 
 .mb-1 {
-  margin-bottom: 1rem !important;
+    margin-bottom: 1rem !important;
 }
 
 .ml-1 {
-  margin-left: 1rem !important;
+    margin-left: 1rem !important;
 }
 
 .mx-1 {
-  margin-right: 1rem !important;
-  margin-left: 1rem !important;
+    margin-right: 1rem !important;
+    margin-left: 1rem !important;
 }
 
 .my-1 {
-  margin-top: 1rem !important;
-  margin-bottom: 1rem !important;
+    margin-top: 1rem !important;
+    margin-bottom: 1rem !important;
 }
 
 .m-2 {
-  margin: 1.5rem !important;
+    margin: 1.5rem !important;
 }
 
 .mt-2 {
-  margin-top: 1.5rem !important;
+    margin-top: 1.5rem !important;
 }
 
 .mr-2 {
-  margin-right: 1.5rem !important;
+    margin-right: 1.5rem !important;
 }
 
 .mb-2 {
-  margin-bottom: 1.5rem !important;
+    margin-bottom: 1.5rem !important;
 }
 
 .ml-2 {
-  margin-left: 1.5rem !important;
+    margin-left: 1.5rem !important;
 }
 
 .mx-2 {
-  margin-right: 1.5rem !important;
-  margin-left: 1.5rem !important;
+    margin-right: 1.5rem !important;
+    margin-left: 1.5rem !important;
 }
 
 .my-2 {
-  margin-top: 1.5rem !important;
-  margin-bottom: 1.5rem !important;
+    margin-top: 1.5rem !important;
+    margin-bottom: 1.5rem !important;
 }
 
 .m-3 {
-  margin: 3rem !important;
+    margin: 3rem !important;
 }
 
 .mt-3 {
-  margin-top: 3rem !important;
+    margin-top: 3rem !important;
 }
 
 .mr-3 {
-  margin-right: 3rem !important;
+    margin-right: 3rem !important;
 }
 
 .mb-3 {
-  margin-bottom: 3rem !important;
+    margin-bottom: 3rem !important;
 }
 
 .ml-3 {
-  margin-left: 3rem !important;
+    margin-left: 3rem !important;
 }
 
 .mx-3 {
-  margin-right: 3rem !important;
-  margin-left: 3rem !important;
+    margin-right: 3rem !important;
+    margin-left: 3rem !important;
 }
 
 .my-3 {
-  margin-top: 3rem !important;
-  margin-bottom: 3rem !important;
+    margin-top: 3rem !important;
+    margin-bottom: 3rem !important;
 }
 
 .p-0 {
-  padding: 0 !important;
+    padding: 0 !important;
 }
 
 .pt-0 {
-  padding-top: 0 !important;
+    padding-top: 0 !important;
 }
 
 .pr-0 {
-  padding-right: 0 !important;
+    padding-right: 0 !important;
 }
 
 .pb-0 {
-  padding-bottom: 0 !important;
+    padding-bottom: 0 !important;
 }
 
 .pl-0 {
-  padding-left: 0 !important;
+    padding-left: 0 !important;
 }
 
 .px-0 {
-  padding-right: 0 !important;
-  padding-left: 0 !important;
+    padding-right: 0 !important;
+    padding-left: 0 !important;
 }
 
 .py-0 {
-  padding-top: 0 !important;
-  padding-bottom: 0 !important;
+    padding-top: 0 !important;
+    padding-bottom: 0 !important;
 }
 
 .p-1 {
-  padding: 1rem !important;
+    padding: 1rem !important;
 }
 
 .pt-1 {
-  padding-top: 1rem !important;
+    padding-top: 1rem !important;
 }
 
 .pr-1 {
-  padding-right: 1rem !important;
+    padding-right: 1rem !important;
 }
 
 .pb-1 {
-  padding-bottom: 1rem !important;
+    padding-bottom: 1rem !important;
 }
 
 .pl-1 {
-  padding-left: 1rem !important;
+    padding-left: 1rem !important;
 }
 
 .px-1 {
-  padding-right: 1rem !important;
-  padding-left: 1rem !important;
+    padding-right: 1rem !important;
+    padding-left: 1rem !important;
 }
 
 .py-1 {
-  padding-top: 1rem !important;
-  padding-bottom: 1rem !important;
+    padding-top: 1rem !important;
+    padding-bottom: 1rem !important;
 }
 
 .p-2 {
-  padding: 1.5rem !important;
+    padding: 1.5rem !important;
 }
 
 .pt-2 {
-  padding-top: 1.5rem !important;
+    padding-top: 1.5rem !important;
 }
 
 .pr-2 {
-  padding-right: 1.5rem !important;
+    padding-right: 1.5rem !important;
 }
 
 .pb-2 {
-  padding-bottom: 1.5rem !important;
+    padding-bottom: 1.5rem !important;
 }
 
 .pl-2 {
-  padding-left: 1.5rem !important;
+    padding-left: 1.5rem !important;
 }
 
 .px-2 {
-  padding-right: 1.5rem !important;
-  padding-left: 1.5rem !important;
+    padding-right: 1.5rem !important;
+    padding-left: 1.5rem !important;
 }
 
 .py-2 {
-  padding-top: 1.5rem !important;
-  padding-bottom: 1.5rem !important;
+    padding-top: 1.5rem !important;
+    padding-bottom: 1.5rem !important;
 }
 
 .p-3 {
-  padding: 3rem !important;
+    padding: 3rem !important;
 }
 
 .pt-3 {
-  padding-top: 3rem !important;
+    padding-top: 3rem !important;
 }
 
 .pr-3 {
-  padding-right: 3rem !important;
+    padding-right: 3rem !important;
 }
 
 .pb-3 {
-  padding-bottom: 3rem !important;
+    padding-bottom: 3rem !important;
 }
 
 .pl-3 {
-  padding-left: 3rem !important;
+    padding-left: 3rem !important;
 }
 
 .px-3 {
-  padding-right: 3rem !important;
-  padding-left: 3rem !important;
+    padding-right: 3rem !important;
+    padding-left: 3rem !important;
 }
 
 .py-3 {
-  padding-top: 3rem !important;
-  padding-bottom: 3rem !important;
+    padding-top: 3rem !important;
+    padding-bottom: 3rem !important;
 }
 
 .pos-f-t {
-  position: fixed;
-  top: 0;
-  right: 0;
-  left: 0;
-  z-index: 1030;
+    position: fixed;
+    top: 0;
+    right: 0;
+    left: 0;
+    z-index: 1030;
 }
 
 .text-justify {
-  text-align: justify !important;
+    text-align: justify !important;
 }
 
 .text-nowrap {
-  white-space: nowrap !important;
+    white-space: nowrap !important;
 }
 
 .text-truncate {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .text-xs-left {
-  text-align: left !important;
+    text-align: left !important;
 }
 
 .text-xs-right {
-  text-align: right !important;
+    text-align: right !important;
 }
 
 .text-xs-center {
-  text-align: center !important;
+    text-align: center !important;
 }
 
 .float-lg-right {
-  float: right;
+    float: right;
 }
 
 .position-relative {
-  position: relative;
+    position: relative;
 }
 
 clr-datagrid {
-  clr-dg-row {
-    .datagrid-scrolling-cells {
-      align-items: center;
-      width: 100%;
+    clr-dg-row {
+        .datagrid-scrolling-cells {
+            align-items: center;
+            width: 100%;
+        }
+
+        clr-dg-cell {
+            overflow-wrap: break-word;
+        }
+
+        .datagrid-expandable-caret-icon {
+            margin-top: 0;
+        }
     }
 
-    clr-dg-cell {
-      overflow-wrap: break-word;
+    .datagrid-select {
+        display: flex;
+        align-items: center;
+
+        clr-checkbox-wrapper,
+        clr-radio-wrapper {
+            .clr-control-label {
+                min-height: 0.8rem;
+                width: 0.5rem;
+            }
+        }
     }
 
-    .datagrid-expandable-caret-icon {
-      margin-top: 0;
+    .datagrid-table {
+        .datagrid-column {
+            .datagrid-column-title,
+            clr-dg-filter {
+                align-self: center;
+            }
+        }
     }
-  }
-
-  .datagrid-select {
-    display: flex;
-    align-items: center;
-
-    clr-checkbox-wrapper,
-    clr-radio-wrapper {
-      .clr-control-label {
-        min-height: 0.8rem;
-        width: 0.5rem;
-      }
-    }
-  }
-
-  .datagrid-table {
-    .datagrid-column {
-      .datagrid-column-title,
-      clr-dg-filter {
-        align-self: center;
-      }
-    }
-  }
 }
 /* stylelint-disable no-descending-specificity */
 button:focus {
-  outline: none !important;
+    outline: none !important;
 }
 
 .cursor-pointer {
-  cursor: pointer
+    cursor: pointer;
 }
 
 .text-align-r {
-  text-align: right !important;
+    text-align: right !important;
 }
 
 .datagrid-expandable-caret.datagrid-fixed-column.datagrid-cell.ng-star-inserted {
-  align-items: center;
-  display: flex;
+    align-items: center;
+    display: flex;
+}
+
+a {
+    color: var(--clr-link-color);
+    text-decoration: none;
 }


### PR DESCRIPTION
# Issue being fixed

- Issue 48: Links turn red on click — add global `a { color: var(--clr-link-color) }` override in global.scss so active/visited anchor color stays consistent
- Issue 49: Edit Endpoint modal shows green outlines on open — wrap the form in @if (createEditDestinationOpened) so Clarity does not pre-initialize and validate the form before the modal is actually opened
- Issue 52/53: Copy button icon state broken — replace [class.is-success] / [class.is-error] with [status] binding in copy-input component so icon correctly reflects copied / error / default states
- Issue 54: Sign-up / new-user form layout misaligned — add clrForm, clrLayout, clrLabelSize="4", clr-row and responsive grid classes to new-user-form; wrap input + icon combos in div.clr-input-group in sign-in, account-settings and create-project to fix horizontal label-input alignment
- Also replace deprecated class="is-error" with status="danger" on clr-icon in sbom-scan and vulnerability result-bar-chart components; normalize global.scss indentation from 2-space to 4-space throughout

Testing:
- Verified locally

Signed-off-by: Ashish Patel zoom2ashish@gmail.com
