### PR TITLE
fix: add registry component to proxy configuration support

### DIFF
--- a/make/harbor.yml.tmpl
+++ b/make/harbor.yml.tmpl
@@ -255,6 +255,7 @@ proxy:
   components:
     - core
     - jobservice
+    - registry
     - trivy
 
 # metric:

--- a/make/photon/prepare/templates/docker_compose/docker-compose.yml.jinja
+++ b/make/photon/prepare/templates/docker_compose/docker-compose.yml.jinja
@@ -32,6 +32,8 @@ services:
       - CHOWN
       - SETGID
       - SETUID
+    env_file:
+      - ./common/config/registry/env
     volumes:
       - {{data_volume}}/registry:/storage:z
       - ./common/config/registry/:/etc/registry/:z

--- a/make/photon/prepare/templates/registry/env.jinja
+++ b/make/photon/prepare/templates/registry/env.jinja
@@ -1,0 +1,3 @@
+HTTP_PROXY={{registry_http_proxy}}
+HTTPS_PROXY={{registry_https_proxy}}
+NO_PROXY={{registry_no_proxy}}

--- a/make/photon/prepare/utils/registry.py
+++ b/make/photon/prepare/utils/registry.py
@@ -9,6 +9,8 @@ from utils.misc import prepare_dir
 registry_config_dir = os.path.join(config_dir, "registry")
 registry_config_template_path = os.path.join(templates_dir, "registry", "config.yml.jinja")
 registry_conf = os.path.join(config_dir, "registry", "config.yml")
+registry_env_template_path = os.path.join(templates_dir, "registry", "env.jinja")
+registry_conf_env = os.path.join(config_dir, "registry", "env")
 registry_passwd_path = os.path.join(config_dir, "registry", "passwd")
 registry_data_dir = os.path.join(data_dir, 'registry')
 
@@ -40,6 +42,12 @@ def prepare_registry(config_dict):
         level=levels_map[config_dict['log_level']],
         storage_provider_info=storage_provider_info,
         **config_dict, **redis_ops)
+
+    # Render Registry env
+    render_jinja(
+        registry_env_template_path,
+        registry_conf_env,
+        **config_dict)
 
 def parse_redis(redis_url):
     u = urlsplit(redis_url)

--- a/src/pkg/chart/testdata/harbor-schema1/values.yaml
+++ b/src/pkg/chart/testdata/harbor-schema1/values.yaml
@@ -371,6 +371,7 @@ proxy:
   components:
     - core
     - jobservice
+    - registry
     - trivy
 
 # Run the migration job via helm hook

--- a/src/pkg/chart/testdata/harbor-schema2/values.yaml
+++ b/src/pkg/chart/testdata/harbor-schema2/values.yaml
@@ -371,6 +371,7 @@ proxy:
   components:
     - core
     - jobservice
+    - registry
     - trivy
 
 # Run the migration job via helm hook


### PR DESCRIPTION
PR Summary:
When `registry` is included in `proxy.components`, the registry service now receives proxy environment variables (`HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY`) via the `registry/env` file.

Changes:

* Added `registry` to the `proxy.components` list in `harbor.yml.tmpl`
* Added `registry` to the `proxy.components` list in `values.yaml` for Helm charts
* Created `registry/env.jinja` template with proxy environment variables
* Updated `registry.py` to render the registry env file
* Added `env_file` directive to the registry service in `docker-compose.yml`

Labels needed:

* `release-note/enhancement`

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

This change adds proxy configuration support for the `registry` component.

It fixes a problem in restricted or closed environments where Harbor uses S3 as the storage backend and the registry must connect to S3 through an HTTP/HTTPS proxy. Previously, even if `registry` was included in `proxy.components`, the registry service did not receive proxy-related environment variables and therefore could not use the configured proxy for outbound S3 access.

With this update, the installer generates a dedicated `registry/env` file containing `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY`, and mounts it into the registry service via `env_file`.

As a result, when `registry` is included in `proxy.components`, the registry container will correctly use the configured proxy settings for S3 connectivity in closed-network deployments.

# Issue being fixed

Fixes #(issue)

Please indicate you've done the following:

* [x] Well Written Title and Summary of the PR
* [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
* [x] Accepted the DCO. Commits without the DCO will delay acceptance.
* [x] Made sure tests are passing and test coverage is added if needed.
* [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in the website repository.
