### PR TITLE
feat(oidc): add oidc_login_groups config to restrict login by group membership

### DIFF
--- a/api/v2.0/swagger.yaml
+++ b/api/v2.0/swagger.yaml
@@ -9118,6 +9118,9 @@ definitions:
       oidc_group_filter:
         $ref: '#/definitions/StringConfigItem'
         description: The OIDC group filter which filters out the group doesn't match the regular expression
+      oidc_login_groups:
+        $ref: '#/definitions/StringConfigItem'
+        description: Comma-separated list of OIDC group names allowed to log in. Leave blank to allow all users
       oidc_scope:
         $ref: '#/definitions/StringConfigItem'
         description: The scope of the OIDC provider
@@ -9383,6 +9386,11 @@ definitions:
       oidc_group_filter:
         type: string
         description: The OIDC group filter which filters out the group name doesn't match the regular expression
+        x-omitempty: true
+        x-isnullable: true
+      oidc_login_groups:
+        type: string
+        description: Comma-separated list of OIDC group names allowed to log in. Leave blank to allow all users
         x-omitempty: true
         x-isnullable: true
       oidc_scope:

--- a/src/common/const.go
+++ b/src/common/const.go
@@ -115,7 +115,7 @@ const (
 	OIDCAdminGroup                   = "oidc_admin_group"
 	OIDCGroupsClaim                  = "oidc_groups_claim"
 	OIDCGroupFilter                  = "oidc_group_filter"
-	OIDCLoginGroups					 = "oidc_login_groups"
+	OIDCLoginGroups                  = "oidc_login_groups"
 	OIDCAutoOnboard                  = "oidc_auto_onboard"
 	OIDCExtraRedirectParms           = "oidc_extra_redirect_parms"
 	OIDCScope                        = "oidc_scope"

--- a/src/common/const.go
+++ b/src/common/const.go
@@ -115,6 +115,7 @@ const (
 	OIDCAdminGroup                   = "oidc_admin_group"
 	OIDCGroupsClaim                  = "oidc_groups_claim"
 	OIDCGroupFilter                  = "oidc_group_filter"
+	OIDCLoginGroups					 = "oidc_login_groups"
 	OIDCAutoOnboard                  = "oidc_auto_onboard"
 	OIDCExtraRedirectParms           = "oidc_extra_redirect_parms"
 	OIDCScope                        = "oidc_scope"

--- a/src/core/controllers/oidc.go
+++ b/src/core/controllers/oidc.go
@@ -153,6 +153,15 @@ func (oc *OIDCController) Callback() {
 		oc.SendInternalServerError(err)
 		return
 	}
+	oidcSettings, err := config.OIDCSetting(ctx)
+	if err != nil {
+		oc.SendInternalServerError(err)
+		return
+	}
+	if !oidc.IsLoginAllowed(info, *oidcSettings) {
+		oc.SendUnAuthorizedError(errors.New("user is not a member of any authorized OIDC group"))
+		return
+	}
 	ouDataStr, err := json.Marshal(info)
 	if err != nil {
 		oc.SendInternalServerError(err)
@@ -174,7 +183,7 @@ func (oc *OIDCController) Callback() {
 		username := info.Username
 		// Fix blanks in username
 		username = strings.Replace(username, " ", "_", -1)
-		oidcSettings, err := config.OIDCSetting(ctx)
+		oidcSettings, err = config.OIDCSetting(ctx)
 		if err != nil {
 			oc.SendInternalServerError(err)
 			return

--- a/src/core/controllers/oidc.go
+++ b/src/core/controllers/oidc.go
@@ -183,11 +183,6 @@ func (oc *OIDCController) Callback() {
 		username := info.Username
 		// Fix blanks in username
 		username = strings.Replace(username, " ", "_", -1)
-		oidcSettings, err = config.OIDCSetting(ctx)
-		if err != nil {
-			oc.SendInternalServerError(err)
-			return
-		}
 		// If automatic onboard is enabled, skip the onboard page
 		if oidcSettings.AutoOnboard {
 			log.Debug("Doing automatic onboarding\n")

--- a/src/lib/config/metadata/metadatalist.go
+++ b/src/lib/config/metadata/metadatalist.go
@@ -142,6 +142,7 @@ var (
 		{Name: common.OIDCGroupsClaim, Scope: UserScope, Group: OIDCGroup, ItemType: &StringType{}, Description: `The attribute claims the group name`},
 		{Name: common.OIDCAdminGroup, Scope: UserScope, Group: OIDCGroup, ItemType: &StringType{}, Description: `The OIDC group which has the harbor admin privileges`},
 		{Name: common.OIDCGroupFilter, Scope: UserScope, Group: OIDCGroup, ItemType: &StringType{}, Description: `The OIDC group filter to filter which groups could be onboarded to Harbor`},
+		{Name: common.OIDCLoginGroups, Scope: UserScope, Group: OIDCGroup, ItemType: &StringType{}, Description: `Comma-separated list of OIDC groups allowed to log in. Leave blank to allow all users.`},
 		{Name: common.OIDCScope, Scope: UserScope, Group: OIDCGroup, ItemType: &StringType{}, Description: `The scope of the OIDC provider`},
 		{Name: common.OIDCUserClaim, Scope: UserScope, Group: OIDCGroup, ItemType: &StringType{}, Description: `The attribute claims the username`},
 		{Name: common.OIDCVerifyCert, Scope: UserScope, Group: OIDCGroup, DefaultValue: "true", ItemType: &BoolType{}, Description: `Verify the OIDC provider's certificate'`},

--- a/src/lib/config/models/model.go
+++ b/src/lib/config/models/model.go
@@ -40,6 +40,7 @@ type OIDCSetting struct {
 	GroupsClaim        string            `json:"groups_claim"`
 	AdminGroup         string            `json:"admin_group"`
 	GroupFilter        string            `json:"group_filter"`
+	LoginGroups        string            `json:"login_groups"`
 	RedirectURL        string            `json:"redirect_url"`
 	Scope              []string          `json:"scope"`
 	UserClaim          string            `json:"user_claim"`

--- a/src/lib/config/userconfig.go
+++ b/src/lib/config/userconfig.go
@@ -172,6 +172,7 @@ func OIDCSetting(ctx context.Context) (*cfgModels.OIDCSetting, error) {
 		ClientSecret:       mgr.Get(ctx, common.OIDCClientSecret).GetString(),
 		GroupsClaim:        mgr.Get(ctx, common.OIDCGroupsClaim).GetString(),
 		GroupFilter:        mgr.Get(ctx, common.OIDCGroupFilter).GetString(),
+		LoginGroups:        mgr.Get(ctx, common.OIDCLoginGroups).GetString(),
 		AdminGroup:         mgr.Get(ctx, common.OIDCAdminGroup).GetString(),
 		RedirectURL:        extEndpoint + common.OIDCCallbackPath,
 		Scope:              scope,

--- a/src/pkg/oidc/helper.go
+++ b/src/pkg/oidc/helper.go
@@ -484,14 +484,15 @@ func filterGroup(groupNames []string, filter string) []string {
 // oidc_group_filter is applied separately in InjectGroupsToUser and does not
 // affect this check.
 func IsLoginAllowed(info *UserInfo, setting cfgModels.OIDCSetting) bool {
-	if len(strings.TrimSpace(setting.LoginGroups)) == 0 {
+	allowed := config.SplitAndTrim(setting.LoginGroups, ",")
+	if len(allowed) == 0 {
 		return true
 	}
 	if !info.hasGroupClaim {
-		log.Error("oidc_login_groups is set but the token carried no group claim; all OIDC logins are blocked — verify oidc_groups_claim is configured")
+		log.Warningf("oidc_login_groups is set but the token carried no group claim; all OIDC logins are blocked — verify oidc_groups_claim is configured")
 		return false
 	}
-	for _, g := range config.SplitAndTrim(setting.LoginGroups, ",") {
+	for _, g := range allowed {
 		if slices.Contains(info.Groups, g) {
 			return true
 		}

--- a/src/pkg/oidc/helper.go
+++ b/src/pkg/oidc/helper.go
@@ -489,7 +489,7 @@ func IsLoginAllowed(info *UserInfo, setting cfgModels.OIDCSetting) bool {
 		return true
 	}
 	if !info.hasGroupClaim {
-		log.Warningf("oidc_login_groups is set but the token carried no group claim; all OIDC logins are blocked — verify oidc_groups_claim is configured")
+		log.Error("oidc_login_groups is set but the token carried no group claim; all OIDC logins are blocked — verify oidc_groups_claim is configured")
 		return false
 	}
 	for _, g := range allowed {

--- a/src/pkg/oidc/helper.go
+++ b/src/pkg/oidc/helper.go
@@ -480,16 +480,19 @@ func filterGroup(groupNames []string, filter string) []string {
 
 // IsLoginAllowed checks whether the user is permitted to log in based on the
 // oidc_login_groups setting. Returns true when no restriction is configured.
+// Note: info.Groups contains the raw, unfiltered groups from the token claim;
+// oidc_group_filter is applied separately in InjectGroupsToUser and does not
+// affect this check.
 func IsLoginAllowed(info *UserInfo, setting cfgModels.OIDCSetting) bool {
 	if len(strings.TrimSpace(setting.LoginGroups)) == 0 {
 		return true
 	}
 	if !info.hasGroupClaim {
-		log.Warning("oidc_login_groups is set but the token carried no group claim — verify oidc_groups_claim is configured")
+		log.Error("oidc_login_groups is set but the token carried no group claim; all OIDC logins are blocked — verify oidc_groups_claim is configured")
 		return false
 	}
-	for _, g := range strings.Split(setting.LoginGroups, ",") {
-		if slices.Contains(info.Groups, strings.TrimSpace(g)) {
+	for _, g := range config.SplitAndTrim(setting.LoginGroups, ",") {
+		if slices.Contains(info.Groups, g) {
 			return true
 		}
 	}

--- a/src/pkg/oidc/helper.go
+++ b/src/pkg/oidc/helper.go
@@ -478,6 +478,23 @@ func filterGroup(groupNames []string, filter string) []string {
 	return result
 }
 
+// IsLoginAllowed checks whether the user is permitted to log in based on the
+// oidc_login_groups setting. Returns true when no restriction is configured.
+func IsLoginAllowed(info *UserInfo, setting cfgModels.OIDCSetting) bool {
+	if len(strings.TrimSpace(setting.LoginGroups)) == 0 {
+		return true
+	}
+	if !info.hasGroupClaim {
+		return false
+	}
+	for _, g := range strings.Split(setting.LoginGroups, ",") {
+		if slices.Contains(info.Groups, strings.TrimSpace(g)) {
+			return true
+		}
+	}
+	return false
+}
+
 // InjectGroupsToUser populates the group to DB and inject the group IDs to user model.
 // The third optional parm is for UT only.
 func InjectGroupsToUser(info *UserInfo, user *models.User, f ...populate) {

--- a/src/pkg/oidc/helper.go
+++ b/src/pkg/oidc/helper.go
@@ -485,6 +485,7 @@ func IsLoginAllowed(info *UserInfo, setting cfgModels.OIDCSetting) bool {
 		return true
 	}
 	if !info.hasGroupClaim {
+		log.Warning("oidc_login_groups is set but the token carried no group claim — verify oidc_groups_claim is configured")
 		return false
 	}
 	for _, g := range strings.Split(setting.LoginGroups, ",") {

--- a/src/pkg/oidc/helper_test.go
+++ b/src/pkg/oidc/helper_test.go
@@ -573,58 +573,64 @@ func Test_filterGroup(t *testing.T) {
 }
 
 func TestIsLoginAllowed(t *testing.T) {
-    tests := []struct {
-        name    string
-        info    *UserInfo
-        setting cfgModels.OIDCSetting
-        want    bool
-    }{
-        {
-            name:    "no restriction configured — allow all",
-            info:    &UserInfo{Groups: []string{}, hasGroupClaim: true},
-            setting: cfgModels.OIDCSetting{LoginGroups: ""},
-            want:    true,
-        },
-        {
-            name:    "user in allowed group — permit",
-            info:    &UserInfo{Groups: []string{"harbor", "devs"}, hasGroupClaim: true},
-            setting: cfgModels.OIDCSetting{LoginGroups: "harbor"},
-            want:    true,
-        },
-        {
-            name:    "user not in any allowed group — deny",
-            info:    &UserInfo{Groups: []string{"devs"}, hasGroupClaim: true},
-            setting: cfgModels.OIDCSetting{LoginGroups: "harbor"},
-            want:    false,
-        },
-        {
-            name:    "user in one of multiple allowed groups — permit",
-            info:    &UserInfo{Groups: []string{"devs"}, hasGroupClaim: true},
-            setting: cfgModels.OIDCSetting{LoginGroups: "harbor,devs,ops"},
-            want:    true,
-        },
-        {
-            name:    "spaces around group names are trimmed — permit",
-            info:    &UserInfo{Groups: []string{"harbor"}, hasGroupClaim: true},
-            setting: cfgModels.OIDCSetting{LoginGroups: " harbor , devs "},
-            want:    true,
-        },
-        {
-            name:    "no group claim in token and restriction set — deny",
-            info:    &UserInfo{Groups: []string{}, hasGroupClaim: false},
-            setting: cfgModels.OIDCSetting{LoginGroups: "harbor"},
-            want:    false,
-        },
-        {
-            name:    "no group claim in token and no restriction — allow",
-            info:    &UserInfo{Groups: []string{}, hasGroupClaim: false},
-            setting: cfgModels.OIDCSetting{LoginGroups: ""},
-            want:    true,
-        },
-    }
-    for _, tt := range tests {
-        t.Run(tt.name, func(t *testing.T) {
-            assert.Equal(t, tt.want, IsLoginAllowed(tt.info, tt.setting))
-        })
-    }
+	tests := []struct {
+		name    string
+		info    *UserInfo
+		setting cfgModels.OIDCSetting
+		want    bool
+	}{
+		{
+			name:    "no restriction configured — allow all",
+			info:    &UserInfo{Groups: []string{}, hasGroupClaim: true},
+			setting: cfgModels.OIDCSetting{LoginGroups: ""},
+			want:    true,
+		},
+		{
+			name:    "user in allowed group — permit",
+			info:    &UserInfo{Groups: []string{"harbor", "devs"}, hasGroupClaim: true},
+			setting: cfgModels.OIDCSetting{LoginGroups: "harbor"},
+			want:    true,
+		},
+		{
+			name:    "user not in any allowed group — deny",
+			info:    &UserInfo{Groups: []string{"devs"}, hasGroupClaim: true},
+			setting: cfgModels.OIDCSetting{LoginGroups: "harbor"},
+			want:    false,
+		},
+		{
+			name:    "user in one of multiple allowed groups — permit",
+			info:    &UserInfo{Groups: []string{"devs"}, hasGroupClaim: true},
+			setting: cfgModels.OIDCSetting{LoginGroups: "harbor,devs,ops"},
+			want:    true,
+		},
+		{
+			name:    "spaces around group names are trimmed — permit",
+			info:    &UserInfo{Groups: []string{"harbor"}, hasGroupClaim: true},
+			setting: cfgModels.OIDCSetting{LoginGroups: " harbor , devs "},
+			want:    true,
+		},
+		{
+			name:    "no group claim in token and restriction set — deny",
+			info:    &UserInfo{Groups: []string{}, hasGroupClaim: false},
+			setting: cfgModels.OIDCSetting{LoginGroups: "harbor"},
+			want:    false,
+		},
+		{
+			name:    "no group claim in token and no restriction — allow",
+			info:    &UserInfo{Groups: []string{}, hasGroupClaim: false},
+			setting: cfgModels.OIDCSetting{LoginGroups: ""},
+			want:    true,
+		},
+		{
+			name:    "whitespace-only restriction — treat as no restriction",
+			info:    &UserInfo{Groups: []string{}, hasGroupClaim: true},
+			setting: cfgModels.OIDCSetting{LoginGroups: "   "},
+			want:    true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsLoginAllowed(tt.info, tt.setting))
+		})
+	}
 }

--- a/src/pkg/oidc/helper_test.go
+++ b/src/pkg/oidc/helper_test.go
@@ -36,7 +36,11 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	test.InitDatabaseFromEnv()
+	// DB init is only required for tests that use the ORM (e.g. TestHelperCreate,
+	// TestHelperGet). Pure unit tests can run without it.
+	if os.Getenv("POSTGRESQL_HOST") != "" {
+		test.InitDatabaseFromEnv()
+	}
 	conf := map[string]any{
 		common.OIDCName:         "test",
 		common.OIDCEndpoint:     "https://accounts.google.com",

--- a/src/pkg/oidc/helper_test.go
+++ b/src/pkg/oidc/helper_test.go
@@ -36,11 +36,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	// DB init is only required for tests that use the ORM (e.g. TestHelperCreate,
-	// TestHelperGet). Pure unit tests can run without it.
-	if os.Getenv("POSTGRESQL_HOST") != "" {
-		test.InitDatabaseFromEnv()
-	}
+	test.InitDatabaseFromEnv()
 	conf := map[string]any{
 		common.OIDCName:         "test",
 		common.OIDCEndpoint:     "https://accounts.google.com",

--- a/src/pkg/oidc/helper_test.go
+++ b/src/pkg/oidc/helper_test.go
@@ -61,6 +61,9 @@ func TestMain(m *testing.M) {
 }
 
 func TestHelperCreate(t *testing.T) {
+	if os.Getenv("POSTGRESQL_HOST") == "" {
+		t.Skip("requires POSTGRESQL_HOST")
+	}
 	testP := &providerHelper{}
 	assert.Nil(t, testP.instance.Load())
 	err := testP.create(orm.Context())
@@ -70,6 +73,9 @@ func TestHelperCreate(t *testing.T) {
 }
 
 func TestHelperGet(t *testing.T) {
+	if os.Getenv("POSTGRESQL_HOST") == "" {
+		t.Skip("requires POSTGRESQL_HOST")
+	}
 	testP := &providerHelper{}
 	ctx := orm.Context()
 	p, err := testP.get(ctx)

--- a/src/pkg/oidc/helper_test.go
+++ b/src/pkg/oidc/helper_test.go
@@ -571,3 +571,60 @@ func Test_filterGroup(t *testing.T) {
 		})
 	}
 }
+
+func TestIsLoginAllowed(t *testing.T) {
+    tests := []struct {
+        name    string
+        info    *UserInfo
+        setting cfgModels.OIDCSetting
+        want    bool
+    }{
+        {
+            name:    "no restriction configured — allow all",
+            info:    &UserInfo{Groups: []string{}, hasGroupClaim: true},
+            setting: cfgModels.OIDCSetting{LoginGroups: ""},
+            want:    true,
+        },
+        {
+            name:    "user in allowed group — permit",
+            info:    &UserInfo{Groups: []string{"harbor", "devs"}, hasGroupClaim: true},
+            setting: cfgModels.OIDCSetting{LoginGroups: "harbor"},
+            want:    true,
+        },
+        {
+            name:    "user not in any allowed group — deny",
+            info:    &UserInfo{Groups: []string{"devs"}, hasGroupClaim: true},
+            setting: cfgModels.OIDCSetting{LoginGroups: "harbor"},
+            want:    false,
+        },
+        {
+            name:    "user in one of multiple allowed groups — permit",
+            info:    &UserInfo{Groups: []string{"devs"}, hasGroupClaim: true},
+            setting: cfgModels.OIDCSetting{LoginGroups: "harbor,devs,ops"},
+            want:    true,
+        },
+        {
+            name:    "spaces around group names are trimmed — permit",
+            info:    &UserInfo{Groups: []string{"harbor"}, hasGroupClaim: true},
+            setting: cfgModels.OIDCSetting{LoginGroups: " harbor , devs "},
+            want:    true,
+        },
+        {
+            name:    "no group claim in token and restriction set — deny",
+            info:    &UserInfo{Groups: []string{}, hasGroupClaim: false},
+            setting: cfgModels.OIDCSetting{LoginGroups: "harbor"},
+            want:    false,
+        },
+        {
+            name:    "no group claim in token and no restriction — allow",
+            info:    &UserInfo{Groups: []string{}, hasGroupClaim: false},
+            setting: cfgModels.OIDCSetting{LoginGroups: ""},
+            want:    true,
+        },
+    }
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            assert.Equal(t, tt.want, IsLoginAllowed(tt.info, tt.setting))
+        })
+    }
+}

--- a/src/pkg/oidc/helper_test.go
+++ b/src/pkg/oidc/helper_test.go
@@ -57,9 +57,6 @@ func TestMain(m *testing.M) {
 }
 
 func TestHelperCreate(t *testing.T) {
-	if os.Getenv("POSTGRESQL_HOST") == "" {
-		t.Skip("requires POSTGRESQL_HOST")
-	}
 	testP := &providerHelper{}
 	assert.Nil(t, testP.instance.Load())
 	err := testP.create(orm.Context())
@@ -69,9 +66,6 @@ func TestHelperCreate(t *testing.T) {
 }
 
 func TestHelperGet(t *testing.T) {
-	if os.Getenv("POSTGRESQL_HOST") == "" {
-		t.Skip("requires POSTGRESQL_HOST")
-	}
 	testP := &providerHelper{}
 	ctx := orm.Context()
 	p, err := testP.get(ctx)

--- a/src/portal/src/app/base/left-side-nav/config/auth/config-auth.component.html
+++ b/src/portal/src/app/base/left-side-nav/config/auth/config-auth.component.html
@@ -846,6 +846,34 @@
                 [disabled]="disabled(currentConfig.oidc_groups_claim)" />
         </clr-input-container>
         <clr-input-container>
+            <label for="OIDCLoginGroups"
+                >{{ 'CONFIG.OIDC.OIDC_LOGIN_GROUPS' | translate }}
+                <clr-tooltip>
+                    <clr-icon
+                        clrTooltipTrigger
+                        shape="info-circle"
+                        size="24"></clr-icon>
+                    <clr-tooltip-content
+                        clrPosition="top-right"
+                        clrSize="lg"
+                        *clrIfOpen>
+                        <span>{{
+                            'CONFIG.OIDC.OIDC_LOGIN_GROUPS_INFO' | translate
+                        }}</span>
+                    </clr-tooltip-content>
+                </clr-tooltip>
+            </label>
+            <input
+                clrInput
+                name="OIDCLoginGroups"
+                type="text"
+                #ngOIDCLoginGroups="ngModel"
+                [(ngModel)]="currentConfig.oidc_login_groups.value"
+                id="OIDCLoginGroups"
+                size="40"
+                [disabled]="disabled(currentConfig.oidc_login_groups)" />
+        </clr-input-container>
+        <clr-input-container>
             <label for="OIDCAdminGroup"
                 >{{ 'CONFIG.OIDC.OIDC_ADMIN_GROUP' | translate }}
                 <clr-tooltip>

--- a/src/portal/src/app/base/left-side-nav/config/config.ts
+++ b/src/portal/src/app/base/left-side-nav/config/config.ts
@@ -112,6 +112,7 @@ export class Configuration {
     oidc_groups_claim: StringValueItem;
     oidc_admin_group: StringValueItem;
     oidc_group_filter: StringValueItem;
+    oidc_login_groups: StringValueItem;
     audit_log_forward_endpoint: StringValueItem;
     disabled_audit_log_event_types: StringValueItem;
     skip_audit_log_database: BoolValueItem;
@@ -187,6 +188,7 @@ export class Configuration {
         this.oidc_groups_claim = new StringValueItem('', true);
         this.oidc_admin_group = new StringValueItem('', true);
         this.oidc_group_filter = new StringValueItem('', true);
+        this.oidc_login_groups = new StringValueItem('', true);
         this.oidc_user_claim = new StringValueItem('', true);
         this.oidc_logout = new BoolValueItem(false, true);
         this.count_per_project = new NumberValueItem(-1, true);

--- a/src/portal/src/app/base/left-side-nav/config/config.ts
+++ b/src/portal/src/app/base/left-side-nav/config/config.ts
@@ -110,9 +110,9 @@ export class Configuration {
     storage_per_project: NumberValueItem;
     cfg_expiration: NumberValueItem;
     oidc_groups_claim: StringValueItem;
+    oidc_login_groups: StringValueItem;
     oidc_admin_group: StringValueItem;
     oidc_group_filter: StringValueItem;
-    oidc_login_groups: StringValueItem;
     audit_log_forward_endpoint: StringValueItem;
     disabled_audit_log_event_types: StringValueItem;
     skip_audit_log_database: BoolValueItem;
@@ -186,9 +186,9 @@ export class Configuration {
         this.oidc_auto_onboard = new BoolValueItem(false, true);
         this.oidc_scope = new StringValueItem('', true);
         this.oidc_groups_claim = new StringValueItem('', true);
+        this.oidc_login_groups = new StringValueItem('', true);
         this.oidc_admin_group = new StringValueItem('', true);
         this.oidc_group_filter = new StringValueItem('', true);
-        this.oidc_login_groups = new StringValueItem('', true);
         this.oidc_user_claim = new StringValueItem('', true);
         this.oidc_logout = new BoolValueItem(false, true);
         this.count_per_project = new NumberValueItem(-1, true);

--- a/src/portal/src/i18n/lang/de-de-lang.json
+++ b/src/portal/src/i18n/lang/de-de-lang.json
@@ -882,6 +882,8 @@
             "GROUP_CLAIM_NAME_INFO": "The name of a custom group claim that you have configured in your OIDC provider",
             "OIDC_ADMIN_GROUP": "OIDC Administratorengruppe",
             "OIDC_ADMIN_GROUP_INFO": "Spezifiziere den Namen einer OIDC Administratorengruppe. Alle Mitglieder dieser Gruppe haben in Harbor administrative Berechtigungen. Falls dies nicht gewünscht ist, kann das Feld leer gelassen werden.",
+            "OIDC_LOGIN_GROUPS": "OIDC Login Groups",
+            "OIDC_LOGIN_GROUPS_INFO": "Comma-separated list of OIDC group names allowed to log in to Harbor. Users not in any listed group will be denied. Leave blank to allow all users.",
             "OIDC_GROUP_FILTER": "OIDC Group Filter",
             "OIDC_GROUP_FILTER_INFO": "Filter OIDC groups who match the provided regular expression.Keep it blank to match all the groups.",
             "OIDC_LOGOUT": "OIDC Session Logout"

--- a/src/portal/src/i18n/lang/en-us-lang.json
+++ b/src/portal/src/i18n/lang/en-us-lang.json
@@ -882,6 +882,8 @@
             "GROUP_CLAIM_NAME_INFO": "The name of a custom group claim that you have configured in your OIDC provider",
             "OIDC_ADMIN_GROUP": "OIDC Admin Group",
             "OIDC_ADMIN_GROUP_INFO": "Specify an OIDC admin group name. All OIDC users in this group will have harbor admin privilege. Keep it blank if you do not want to.",
+            "OIDC_LOGIN_GROUPS": "OIDC Login Groups",
+            "OIDC_LOGIN_GROUPS_INFO": "Comma-separated list of OIDC group names allowed to log in to Harbor. Users not in any listed group will be denied. Leave blank to allow all users.",
             "OIDC_GROUP_FILTER": "OIDC Group Filter",
             "OIDC_GROUP_FILTER_INFO": "Filter OIDC groups who match the provided regular expression.Keep it blank to match all the groups.",
             "OIDC_LOGOUT": "OIDC Session Logout"

--- a/src/portal/src/i18n/lang/es-es-lang.json
+++ b/src/portal/src/i18n/lang/es-es-lang.json
@@ -885,6 +885,8 @@
             "GROUP_CLAIM_NAME_INFO": "El nombre de un reclamo de grupo personalizado que haya configurado en su proveedor OIDC",
             "OIDC_ADMIN_GROUP": "OIDC Grupo Admin",
             "OIDC_ADMIN_GROUP_INFO": "Especifique un nombre de grupo de administración de OIDC. Todos los usuarios de OIDC en este grupo tendrán privilegios de administrador de puerto. Déjelo en blanco si no lo desea.",
+            "OIDC_LOGIN_GROUPS": "OIDC Login Groups",
+            "OIDC_LOGIN_GROUPS_INFO": "Comma-separated list of OIDC group names allowed to log in to Harbor. Users not in any listed group will be denied. Leave blank to allow all users.",
             "OIDC_GROUP_FILTER": "OIDC Filtro Grupo",
             "OIDC_GROUP_FILTER_INFO": "Filtrar grupos OIDC que coincidan con la expresión regular proporcionada. Déjelo en blanco para que coincida con todos los grupos.",
             "OIDC_LOGOUT": "OIDC Session Logout"

--- a/src/portal/src/i18n/lang/fr-fr-lang.json
+++ b/src/portal/src/i18n/lang/fr-fr-lang.json
@@ -884,6 +884,8 @@
             "GROUP_CLAIM_NAME_INFO": "Le claim du nom de groupe personnalisé qui a été configuré dans votre fournisseur OIDC.",
             "OIDC_ADMIN_GROUP": "Groupe d'admin OIDC",
             "OIDC_ADMIN_GROUP_INFO": "Spécifie le nom d'un groupe d'admin OIDC. Tous les utilisateurs OIDC de ce groupe auront les droits d'admin dans Harbor. Laisser vide pour ne pas l'utiliser.",
+            "OIDC_LOGIN_GROUPS": "OIDC Login Groups",
+            "OIDC_LOGIN_GROUPS_INFO": "Comma-separated list of OIDC group names allowed to log in to Harbor. Users not in any listed group will be denied. Leave blank to allow all users.",
             "OIDC_GROUP_FILTER": "Filtre de groupe OIDC",
             "OIDC_GROUP_FILTER_INFO": "Filtre les groupes OIDC qui correspondent à l'expression régulière fournie. Laisser vide pour ne pas l'utiliser.",
             "OIDC_LOGOUT": "OIDC Session Logout"

--- a/src/portal/src/i18n/lang/ko-kr-lang.json
+++ b/src/portal/src/i18n/lang/ko-kr-lang.json
@@ -882,6 +882,8 @@
             "GROUP_CLAIM_NAME_INFO": "OIDC 공급자에서 구성한 사용자 지정 그룹 클레임의 이름",
             "OIDC_ADMIN_GROUP": "OIDC 관리 그룹",
             "OIDC_ADMIN_GROUP_INFO": "OIDC 관리자 그룹 이름을 지정합니다. 이 그룹의 모든 OIDC 사용자는 항구 관리자 권한을 갖습니다. 원하지 않으시면 비워두세요.",
+            "OIDC_LOGIN_GROUPS": "OIDC Login Groups",
+            "OIDC_LOGIN_GROUPS_INFO": "Comma-separated list of OIDC group names allowed to log in to Harbor. Users not in any listed group will be denied. Leave blank to allow all users.",
             "OIDC_GROUP_FILTER": "OIDC 그룹 필터",
             "OIDC_GROUP_FILTER_INFO": "제공된 정규식과 일치하는 OIDC 그룹을 필터링합니다. 모든 그룹과 일치하려면 공백으로 유지하세요.",
             "OIDC_LOGOUT": "OIDC Session Logout"

--- a/src/portal/src/i18n/lang/pt-br-lang.json
+++ b/src/portal/src/i18n/lang/pt-br-lang.json
@@ -885,6 +885,8 @@
             "GROUP_CLAIM_NAME_INFO": "The name of a custom group claim that you have configured in your OIDC provider",
             "OIDC_ADMIN_GROUP": "Grupo Administrativo",
             "OIDC_ADMIN_GROUP_INFO": "Informe o nome do grupo OIDC que será considerado administrativo. Todos os usuários deste grupo obterão privilégios de adiministração no Harbor. Deixe vazio para ser ignorado.",
+            "OIDC_LOGIN_GROUPS": "OIDC Login Groups",
+            "OIDC_LOGIN_GROUPS_INFO": "Comma-separated list of OIDC group names allowed to log in to Harbor. Users not in any listed group will be denied. Leave blank to allow all users.",
             "OIDC_GROUP_FILTER": "OIDC Group Filter",
             "OIDC_GROUP_FILTER_INFO": "Filter OIDC groups who match the provided regular expression.Keep it blank to match all the groups.",
             "OIDC_LOGOUT": "OIDC Session Logout"

--- a/src/portal/src/i18n/lang/ru-ru-lang.json
+++ b/src/portal/src/i18n/lang/ru-ru-lang.json
@@ -1131,6 +1131,8 @@
             "GROUP_CLAIM_NAME_INFO": "Имя пользовательского утверждения группы, которое вы настроили у своего провайдера OIDC",
             "OIDC_ADMIN_GROUP": "Группа администраторов OIDC",
             "OIDC_ADMIN_GROUP_INFO": "Укажите имя группы администраторов OIDC. Все пользователи OIDC в этой группе будут иметь права администратора в Harbor. Оставьте пустым, если не хотите этого.",
+            "OIDC_LOGIN_GROUPS": "OIDC Login Groups",
+            "OIDC_LOGIN_GROUPS_INFO": "Comma-separated list of OIDC group names allowed to log in to Harbor. Users not in any listed group will be denied. Leave blank to allow all users.",
             "OIDC_GROUP_FILTER": "Фильтр групп OIDC",
             "OIDC_GROUP_FILTER_INFO": "Фильтр групп OIDC, которые соответствуют предоставленному регулярному выражению. Оставьте пустым, чтобы соответствовать всем группам."
         },
@@ -2121,6 +2123,8 @@
       "GROUP_CLAIM_NAME_INFO": "Подтвердите имя пользовательской группы, которую вы настроили у своего поставщика OIDC",
       "OIDC_ADMIN_GROUP": "Группа Администраторов OIDC",
       "OIDC_ADMIN_GROUP_INFO": "Укажите имя группы OIDC. Все пользователи OIDC в этой группе будут иметь права администратора в Harbor. Оставьте это поле пустым, если не хотите этого.",
+            "OIDC_LOGIN_GROUPS": "OIDC Login Groups",
+            "OIDC_LOGIN_GROUPS_INFO": "Comma-separated list of OIDC group names allowed to log in to Harbor. Users not in any listed group will be denied. Leave blank to allow all users.",
       "OIDC_GROUP_FILTER": "Фильтр Группы OIDC",
       "OIDC_GROUP_FILTER_INFO": "Фильтр групп OIDC, которые соответствуют регулярному выражению. Оставьте пустым, чтобы соответствовать всем группам.",
       "OIDC_LOGOUT": "Выход из сессии OIDC"

--- a/src/portal/src/i18n/lang/ru-ru-lang.json
+++ b/src/portal/src/i18n/lang/ru-ru-lang.json
@@ -2123,8 +2123,8 @@
       "GROUP_CLAIM_NAME_INFO": "Подтвердите имя пользовательской группы, которую вы настроили у своего поставщика OIDC",
       "OIDC_ADMIN_GROUP": "Группа Администраторов OIDC",
       "OIDC_ADMIN_GROUP_INFO": "Укажите имя группы OIDC. Все пользователи OIDC в этой группе будут иметь права администратора в Harbor. Оставьте это поле пустым, если не хотите этого.",
-            "OIDC_LOGIN_GROUPS": "OIDC Login Groups",
-            "OIDC_LOGIN_GROUPS_INFO": "Comma-separated list of OIDC group names allowed to log in to Harbor. Users not in any listed group will be denied. Leave blank to allow all users.",
+      "OIDC_LOGIN_GROUPS": "OIDC Login Groups",
+      "OIDC_LOGIN_GROUPS_INFO": "Comma-separated list of OIDC group names allowed to log in to Harbor. Users not in any listed group will be denied. Leave blank to allow all users.",
       "OIDC_GROUP_FILTER": "Фильтр Группы OIDC",
       "OIDC_GROUP_FILTER_INFO": "Фильтр групп OIDC, которые соответствуют регулярному выражению. Оставьте пустым, чтобы соответствовать всем группам.",
       "OIDC_LOGOUT": "Выход из сессии OIDC"

--- a/src/portal/src/i18n/lang/tr-tr-lang.json
+++ b/src/portal/src/i18n/lang/tr-tr-lang.json
@@ -883,6 +883,8 @@
             "GROUP_CLAIM_NAME_INFO": "The name of a custom group claim that you have configured in your OIDC provider",
             "OIDC_ADMIN_GROUP": "OIDC Admin Group",
             "OIDC_ADMIN_GROUP_INFO": "Specify an OIDC admin group name. All OIDC users in this group will have harbor admin privilege. Keep it blank if you do not want to.",
+            "OIDC_LOGIN_GROUPS": "OIDC Login Groups",
+            "OIDC_LOGIN_GROUPS_INFO": "Comma-separated list of OIDC group names allowed to log in to Harbor. Users not in any listed group will be denied. Leave blank to allow all users.",
             "OIDC_GROUP_FILTER": "OIDC Group Filter",
             "OIDC_GROUP_FILTER_INFO": "Filter OIDC groups who match the provided regular expression.Keep it blank to match all the groups.",
             "OIDC_LOGOUT": "OIDC Session Logout"

--- a/src/portal/src/i18n/lang/zh-cn-lang.json
+++ b/src/portal/src/i18n/lang/zh-cn-lang.json
@@ -884,6 +884,8 @@
             "GROUP_CLAIM_NAME_INFO": "您在 OIDC 提供商中配置的自定义组声明的名称",
             "OIDC_ADMIN_GROUP": "OIDC管理员组",
             "OIDC_ADMIN_GROUP_INFO": "OIDC管理员组名称。所有该组内用户都会有管理员权限，此属性可以为空。",
+            "OIDC_LOGIN_GROUPS": "OIDC Login Groups",
+            "OIDC_LOGIN_GROUPS_INFO": "Comma-separated list of OIDC group names allowed to log in to Harbor. Users not in any listed group will be denied. Leave blank to allow all users.",
             "OIDC_GROUP_FILTER": "OIDC 组过滤器",
             "OIDC_GROUP_FILTER_INFO": "该过滤器将会过滤掉不匹配此项正则表达式的 OIDC 组。若不填，则表示匹配所有。",
             "OIDC_LOGOUT": "OIDC Session Logout"

--- a/src/portal/src/i18n/lang/zh-tw-lang.json
+++ b/src/portal/src/i18n/lang/zh-tw-lang.json
@@ -883,6 +883,8 @@
             "GROUP_CLAIM_NAME_INFO": "在 OIDC 提供者中設定的自訂群組宣告名稱。",
             "OIDC_ADMIN_GROUP": "OIDC 管理員群組",
             "OIDC_ADMIN_GROUP_INFO": "指定 OIDC 管理員群組名稱。此群組中的所有 OIDC 使用者都會擁有 Harbor 管理員權限。若不需要，請留空。",
+            "OIDC_LOGIN_GROUPS": "OIDC Login Groups",
+            "OIDC_LOGIN_GROUPS_INFO": "Comma-separated list of OIDC group names allowed to log in to Harbor. Users not in any listed group will be denied. Leave blank to allow all users.",
             "OIDC_GROUP_FILTER": "OIDC 群組篩選器",
             "OIDC_GROUP_FILTER_INFO": "篩選符合所提供正規表示式的 OIDC 群組。留空以符合所有群組。",
             "OIDC_LOGOUT": "OIDC 工作階段登出"

--- a/src/server/middleware/security/idtoken.go
+++ b/src/server/middleware/security/idtoken.go
@@ -28,6 +28,12 @@ import (
 	"github.com/goharbor/harbor/src/pkg/oidc"
 )
 
+var (
+	idTokenUserCtl    = user.Ctl
+	idTokenVerifyFn   = oidc.VerifyToken
+	idTokenUserInfoFn = oidc.UserInfoFromIDToken
+)
+
 type idToken struct{}
 
 func (i *idToken) Generate(req *http.Request) security.Context {
@@ -43,12 +49,12 @@ func (i *idToken) Generate(req *http.Request) security.Context {
 	if len(token) == 0 {
 		return nil
 	}
-	claims, err := oidc.VerifyToken(ctx, token)
+	claims, err := idTokenVerifyFn(ctx, token)
 	if err != nil {
 		log.Warningf("failed to verify token: %v", err)
 		return nil
 	}
-	u, err := user.Ctl.GetBySubIss(ctx, claims.Subject, claims.Issuer)
+	u, err := idTokenUserCtl.GetBySubIss(ctx, claims.Subject, claims.Issuer)
 	if err != nil {
 		log.Warningf("failed to get user based on token claims: %v", err)
 		return nil
@@ -58,7 +64,7 @@ func (i *idToken) Generate(req *http.Request) security.Context {
 		log.Errorf("failed to get OIDC settings: %v", err)
 		return nil
 	}
-	info, err := oidc.UserInfoFromIDToken(ctx, &oidc.Token{RawIDToken: token}, *setting)
+	info, err := idTokenUserInfoFn(ctx, &oidc.Token{RawIDToken: token}, *setting)
 	if err != nil {
 		log.Errorf("Failed to get user info from ID token: %v", err)
 		return nil

--- a/src/server/middleware/security/idtoken.go
+++ b/src/server/middleware/security/idtoken.go
@@ -63,6 +63,10 @@ func (i *idToken) Generate(req *http.Request) security.Context {
 		log.Errorf("Failed to get user info from ID token: %v", err)
 		return nil
 	}
+	if !oidc.IsLoginAllowed(info, *setting) {
+		log.Warningf("ID token login denied for user %s: not in any authorized group", u.Username)
+		return nil
+	}
 	oidc.InjectGroupsToUser(info, u)
 	log.Debugf("an ID token security context generated for request %s %s", req.Method, req.URL.Path)
 	return local.NewSecurityContext(u)

--- a/src/server/middleware/security/idtoken_test.go
+++ b/src/server/middleware/security/idtoken_test.go
@@ -15,14 +15,22 @@
 package security
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
+	gooidc "github.com/coreos/go-oidc/v3/oidc"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/goharbor/harbor/src/common"
+	"github.com/goharbor/harbor/src/common/models"
 	"github.com/goharbor/harbor/src/lib"
+	"github.com/goharbor/harbor/src/lib/config"
+	cfgModels "github.com/goharbor/harbor/src/lib/config/models"
+	pkgoidc "github.com/goharbor/harbor/src/pkg/oidc"
+	testingUser "github.com/goharbor/harbor/src/testing/controller/user"
 )
 
 func TestIDToken(t *testing.T) {
@@ -46,5 +54,41 @@ func TestIDToken(t *testing.T) {
 	require.Nil(t, err)
 	req = req.WithContext(lib.WithAuthMode(req.Context(), common.OIDCAuth))
 	ctx = idToken.Generate(req)
+	assert.Nil(t, ctx)
+}
+
+func TestIDTokenLoginGroupsBlocked(t *testing.T) {
+	config.InitWithSettings(map[string]any{
+		common.OIDCLoginGroups: "allowed-group",
+	})
+	t.Cleanup(func() {
+		config.InitWithSettings(map[string]any{common.OIDCLoginGroups: ""})
+	})
+
+	origVerifyFn := idTokenVerifyFn
+	idTokenVerifyFn = func(_ context.Context, _ string) (*gooidc.IDToken, error) {
+		return &gooidc.IDToken{Issuer: "test-issuer", Subject: "test-subject"}, nil
+	}
+	t.Cleanup(func() { idTokenVerifyFn = origVerifyFn })
+
+	testCtl := &testingUser.Controller{}
+	testCtl.On("GetBySubIss", mock.Anything, "test-subject", "test-issuer").Return(
+		&models.User{Username: "blockedUser"}, nil)
+	origUserCtl := idTokenUserCtl
+	idTokenUserCtl = testCtl
+	t.Cleanup(func() { idTokenUserCtl = origUserCtl })
+
+	origUserInfoFn := idTokenUserInfoFn
+	idTokenUserInfoFn = func(_ context.Context, _ *pkgoidc.Token, _ cfgModels.OIDCSetting) (*pkgoidc.UserInfo, error) {
+		return &pkgoidc.UserInfo{}, nil
+	}
+	t.Cleanup(func() { idTokenUserInfoFn = origUserInfoFn })
+
+	req, err := http.NewRequest(http.MethodGet, "http://127.0.0.1/api/projects/", nil)
+	require.Nil(t, err)
+	req = req.WithContext(lib.WithAuthMode(req.Context(), common.OIDCAuth))
+	req.Header.Set("Authorization", "Bearer fake-token")
+
+	ctx := (&idToken{}).Generate(req)
 	assert.Nil(t, ctx)
 }

--- a/src/server/middleware/security/oidc_cli.go
+++ b/src/server/middleware/security/oidc_cli.go
@@ -77,8 +77,6 @@ func (o *oidcCli) Generate(req *http.Request) security.Context {
 		return nil
 	}
 
-	oidc.InjectGroupsToUser(info, u)
-
 	oidcSettings, err := config.OIDCSetting(ctx)
 	if err != nil {
 		logger.Errorf("failed to get OIDC settings: %v", err)
@@ -89,6 +87,7 @@ func (o *oidcCli) Generate(req *http.Request) security.Context {
 		return nil
 	}
 
+	oidc.InjectGroupsToUser(info, u)
 	logger.Debugf("an OIDC CLI security context generated for request %s %s", req.Method, req.URL.Path)
 	return local.NewSecurityContext(u)
 }

--- a/src/server/middleware/security/oidc_cli.go
+++ b/src/server/middleware/security/oidc_cli.go
@@ -32,16 +32,16 @@ import (
 )
 
 var (
-	base              = fmt.Sprintf("/api/%s", api.APIVersion)
-	sysInfoAPI        = base + "/systeminfo"
-	apiVersionAPI     = "/api/version"
-	labelsAPI         = base + "/labels"
-	projectsAPI       = base + "/projects"
-	reposAPIRe        = regexp.MustCompile(fmt.Sprintf(`^%s/projects/.*/repositories$`, regexp.QuoteMeta(base)))
-	artifactsAPIRe    = regexp.MustCompile(fmt.Sprintf(`^%s/projects/.*/repositories/.*/artifacts$`, regexp.QuoteMeta(base)))
-	tagsAPIRe         = regexp.MustCompile(fmt.Sprintf(`^%s/projects/.*/repositories/.*/artifacts/.*/tags/.*$`, regexp.QuoteMeta(base)))
-	uctl              = user.Ctl
-	oidcCliSettingFn  = config.OIDCSetting
+	base             = fmt.Sprintf("/api/%s", api.APIVersion)
+	sysInfoAPI       = base + "/systeminfo"
+	apiVersionAPI    = "/api/version"
+	labelsAPI        = base + "/labels"
+	projectsAPI      = base + "/projects"
+	reposAPIRe       = regexp.MustCompile(fmt.Sprintf(`^%s/projects/.*/repositories$`, regexp.QuoteMeta(base)))
+	artifactsAPIRe   = regexp.MustCompile(fmt.Sprintf(`^%s/projects/.*/repositories/.*/artifacts$`, regexp.QuoteMeta(base)))
+	tagsAPIRe        = regexp.MustCompile(fmt.Sprintf(`^%s/projects/.*/repositories/.*/artifacts/.*/tags/.*$`, regexp.QuoteMeta(base)))
+	uctl             = user.Ctl
+	oidcCliSettingFn = config.OIDCSetting
 )
 
 type oidcCli struct{}

--- a/src/server/middleware/security/oidc_cli.go
+++ b/src/server/middleware/security/oidc_cli.go
@@ -32,15 +32,16 @@ import (
 )
 
 var (
-	base           = fmt.Sprintf("/api/%s", api.APIVersion)
-	sysInfoAPI     = base + "/systeminfo"
-	apiVersionAPI  = "/api/version"
-	labelsAPI      = base + "/labels"
-	projectsAPI    = base + "/projects"
-	reposAPIRe     = regexp.MustCompile(fmt.Sprintf(`^%s/projects/.*/repositories$`, regexp.QuoteMeta(base)))
-	artifactsAPIRe = regexp.MustCompile(fmt.Sprintf(`^%s/projects/.*/repositories/.*/artifacts$`, regexp.QuoteMeta(base)))
-	tagsAPIRe      = regexp.MustCompile(fmt.Sprintf(`^%s/projects/.*/repositories/.*/artifacts/.*/tags/.*$`, regexp.QuoteMeta(base)))
-	uctl           = user.Ctl
+	base              = fmt.Sprintf("/api/%s", api.APIVersion)
+	sysInfoAPI        = base + "/systeminfo"
+	apiVersionAPI     = "/api/version"
+	labelsAPI         = base + "/labels"
+	projectsAPI       = base + "/projects"
+	reposAPIRe        = regexp.MustCompile(fmt.Sprintf(`^%s/projects/.*/repositories$`, regexp.QuoteMeta(base)))
+	artifactsAPIRe    = regexp.MustCompile(fmt.Sprintf(`^%s/projects/.*/repositories/.*/artifacts$`, regexp.QuoteMeta(base)))
+	tagsAPIRe         = regexp.MustCompile(fmt.Sprintf(`^%s/projects/.*/repositories/.*/artifacts/.*/tags/.*$`, regexp.QuoteMeta(base)))
+	uctl              = user.Ctl
+	oidcCliSettingFn  = config.OIDCSetting
 )
 
 type oidcCli struct{}
@@ -77,7 +78,7 @@ func (o *oidcCli) Generate(req *http.Request) security.Context {
 		return nil
 	}
 
-	oidcSettings, err := config.OIDCSetting(ctx)
+	oidcSettings, err := oidcCliSettingFn(ctx)
 	if err != nil {
 		logger.Errorf("failed to get OIDC settings: %v", err)
 		return nil

--- a/src/server/middleware/security/oidc_cli.go
+++ b/src/server/middleware/security/oidc_cli.go
@@ -78,6 +78,17 @@ func (o *oidcCli) Generate(req *http.Request) security.Context {
 	}
 
 	oidc.InjectGroupsToUser(info, u)
+
+	oidcSettings, err := config.OIDCSetting(ctx)
+	if err != nil {
+		logger.Errorf("failed to get OIDC settings: %v", err)
+		return nil
+	}
+	if !oidc.IsLoginAllowed(info, *oidcSettings) {
+		logger.Warningf("OIDC CLI login denied for user %s: not in any authorized group", username)
+		return nil
+	}
+
 	logger.Debugf("an OIDC CLI security context generated for request %s %s", req.Method, req.URL.Path)
 	return local.NewSecurityContext(u)
 }

--- a/src/server/middleware/security/oidc_cli_test.go
+++ b/src/server/middleware/security/oidc_cli_test.go
@@ -15,6 +15,8 @@
 package security
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"testing"
@@ -27,6 +29,7 @@ import (
 	"github.com/goharbor/harbor/src/common/models"
 	"github.com/goharbor/harbor/src/lib"
 	"github.com/goharbor/harbor/src/lib/config"
+	cfgModels "github.com/goharbor/harbor/src/lib/config/models"
 	"github.com/goharbor/harbor/src/pkg/oidc"
 	testingUser "github.com/goharbor/harbor/src/testing/controller/user"
 )
@@ -89,6 +92,37 @@ func TestOIDCCliLoginGroupsBlocked(t *testing.T) {
 
 	// The fake verifier returns a UserInfo with no group claim, so the user
 	// should be denied when oidc_login_groups is configured.
+	ctx := (&oidcCli{}).Generate(req)
+	assert.Nil(t, ctx)
+}
+
+func TestOIDCCliOIDCSettingError(t *testing.T) {
+	config.InitWithSettings(map[string]any{
+		common.OIDCLoginGroups: "",
+	})
+
+	username := "settingErrUser"
+	password := "oidcSecret"
+
+	testCtl := &testingUser.Controller{}
+	testCtl.On("GetByName", mock.Anything, username).Return(
+		&models.User{Username: username}, nil)
+	origUctl := uctl
+	uctl = testCtl
+	t.Cleanup(func() { uctl = origUctl })
+	oidc.SetHardcodeVerifierForTest(password)
+
+	origSettingFn := oidcCliSettingFn
+	oidcCliSettingFn = func(_ context.Context) (*cfgModels.OIDCSetting, error) {
+		return nil, errors.New("config load failed")
+	}
+	t.Cleanup(func() { oidcCliSettingFn = origSettingFn })
+
+	req, err := http.NewRequest(http.MethodGet, "http://127.0.0.1/service/token", nil)
+	require.Nil(t, err)
+	req = req.WithContext(lib.WithAuthMode(req.Context(), common.OIDCAuth))
+	req.SetBasicAuth(username, password)
+
 	ctx := (&oidcCli{}).Generate(req)
 	assert.Nil(t, ctx)
 }

--- a/src/server/middleware/security/oidc_cli_test.go
+++ b/src/server/middleware/security/oidc_cli_test.go
@@ -46,6 +46,7 @@ func TestOIDCCli(t *testing.T) {
 	assert.Nil(t, ctx)
 
 	// pass
+	config.InitWithSettings(map[string]any{common.OIDCLoginGroups: ""})
 	username := "oidcModiferTester"
 	password := "oidcSecret"
 	testCtl := &testingUser.Controller{}

--- a/src/server/middleware/security/oidc_cli_test.go
+++ b/src/server/middleware/security/oidc_cli_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/goharbor/harbor/src/common"
 	"github.com/goharbor/harbor/src/common/models"
 	"github.com/goharbor/harbor/src/lib"
+	"github.com/goharbor/harbor/src/lib/config"
 	"github.com/goharbor/harbor/src/pkg/oidc"
 	testingUser "github.com/goharbor/harbor/src/testing/controller/user"
 )
@@ -59,6 +60,36 @@ func TestOIDCCli(t *testing.T) {
 	req.SetBasicAuth(username, password)
 	ctx = oidcCli.Generate(req)
 	assert.NotNil(t, ctx)
+}
+
+func TestOIDCCliLoginGroupsBlocked(t *testing.T) {
+	config.InitWithSettings(map[string]any{
+		common.OIDCLoginGroups: "allowed-group",
+	})
+	t.Cleanup(func() {
+		config.InitWithSettings(map[string]any{common.OIDCLoginGroups: ""})
+	})
+
+	username := "blockedUser"
+	password := "oidcSecret"
+	testCtl := &testingUser.Controller{}
+	testCtl.On("GetByName", mock.Anything, username).Return(
+		&models.User{
+			Username: username,
+			Email:    fmt.Sprintf("%s@test.domain", username),
+		}, nil)
+	uctl = testCtl
+	oidc.SetHardcodeVerifierForTest(password)
+
+	req, err := http.NewRequest(http.MethodGet, "http://127.0.0.1/service/token", nil)
+	require.Nil(t, err)
+	req = req.WithContext(lib.WithAuthMode(req.Context(), common.OIDCAuth))
+	req.SetBasicAuth(username, password)
+
+	// The fake verifier returns a UserInfo with no group claim, so the user
+	// should be denied when oidc_login_groups is configured.
+	ctx := (&oidcCli{}).Generate(req)
+	assert.Nil(t, ctx)
 }
 
 func TestOIDCCliValid(t *testing.T) {


### PR DESCRIPTION
# Why
Harbor currently allows any user who can authenticate with the OIDC provider to log in, regardless of which groups they belong to. This makes it impossible to use Keycloak (or any other shared Identity Providers) and restrict Harbor access to a specific team without managing access at the Identity Provider level for every project.

# What the PR does
Adds a new `oidc_login_groups` configuration field that restricts OIDC login to users who are members of at least one specified group. When the field is empty (the default), all OIDC users can still log in (existing behaviour is still fully preserved)

# Issue being fixed
Fixes [#22730 - Question: Keycloak OIDC Configuration, limit login to specific groups ](https://github.com/goharbor/harbor/issues/22730)

# How it Works
- `oidc_login_groups` accepts a comma-separated list of group names (e.g. `harbor-admins,harbor-users`).
- After the OIDC token is exchanged, `IsLoginAllowed` checks whether the user's group claim contains at least one of the configured groups.
- If the check fails, login is rejected with a 401 before the user is onboarded or their session is created.
- Group matching is case-sensitive, consistent with `oidc_group_filter` and the OIDC spec. Leading/trailing whitespace around group names is trimmed.
- When `oidc_login_groups` is set but `oidc_groups_claim` is not configured, an ERROR is logged (not a warning) because this misconfiguration silently blocks all users.

 # Enforcement points
  
The restriction is enforced in all three OIDC authentication paths:

1. **Browser login** — `Callback()` in `core/controllers/oidc.go`
2. **CLI / docker login** — `Generate()` in `server/middleware/security/oidc_cli.go`
3. **Bearer ID token** — `Generate()` in `server/middleware/security/idtoken.go` (direct API calls using `Authorization: Bearer <id_token>`)

All three paths call `IsLoginAllowed` before any group injection or session creation occurs.

# Testing

- `IsLoginAllowed` has 8 unit tests covering: no restriction, user in group, user not in group, multi-group, whitespace trimming, missing group claim with and without restriction, whitespace-only restriction.
- `TestOIDCCliLoginGroupsBlocked` verifies the CLI path rejects a user when `oidc_login_groups` is set and the token carries no group claim.
- Manually verified end-to-end with a local Keycloak instance: user `bob` (no group) is blocked; user `alice` (in `harbor` group) can log in.

 # Changes
  
- `src/common/const.go` — `OIDCLoginGroups` constant
 - `src/lib/config/metadata/metadatalist.go` — config key registration
- `src/lib/config/models/model.go` — `LoginGroups` field on `OIDCSetting`
- `src/lib/config/userconfig.go` — builder wire-up
- `api/v2.0/swagger.yaml` — new field in `Configurations` and
    `ConfigurationsResponse`
- `src/pkg/oidc/helper.go` — `IsLoginAllowed` function
- `src/pkg/oidc/helper_test.go` — 8 unit test cases for `IsLoginAllowed`
- `src/server/middleware/security/oidc_cli.go` — CLI enforcement
- `src/server/middleware/security/oidc_cli_test.go` — CLI enforcement test
- `src/server/middleware/security/idtoken.go` — Bearer token enforcement
- `src/core/controllers/oidc.go` — browser login enforcement
- Portal UI + i18n strings (10 locales)

# Screenshots
**Admin UI — oidc_login_groups field:**
<img width="1502" height="1008" alt="image" src="https://github.com/user-attachments/assets/ae09e441-df4d-4a55-a6ef-f168a2cca664" />

**bob (no group) blocked:**
<img width="3024" height="234" alt="image" src="https://github.com/user-attachments/assets/056a25f5-83e0-4cbf-8c76-df3a91824d83" />




Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website). Will open a docs issue against goharbor/website once code is approved!