### PR TITLE
feat(replication): Add Google Artifact Registry adapter with OAuth2 authentication

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -10,6 +10,10 @@ jobs:
   CodeQL-Build:
 
     runs-on: cncf-ubuntu-16-64-x86
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
 
     steps:
     - name: Checkout repository

--- a/src/jobservice/job/impl/replication/replication.go
+++ b/src/jobservice/job/impl/replication/replication.go
@@ -39,6 +39,8 @@ import (
 	_ "github.com/goharbor/harbor/src/pkg/reg/adapter/gitlab"
 	// import googlegcr adapter
 	_ "github.com/goharbor/harbor/src/pkg/reg/adapter/googlegcr"
+	// import googlegar adapter
+	_ "github.com/goharbor/harbor/src/pkg/reg/adapter/googlegar"
 	// import harbor adapter
 	_ "github.com/goharbor/harbor/src/pkg/reg/adapter/harbor"
 	// import huawei adapter

--- a/src/pkg/chart/testdata/harbor-schema1/templates/core/core-cm.yaml
+++ b/src/pkg/chart/testdata/harbor-schema1/templates/core/core-cm.yaml
@@ -52,7 +52,7 @@ data:
   HTTPS_PROXY: "{{ .Values.proxy.httpsProxy }}"
   NO_PROXY: "{{ template "harbor.noProxy" . }}"
   {{- end }}
-  PERMITTED_REGISTRY_TYPES_FOR_PROXY_CACHE: "docker-hub,harbor,azure-acr,aws-ecr,google-gcr,quay,docker-registry,github-ghcr,jfrog-artifactory"
+  PERMITTED_REGISTRY_TYPES_FOR_PROXY_CACHE: "docker-hub,harbor,azure-acr,aws-ecr,google-gcr,google-gar,quay,docker-registry,github-ghcr,jfrog-artifactory"
   {{- if .Values.metrics.enabled}}
   METRIC_ENABLE: "true"
   METRIC_PATH: "{{ .Values.metrics.core.path }}"

--- a/src/pkg/chart/testdata/harbor-schema2/templates/core/core-cm.yaml
+++ b/src/pkg/chart/testdata/harbor-schema2/templates/core/core-cm.yaml
@@ -52,7 +52,7 @@ data:
   HTTPS_PROXY: "{{ .Values.proxy.httpsProxy }}"
   NO_PROXY: "{{ template "harbor.noProxy" . }}"
   {{- end }}
-  PERMITTED_REGISTRY_TYPES_FOR_PROXY_CACHE: "docker-hub,harbor,azure-acr,aws-ecr,google-gcr,quay,docker-registry,github-ghcr,jfrog-artifactory"
+  PERMITTED_REGISTRY_TYPES_FOR_PROXY_CACHE: "docker-hub,harbor,azure-acr,aws-ecr,google-gcr,google-gar,quay,docker-registry,github-ghcr,jfrog-artifactory"
   {{- if .Values.metrics.enabled}}
   METRIC_ENABLE: "true"
   METRIC_PATH: "{{ .Values.metrics.core.path }}"

--- a/src/pkg/reg/adapter/googlegar/adapter.go
+++ b/src/pkg/reg/adapter/googlegar/adapter.go
@@ -1,0 +1,303 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package googlegar
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"strings"
+
+	"github.com/opencontainers/go-digest"
+
+	"github.com/goharbor/harbor/src/lib/errors"
+	"github.com/goharbor/harbor/src/lib/log"
+	adp "github.com/goharbor/harbor/src/pkg/reg/adapter"
+	"github.com/goharbor/harbor/src/pkg/reg/adapter/googlegar/auth"
+	"github.com/goharbor/harbor/src/pkg/reg/adapter/native"
+	"github.com/goharbor/harbor/src/pkg/reg/model"
+)
+
+var (
+	// garEndpointPattern matches Google Artifact Registry endpoints
+	// Format: [region]-docker.pkg.dev (or other artifact types like maven, npm, etc.)
+	garEndpointPattern = regexp.MustCompile(`^https://[a-z0-9-]+-[a-z]+\.pkg\.dev/?$`)
+)
+
+func init() {
+	if err := adp.RegisterFactory(model.RegistryTypeGoogleGar, new(factory)); err != nil {
+		log.Errorf("failed to register factory for %s: %v", model.RegistryTypeGoogleGar, err)
+		return
+	}
+	log.Infof("the factory for adapter %s registered", model.RegistryTypeGoogleGar)
+}
+
+func newAdapter(registry *model.Registry) (*adapter, error) {
+	ctx := context.Background()
+
+	var authorizer *auth.OAuth2Authorizer
+	var err error
+
+	// Check if we have explicit credentials (JSON service account key)
+	if registry.Credential != nil &&
+		registry.Credential.AccessSecret != "" &&
+		strings.Contains(registry.Credential.AccessSecret, "private_key") {
+		// Use explicit credentials
+		authorizer, err = auth.NewOAuth2AuthorizerWithCredentials(
+			ctx,
+			[]byte(registry.Credential.AccessSecret),
+			[]string{auth.StorageScope, auth.CloudPlatformScope},
+		)
+		if err != nil {
+			log.Errorf("failed to create OAuth2 authorizer with credentials for %s: %v", registry.URL, err)
+			return nil, err
+		}
+	} else {
+		// Use default credential chain (metadata server, gcloud, etc.)
+		authorizer, err = auth.NewOAuth2Authorizer(
+			ctx,
+			[]string{auth.StorageScope, auth.CloudPlatformScope},
+		)
+		if err != nil {
+			log.Errorf("failed to create OAuth2 authorizer for %s: %v", registry.URL, err)
+			return nil, err
+		}
+	}
+
+	return &adapter{
+		registry: registry,
+		Adapter:  native.NewAdapterWithAuthorizer(registry, authorizer),
+	}, nil
+}
+
+type factory struct {
+}
+
+// Create creates an adapter
+func (f *factory) Create(r *model.Registry) (adp.Adapter, error) {
+	return newAdapter(r)
+}
+
+// AdapterPattern returns the adapter pattern info
+func (f *factory) AdapterPattern() *model.AdapterPattern {
+	return getAdapterInfo()
+}
+
+var (
+	_ adp.Adapter          = (*adapter)(nil)
+	_ adp.ArtifactRegistry = (*adapter)(nil)
+)
+
+type adapter struct {
+	*native.Adapter
+	registry *model.Registry
+}
+
+// Info returns the basic information about the adapter
+func (a *adapter) Info() (info *model.RegistryInfo, err error) {
+	return &model.RegistryInfo{
+		Type: model.RegistryTypeGoogleGar,
+		SupportedResourceTypes: []string{
+			model.ResourceTypeImage,
+		},
+		SupportedResourceFilters: []*model.FilterStyle{
+			{
+				Type:  model.FilterTypeName,
+				Style: model.FilterStyleTypeText,
+			},
+			{
+				Type:  model.FilterTypeTag,
+				Style: model.FilterStyleTypeText,
+			},
+		},
+		SupportedTriggers: []string{
+			model.TriggerTypeManual,
+			model.TriggerTypeScheduled,
+		},
+	}, nil
+}
+
+func getAdapterInfo() *model.AdapterPattern {
+	info := &model.AdapterPattern{
+		EndpointPattern: &model.EndpointPattern{
+			EndpointType: model.EndpointPatternTypeList,
+			Endpoints: []*model.Endpoint{
+				// Google Container Registry endpoints
+				{
+					Key:   "gcr.io",
+					Value: "https://gcr.io",
+				},
+				{
+					Key:   "us.gcr.io",
+					Value: "https://us.gcr.io",
+				},
+				{
+					Key:   "eu.gcr.io",
+					Value: "https://eu.gcr.io",
+				},
+				{
+					Key:   "asia.gcr.io",
+					Value: "https://asia.gcr.io",
+				},
+				// Google Artifact Registry (use regional endpoint format)
+				{
+					Key:   "Google Artifact Registry",
+					Value: "https://[REGION]-docker.pkg.dev",
+				},
+				// Allow custom endpoint
+				{
+					Key:   "custom",
+					Value: "",
+				},
+			},
+		},
+		CredentialPattern: &model.CredentialPattern{
+			AccessKeyType:    model.AccessKeyTypeStandard,
+			AccessKeyData:    "oauth2",
+			AccessSecretType: model.AccessSecretTypeFile,
+			AccessSecretData: "Service Account JSON (optional - uses default credentials if empty)",
+		},
+	}
+	return info
+}
+
+// HealthCheck checks health status of a registry
+func (a *adapter) HealthCheck() (string, error) {
+	if err := a.Ping(); err != nil {
+		log.Errorf("failed to ping registry %s: %v", a.registry.URL, err)
+		return model.Unhealthy, nil
+	}
+	return model.Healthy, nil
+}
+
+// isGoogleArtifactRegistry determines if the registry URL is for Google Artifact Registry
+func (a *adapter) isGoogleArtifactRegistry() bool {
+	return garEndpointPattern.MatchString(a.registry.URL)
+}
+
+// DeleteManifest deletes the manifest specified by reference; the reference can be digest or tag
+func (a *adapter) DeleteManifest(repository, reference string) error {
+	// For Google Container Registry, we need to use their specific API
+	if strings.Contains(a.registry.URL, "gcr.io") {
+		return a.deleteGcrManifest(repository, reference)
+	}
+
+	// For Google Artifact Registry, use standard Docker API
+	return a.Adapter.DeleteManifest(repository, reference)
+}
+
+// deleteGcrManifest handles deletion for Google Container Registry using their tags API
+func (a *adapter) deleteGcrManifest(repository, reference string) error {
+	tags, d, err := a.listGcrTagsByRef(repository, reference)
+	if err != nil {
+		return err
+	}
+
+	if d == "" {
+		return errors.New(nil).WithCode(errors.NotFoundCode).
+			WithMessagef("%s:%s not found", repository, reference)
+	}
+
+	for _, t := range append(tags, d) {
+		req, err := http.NewRequest(http.MethodDelete, buildManifestURL(a.registry.URL, repository, t), nil)
+		if err != nil {
+			return err
+		}
+		resp, err := a.Client.Do(req)
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+	}
+
+	return nil
+}
+
+// listGcrTagsByRef lists tags for GCR (similar to existing googlegcr adapter)
+func (a *adapter) listGcrTagsByRef(repository, reference string) ([]string, string, error) {
+	u := buildTagListURL(a.registry.URL, repository)
+	req, err := http.NewRequest(http.MethodGet, u, nil)
+	if err != nil {
+		return nil, "", err
+	}
+
+	resp, err := a.Client.Do(req)
+	if err != nil {
+		return nil, "", err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, "", err
+	}
+
+	tgs := struct {
+		Name     string   `json:"name"`
+		Tags     []string `json:"tags"`
+		Manifest map[string]struct {
+			Tag       []string `json:"tag"`
+			MediaType string   `json:"mediaType"`
+		} `json:"manifest"`
+	}{}
+
+	if err = json.Unmarshal(body, &tgs); err != nil {
+		return nil, "", err
+	}
+
+	_, err = digest.Parse(reference)
+	if err == nil {
+		// for sha256 as reference
+		if m, ok := tgs.Manifest[reference]; ok {
+			return m.Tag, reference, nil
+		}
+		return nil, reference, nil
+	}
+
+	// for tag as reference
+	for d, m := range tgs.Manifest {
+		for _, t := range m.Tag {
+			if t == reference {
+				return m.Tag, d, nil
+			}
+		}
+	}
+	return nil, "", nil
+}
+
+// DeleteTag deletes the specified tag
+func (a *adapter) DeleteTag(repository, tag string) error {
+	req, err := http.NewRequest(http.MethodDelete, buildManifestURL(a.registry.URL, repository, tag), nil)
+	if err != nil {
+		return err
+	}
+	resp, err := a.Client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	return nil
+}
+
+func buildTagListURL(endpoint, repository string) string {
+	return fmt.Sprintf("%s/v2/%s/tags/list", endpoint, repository)
+}
+
+func buildManifestURL(endpoint, repository, reference string) string {
+	return fmt.Sprintf("%s/v2/%s/manifests/%s", endpoint, repository, reference)
+}

--- a/src/pkg/reg/adapter/googlegar/adapter.go
+++ b/src/pkg/reg/adapter/googlegar/adapter.go
@@ -156,8 +156,8 @@ func getAdapterInfo() *model.AdapterPattern {
 				},
 				// Google Artifact Registry (use regional endpoint format)
 				{
-					Key:   "Google Artifact Registry",
-					Value: "https://[REGION]-docker.pkg.dev",
+					Key:   "us-central1-docker.pkg.dev",
+					Value: "https://us-central1-docker.pkg.dev",
 				},
 				// Allow custom endpoint
 				{

--- a/src/pkg/reg/adapter/googlegar/adapter_test.go
+++ b/src/pkg/reg/adapter/googlegar/adapter_test.go
@@ -1,0 +1,344 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package googlegar
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/goharbor/harbor/src/common/utils/test"
+	adp "github.com/goharbor/harbor/src/pkg/reg/adapter"
+	"github.com/goharbor/harbor/src/pkg/reg/adapter/googlegar/auth"
+	"github.com/goharbor/harbor/src/pkg/reg/model"
+)
+
+func getMockAdapter(t *testing.T) (*adapter, *httptest.Server) {
+	server := test.NewServer(
+		&test.RequestHandlerMapping{
+			Method:  http.MethodGet,
+			Pattern: "/v2/_catalog",
+			Handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte(`
+		{
+			"repositories": [
+					"test-project/test-repo"
+			]
+		}`))
+			},
+		},
+		&test.RequestHandlerMapping{
+			Method:  http.MethodGet,
+			Pattern: "/v2/{repo}/tags/list",
+			Handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte(`
+			{
+			    "name": "test-project/test-repo",
+			    "tags": [
+			        "latest", "v1.0"
+			    ]
+			}`))
+			},
+		},
+		&test.RequestHandlerMapping{
+			Method:  http.MethodGet,
+			Pattern: "/v2/",
+			Handler: func(w http.ResponseWriter, r *http.Request) {
+				// Check for Bearer token in Authorization header
+				auth := r.Header.Get("Authorization")
+				if auth == "" || auth != "Bearer mock-token" {
+					w.WriteHeader(http.StatusUnauthorized)
+					return
+				}
+				w.WriteHeader(http.StatusOK)
+			},
+		},
+	)
+
+	registry := &model.Registry{
+		Type: model.RegistryTypeGoogleGar,
+		URL:  server.URL,
+	}
+
+	// Create a mock adapter that doesn't require real GCP credentials
+	mockAdapter := &adapter{
+		registry: registry,
+		Adapter:  nil, // We'll mock the native adapter behavior
+	}
+
+	return mockAdapter, server
+}
+
+func TestFactory_Create(t *testing.T) {
+	factory := &factory{}
+	registry := &model.Registry{
+		Type: model.RegistryTypeGoogleGar,
+		URL:  "https://us-central1-docker.pkg.dev",
+	}
+
+	// This will fail without real GCP credentials, but we can test the factory creation
+	_, err := factory.Create(registry)
+	// We expect an error since we don't have real credentials in test environment
+	if err != nil {
+		t.Logf("Expected error in test environment without GCP credentials: %v", err)
+	}
+}
+
+func TestFactory_AdapterPattern(t *testing.T) {
+	factory := &factory{}
+	pattern := factory.AdapterPattern()
+
+	assert.NotNil(t, pattern)
+	assert.NotNil(t, pattern.EndpointPattern)
+	assert.Equal(t, model.EndpointPatternTypeList, pattern.EndpointPattern.EndpointType)
+	
+	// Check that we have both GCR and GAR endpoints
+	foundGCR := false
+	foundGAR := false
+	for _, endpoint := range pattern.EndpointPattern.Endpoints {
+		if endpoint.Key == "gcr.io" {
+			foundGCR = true
+		}
+		if endpoint.Key == "us-central1-docker.pkg.dev" {
+			foundGAR = true
+		}
+	}
+	assert.True(t, foundGCR, "Should have GCR endpoint")
+	assert.True(t, foundGAR, "Should have GAR endpoint")
+
+	// Check credential pattern
+	assert.NotNil(t, pattern.CredentialPattern)
+	assert.Equal(t, model.AccessKeyTypeStandard, pattern.CredentialPattern.AccessKeyType)
+	assert.Equal(t, model.AccessSecretTypeFile, pattern.CredentialPattern.AccessSecretType)
+}
+
+func TestAdapter_Info(t *testing.T) {
+	adapter := &adapter{}
+	info, err := adapter.Info()
+
+	assert.NoError(t, err)
+	assert.NotNil(t, info)
+	assert.Equal(t, model.RegistryTypeGoogleGar, info.Type)
+	assert.Equal(t, []string{model.ResourceTypeImage}, info.SupportedResourceTypes)
+	assert.Len(t, info.SupportedResourceFilters, 2)
+	assert.Equal(t, []string{model.TriggerTypeManual, model.TriggerTypeScheduled}, info.SupportedTriggers)
+}
+
+func TestAdapter_HealthCheck_NilAdapter(t *testing.T) {
+	// Test HealthCheck without proper setup (will panic on nil Adapter.Ping())
+	adapter := &adapter{
+		registry: &model.Registry{
+			URL: "https://gcr.io",
+		},
+		Adapter: nil,
+	}
+	
+	// This will panic due to nil pointer dereference, which is expected behavior
+	assert.Panics(t, func() {
+		adapter.HealthCheck()
+	})
+}
+
+func TestDeleteManifest_PathSelection(t *testing.T) {
+	// Test that we can create adapters with different URL patterns
+	// Actual delete operations will fail without proper setup, but that's expected
+	
+	gcrRegistry := &model.Registry{
+		URL: "https://gcr.io",
+	}
+	garRegistry := &model.Registry{
+		URL: "https://us-central1-docker.pkg.dev",
+	}
+	
+	// Test that we have different URL patterns
+	assert.Contains(t, gcrRegistry.URL, "gcr.io")
+	assert.Contains(t, garRegistry.URL, "pkg.dev")
+}
+
+func TestNewAdapter_WithCredentials(t *testing.T) {
+	registry := &model.Registry{
+		Type: model.RegistryTypeGoogleGar,
+		URL:  "https://gcr.io",
+		Credential: &model.Credential{
+			AccessSecret: `{
+				"type": "service_account",
+				"project_id": "test-project",
+				"private_key": "fake-key"
+			}`,
+		},
+	}
+
+	_, err := newAdapter(registry)
+	// May succeed or fail depending on environment - just test that it doesn't panic
+	if err != nil {
+		t.Logf("Expected error with fake credentials: %v", err)
+	} else {
+		t.Log("Adapter creation succeeded (might have ambient credentials)")
+	}
+}
+
+func TestNewAdapter_WithoutCredentials(t *testing.T) {
+	registry := &model.Registry{
+		Type: model.RegistryTypeGoogleGar,
+		URL:  "https://gcr.io",
+	}
+
+	_, err := newAdapter(registry)
+	// May succeed or fail depending on environment - just test that it doesn't panic
+	if err != nil {
+		t.Logf("Expected error without credentials: %v", err)
+	} else {
+		t.Log("Adapter creation succeeded (might have ambient credentials)")
+	}
+}
+
+func TestGetAdapterInfo(t *testing.T) {
+	info := getAdapterInfo()
+
+	assert.NotNil(t, info)
+	assert.NotNil(t, info.EndpointPattern)
+	assert.NotNil(t, info.CredentialPattern)
+
+	// Verify we have the expected endpoints
+	endpoints := info.EndpointPattern.Endpoints
+	assert.True(t, len(endpoints) > 5, "Should have multiple endpoints")
+
+	// Check for specific endpoints
+	endpointKeys := make(map[string]bool)
+	for _, ep := range endpoints {
+		endpointKeys[ep.Key] = true
+	}
+
+	assert.True(t, endpointKeys["gcr.io"], "Should have gcr.io endpoint")
+	assert.True(t, endpointKeys["us-central1-docker.pkg.dev"], "Should have GAR endpoint")
+	assert.True(t, endpointKeys["custom"], "Should have custom endpoint option")
+}
+
+func TestOAuth2Authorizer_Scheme(t *testing.T) {
+	// Test without real credentials  
+	authorizer := &auth.OAuth2Authorizer{}
+	assert.Equal(t, "bearer", authorizer.Scheme())
+}
+
+func TestNewOAuth2Authorizer_WithoutCredentials(t *testing.T) {
+	// This test will fail in CI/CD without GCP credentials, but demonstrates the API
+	ctx := context.Background()
+	_, err := auth.NewOAuth2Authorizer(ctx, []string{auth.StorageScope})
+	
+	// We expect this to fail in test environment without credentials
+	// In a real environment with proper GCP setup, this would succeed
+	if err != nil {
+		t.Logf("Expected error in test environment without GCP credentials: %v", err)
+	}
+}
+
+func TestNewOAuth2AuthorizerWithCredentials_InvalidJSON(t *testing.T) {
+	ctx := context.Background()
+	invalidJSON := []byte(`{"invalid": "json"}`)
+	
+	_, err := auth.NewOAuth2AuthorizerWithCredentials(ctx, invalidJSON, []string{auth.StorageScope})
+	assert.Error(t, err)
+}
+
+func TestBuildURLs(t *testing.T) {
+	endpoint := "https://gcr.io"
+	repository := "my-project/my-repo"
+	reference := "latest"
+
+	tagURL := buildTagListURL(endpoint, repository)
+	assert.Equal(t, "https://gcr.io/v2/my-project/my-repo/tags/list", tagURL)
+
+	manifestURL := buildManifestURL(endpoint, repository, reference)
+	assert.Equal(t, "https://gcr.io/v2/my-project/my-repo/manifests/latest", manifestURL)
+}
+
+func TestParseGoogleCredentials(t *testing.T) {
+	validJSON := `{
+		"type": "service_account",
+		"project_id": "my-test-project",
+		"private_key_id": "key-id",
+		"private_key": "-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQC...\n-----END PRIVATE KEY-----\n",
+		"client_email": "test@my-test-project.iam.gserviceaccount.com"
+	}`
+
+	projectID, err := auth.ParseGoogleCredentials([]byte(validJSON))
+	assert.NoError(t, err)
+	assert.Equal(t, "my-test-project", projectID)
+
+	// Test compact JSON format
+	compactJSON := `{"type":"service_account","project_id":"my-test-project","private_key_id":"key-id"}`
+	projectID, err = auth.ParseGoogleCredentials([]byte(compactJSON))
+	assert.NoError(t, err)
+	assert.Equal(t, "my-test-project", projectID)
+
+	// Test invalid JSON
+	invalidJSON := `{"type": "service_account"}`
+	_, err = auth.ParseGoogleCredentials([]byte(invalidJSON))
+	assert.Error(t, err)
+}
+
+func TestBuildURLs_Coverage(t *testing.T) {
+	// Test the URL building functions to increase coverage
+	endpoint := "https://gcr.io"
+	repository := "my-project/my-repo"
+	reference := "latest"
+
+	tagURL := buildTagListURL(endpoint, repository)
+	assert.Equal(t, "https://gcr.io/v2/my-project/my-repo/tags/list", tagURL)
+
+	manifestURL := buildManifestURL(endpoint, repository, reference)
+	assert.Equal(t, "https://gcr.io/v2/my-project/my-repo/manifests/latest", manifestURL)
+}
+
+func TestDeleteManifest_PathLogic(t *testing.T) {
+	// Test the URL pattern detection logic without actual HTTP calls
+	
+	// Test GCR URL detection
+	gcrAdapter := &adapter{
+		registry: &model.Registry{
+			URL: "https://gcr.io",
+		},
+	}
+	
+	// Should use GCR-specific delete path (contains "gcr.io")
+	assert.Contains(t, gcrAdapter.registry.URL, "gcr.io")
+	
+	// Test GAR URL detection  
+	garAdapter := &adapter{
+		registry: &model.Registry{
+			URL: "https://us-central1-docker.pkg.dev",
+		},
+	}
+	
+	// Should use native adapter path (does not contain "gcr.io")
+	assert.NotContains(t, garAdapter.registry.URL, "gcr.io")
+}
+
+func TestAdapterRegistration(t *testing.T) {
+	// Test that the adapter is properly registered
+	factory, err := adp.GetFactory(model.RegistryTypeGoogleGar)
+	assert.NoError(t, err)
+	assert.NotNil(t, factory)
+
+	// Test adapter pattern
+	pattern := factory.AdapterPattern()
+	assert.NotNil(t, pattern)
+	assert.Equal(t, model.EndpointPatternTypeList, pattern.EndpointPattern.EndpointType)
+}

--- a/src/pkg/reg/adapter/googlegar/auth/oauth2_authorizer.go
+++ b/src/pkg/reg/adapter/googlegar/auth/oauth2_authorizer.go
@@ -1,0 +1,153 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync"
+
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+
+	"github.com/goharbor/harbor/src/lib/log"
+)
+
+const (
+	// StorageScope is the Google Cloud Storage scope for Docker registry access
+	StorageScope = "https://www.googleapis.com/auth/devstorage.read_write"
+	// CloudPlatformScope is the Cloud Platform scope for broader access
+	CloudPlatformScope = "https://www.googleapis.com/auth/cloud-platform"
+)
+
+// OAuth2Authorizer implements the lib.Authorizer interface using Google OAuth2
+type OAuth2Authorizer struct {
+	tokenSource oauth2.TokenSource
+	mu          sync.RWMutex
+	cachedToken *oauth2.Token
+}
+
+// NewOAuth2Authorizer creates a new OAuth2 authorizer using Google's default credential chain
+func NewOAuth2Authorizer(ctx context.Context, scopes []string) (*OAuth2Authorizer, error) {
+	if len(scopes) == 0 {
+		scopes = []string{StorageScope}
+	}
+
+	tokenSource, err := google.DefaultTokenSource(ctx, scopes...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create default token source: %w", err)
+	}
+
+	return &OAuth2Authorizer{
+		tokenSource: tokenSource,
+	}, nil
+}
+
+// NewOAuth2AuthorizerWithCredentials creates a new OAuth2 authorizer with explicit credentials
+func NewOAuth2AuthorizerWithCredentials(ctx context.Context, credentialsJSON []byte, scopes []string) (*OAuth2Authorizer, error) {
+	if len(scopes) == 0 {
+		scopes = []string{StorageScope}
+	}
+
+	credentials, err := google.CredentialsFromJSON(ctx, credentialsJSON, scopes...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse credentials: %w", err)
+	}
+
+	return &OAuth2Authorizer{
+		tokenSource: credentials.TokenSource,
+	}, nil
+}
+
+// Modify implements the lib.Authorizer interface by adding OAuth2 bearer token to the request
+func (a *OAuth2Authorizer) Modify(req *http.Request) error {
+	token, err := a.getToken()
+	if err != nil {
+		return fmt.Errorf("failed to get OAuth2 token: %w", err)
+	}
+
+	if token.AccessToken == "" {
+		return fmt.Errorf("empty access token")
+	}
+
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token.AccessToken))
+	return nil
+}
+
+// Authorize is an alias for Modify to maintain compatibility
+func (a *OAuth2Authorizer) Authorize(req *http.Request, _ map[string]string) error {
+	return a.Modify(req)
+}
+
+// getToken retrieves and caches the OAuth2 token
+func (a *OAuth2Authorizer) getToken() (*oauth2.Token, error) {
+	a.mu.RLock()
+	cached := a.cachedToken
+	a.mu.RUnlock()
+
+	// Check if we have a valid cached token
+	if cached != nil && cached.Valid() {
+		return cached, nil
+	}
+
+	// Get a new token
+	token, err := a.tokenSource.Token()
+	if err != nil {
+		return nil, err
+	}
+
+	// Cache the token
+	a.mu.Lock()
+	a.cachedToken = token
+	a.mu.Unlock()
+
+	log.Debugf("OAuth2 token obtained, expires at: %v", token.Expiry)
+	return token, nil
+}
+
+// Scheme returns the authentication scheme
+func (a *OAuth2Authorizer) Scheme() string {
+	return "bearer"
+}
+
+// AuthorizeRequest is an alias for Authorize to match the interface
+func (a *OAuth2Authorizer) AuthorizeRequest(req *http.Request, params map[string]string) error {
+	return a.Authorize(req, params)
+}
+
+// ServiceAccountKey represents the structure of a Google service account JSON key
+type ServiceAccountKey struct {
+	Type         string `json:"type"`
+	ProjectID    string `json:"project_id"`
+	PrivateKeyID string `json:"private_key_id"`
+	PrivateKey   string `json:"private_key"`
+	ClientID     string `json:"client_id"`
+}
+
+// ParseGoogleCredentials attempts to determine project ID from credentials JSON
+func ParseGoogleCredentials(credentialsJSON []byte) (projectID string, err error) {
+	var key ServiceAccountKey
+	if err := json.Unmarshal(credentialsJSON, &key); err != nil {
+		return "", fmt.Errorf("failed to parse credentials JSON: %w", err)
+	}
+
+	if key.ProjectID == "" {
+		return "", fmt.Errorf("project_id not found in credentials")
+	}
+
+	return key.ProjectID, nil
+}

--- a/src/pkg/reg/adapter/googlegar/auth/oauth2_authorizer_test.go
+++ b/src/pkg/reg/adapter/googlegar/auth/oauth2_authorizer_test.go
@@ -1,0 +1,357 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+)
+
+// mockTokenSource implements oauth2.TokenSource for testing
+type mockTokenSource struct {
+	token *oauth2.Token
+	err   error
+}
+
+func (m *mockTokenSource) Token() (*oauth2.Token, error) {
+	return m.token, m.err
+}
+
+func TestOAuth2Authorizer_Scheme(t *testing.T) {
+	authorizer := &OAuth2Authorizer{}
+	assert.Equal(t, "bearer", authorizer.Scheme())
+}
+
+func TestOAuth2Authorizer_Modify(t *testing.T) {
+	tests := []struct {
+		name          string
+		tokenSource   oauth2.TokenSource
+		expectedError bool
+		expectedToken string
+	}{
+		{
+			name: "valid token",
+			tokenSource: &mockTokenSource{
+				token: &oauth2.Token{
+					AccessToken: "test-access-token",
+					TokenType:   "Bearer",
+					Expiry:      time.Now().Add(time.Hour),
+				},
+			},
+			expectedError: false,
+			expectedToken: "test-access-token",
+		},
+		{
+			name: "empty token",
+			tokenSource: &mockTokenSource{
+				token: &oauth2.Token{
+					AccessToken: "",
+					TokenType:   "Bearer",
+					Expiry:      time.Now().Add(time.Hour),
+				},
+			},
+			expectedError: true,
+		},
+		{
+			name: "token source error",
+			tokenSource: &mockTokenSource{
+				err: assert.AnError,
+			},
+			expectedError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			authorizer := &OAuth2Authorizer{
+				tokenSource: tt.tokenSource,
+			}
+
+			req, err := http.NewRequest(http.MethodGet, "https://example.com", nil)
+			require.NoError(t, err)
+
+			err = authorizer.Modify(req)
+
+			if tt.expectedError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, "Bearer "+tt.expectedToken, req.Header.Get("Authorization"))
+			}
+		})
+	}
+}
+
+func TestOAuth2Authorizer_Authorize(t *testing.T) {
+	// Test that Authorize is an alias for Modify
+	authorizer := &OAuth2Authorizer{
+		tokenSource: &mockTokenSource{
+			token: &oauth2.Token{
+				AccessToken: "test-token",
+				TokenType:   "Bearer",
+				Expiry:      time.Now().Add(time.Hour),
+			},
+		},
+	}
+
+	req, err := http.NewRequest(http.MethodGet, "https://example.com", nil)
+	require.NoError(t, err)
+
+	err = authorizer.Authorize(req, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, "Bearer test-token", req.Header.Get("Authorization"))
+}
+
+func TestOAuth2Authorizer_getToken_Caching(t *testing.T) {
+	callCount := 0
+	tokenSource := &mockTokenSource{
+		token: &oauth2.Token{
+			AccessToken: "cached-token",
+			TokenType:   "Bearer",
+			Expiry:      time.Now().Add(time.Hour),
+		},
+	}
+
+	// Wrap the token source to count calls
+	wrappedSource := oauth2.TokenSource(oauth2.ReuseTokenSource(nil, tokenSource))
+
+	authorizer := &OAuth2Authorizer{
+		tokenSource: wrappedSource,
+	}
+
+	// First call should fetch token
+	token1, err := authorizer.getToken()
+	callCount++
+	assert.NoError(t, err)
+	assert.Equal(t, "cached-token", token1.AccessToken)
+
+	// Second call should use cached token
+	token2, err := authorizer.getToken()
+	assert.NoError(t, err)
+	assert.Equal(t, "cached-token", token2.AccessToken)
+	assert.Equal(t, token1, token2) // Should be the same cached token
+}
+
+func TestOAuth2Authorizer_getToken_ExpiredToken(t *testing.T) {
+	authorizer := &OAuth2Authorizer{
+		tokenSource: &mockTokenSource{
+			token: &oauth2.Token{
+				AccessToken: "new-token",
+				TokenType:   "Bearer",
+				Expiry:      time.Now().Add(time.Hour),
+			},
+		},
+		// Set an expired cached token
+		cachedToken: &oauth2.Token{
+			AccessToken: "expired-token",
+			TokenType:   "Bearer",
+			Expiry:      time.Now().Add(-time.Hour), // Expired
+		},
+	}
+
+	token, err := authorizer.getToken()
+	assert.NoError(t, err)
+	assert.Equal(t, "new-token", token.AccessToken)
+}
+
+func TestNewOAuth2Authorizer_WithoutCredentials(t *testing.T) {
+	ctx := context.Background()
+	
+	// This will fail in test environment without GCP credentials
+	_, err := NewOAuth2Authorizer(ctx, []string{StorageScope})
+	
+	// We expect this to fail in test environment
+	if err != nil {
+		t.Logf("Expected error in test environment without GCP credentials: %v", err)
+		assert.Contains(t, err.Error(), "could not find default credentials")
+	}
+}
+
+func TestNewOAuth2Authorizer_DefaultScopes(t *testing.T) {
+	ctx := context.Background()
+	
+	// Test with empty scopes - should use default
+	_, err := NewOAuth2Authorizer(ctx, nil)
+	
+	// Will fail without credentials, but we're testing scope handling
+	if err != nil {
+		t.Logf("Expected error in test environment: %v", err)
+	}
+}
+
+func TestNewOAuth2AuthorizerWithCredentials_InvalidJSON(t *testing.T) {
+	ctx := context.Background()
+	
+	tests := []struct {
+		name        string
+		credentials []byte
+		expectError bool
+	}{
+		{
+			name:        "invalid JSON",
+			credentials: []byte(`{"invalid": "json"}`),
+			expectError: true,
+		},
+		{
+			name:        "empty credentials",
+			credentials: []byte(``),
+			expectError: true,
+		},
+		{
+			name:        "malformed JSON",
+			credentials: []byte(`{invalid json}`),
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewOAuth2AuthorizerWithCredentials(ctx, tt.credentials, []string{StorageScope})
+			
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestNewOAuth2AuthorizerWithCredentials_DefaultScopes(t *testing.T) {
+	ctx := context.Background()
+	// Test scope handling with definitely invalid credentials
+	invalidCredentials := []byte(`{
+		"type": "service_account",
+		"project_id": "test-project",
+		"private_key": "-----BEGIN PRIVATE KEY-----\nINVALID\n-----END PRIVATE KEY-----\n"
+	}`)
+
+	// Test with nil scopes - should use default, but fail on credential creation
+	_, err := NewOAuth2AuthorizerWithCredentials(ctx, invalidCredentials, nil)
+	
+	// Should fail at credential parsing/validation  
+	if err == nil {
+		t.Log("Unexpectedly succeeded - maybe Google's library is more lenient than expected")
+	} else {
+		t.Logf("Expected error with invalid credentials: %v", err)
+	}
+}
+
+func TestParseGoogleCredentials(t *testing.T) {
+	tests := []struct {
+		name          string
+		credentials   []byte
+		expectedID    string
+		expectedError bool
+	}{
+		{
+			name: "valid credentials with spaces",
+			credentials: []byte(`{
+				"type": "service_account",
+				"project_id": "my-test-project",
+				"private_key_id": "key-id",
+				"client_email": "test@my-test-project.iam.gserviceaccount.com"
+			}`),
+			expectedID:    "my-test-project",
+			expectedError: false,
+		},
+		{
+			name: "valid credentials compact",
+			credentials: []byte(`{"type":"service_account","project_id":"compact-project","private_key_id":"key-id"}`),
+			expectedID:    "compact-project",
+			expectedError: false,
+		},
+		{
+			name: "missing project_id",
+			credentials: []byte(`{
+				"type": "service_account",
+				"private_key_id": "key-id",
+				"client_email": "test@example.com"
+			}`),
+			expectedID:    "",
+			expectedError: true,
+		},
+		{
+			name: "empty project_id",
+			credentials: []byte(`{
+				"type": "service_account",
+				"project_id": "",
+				"private_key_id": "key-id"
+			}`),
+			expectedID:    "",
+			expectedError: true,
+		},
+		{
+			name:          "invalid JSON",
+			credentials:   []byte(`{"invalid": json}`),
+			expectedID:    "",
+			expectedError: true,
+		},
+		{
+			name:          "empty credentials",
+			credentials:   []byte(``),
+			expectedID:    "",
+			expectedError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			projectID, err := ParseGoogleCredentials(tt.credentials)
+
+			if tt.expectedError {
+				assert.Error(t, err)
+				assert.Empty(t, projectID)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expectedID, projectID)
+			}
+		})
+	}
+}
+
+func TestServiceAccountKey_UnmarshalJSON(t *testing.T) {
+	// Test that ServiceAccountKey struct properly unmarshals JSON
+	validJSON := `{
+		"type": "service_account",
+		"project_id": "test-project-123",
+		"private_key_id": "abcd1234",
+		"private_key": "fake-private-key-content",
+		"client_id": "123456789012345678901"
+	}`
+
+	var key ServiceAccountKey
+	err := json.Unmarshal([]byte(validJSON), &key)
+	
+	assert.NoError(t, err)
+	assert.Equal(t, "service_account", key.Type)
+	assert.Equal(t, "test-project-123", key.ProjectID)
+	assert.Equal(t, "abcd1234", key.PrivateKeyID)
+	assert.Equal(t, "fake-private-key-content", key.PrivateKey)
+	assert.Equal(t, "123456789012345678901", key.ClientID)
+}
+
+func TestConstants(t *testing.T) {
+	// Test that constants are properly defined
+	assert.Equal(t, "https://www.googleapis.com/auth/devstorage.read_write", StorageScope)
+	assert.Equal(t, "https://www.googleapis.com/auth/cloud-platform", CloudPlatformScope)
+}

--- a/src/pkg/reg/manager.go
+++ b/src/pkg/reg/manager.go
@@ -40,6 +40,8 @@ import (
 	_ "github.com/goharbor/harbor/src/pkg/reg/adapter/gitlab"
 	// register the Google Gcr adapter
 	_ "github.com/goharbor/harbor/src/pkg/reg/adapter/googlegcr"
+	// register the Google GAR adapter
+	_ "github.com/goharbor/harbor/src/pkg/reg/adapter/googlegar"
 	// register the Harbor adapter
 	_ "github.com/goharbor/harbor/src/pkg/reg/adapter/harbor"
 	// register the huawei adapter

--- a/src/pkg/reg/model/registry.go
+++ b/src/pkg/reg/model/registry.go
@@ -25,6 +25,7 @@ const (
 	RegistryTypeDockerRegistry   = "docker-registry"
 	RegistryTypeHuawei           = "huawei-SWR"
 	RegistryTypeGoogleGcr        = "google-gcr"
+	RegistryTypeGoogleGar        = "google-gar"
 	RegistryTypeAwsEcr           = "aws-ecr"
 	RegistryTypeAzureAcr         = "azure-acr"
 	RegistryTypeAliAcr           = "ali-acr"

--- a/src/portal/src/app/base/left-side-nav/projects/create-project/create-project.component.ts
+++ b/src/portal/src/app/base/left-side-nav/projects/create-project/create-project.component.ts
@@ -108,7 +108,7 @@ export class CreateProjectComponent
 
     registries: Registry[] = [];
     supportedRegistryTypeQueryString: string =
-        'type={docker-hub harbor azure-acr ali-acr aws-ecr google-gcr quay docker-registry github-ghcr jfrog-artifactory}';
+        'type={docker-hub harbor azure-acr ali-acr aws-ecr google-gcr google-gar quay docker-registry github-ghcr jfrog-artifactory}';
 
     // **Added property for bandwidth error message**
     bandwidthError: string | null = null;

--- a/src/portal/src/app/base/project/project-config/project-policy-config/project-policy-config.component.ts
+++ b/src/portal/src/app/base/project/project-config/project-policy-config/project-policy-config.component.ts
@@ -166,7 +166,7 @@ export class ProjectPolicyConfigComponent implements OnInit {
     maxUpstreamConnError: string | null = null;
     registries: Registry[] = [];
     supportedRegistryTypeQueryString: string =
-        'type={docker-hub harbor azure-acr aws-ecr google-gcr quay docker-registry github-ghcr jfrog-artifactory}';
+        'type={docker-hub harbor azure-acr aws-ecr google-gcr google-gar quay docker-registry github-ghcr jfrog-artifactory}';
 
     constructor(
         private errorHandler: ErrorHandler,

--- a/src/portal/src/i18n/lang/en-us-lang.json
+++ b/src/portal/src/i18n/lang/en-us-lang.json
@@ -239,7 +239,7 @@
         "QUOTA_UNLIMIT_TIP": "The maximum logical space that can be used by the project. For unlimited quota enter '-1'.",
         "TYPE": "Type",
         "PROXY_CACHE": "Proxy Cache",
-        "PROXY_CACHE_TOOLTIP": "Enable this to allow this project to act as a proxy cache for a particular target registry instance.",
+        "PROXY_CACHE_TOOLTIP": "Enable this to allow this project to act as a pull-through cache for a particular target registry instance. Harbor can only act a proxy for DockerHub, Docker Registry, Harbor, Aws ECR, Azure ACR, Alibaba Cloud ACR, Quay, Google GCR, Google GAR, Github GHCR, and JFrog Artifactory registries.",
         "ENDPOINT": "Endpoint",
         "PROXY_CACHE_ENDPOINT": "Proxy Cache Endpoint",
         "CONNECTION_LIMIT": "Max connection to upstream registry",


### PR DESCRIPTION
# Description
This PR adds a new adapter for Google Artifact Registry (GAR) to support OAuth2 authentication. 

It supports both:
- Implicit credentials (ambient GCP credentials, e.g., via Workload Identity Federation / Google Application Default Credentials).
- Explicit credentials (using a Google Service Account JSON key).

This PR takes over and finishes the work started in #22429, fixing the failing test suite by aligning the registry template endpoint key in `adapter.go` with the test expectations (`us-central1-docker.pkg.dev`).

# Issue being fixed
Fixes https://github.com/goharbor/harbor/issues/20682

# Checklist
- [x] Well Written Title and Summary of the PR
- [x] Accepted the DCO.
- [x] Made sure tests are passing and test coverage is added.