### PR TITLE
fix: improve robot permissions checkbox alignment and click targets

### DIFF
--- a/src/portal/src/app/shared/components/robot-permissions-panel/robot-permissions-panel.component.html
+++ b/src/portal/src/app/shared/components/robot-permissions-panel/robot-permissions-panel.component.html
@@ -27,16 +27,18 @@
                         {{ convertKey(resource) | translate }}
                     </td>
                     @for (action of candidateActions; track action) {
-                    <td class="td">
+                    <td class="td checkbox-cell">
                         @if (isCandidate(resource, action)) {
-                        <input
-                            type="checkbox"
-                            clrCheckbox
-                            [disabled]="true"
-                            [ngModel]="getCheckBoxValue(resource, action)"
-                            (ngModelChange)="
-                                setCheckBoxValue(resource, action, $event)
-                            " />
+                        <clr-checkbox-wrapper>
+                            <input
+                                type="checkbox"
+                                clrCheckbox
+                                [disabled]="true"
+                                [ngModel]="getCheckBoxValue(resource, action)"
+                                (ngModelChange)="
+                                    setCheckBoxValue(resource, action, $event)
+                                " />
+                        </clr-checkbox-wrapper>
                         }
                     </td>
                     }
@@ -89,15 +91,17 @@
                         {{ convertKey(resource) | translate }}
                     </td>
                     @for (action of candidateActions; track action) {
-                    <td class="td">
+                    <td class="td checkbox-cell">
                         @if (isCandidate(resource, action)) {
-                        <input
-                            type="checkbox"
-                            clrCheckbox
-                            [ngModel]="getCheckBoxValue(resource, action)"
-                            (ngModelChange)="
-                                setCheckBoxValue(resource, action, $event)
-                            " />
+                        <clr-checkbox-wrapper>
+                            <input
+                                type="checkbox"
+                                clrCheckbox
+                                [ngModel]="getCheckBoxValue(resource, action)"
+                                (ngModelChange)="
+                                    setCheckBoxValue(resource, action, $event)
+                                " />
+                        </clr-checkbox-wrapper>
                         }
                     </td>
                     }
@@ -135,15 +139,17 @@
         <tr>
             <td class="left td">{{ convertKey(resource) | translate }}</td>
             @for (action of candidateActions; track action) {
-            <td class="td">
+            <td class="td checkbox-cell">
                 @if (isCandidate(resource, action)) {
-                <input
-                    type="checkbox"
-                    clrCheckbox
-                    [ngModel]="getCheckBoxValue(resource, action)"
-                    (ngModelChange)="
-                        setCheckBoxValue(resource, action, $event)
-                    " />
+                <clr-checkbox-wrapper>
+                    <input
+                        type="checkbox"
+                        clrCheckbox
+                        [ngModel]="getCheckBoxValue(resource, action)"
+                        (ngModelChange)="
+                            setCheckBoxValue(resource, action, $event)
+                        " />
+                </clr-checkbox-wrapper>
                 }
             </td>
             }

--- a/src/portal/src/app/shared/components/robot-permissions-panel/robot-permissions-panel.component.scss
+++ b/src/portal/src/app/shared/components/robot-permissions-panel/robot-permissions-panel.component.scss
@@ -34,3 +34,15 @@
   }
 }
 
+.checkbox-cell {
+  min-height: 32px;
+  display: flex;
+  align-items: center;
+  padding: 8px 4px;
+
+  clr-checkbox-wrapper {
+    margin: 0;
+  }
+}
+
+


### PR DESCRIPTION
## Summary
This PR improves the robot permissions checkbox component to follow Clarity 
design system standards and recent checkbox alignment fixes (PR #23439).

## Changes
- Wrap checkboxes with `clr-checkbox-wrapper` for consistent Clarity styling
- Add `.checkbox-cell` class with proper alignment (min-height: 32px)
- Improve spacing and padding for better click targets
- Ensures minimum 32px click target size for accessibility

## Testing
- Tested checkbox rendering in robot account wizard
- Verified click targets are properly sized
- Alignment matches Clarity design system standards

Fixes #23448