### PR TITLE
bump: bump up golang to 1.26.4 and trivy adapter version to v0.37.2-rc2

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Set up Go 1.26
         uses: actions/setup-go@v5
         with:
-           go-version: 1.26.3
+           go-version: 1.26.4
         id: go
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.26.3
+          go-version: 1.26.4
         id: go
       - name: Setup Docker
         uses: docker-practice/actions-setup-docker@master

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -169,8 +169,8 @@ Harbor backend is written in [Go](http://golang.org/). If you don't have a Harbo
 | 2.12   | 1.23.2      |
 | 2.13   | 1.23.8      |
 | 2.14   | 1.24.6      |
-| 2.15   | 1.26.3      |
-| 2.16   | 1.26.3      |
+| 2.15   | 1.26.4      |
+| 2.16   | 1.26.4      |
 
 
 Ensure your GOPATH and PATH have been configured in accordance with the Go environment instructions.

--- a/Makefile
+++ b/Makefile
@@ -132,7 +132,7 @@ PREPARE_VERSION_NAME=versions
 #versions
 REGISTRYVERSION=v2.8.3-patch-redis
 TRIVYVERSION=v0.71.1
-TRIVYADAPTERVERSION=v0.37.1
+TRIVYADAPTERVERSION=v0.37.2-rc2
 # VALKEYVERSION and VALKEYSHA256 are only used for the arm64 source build.
 # On amd64 the Photon tdnf package version is used directly.
 VALKEYVERSION=9.0.3

--- a/Makefile
+++ b/Makefile
@@ -179,7 +179,7 @@ GOINSTALL=$(GOCMD) install
 GOTEST=$(GOCMD) test
 GODEP=$(GOTEST) -i
 GOFMT=gofmt -w
-GOBUILDIMAGE=golang:1.26.3
+GOBUILDIMAGE=golang:1.26.4
 GOBUILDPATHINCONTAINER=/harbor
 
 # go build

--- a/src/go.mod
+++ b/src/go.mod
@@ -1,6 +1,6 @@
 module github.com/goharbor/harbor/src
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/FZambia/sentinel v1.1.0

--- a/tests/ci/distro_installer.sh
+++ b/tests/ci/distro_installer.sh
@@ -3,5 +3,5 @@ set -x
 
 set -e
 
-sudo make package_online GOBUILDTAGS="include_oss include_gcs" VERSIONTAG=dev-gitaction PKGVERSIONTAG=dev-gitaction UIVERSIONTAG=dev-gitaction GOBUILDIMAGE=golang:1.26.3 COMPILETAG=compile_golangimage TRIVYFLAG=true EXPORTERFLAG=true HTTPPROXY= PULL_BASE_FROM_DOCKERHUB=false
-sudo make package_offline GOBUILDTAGS="include_oss include_gcs" VERSIONTAG=dev-gitaction PKGVERSIONTAG=dev-gitaction UIVERSIONTAG=dev-gitaction GOBUILDIMAGE=golang:1.26.3 COMPILETAG=compile_golangimage TRIVYFLAG=true EXPORTERFLAG=true HTTPPROXY= PULL_BASE_FROM_DOCKERHUB=false
+sudo make package_online GOBUILDTAGS="include_oss include_gcs" VERSIONTAG=dev-gitaction PKGVERSIONTAG=dev-gitaction UIVERSIONTAG=dev-gitaction GOBUILDIMAGE=golang:1.26.4 COMPILETAG=compile_golangimage TRIVYFLAG=true EXPORTERFLAG=true HTTPPROXY= PULL_BASE_FROM_DOCKERHUB=false
+sudo make package_offline GOBUILDTAGS="include_oss include_gcs" VERSIONTAG=dev-gitaction PKGVERSIONTAG=dev-gitaction UIVERSIONTAG=dev-gitaction GOBUILDIMAGE=golang:1.26.4 COMPILETAG=compile_golangimage TRIVYFLAG=true EXPORTERFLAG=true HTTPPROXY= PULL_BASE_FROM_DOCKERHUB=false


### PR DESCRIPTION
Update TRIVYADAPTERVERSION to v0.37.2-rc2 in Makefile.

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [ ] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [ ] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
