### PR TITLE
fix: avoid panic in user audit event resolver on nil event data

### DIFF
--- a/src/pkg/auditext/event/user/user.go
+++ b/src/pkg/auditext/event/user/user.go
@@ -73,9 +73,7 @@ func (u *userEventResolver) Resolve(ce *commonevent.Metadata, event *notifiereve
 	if ce.RequestMethod != http.MethodPut {
 		return nil
 	}
-	// the base resolver leaves event.Data nil when the request URL does not match
-	// a specific user resource (e.g. PUT on the /api/v2.0/users collection), so
-	// skip the update instead of asserting on a nil value
+	// base resolver leaves Data nil for a PUT that isn't on a specific user (e.g. the /users collection)
 	commonEvent, ok := event.Data.(*model.CommonEvent)
 	if !ok || commonEvent == nil {
 		return nil

--- a/src/pkg/auditext/event/user/user.go
+++ b/src/pkg/auditext/event/user/user.go
@@ -73,12 +73,19 @@ func (u *userEventResolver) Resolve(ce *commonevent.Metadata, event *notifiereve
 	if ce.RequestMethod != http.MethodPut {
 		return nil
 	}
+	// the base resolver leaves event.Data nil when the request URL does not match
+	// a specific user resource (e.g. PUT on the /api/v2.0/users collection), so
+	// skip the update instead of asserting on a nil value
+	commonEvent, ok := event.Data.(*model.CommonEvent)
+	if !ok || commonEvent == nil {
+		return nil
+	}
 	// update operation description for update user password and add/remove user as system administrator
-	origin := event.Data.(*model.CommonEvent).OperationDescription
+	origin := commonEvent.OperationDescription
 	if strings.HasSuffix(ce.RequestURL, "/sysadmin") {
-		event.Data.(*model.CommonEvent).OperationDescription = origin + ", add/remove user as system administrator"
+		commonEvent.OperationDescription = origin + ", add/remove user as system administrator"
 	} else if strings.HasSuffix(ce.RequestURL, "/password") {
-		event.Data.(*model.CommonEvent).OperationDescription = origin + ", change user password"
+		commonEvent.OperationDescription = origin + ", change user password"
 	}
 	return nil
 }

--- a/src/pkg/auditext/event/user/user_resolve_test.go
+++ b/src/pkg/auditext/event/user/user_resolve_test.go
@@ -1,3 +1,17 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package user
 
 import (

--- a/src/pkg/auditext/event/user/user_resolve_test.go
+++ b/src/pkg/auditext/event/user/user_resolve_test.go
@@ -1,0 +1,39 @@
+package user
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/goharbor/harbor/src/common/rbac"
+	"github.com/goharbor/harbor/src/controller/event/metadata/commonevent"
+	"github.com/goharbor/harbor/src/pkg/auditext/event"
+	notifierevent "github.com/goharbor/harbor/src/pkg/notifier/event"
+)
+
+// TestResolvePutUsersCollectionNilData verifies Resolve handles a PUT whose URL
+// does not match a specific user id (the /api/v2.0/users collection). In that
+// case the base resolver returns without populating event.Data, so Resolve must
+// not dereference a nil event.Data.
+func TestResolvePutUsersCollectionNilData(t *testing.T) {
+	r := &userEventResolver{
+		Resolver: event.Resolver{
+			ResourceType:      rbac.ResourceUser.String(),
+			SucceedCodes:      []int{http.StatusCreated, http.StatusOK},
+			ResourceIDPattern: urlPattern,
+		},
+	}
+
+	ce := &commonevent.Metadata{
+		RequestMethod: http.MethodPut,
+		RequestURL:    "/api/v2.0/users", // collection path, no /{id}
+		ResponseCode:  http.StatusMethodNotAllowed,
+	}
+	evt := &notifierevent.Event{}
+
+	assert.NotPanics(t, func() {
+		err := r.Resolve(ce, evt)
+		assert.NoError(t, err)
+	})
+}

--- a/src/pkg/notifier/event/event.go
+++ b/src/pkg/notifier/event/event.go
@@ -101,8 +101,7 @@ func (e *Event) Publish(ctx context.Context) error {
 // The process is done in a separated goroutine
 func BuildAndPublish(ctx context.Context, metadata ...Metadata) {
 	go func() {
-		// recover in case of panic during building or publishing the event,
-		// otherwise a panic in this detached goroutine would crash the process
+		// a panic in this detached goroutine would otherwise crash the whole process
 		defer func() {
 			if err := recover(); err != nil {
 				buf := make([]byte, 1<<20)

--- a/src/pkg/notifier/event/event.go
+++ b/src/pkg/notifier/event/event.go
@@ -100,6 +100,13 @@ func (e *Event) Publish(ctx context.Context) error {
 // The process is done in a separated goroutine
 func BuildAndPublish(ctx context.Context, metadata ...Metadata) {
 	go func() {
+		// recover in case of panic during building or publishing the event,
+		// otherwise a panic in this detached goroutine would crash the process
+		defer func() {
+			if err := recover(); err != nil {
+				log.Errorf("recovered from the panic when building and publishing event: %v", err)
+			}
+		}()
 		event := &Event{}
 		if err := event.Build(ctx, metadata...); err != nil {
 			log.Errorf("failed to build the event from metadata: %v", err)

--- a/src/pkg/notifier/event/event.go
+++ b/src/pkg/notifier/event/event.go
@@ -16,6 +16,7 @@ package event
 
 import (
 	"context"
+	"runtime"
 
 	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/lib/log"
@@ -104,7 +105,9 @@ func BuildAndPublish(ctx context.Context, metadata ...Metadata) {
 		// otherwise a panic in this detached goroutine would crash the process
 		defer func() {
 			if err := recover(); err != nil {
-				log.Errorf("recovered from the panic when building and publishing event: %v", err)
+				buf := make([]byte, 1<<20)
+				size := runtime.Stack(buf, false)
+				log.Errorf("recovered from the panic when building and publishing event: %v; stack: %s", err, buf[0:size])
 			}
 		}()
 		event := &Event{}


### PR DESCRIPTION
The user audit-event resolver is registered for both the /api/v2.0/users collection and the /api/v2.0/users/{id} resource. For a PUT whose URL does not match a specific user id, the base resolver returns without populating event.Data, leaving it nil. userEventResolver.Resolve then dereferenced event.Data through an unchecked type assertion, which panics.

Audit events are built and published in a detached goroutine (BuildAndPublish) that had no recover(), so the panic propagated and terminated the process instead of failing the single request.

- user.go: use a checked type assertion and skip the update when event.Data is nil.
- event.go: recover() in the BuildAndPublish goroutine as a safeguard.

Add a regression test covering the nil event.Data path.

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
