### PR TITLE
build(registry): update distribution source tag to rc.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,7 @@ VALKEYSHA256=e220f4b0143292ee6ea6d705aa40d45a0c8a77759b3e94c201cb5c25dbdca42f
 NODEBUILDIMAGE=node:22.22.3
 
 # version of registry for pulling the source code
-REGISTRY_SRC_TAG=v2.8.3-harbor.1-rc.4
+REGISTRY_SRC_TAG=v2.8.3-harbor.1-rc.5
 # source of upstream distribution code
 DISTRIBUTION_SRC=https://github.com/goharbor/distribution.git
 


### PR DESCRIPTION
Thank you for contributing to Harbor!

# Comprehensive Summary of your change
This pull request updates the `REGISTRY_SRC_TAG` version in the `Makefile` to use a newer release candidate for the registry source code.

Version update:

* Updated the `REGISTRY_SRC_TAG` in `Makefile` from `v2.8.3-harbor.1-rc.4` to `v2.8.3-harbor.1-rc.5`, ensuring the build uses the latest release candidate of the registry source.
# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [ ] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [ ] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
