### PR TITLE
build(registry): use stable registry source release v2.8.3-harbor.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ VALKEYSHA256=e220f4b0143292ee6ea6d705aa40d45a0c8a77759b3e94c201cb5c25dbdca42f
 NODEBUILDIMAGE=node:22.22.3
 
 # version of registry for pulling the source code
-REGISTRY_SRC_TAG=v2.8.3-harbor.1-rc.5
+REGISTRY_SRC_TAG=v2.8.3-harbor.1
 # source of upstream distribution code
 DISTRIBUTION_SRC=https://github.com/goharbor/distribution.git
 


### PR DESCRIPTION
Thank you for contributing to Harbor!

# Comprehensive Summary of your change
This pull request makes a small update to the `Makefile`, changing the `REGISTRY_SRC_TAG` from a release candidate to the final release version. This ensures the build uses the latest stable source code.

* Updated the `REGISTRY_SRC_TAG` from `v2.8.3-harbor.1-rc.5` to the final release `v2.8.3-harbor.1` in the `Makefile` to pull the stable upstream distribution source.
# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [ ] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [ ] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
