### PR TITLE
build(registry): use stable registry source tag v2.8.3-harbor.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ TRIVYADAPTERVERSION=v0.37.1
 NODEBUILDIMAGE=node:22.22.3
 
 # version of registry for pulling the source code
-REGISTRY_SRC_TAG=v2.8.3-harbor.1-rc.5
+REGISTRY_SRC_TAG=v2.8.3-harbor.1
 # source of upstream distribution code
 DISTRIBUTION_SRC=https://github.com/goharbor/distribution.git
 


### PR DESCRIPTION
Thank you for contributing to Harbor!

# Comprehensive Summary of your change
This pull request updates the `REGISTRY_SRC_TAG` version in the `Makefile` to use the stable `v2.8.3-harbor.1` tag instead of the previous release candidate.

- Version Updates:
  * Updated the `REGISTRY_SRC_TAG` from `v2.8.3-harbor.1-rc.5` to the stable `v2.8.3-harbor.1` release in the `Makefile`.
# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [ ] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [ ] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
