### PR TITLE
fix(registry): send fallback scope for base /v2 ping requests

### DIFF
--- a/src/pkg/registry/auth/bearer/scope.go
+++ b/src/pkg/registry/auth/bearer/scope.go
@@ -113,7 +113,7 @@ func parseScopes(req *http.Request) []*scope {
 	// minimal registry-level scope used for catalog listing so the ping still
 	// succeeds; a registry that doesn't grant it will simply respond with
 	// 401/403, which PingSimple already treats as "reachable".
-	if path == "/v2" {
+	if strings.HasSuffix(path, "/v2") {
 		return []*scope{
 			{
 				Type:    scopeTypeRegistry,

--- a/src/pkg/registry/auth/bearer/scope.go
+++ b/src/pkg/registry/auth/bearer/scope.go
@@ -107,6 +107,21 @@ func parseScopes(req *http.Request) []*scope {
 			}}
 	}
 
-	// base or no match, return nil
+	// base ping request (e.g. GET /v2/): no resource-specific scope can be
+	// derived from the path, but some token services (e.g. registry.istio.io)
+	// reject a token request that carries no scope at all. Request the same
+	// minimal registry-level scope used for catalog listing so the ping still
+	// succeeds; a registry that doesn't grant it will simply respond with
+	// 401/403, which PingSimple already treats as "reachable".
+	if path == "/v2" {
+		return []*scope{
+			{
+				Type:    scopeTypeRegistry,
+				Name:    "catalog",
+				Actions: []string{scopeActionAll},
+			}}
+	}
+
+	// no match, return nil
 	return nil
 }

--- a/src/pkg/registry/auth/bearer/scope_test.go
+++ b/src/pkg/registry/auth/bearer/scope_test.go
@@ -35,7 +35,11 @@ func TestParseScopes(t *testing.T) {
 	// base
 	req, _ := http.NewRequest(http.MethodGet, "/v2/", nil)
 	scopes := parseScopes(req)
-	require.Nil(t, scopes)
+	require.Len(t, scopes, 1)
+	assert.Equal(t, scopeTypeRegistry, scopes[0].Type)
+	assert.Equal(t, "catalog", scopes[0].Name)
+	require.Len(t, scopes[0].Actions, 1)
+	assert.Equal(t, scopeActionAll, scopes[0].Actions[0])
 
 	// catalog
 	req, _ = http.NewRequest(http.MethodGet, "/v2/_catalog", nil)
@@ -151,4 +155,13 @@ func TestParseScopes(t *testing.T) {
 	assert.Equal(t, "library/hello-world", scopes[0].Name)
 	require.Len(t, scopes[0].Actions, 1)
 	assert.Equal(t, scopeActionPull, scopes[0].Actions[0])
+}
+
+func TestParseScopesBasePing(t *testing.T) {
+	req, _ := http.NewRequest(http.MethodGet, "https://registry.example.com/v2/", nil)
+	scopes := parseScopes(req)
+	require.Len(t, scopes, 1)
+	assert.Equal(t, scopeTypeRegistry, scopes[0].Type)
+	assert.Equal(t, "catalog", scopes[0].Name)
+	assert.Equal(t, []string{scopeActionAll}, scopes[0].Actions)
 }

--- a/src/pkg/registry/auth/bearer/scope_test.go
+++ b/src/pkg/registry/auth/bearer/scope_test.go
@@ -165,3 +165,12 @@ func TestParseScopesBasePing(t *testing.T) {
 	assert.Equal(t, "catalog", scopes[0].Name)
 	assert.Equal(t, []string{scopeActionAll}, scopes[0].Actions)
 }
+
+func TestParseScopesBasePingWithPrefix(t *testing.T) {
+	req, _ := http.NewRequest(http.MethodGet, "https://registry.example.com/prefix/v2/", nil)
+	scopes := parseScopes(req)
+	require.Len(t, scopes, 1)
+	assert.Equal(t, scopeTypeRegistry, scopes[0].Type)
+	assert.Equal(t, "catalog", scopes[0].Name)
+	assert.Equal(t, []string{scopeActionAll}, scopes[0].Actions)
+}


### PR DESCRIPTION
Thank you for contributing to Harbor!

# Comprehensive Summary of your change

Harbor's `PingSimple()` health check (used when a registry endpoint has no credentials configured) sends an unauthenticated `GET /v2/` to the remote registry. When no resource-specific scope can be derived from that base path, `parseScopes()` previously returned `nil`, so the subsequent bearer token request was sent with no `scope` param at all.

Most token services tolerate a scope-less anonymous token request. `registry.istio.io`'s token service does not — it rejects it with `400 {"error":"scope is required"}`. Since `PingSimple()` only tolerates `401`/`403` as "registry is reachable," this `400` was treated as a genuine failure, so the endpoint was marked unhealthy even though it's fully pullable anonymously (`docker pull registry.istio.io/release/proxyv2:1.26.4` works fine).

This PR makes `parseScopes()` fall back to the same `registry:catalog:*` scope already used for catalog listing when no resource-specific scope can be derived from the path (i.e. for the base `/v2` ping). This gives strict token services a non-empty scope to evaluate, while registries that don't grant it will simply respond `401`/`403` as before — which `PingSimple()` already tolerates.

**Files changed:**
- `src/pkg/registry/auth/bearer/scope.go` — added the base-ping fallback case
- `src/pkg/registry/auth/bearer/scope_test.go` — updated the existing base-path assertion to expect the fallback scope instead of `nil`, and added `TestParseScopesBasePing` as a regression test

No changes were needed in `authorizer.go` (the existing scope-iteration loop in `fetchToken` already handles a single-element slice correctly) or `adapter.go` (`PingSimple`'s 401/403 tolerance is unchanged).

**Follow-up not included in this PR:** a mock-token-server integration test that exercises the full `GET /v2/` → `401` challenge → token fetch → `400`/`200` round trip end-to-end, rather than just the unit-level `parseScopes` behavior. Kept out for now to keep this PR small per the contributing guide; happy to add it here if a reviewer wants broader coverage.

# Issue being fixed
Fixes #23466

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
