### PR TITLE
fix(cnai-parser): enforce actual byte limit to prevent decompression

### DIFF
--- a/src/controller/artifact/processor/cnai/parser/base.go
+++ b/src/controller/artifact/processor/cnai/parser/base.go
@@ -67,6 +67,10 @@ func (b *base) Parse(_ context.Context, artifact *artifact.Artifact, layer *ocis
 		return "", nil, fmt.Errorf("artifact or manifest cannot be nil")
 	}
 
+	// Reject early based on the manifest-declared size. This is only a cheap
+	// pre-check: layer.Size is attacker-controlled and reflects the packed blob
+	// size, which can be far smaller than the number of bytes materialized when
+	// the content is decompressed/expanded (e.g. GNU tar sparse files).
 	if layer.Size > defaultFileSizeLimit {
 		return "", nil, errors.RequestEntityTooLargeError(errFileTooLarge)
 	}
@@ -78,7 +82,10 @@ func (b *base) Parse(_ context.Context, artifact *artifact.Artifact, layer *ocis
 
 	defer stream.Close()
 
-	content, err := decodeContent(layer.MediaType, stream)
+	// Enforce the size limit against the actual bytes materialized, not just the
+	// declared blob size, to prevent decompression/sparse-file bombs from
+	// exhausting memory.
+	content, err := decodeContent(layer.MediaType, stream, defaultFileSizeLimit)
 	if err != nil {
 		return "", nil, fmt.Errorf("failed to decode content: %w", err)
 	}
@@ -86,14 +93,37 @@ func (b *base) Parse(_ context.Context, artifact *artifact.Artifact, layer *ocis
 	return contentTypeTextPlain, content, nil
 }
 
-func decodeContent(mediaType string, reader io.Reader) ([]byte, error) {
+// decodeContent decodes the content read from reader according to mediaType,
+// enforcing that no more than limit bytes are materialized in memory.
+func decodeContent(mediaType string, reader io.Reader, limit int64) ([]byte, error) {
 	format := filepath.Ext(mediaType)
 	switch format {
 	case formatTar:
-		return untar(reader)
+		return untar(reader, limit)
 	case formatRaw:
-		return io.ReadAll(reader)
+		return readAllLimited(reader, limit)
 	default:
 		return nil, fmt.Errorf("unsupported format: %s", format)
 	}
+}
+
+// readAllLimited reads from reader until EOF, but fails once more than limit
+// bytes have been read.
+func readAllLimited(reader io.Reader, limit int64) ([]byte, error) {
+	if limit < 0 {
+		return nil, fmt.Errorf("invalid limit: %d", limit)
+	}
+
+	// Read up to limit+1 bytes so we can distinguish "exactly at the limit"
+	// from "over the limit".
+	content, err := io.ReadAll(io.LimitReader(reader, limit+1))
+	if err != nil {
+		return nil, err
+	}
+
+	if int64(len(content)) > limit {
+		return nil, errors.RequestEntityTooLargeError(errFileTooLarge)
+	}
+
+	return content, nil
 }

--- a/src/controller/artifact/processor/cnai/parser/base_test.go
+++ b/src/controller/artifact/processor/cnai/parser/base_test.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"testing"
 
+	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/pkg/artifact"
 	"github.com/goharbor/harbor/src/pkg/registry"
 	mock "github.com/goharbor/harbor/src/testing/pkg/registry"
@@ -32,12 +33,13 @@ import (
 
 func TestBaseParse(t *testing.T) {
 	tests := []struct {
-		name          string
-		artifact      *artifact.Artifact
-		layer         *v1.Descriptor
-		mockSetup     func(*mock.Client)
-		expectedType  string
-		expectedError string
+		name            string
+		artifact        *artifact.Artifact
+		layer           *v1.Descriptor
+		mockSetup       func(*mock.Client)
+		expectedType    string
+		expectedError   string
+		expectedErrCode string
 	}{
 		{
 			name:          "nil artifact",
@@ -50,6 +52,29 @@ func TestBaseParse(t *testing.T) {
 			artifact:      &artifact.Artifact{},
 			layer:         nil,
 			expectedError: "artifact or manifest cannot be nil",
+		},
+		{
+			name:     "declared layer size exceeds limit",
+			artifact: &artifact.Artifact{RepositoryName: "test/repo"},
+			layer: &v1.Descriptor{
+				Digest: "sha256:1234",
+				Size:   defaultFileSizeLimit + 1,
+			},
+			expectedErrCode: errors.RequestEntityTooLargeCode,
+		},
+		{
+			name:     "raw content exceeds limit despite small declared size",
+			artifact: &artifact.Artifact{RepositoryName: "test/repo"},
+			layer: &v1.Descriptor{
+				MediaType: "vnd.foo.bar.raw",
+				Digest:    "sha256:1234",
+				Size:      1, // lies about the actual size
+			},
+			mockSetup: func(m *mock.Client) {
+				content := bytes.Repeat([]byte("a"), defaultFileSizeLimit+1)
+				m.On("PullBlob", "test/repo", "sha256:1234").Return(int64(0), io.NopCloser(bytes.NewReader(content)), nil)
+			},
+			expectedErrCode: errors.RequestEntityTooLargeCode,
 		},
 		{
 			name:     "registry client error",
@@ -123,9 +148,13 @@ func TestBaseParse(t *testing.T) {
 			b := &base{regCli: mockClient}
 			contentType, _, err := b.Parse(context.Background(), tt.artifact, tt.layer)
 
-			if tt.expectedError != "" {
+			switch {
+			case tt.expectedErrCode != "":
+				assert.Error(t, err)
+				assert.True(t, errors.IsErr(err, tt.expectedErrCode), "expected error code %s, got %v", tt.expectedErrCode, err)
+			case tt.expectedError != "":
 				assert.EqualError(t, err, tt.expectedError)
-			} else {
+			default:
 				assert.NoError(t, err)
 				assert.Equal(t, tt.expectedType, contentType)
 			}

--- a/src/controller/artifact/processor/cnai/parser/util.go
+++ b/src/controller/artifact/processor/cnai/parser/util.go
@@ -22,11 +22,54 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+
+	"github.com/goharbor/harbor/src/lib/errors"
 )
 
-func untar(reader io.Reader) ([]byte, error) {
-	tr := tar.NewReader(reader)
+// maxTarMetadataOverhead is the extra budget of raw tar stream bytes allowed
+// on top of the logical content limit, to account for tar headers (including
+// PAX extended records and GNU sparse maps), block padding and end-of-archive
+// markers of a legitimate archive.
+const maxTarMetadataOverhead = 1 << 20 // 1MB
+
+// limitedReader is like io.LimitReader, but returns a RequestEntityTooLarge
+// error instead of io.EOF once more than remaining bytes have been consumed,
+// so that hitting the limit is distinguishable from a legitimate end of
+// stream.
+type limitedReader struct {
+	r         io.Reader
+	remaining int64
+}
+
+func (l *limitedReader) Read(p []byte) (int, error) {
+	if l.remaining <= 0 {
+		return 0, errors.RequestEntityTooLargeError(errFileTooLarge)
+	}
+	if int64(len(p)) > l.remaining {
+		p = p[:l.remaining]
+	}
+	n, err := l.r.Read(p)
+	l.remaining -= int64(n)
+	return n, err
+}
+
+// untar reads all file entries from the tar stream and returns their
+// concatenated content. It enforces that the total number of bytes written
+// across all entries does not exceed limit, so that a tar declaring a small
+// blob size but expanding to a huge payload (e.g. GNU sparse files) cannot
+// exhaust memory.
+func untar(reader io.Reader, limit int64) ([]byte, error) {
+	if limit < 0 {
+		return nil, fmt.Errorf("invalid limit: %d", limit)
+	}
+
+	// Cap the raw bytes consumed from the underlying stream as well: the
+	// manifest-declared blob size can lie, and tar.Reader.Next() materializes
+	// metadata (PAX extended records, GNU sparse maps) in memory before the
+	// per-entry content copy below ever sees it.
+	tr := tar.NewReader(&limitedReader{r: reader, remaining: limit + maxTarMetadataOverhead})
 	var buf bytes.Buffer
+	remaining := limit
 	for {
 		header, err := tr.Next()
 		if err == io.EOF {
@@ -42,8 +85,16 @@ func untar(reader io.Reader) ([]byte, error) {
 			continue
 		}
 
-		if _, err := io.Copy(&buf, tr); err != nil {
+		// Copy at most remaining+1 bytes so we can detect when the cumulative
+		// content exceeds the limit without trusting the declared header size.
+		n, err := io.Copy(&buf, io.LimitReader(tr, remaining+1))
+		if err != nil {
 			return nil, fmt.Errorf("failed to copy content to buffer: %w", err)
+		}
+
+		remaining -= n
+		if remaining < 0 {
+			return nil, errors.RequestEntityTooLargeError(errFileTooLarge)
 		}
 	}
 

--- a/src/controller/artifact/processor/cnai/parser/util_test.go
+++ b/src/controller/artifact/processor/cnai/parser/util_test.go
@@ -17,9 +17,13 @@ package parser
 import (
 	"archive/tar"
 	"bytes"
+	"fmt"
+	"io"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/goharbor/harbor/src/lib/errors"
 )
 
 func TestUntar(t *testing.T) {
@@ -55,7 +59,7 @@ func TestUntar(t *testing.T) {
 			}
 			tw.Close()
 
-			result, err := untar(&buf)
+			result, err := untar(&buf, defaultFileSizeLimit)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("untar() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -65,6 +69,129 @@ func TestUntar(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestUntarExceedsLimit(t *testing.T) {
+	// A single tar entry whose content exceeds the limit must be rejected
+	// before it is fully materialized in memory. Note: Go's tar writer cannot
+	// emit GNU sparse entries, so this test writes the full zero-filled
+	// payload; on the read side untar behaves identically for a sparse entry
+	// declaring the same logical size (the reader expands holes to zeros), so
+	// this covers the sparse-bomb scenario as well.
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	const logicalSize = int64(defaultFileSizeLimit) * 4
+	if err := tw.WriteHeader(&tar.Header{
+		Name: "sparse.bin",
+		Mode: 0600,
+		Size: logicalSize,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	// Write the declared number of bytes so the archive is well-formed; the
+	// point is that untar must stop at the limit regardless of entry size.
+	if _, err := io.CopyN(tw, zeroReader{}, logicalSize); err != nil {
+		t.Fatal(err)
+	}
+	tw.Close()
+
+	_, err := untar(&buf, defaultFileSizeLimit)
+	if err == nil {
+		t.Fatal("expected untar to reject content exceeding the size limit")
+	}
+	if !errors.IsErr(err, errors.RequestEntityTooLargeCode) {
+		t.Errorf("expected RequestEntityTooLarge error, got %v", err)
+	}
+}
+
+func TestUntarOversizedMetadataInNext(t *testing.T) {
+	// tar.Reader.Next() materializes PAX extended records in memory before
+	// untar's per-entry content copy runs, and those bytes never count against
+	// the logical content limit. Many zero-size entries carrying large PAX
+	// records keep the logical content at 0 bytes while the raw stream grows
+	// unboundedly; the raw-stream limit must stop it.
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	chunk := strings.Repeat("x", 256*1024) // 256KB per record, under the reader's 1MB special-file cap
+	for i := 0; int64(buf.Len()) <= int64(defaultFileSizeLimit)+maxTarMetadataOverhead; i++ {
+		if err := tw.WriteHeader(&tar.Header{
+			Name:       fmt.Sprintf("empty-%d.txt", i),
+			Mode:       0600,
+			Size:       0,
+			Format:     tar.FormatPAX,
+			PAXRecords: map[string]string{"HARBOR.padding": chunk},
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	tw.Close()
+
+	_, err := untar(&buf, defaultFileSizeLimit)
+	if err == nil {
+		t.Fatal("expected untar to reject oversized tar metadata")
+	}
+	if !errors.IsErr(err, errors.RequestEntityTooLargeCode) {
+		t.Errorf("expected RequestEntityTooLarge error, got %v", err)
+	}
+}
+
+func TestUntarNegativeLimit(t *testing.T) {
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	if err := tw.WriteHeader(&tar.Header{Name: "a.txt", Mode: 0600, Size: 1}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tw.Write([]byte("a")); err != nil {
+		t.Fatal(err)
+	}
+	tw.Close()
+
+	_, err := untar(&buf, -1)
+	if err == nil {
+		t.Fatal("expected untar to reject a negative limit")
+	}
+	if errors.IsErr(err, errors.RequestEntityTooLargeCode) {
+		t.Errorf("negative limit should be a programmer error, not RequestEntityTooLarge, got %v", err)
+	}
+}
+
+func TestUntarMultipleEntriesExceedLimit(t *testing.T) {
+	// Many small entries individually under the limit must still be rejected
+	// once their cumulative size crosses the limit.
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	chunk := bytes.Repeat([]byte("a"), 1024*1024) // 1MB each
+	for i := 0; i < 8; i++ {                      // 8MB total > 4MB limit
+		if err := tw.WriteHeader(&tar.Header{
+			Name: fmt.Sprintf("file-%d.txt", i),
+			Mode: 0600,
+			Size: int64(len(chunk)),
+		}); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := tw.Write(chunk); err != nil {
+			t.Fatal(err)
+		}
+	}
+	tw.Close()
+
+	_, err := untar(&buf, defaultFileSizeLimit)
+	if err == nil {
+		t.Fatal("expected untar to reject cumulative content exceeding the size limit")
+	}
+	if !errors.IsErr(err, errors.RequestEntityTooLargeCode) {
+		t.Errorf("expected RequestEntityTooLarge error, got %v", err)
+	}
+}
+
+// zeroReader is an infinite source of zero bytes.
+type zeroReader struct{}
+
+func (zeroReader) Read(p []byte) (int, error) {
+	for i := range p {
+		p[i] = 0
+	}
+	return len(p), nil
 }
 
 func TestFileNode(t *testing.T) {


### PR DESCRIPTION
This pull request strengthens memory safety in the artifact parsing pipeline by enforcing strict limits on the number of bytes materialized from compressed or archived layers. It ensures that neither the declared blob size nor the logical size of tar entries can cause excessive memory usage, preventing decompression and sparse-file attacks. The changes also include comprehensive tests to verify these protections.

**Memory safety and size enforcement:**

* The `Parse` method in `base.go` now enforces the size limit both on the manifest-declared size (`layer.Size`) and, crucially, on the actual bytes materialized during decompression or untarring, preventing decompression/sparse-file bombs from exhausting memory. (`[[1]](diffhunk://#diff-36e2b99b4eeb1ff31d1f6bb263a52732d9a8f8faef1eb83c1c4950171bd17999R70-R73)`, `[[2]](diffhunk://#diff-36e2b99b4eeb1ff31d1f6bb263a52732d9a8f8faef1eb83c1c4950171bd17999L81-R125)`)
* The `decodeContent` and `untar` functions have been updated to take a `limit` parameter and ensure that no more than the allowed number of bytes are read into memory, regardless of what the archive declares. (`[[1]](diffhunk://#diff-36e2b99b4eeb1ff31d1f6bb263a52732d9a8f8faef1eb83c1c4950171bd17999L81-R125)`, `[[2]](diffhunk://#diff-47cd62693560bd395d83301344e8b090538a5eb97885a06a4bd70ef3b55cafd8R25-R37)`, `[[3]](diffhunk://#diff-47cd62693560bd395d83301344e8b090538a5eb97885a06a4bd70ef3b55cafd8L45-R63)`)
* A new `readAllLimited` helper function is introduced to safely read raw files with a strict byte limit. (`[src/controller/artifact/processor/cnai/parser/base.goL81-R125](diffhunk://#diff-36e2b99b4eeb1ff31d1f6bb263a52732d9a8f8faef1eb83c1c4950171bd17999L81-R125)`)

**Testing and validation:**

* The test suite now includes scenarios for tar archives with a single huge sparse entry and for multiple entries whose cumulative size exceeds the limit, verifying that such cases are correctly rejected with a `RequestEntityTooLarge` error. (`[src/controller/artifact/processor/cnai/parser/util_test.goR74-R142](diffhunk://#diff-b29381d535b647bf5fcfa1a541ad45bca711b3579aace44fac89bfeb4a2ec3cdR74-R142)`)
* Existing tests for untar functionality are updated to use the new limit-enforcing signature. (`[src/controller/artifact/processor/cnai/parser/util_test.goL58-R62](diffhunk://#diff-b29381d535b647bf5fcfa1a541ad45bca711b3579aace44fac89bfeb4a2ec3cdL58-R62)`)

These changes significantly improve the robustness of artifact processing against resource exhaustion attacks.

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
