### PR TITLE
(cherry-pick) fix: avoid panic in user audit event resolver on nil event data (#23461)

### DIFF
--- a/src/pkg/auditext/event/user/user.go
+++ b/src/pkg/auditext/event/user/user.go
@@ -73,12 +73,17 @@ func (u *userEventResolver) Resolve(ce *commonevent.Metadata, event *notifiereve
 	if ce.RequestMethod != http.MethodPut {
 		return nil
 	}
+	// base resolver leaves Data nil for a PUT that isn't on a specific user (e.g. the /users collection)
+	commonEvent, ok := event.Data.(*model.CommonEvent)
+	if !ok || commonEvent == nil {
+		return nil
+	}
 	// update operation description for update user password and add/remove user as system administrator
-	origin := event.Data.(*model.CommonEvent).OperationDescription
+	origin := commonEvent.OperationDescription
 	if strings.HasSuffix(ce.RequestURL, "/sysadmin") {
-		event.Data.(*model.CommonEvent).OperationDescription = origin + ", add/remove user as system administrator"
+		commonEvent.OperationDescription = origin + ", add/remove user as system administrator"
 	} else if strings.HasSuffix(ce.RequestURL, "/password") {
-		event.Data.(*model.CommonEvent).OperationDescription = origin + ", change user password"
+		commonEvent.OperationDescription = origin + ", change user password"
 	}
 	return nil
 }

--- a/src/pkg/auditext/event/user/user_resolve_test.go
+++ b/src/pkg/auditext/event/user/user_resolve_test.go
@@ -1,0 +1,53 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package user
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/goharbor/harbor/src/common/rbac"
+	"github.com/goharbor/harbor/src/controller/event/metadata/commonevent"
+	"github.com/goharbor/harbor/src/pkg/auditext/event"
+	notifierevent "github.com/goharbor/harbor/src/pkg/notifier/event"
+)
+
+// TestResolvePutUsersCollectionNilData verifies Resolve handles a PUT whose URL
+// does not match a specific user id (the /api/v2.0/users collection). In that
+// case the base resolver returns without populating event.Data, so Resolve must
+// not dereference a nil event.Data.
+func TestResolvePutUsersCollectionNilData(t *testing.T) {
+	r := &userEventResolver{
+		Resolver: event.Resolver{
+			ResourceType:      rbac.ResourceUser.String(),
+			SucceedCodes:      []int{http.StatusCreated, http.StatusOK},
+			ResourceIDPattern: urlPattern,
+		},
+	}
+
+	ce := &commonevent.Metadata{
+		RequestMethod: http.MethodPut,
+		RequestURL:    "/api/v2.0/users", // collection path, no /{id}
+		ResponseCode:  http.StatusMethodNotAllowed,
+	}
+	evt := &notifierevent.Event{}
+
+	assert.NotPanics(t, func() {
+		err := r.Resolve(ce, evt)
+		assert.NoError(t, err)
+	})
+}

--- a/src/pkg/notifier/event/event.go
+++ b/src/pkg/notifier/event/event.go
@@ -16,6 +16,7 @@ package event
 
 import (
 	"context"
+	"runtime"
 
 	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/lib/log"
@@ -100,6 +101,14 @@ func (e *Event) Publish(ctx context.Context) error {
 // The process is done in a separated goroutine
 func BuildAndPublish(ctx context.Context, metadata ...Metadata) {
 	go func() {
+		// a panic in this detached goroutine would otherwise crash the whole process
+		defer func() {
+			if err := recover(); err != nil {
+				buf := make([]byte, 1<<20)
+				size := runtime.Stack(buf, false)
+				log.Errorf("recovered from the panic when building and publishing event: %v; stack: %s", err, buf[0:size])
+			}
+		}()
 		event := &Event{}
 		if err := event.Build(ctx, metadata...); err != nil {
 			log.Errorf("failed to build the event from metadata: %v", err)


### PR DESCRIPTION
Backport of #23461 to `release-2.15.0`. Cherry-picked from `main`.