### PR TITLE
(cherry-pick) Add a size limit for manifest uploads

### DIFF
--- a/src/common/const.go
+++ b/src/common/const.go
@@ -250,6 +250,10 @@ const (
 	// DefaultBeegoMaxUploadSizeBytes sets default max upload size to 128GB
 	DefaultBeegoMaxUploadSizeBytes = 1 << 37
 
+	// MaxManifestBodySize bounds the manifest PUT body buffered in memory. OCI
+	// manifests are sub-MiB in practice, so 4MiB is a generous ceiling.
+	MaxManifestBodySize = 4 << 20
+
 	// Global Leeway used for token validation
 	JwtLeeway = 60 * time.Second
 

--- a/src/lib/request.go
+++ b/src/lib/request.go
@@ -78,11 +78,16 @@ func ReadRequestBody(r *http.Request, limit int64) ([]byte, error) {
 		return nil, nil
 	}
 
-	var reader io.Reader = r.Body
+	// keep a reference to the original body so we can close it safely once we
+	// have buffered its contents (or bailed out on an over-limit body)
+	originalBody := r.Body
+	defer originalBody.Close()
+
+	var reader io.Reader = originalBody
 	if limit > 0 {
 		// read one extra byte so an over-limit body is detected rather than
 		// silently truncated
-		reader = io.LimitReader(r.Body, limit+1)
+		reader = io.LimitReader(originalBody, limit+1)
 	}
 
 	data, err := io.ReadAll(reader)

--- a/src/lib/request.go
+++ b/src/lib/request.go
@@ -18,6 +18,8 @@ import (
 	"bytes"
 	"io"
 	"net/http"
+
+	"github.com/goharbor/harbor/src/lib/errors"
 )
 
 // nopCloser is just like ioutil's, but here to let us re-read the same
@@ -41,9 +43,7 @@ func (n nopCloser) Close() error {
 	return nil
 }
 
-// limit <= 0 preserves the original unbounded buffering; a positive limit caps
-// the retained bytes to avoid buffering an arbitrarily large body.
-func copyBody(body io.ReadCloser, limit int64) io.ReadCloser {
+func copyBody(body io.ReadCloser) io.ReadCloser {
 	// check if body was already read and converted into our nopCloser
 	if nc, ok := body.(nopCloser); ok {
 		_, _ = nc.Seek(0, io.SeekStart)
@@ -52,22 +52,47 @@ func copyBody(body io.ReadCloser, limit int64) io.ReadCloser {
 
 	defer body.Close()
 
-	var src io.Reader = body
-	if limit > 0 {
-		src = io.LimitReader(body, limit)
-	}
-
 	var buf bytes.Buffer
-	_, _ = io.Copy(&buf, src)
+	_, _ = io.Copy(&buf, body)
 
 	return nopCloser{bytes.NewReader(buf.Bytes())}
 }
 
-// NopCloseRequest makes r.Body re-readable; limit <= 0 keeps it unbounded.
-func NopCloseRequest(r *http.Request, limit int64) *http.Request {
+// NopCloseRequest makes r.Body re-readable so it can be consumed more than once.
+func NopCloseRequest(r *http.Request) *http.Request {
 	if r != nil && r.Body != nil {
-		r.Body = copyBody(r.Body, limit)
+		r.Body = copyBody(r.Body)
 	}
 
 	return r
+}
+
+// ReadRequestBody reads and returns r.Body while enforcing an optional size
+// limit. When limit > 0 and the body is larger than limit, a
+// RequestEntityTooLargeError is returned so callers surface a 413 instead of
+// buffering or parsing a truncated body. On success r.Body is replaced with a
+// re-readable buffer holding the same (<= limit) bytes for any downstream
+// consumer.
+func ReadRequestBody(r *http.Request, limit int64) ([]byte, error) {
+	if r == nil || r.Body == nil {
+		return nil, nil
+	}
+
+	var reader io.Reader = r.Body
+	if limit > 0 {
+		// read one extra byte so an over-limit body is detected rather than
+		// silently truncated
+		reader = io.LimitReader(r.Body, limit+1)
+	}
+
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		return nil, err
+	}
+	if limit > 0 && int64(len(data)) > limit {
+		return nil, errors.RequestEntityTooLargeError(nil)
+	}
+
+	r.Body = nopCloser{bytes.NewReader(data)}
+	return data, nil
 }

--- a/src/lib/request.go
+++ b/src/lib/request.go
@@ -41,7 +41,9 @@ func (n nopCloser) Close() error {
 	return nil
 }
 
-func copyBody(body io.ReadCloser) io.ReadCloser {
+// limit <= 0 preserves the original unbounded buffering; a positive limit caps
+// the retained bytes to avoid buffering an arbitrarily large body.
+func copyBody(body io.ReadCloser, limit int64) io.ReadCloser {
 	// check if body was already read and converted into our nopCloser
 	if nc, ok := body.(nopCloser); ok {
 		_, _ = nc.Seek(0, io.SeekStart)
@@ -50,16 +52,21 @@ func copyBody(body io.ReadCloser) io.ReadCloser {
 
 	defer body.Close()
 
+	var src io.Reader = body
+	if limit > 0 {
+		src = io.LimitReader(body, limit)
+	}
+
 	var buf bytes.Buffer
-	_, _ = io.Copy(&buf, body)
+	_, _ = io.Copy(&buf, src)
 
 	return nopCloser{bytes.NewReader(buf.Bytes())}
 }
 
-// NopCloseRequest ...
-func NopCloseRequest(r *http.Request) *http.Request {
+// NopCloseRequest makes r.Body re-readable; limit <= 0 keeps it unbounded.
+func NopCloseRequest(r *http.Request, limit int64) *http.Request {
 	if r != nil && r.Body != nil {
-		r.Body = copyBody(r.Body)
+		r.Body = copyBody(r.Body, limit)
 	}
 
 	return r

--- a/src/lib/request_test.go
+++ b/src/lib/request_test.go
@@ -39,7 +39,7 @@ func (suite *NopCloseRequestTestSuite) TestReusableBody() {
 	suite.Equal([]byte(""), body)
 
 	r, _ = http.NewRequest(http.MethodPost, "/", strings.NewReader("body"))
-	r = NopCloseRequest(r)
+	r = NopCloseRequest(r, 0)
 
 	body, err = io.ReadAll(r.Body)
 	suite.Nil(err)
@@ -48,6 +48,15 @@ func (suite *NopCloseRequestTestSuite) TestReusableBody() {
 	body, err = io.ReadAll(r.Body)
 	suite.Nil(err)
 	suite.Equal([]byte("body"), body)
+}
+
+func (suite *NopCloseRequestTestSuite) TestLimitCapsBufferedBody() {
+	r, _ := http.NewRequest(http.MethodPost, "/", strings.NewReader("body"))
+	r = NopCloseRequest(r, 2)
+
+	body, err := io.ReadAll(r.Body)
+	suite.Nil(err)
+	suite.Equal([]byte("bo"), body)
 }
 
 func TestNopCloseRequestTestSuite(t *testing.T) {

--- a/src/lib/request_test.go
+++ b/src/lib/request_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/suite"
+
+	"github.com/goharbor/harbor/src/lib/errors"
 )
 
 type NopCloseRequestTestSuite struct {
@@ -39,7 +41,7 @@ func (suite *NopCloseRequestTestSuite) TestReusableBody() {
 	suite.Equal([]byte(""), body)
 
 	r, _ = http.NewRequest(http.MethodPost, "/", strings.NewReader("body"))
-	r = NopCloseRequest(r, 0)
+	r = NopCloseRequest(r)
 
 	body, err = io.ReadAll(r.Body)
 	suite.Nil(err)
@@ -48,17 +50,53 @@ func (suite *NopCloseRequestTestSuite) TestReusableBody() {
 	body, err = io.ReadAll(r.Body)
 	suite.Nil(err)
 	suite.Equal([]byte("body"), body)
-}
-
-func (suite *NopCloseRequestTestSuite) TestLimitCapsBufferedBody() {
-	r, _ := http.NewRequest(http.MethodPost, "/", strings.NewReader("body"))
-	r = NopCloseRequest(r, 2)
-
-	body, err := io.ReadAll(r.Body)
-	suite.Nil(err)
-	suite.Equal([]byte("bo"), body)
 }
 
 func TestNopCloseRequestTestSuite(t *testing.T) {
 	suite.Run(t, &NopCloseRequestTestSuite{})
+}
+
+type ReadRequestBodyTestSuite struct {
+	suite.Suite
+}
+
+func (suite *ReadRequestBodyTestSuite) TestWithinLimit() {
+	r, _ := http.NewRequest(http.MethodPost, "/", strings.NewReader("body"))
+
+	data, err := ReadRequestBody(r, 8)
+	suite.Nil(err)
+	suite.Equal([]byte("body"), data)
+
+	// body is restored and re-readable for downstream consumers
+	rest, err := io.ReadAll(r.Body)
+	suite.Nil(err)
+	suite.Equal([]byte("body"), rest)
+}
+
+func (suite *ReadRequestBodyTestSuite) TestAtLimit() {
+	r, _ := http.NewRequest(http.MethodPost, "/", strings.NewReader("body"))
+
+	data, err := ReadRequestBody(r, 4)
+	suite.Nil(err)
+	suite.Equal([]byte("body"), data)
+}
+
+func (suite *ReadRequestBodyTestSuite) TestOverLimit() {
+	r, _ := http.NewRequest(http.MethodPost, "/", strings.NewReader("body"))
+
+	data, err := ReadRequestBody(r, 3)
+	suite.Nil(data)
+	suite.True(errors.IsErr(err, errors.RequestEntityTooLargeCode))
+}
+
+func (suite *ReadRequestBodyTestSuite) TestUnbounded() {
+	r, _ := http.NewRequest(http.MethodPost, "/", strings.NewReader("body"))
+
+	data, err := ReadRequestBody(r, 0)
+	suite.Nil(err)
+	suite.Equal([]byte("body"), data)
+}
+
+func TestReadRequestBodyTestSuite(t *testing.T) {
+	suite.Run(t, &ReadRequestBodyTestSuite{})
 }

--- a/src/server/middleware/blob/put_manifest.go
+++ b/src/server/middleware/blob/put_manifest.go
@@ -18,6 +18,7 @@ import (
 	"io"
 	"net/http"
 
+	"github.com/goharbor/harbor/src/common"
 	"github.com/goharbor/harbor/src/lib"
 	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/lib/log"
@@ -33,7 +34,7 @@ func PutManifestMiddleware() func(http.Handler) http.Handler {
 		ctx := r.Context()
 		logger := log.G(ctx)
 
-		lib.NopCloseRequest(r) // make the r.Body re-readable
+		lib.NopCloseRequest(r, common.MaxManifestBodySize) // make the r.Body re-readable
 		body, err := io.ReadAll(r.Body)
 		if err != nil {
 			return err

--- a/src/server/middleware/blob/put_manifest.go
+++ b/src/server/middleware/blob/put_manifest.go
@@ -34,8 +34,10 @@ func PutManifestMiddleware() func(http.Handler) http.Handler {
 		ctx := r.Context()
 		logger := log.G(ctx)
 
-		lib.NopCloseRequest(r, common.MaxManifestBodySize) // make the r.Body re-readable
-		body, err := io.ReadAll(r.Body)
+		// bound the buffered manifest body; an over-limit body yields a 413
+		// rather than being parsed as a truncated (and misleadingly invalid)
+		// manifest
+		body, err := lib.ReadRequestBody(r, common.MaxManifestBodySize)
 		if err != nil {
 			return err
 		}

--- a/src/server/middleware/log/log.go
+++ b/src/server/middleware/log/log.go
@@ -52,7 +52,7 @@ func Middleware() func(http.Handler) http.Handler {
 			RequestURL:    r.URL.String(),
 		}
 		if matched, resName := e.PreCheckMetadata(); matched {
-			lib.NopCloseRequest(r)
+			lib.NopCloseRequest(r, 0) // audit path buffers non-manifest API bodies, so the manifest cap doesn't apply
 			body, err := io.ReadAll(r.Body)
 			if err != nil {
 				http.Error(w, "failed to read request body", http.StatusInternalServerError)

--- a/src/server/middleware/log/log.go
+++ b/src/server/middleware/log/log.go
@@ -52,7 +52,7 @@ func Middleware() func(http.Handler) http.Handler {
 			RequestURL:    r.URL.String(),
 		}
 		if matched, resName := e.PreCheckMetadata(); matched {
-			lib.NopCloseRequest(r, 0) // audit path buffers non-manifest API bodies, so the manifest cap doesn't apply
+			lib.NopCloseRequest(r)
 			body, err := io.ReadAll(r.Body)
 			if err != nil {
 				http.Error(w, "failed to read request body", http.StatusInternalServerError)

--- a/src/server/middleware/quota/put_manifest.go
+++ b/src/server/middleware/quota/put_manifest.go
@@ -42,6 +42,10 @@ func putManifestResources(r *http.Request, _, referenceID string) (types.Resourc
 
 	manifest, descriptor, err := unmarshalManifest(r)
 	if err != nil {
+		// an over-limit body is a 413, not an invalid manifest; surface it as-is
+		if errors.IsErr(err, errors.RequestEntityTooLargeCode) {
+			return nil, err
+		}
 		logger.Errorf("unmarshal manifest failed, error: %v", err)
 		return nil, errors.Wrap(err, "unmarshal manifest failed").WithCode(errors.MANIFESTINVALID)
 	}

--- a/src/server/middleware/quota/put_manifest_test.go
+++ b/src/server/middleware/quota/put_manifest_test.go
@@ -294,6 +294,26 @@ func (suite *PutManifestMiddlewareTestSuite) TestPutInvalid() {
 
 }
 
+func (suite *PutManifestMiddlewareTestSuite) TestOverLimitManifestReturns413() {
+	mock.OnAnything(suite.quotaController, "IsEnabled").Return(true, nil)
+
+	// an over-limit body must surface as 413, not be re-wrapped into a
+	// MANIFEST_INVALID (400) by the quota middleware
+	unmarshalManifest = func(_ *http.Request) (distribution.Manifest, distribution.Descriptor, error) {
+		return nil, distribution.Descriptor{}, errors.RequestEntityTooLargeError(nil)
+	}
+
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodPut, "/v2/library/photon/manifests/2.0", nil)
+	rr := httptest.NewRecorder()
+
+	PutManifestMiddleware()(next).ServeHTTP(rr, req)
+	suite.Equal(http.StatusRequestEntityTooLarge, rr.Code)
+}
+
 func TestPutManifestMiddlewareTestSuite(t *testing.T) {
 	suite.Run(t, &PutManifestMiddlewareTestSuite{})
 }

--- a/src/server/middleware/quota/util.go
+++ b/src/server/middleware/quota/util.go
@@ -16,7 +16,6 @@ package quota
 
 import (
 	"fmt"
-	"io"
 	"net/http"
 	"strconv"
 	"time"
@@ -49,9 +48,7 @@ func projectReferenceObject(r *http.Request) (string, string, error) {
 
 var (
 	unmarshalManifest = func(r *http.Request) (distribution.Manifest, distribution.Descriptor, error) {
-		lib.NopCloseRequest(r, common.MaxManifestBodySize)
-
-		body, err := io.ReadAll(r.Body)
+		body, err := lib.ReadRequestBody(r, common.MaxManifestBodySize)
 		if err != nil {
 			return nil, distribution.Descriptor{}, err
 		}

--- a/src/server/middleware/quota/util.go
+++ b/src/server/middleware/quota/util.go
@@ -21,6 +21,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/goharbor/harbor/src/common"
 	"github.com/goharbor/harbor/src/controller/event/metadata"
 	"github.com/goharbor/harbor/src/controller/event/operator"
 	"github.com/goharbor/harbor/src/controller/quota"
@@ -48,7 +49,7 @@ func projectReferenceObject(r *http.Request) (string, string, error) {
 
 var (
 	unmarshalManifest = func(r *http.Request) (distribution.Manifest, distribution.Descriptor, error) {
-		lib.NopCloseRequest(r)
+		lib.NopCloseRequest(r, common.MaxManifestBodySize)
 
 		body, err := io.ReadAll(r.Body)
 		if err != nil {

--- a/src/server/registry/manifest.go
+++ b/src/server/registry/manifest.go
@@ -190,15 +190,11 @@ func putManifest(w http.ResponseWriter, req *http.Request) {
 	// before proxying to the backend. This prevents tags from being stored in the
 	// backend registry storage, while Harbor maintains the tag-to-digest mapping in the database.
 	if _, err := digest.Parse(reference); err != nil {
-		// reference is a tag, not a digest
-		// read one extra byte so an over-limit body is detected rather than silently truncated
-		data, err := io.ReadAll(io.LimitReader(req.Body, common.MaxManifestBodySize+1))
+		// reference is a tag, not a digest; bound the buffered body so an
+		// over-limit manifest is rejected with 413 instead of buffered whole
+		data, err := lib.ReadRequestBody(req, common.MaxManifestBodySize)
 		if err != nil {
 			lib_http.SendError(w, err)
-			return
-		}
-		if int64(len(data)) > common.MaxManifestBodySize {
-			lib_http.SendError(w, errors.RequestEntityTooLargeError(nil))
 			return
 		}
 

--- a/src/server/registry/manifest.go
+++ b/src/server/registry/manifest.go
@@ -191,9 +191,14 @@ func putManifest(w http.ResponseWriter, req *http.Request) {
 	// backend registry storage, while Harbor maintains the tag-to-digest mapping in the database.
 	if _, err := digest.Parse(reference); err != nil {
 		// reference is a tag, not a digest
-		data, err := io.ReadAll(req.Body)
+		// read one extra byte so an over-limit body is detected rather than silently truncated
+		data, err := io.ReadAll(io.LimitReader(req.Body, common.MaxManifestBodySize+1))
 		if err != nil {
 			lib_http.SendError(w, err)
+			return
+		}
+		if int64(len(data)) > common.MaxManifestBodySize {
+			lib_http.SendError(w, errors.RequestEntityTooLargeError(nil))
 			return
 		}
 

--- a/src/server/registry/manifest_test.go
+++ b/src/server/registry/manifest_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/opencontainers/go-digest"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/goharbor/harbor/src/common"
 	"github.com/goharbor/harbor/src/controller/artifact"
 	"github.com/goharbor/harbor/src/controller/repository"
 	"github.com/goharbor/harbor/src/lib/config"
@@ -319,6 +320,59 @@ func (m *manifestTestSuite) TestPutManifestEmptyBody() {
 
 	putManifest(w, req)
 	m.Equal(http.StatusCreated, w.Code)
+}
+
+func (m *manifestTestSuite) TestPutManifestOversizedTagReturns413() {
+	// a tag push must read the body to compute its digest, so an over-limit
+	// body is rejected with 413 before it is buffered or proxied
+	proxyCalled := false
+	proxy = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		proxyCalled = true
+		w.WriteHeader(http.StatusCreated)
+	})
+
+	body := bytes.Repeat([]byte("x"), common.MaxManifestBodySize+1)
+	req := httptest.NewRequest(http.MethodPut, "/v2/library/hello-world/manifests/latest", bytes.NewReader(body))
+	input := &beegocontext.BeegoInput{}
+	input.SetParam(":splat", "library/hello-world")
+	input.SetParam(":reference", "latest")
+	*req = *(req.WithContext(context.WithValue(req.Context(), router.ContextKeyInput{}, input)))
+
+	w := &httptest.ResponseRecorder{}
+	mock.OnAnything(m.repoCtl, "Ensure").Return(false, int64(1), nil)
+
+	putManifest(w, req)
+	m.Equal(http.StatusRequestEntityTooLarge, w.Code)
+	m.False(proxyCalled, "over-limit manifest must not reach the backend proxy")
+}
+
+func (m *manifestTestSuite) TestPutManifestOversizedDigestProxied() {
+	// a digest push is not read by the handler (the digest is taken from the
+	// reference), so the handler does not size-limit it; the bound for the
+	// digest path is enforced by the blob/quota middleware, not here
+	providedDigest := "sha256:418fb88ec412e340cdbef913b8ca1bbe8f9e8dc705f9617414c1f2c8db980180"
+	proxyCalled := false
+	proxy = http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		proxyCalled = true
+		_, _ = io.Copy(io.Discard, req.Body)
+		w.Header().Set("Docker-Content-Digest", providedDigest)
+		w.WriteHeader(http.StatusCreated)
+	})
+
+	body := bytes.Repeat([]byte("x"), common.MaxManifestBodySize+1)
+	req := httptest.NewRequest(http.MethodPut, "/v2/library/hello-world/manifests/"+providedDigest, bytes.NewReader(body))
+	input := &beegocontext.BeegoInput{}
+	input.SetParam(":splat", "library/hello-world")
+	input.SetParam(":reference", providedDigest)
+	*req = *(req.WithContext(context.WithValue(req.Context(), router.ContextKeyInput{}, input)))
+
+	w := &httptest.ResponseRecorder{}
+	mock.OnAnything(m.repoCtl, "Ensure").Return(false, int64(1), nil)
+	mock.OnAnything(m.artCtl, "Ensure").Return(true, int64(1), nil)
+
+	putManifest(w, req)
+	m.Equal(http.StatusCreated, w.Code)
+	m.True(proxyCalled, "digest push is proxied unread by the handler")
 }
 
 func TestManifestTestSuite(t *testing.T) {


### PR DESCRIPTION
Backport of #23500 to `release-2.15.0`. Cherry-picked from `main`.