### PR TITLE
feat(replication): add option to skip repo pre-creation for ECR

### DIFF
--- a/api/v2.0/swagger.yaml
+++ b/api/v2.0/swagger.yaml
@@ -7680,13 +7680,18 @@ definitions:
           Whether to skip execution until the previous active execution finishes,
           avoiding the execution of the same replication rules multiple times in parallel.
         x-isnullable: true # make this field optional to keep backward compatibility
-      create_repo_if_not_exist:
-        type: boolean
+      adapter_options:
+        type: object
+        additionalProperties:
+          type: string
         description: |-
-          Whether Harbor should pre-create the repository on the destination registry
-          before pushing. Defaults to true (current behavior). Set to false to let the
-          destination registry auto-create the repository on push instead, so
-          registry-side automation (e.g. AWS ECR repository creation templates) can apply.
+          Generic key/value options interpreted differently by each registry
+          adapter; unknown keys are ignored by adapters that don't understand
+          them. For example, the AWS ECR adapter reads "skip_repo_creation":
+          "true" to skip pre-creating the destination repository before
+          pushing, letting the destination registry auto-create it on push
+          instead so registry-side automation (e.g. AWS ECR repository
+          creation templates) can apply.
         x-isnullable: true # make this field optional to keep backward compatibility
   ReplicationTrigger:
     type: object

--- a/api/v2.0/swagger.yaml
+++ b/api/v2.0/swagger.yaml
@@ -7680,6 +7680,14 @@ definitions:
           Whether to skip execution until the previous active execution finishes,
           avoiding the execution of the same replication rules multiple times in parallel.
         x-isnullable: true # make this field optional to keep backward compatibility
+      create_repo_if_not_exist:
+        type: boolean
+        description: |-
+          Whether Harbor should pre-create the repository on the destination registry
+          before pushing. Defaults to true (current behavior). Set to false to let the
+          destination registry auto-create the repository on push instead, so
+          registry-side automation (e.g. AWS ECR repository creation templates) can apply.
+        x-isnullable: true # make this field optional to keep backward compatibility
   ReplicationTrigger:
     type: object
     properties:
@@ -7851,6 +7859,11 @@ definitions:
       supported_copy_by_chunk:
         type: boolean
         description: The registry whether support copy by chunk.
+        x-omitempty: true
+        x-isnullable: true
+      supported_create_repo_config:
+        type: boolean
+        description: Whether the registry adapter supports the "create repository if not exists" toggle.
         x-omitempty: true
         x-isnullable: true
   RegistryProviderInfo:

--- a/make/migrations/postgresql/0200_2.17.0_schema.up.sql
+++ b/make/migrations/postgresql/0200_2.17.0_schema.up.sql
@@ -1,0 +1,12 @@
+/*
+Add create_repo_if_not_exist to replication_policy.
+
+Controls whether Harbor pre-creates the repository on the destination registry
+before pushing during replication. NULL/true preserves current behavior
+(Harbor creates the repo if it doesn't exist). false lets the destination
+registry auto-create it on push instead, so registry-side automation such as
+AWS ECR repository creation templates can apply.
+
+See: https://github.com/goharbor/harbor/issues/22842
+*/
+ALTER TABLE replication_policy ADD COLUMN IF NOT EXISTS create_repo_if_not_exist boolean;

--- a/make/migrations/postgresql/0200_2.17.0_schema.up.sql
+++ b/make/migrations/postgresql/0200_2.17.0_schema.up.sql
@@ -1,12 +1,16 @@
 /*
-Add create_repo_if_not_exist to replication_policy.
+Add adapter_options to replication_policy.
 
-Controls whether Harbor pre-creates the repository on the destination registry
-before pushing during replication. NULL/true preserves current behavior
-(Harbor creates the repo if it doesn't exist). false lets the destination
-registry auto-create it on push instead, so registry-side automation such as
-AWS ECR repository creation templates can apply.
+A generic JSON-encoded key/value bag for adapter-specific settings that don't
+warrant a dedicated column of their own. Each registry adapter reads only the
+keys it understands and ignores the rest.
+
+Initial use case: the AWS ECR adapter reads "skip_repo_creation": "true" to
+skip pre-creating the destination repository before pushing, so that ECR
+repository creation templates -- which only apply when ECR creates the
+repository itself, not when it's created via an explicit CreateRepository
+API call -- can take effect.
 
 See: https://github.com/goharbor/harbor/issues/22842
 */
-ALTER TABLE replication_policy ADD COLUMN IF NOT EXISTS create_repo_if_not_exist boolean;
+ALTER TABLE replication_policy ADD COLUMN IF NOT EXISTS adapter_options text;

--- a/src/controller/replication/flow/stage.go
+++ b/src/controller/replication/flow/stage.go
@@ -91,13 +91,14 @@ func assembleDestinationResources(resources []*model.Resource,
 			return nil, err
 		}
 		res := &model.Resource{
-			Type:         resource.Type,
-			Registry:     policy.DestRegistry,
-			ExtendedInfo: resource.ExtendedInfo,
-			Deleted:      resource.Deleted,
-			IsDeleteTag:  resource.IsDeleteTag,
-			Override:     policy.Override,
-			Skip:         resource.Skip,
+			Type:                 resource.Type,
+			Registry:             policy.DestRegistry,
+			ExtendedInfo:         resource.ExtendedInfo,
+			Deleted:              resource.Deleted,
+			IsDeleteTag:          resource.IsDeleteTag,
+			Override:             policy.Override,
+			Skip:                 resource.Skip,
+			CreateRepoIfNotExist: policy.ShouldCreateRepoIfNotExist(),
 		}
 		res.Metadata = &model.ResourceMetadata{
 			Repository: &model.Repository{

--- a/src/controller/replication/flow/stage.go
+++ b/src/controller/replication/flow/stage.go
@@ -91,14 +91,14 @@ func assembleDestinationResources(resources []*model.Resource,
 			return nil, err
 		}
 		res := &model.Resource{
-			Type:                 resource.Type,
-			Registry:             policy.DestRegistry,
-			ExtendedInfo:         resource.ExtendedInfo,
-			Deleted:              resource.Deleted,
-			IsDeleteTag:          resource.IsDeleteTag,
-			Override:             policy.Override,
-			Skip:                 resource.Skip,
-			CreateRepoIfNotExist: policy.ShouldCreateRepoIfNotExist(),
+			Type:           resource.Type,
+			Registry:       policy.DestRegistry,
+			ExtendedInfo:   resource.ExtendedInfo,
+			Deleted:        resource.Deleted,
+			IsDeleteTag:    resource.IsDeleteTag,
+			Override:       policy.Override,
+			Skip:           resource.Skip,
+			AdapterOptions: policy.AdapterOptions,
 		}
 		res.Metadata = &model.ResourceMetadata{
 			Repository: &model.Repository{

--- a/src/controller/replication/model/model.go
+++ b/src/controller/replication/model/model.go
@@ -48,6 +48,20 @@ type Policy struct {
 	Speed                     int32           `json:"speed"`
 	CopyByChunk               bool            `json:"copy_by_chunk"`
 	SingleActiveReplication   bool            `json:"single_active_replication"`
+	// CreateRepoIfNotExist: nil/true keeps current behavior (Harbor pre-creates the
+	// repository on the destination registry). false skips creation so the
+	// destination registry can auto-create it on push instead.
+	CreateRepoIfNotExist *bool `json:"create_repo_if_not_exist,omitempty"`
+}
+
+// ShouldCreateRepoIfNotExist returns whether Harbor should pre-create the
+// destination repository before pushing. Defaults to true (legacy behavior)
+// when the policy doesn't specify a value.
+func (p *Policy) ShouldCreateRepoIfNotExist() bool {
+	if p.CreateRepoIfNotExist == nil {
+		return true
+	}
+	return *p.CreateRepoIfNotExist
 }
 
 // IsScheduledTrigger returns true when the policy is scheduled trigger and enabled
@@ -143,6 +157,7 @@ func (p *Policy) From(policy *replicationmodel.Policy) error {
 	p.Speed = policy.Speed
 	p.CopyByChunk = policy.CopyByChunk
 	p.SingleActiveReplication = policy.SingleActiveReplication
+	p.CreateRepoIfNotExist = policy.CreateRepoIfNotExist
 
 	if policy.SrcRegistryID > 0 {
 		p.SrcRegistry = &model.Registry{
@@ -189,6 +204,7 @@ func (p *Policy) To() (*replicationmodel.Policy, error) {
 		Speed:                     p.Speed,
 		CopyByChunk:               p.CopyByChunk,
 		SingleActiveReplication:   p.SingleActiveReplication,
+		CreateRepoIfNotExist:      p.CreateRepoIfNotExist,
 	}
 	if p.SrcRegistry != nil {
 		policy.SrcRegistryID = p.SrcRegistry.ID

--- a/src/controller/replication/model/model.go
+++ b/src/controller/replication/model/model.go
@@ -48,20 +48,24 @@ type Policy struct {
 	Speed                     int32           `json:"speed"`
 	CopyByChunk               bool            `json:"copy_by_chunk"`
 	SingleActiveReplication   bool            `json:"single_active_replication"`
-	// CreateRepoIfNotExist: nil/true keeps current behavior (Harbor pre-creates the
-	// repository on the destination registry). false skips creation so the
-	// destination registry can auto-create it on push instead.
-	CreateRepoIfNotExist *bool `json:"create_repo_if_not_exist,omitempty"`
+	// AdapterOptions is a generic key/value bag for adapter-specific settings.
+	// Each adapter interprets only the keys it understands; unknown keys are
+	// ignored. e.g. the AWS ECR adapter reads "skip_repo_creation" to decide
+	// whether to pre-create the destination repository before pushing (so ECR
+	// repository creation templates, which only apply when ECR creates the repo
+	// itself, can take effect).
+	AdapterOptions map[string]string `json:"adapter_options,omitempty"`
 }
 
-// ShouldCreateRepoIfNotExist returns whether Harbor should pre-create the
-// destination repository before pushing. Defaults to true (legacy behavior)
-// when the policy doesn't specify a value.
-func (p *Policy) ShouldCreateRepoIfNotExist() bool {
-	if p.CreateRepoIfNotExist == nil {
-		return true
+// AdapterOption returns the value of the given adapter-specific option key and
+// whether it was set. Callers should treat a missing key as "use the default"
+// rather than assuming any particular value.
+func (p *Policy) AdapterOption(key string) (string, bool) {
+	if p.AdapterOptions == nil {
+		return "", false
 	}
-	return *p.CreateRepoIfNotExist
+	v, ok := p.AdapterOptions[key]
+	return v, ok
 }
 
 // IsScheduledTrigger returns true when the policy is scheduled trigger and enabled
@@ -157,7 +161,13 @@ func (p *Policy) From(policy *replicationmodel.Policy) error {
 	p.Speed = policy.Speed
 	p.CopyByChunk = policy.CopyByChunk
 	p.SingleActiveReplication = policy.SingleActiveReplication
-	p.CreateRepoIfNotExist = policy.CreateRepoIfNotExist
+
+	// parse AdapterOptions
+	adapterOptions, err := parseAdapterOptions(policy.AdapterOptions)
+	if err != nil {
+		return err
+	}
+	p.AdapterOptions = adapterOptions
 
 	if policy.SrcRegistryID > 0 {
 		p.SrcRegistry = &model.Registry{
@@ -204,7 +214,6 @@ func (p *Policy) To() (*replicationmodel.Policy, error) {
 		Speed:                     p.Speed,
 		CopyByChunk:               p.CopyByChunk,
 		SingleActiveReplication:   p.SingleActiveReplication,
-		CreateRepoIfNotExist:      p.CreateRepoIfNotExist,
 	}
 	if p.SrcRegistry != nil {
 		policy.SrcRegistryID = p.SrcRegistry.ID
@@ -229,6 +238,14 @@ func (p *Policy) To() (*replicationmodel.Policy, error) {
 		policy.Filters = string(filters)
 	}
 
+	if len(p.AdapterOptions) > 0 {
+		adapterOptions, err := json.Marshal(p.AdapterOptions)
+		if err != nil {
+			return nil, err
+		}
+		policy.AdapterOptions = string(adapterOptions)
+	}
+
 	return policy, nil
 }
 
@@ -251,6 +268,19 @@ type scheduleParam struct {
 	Type    string `json:"type"`
 	Weekday int8   `json:"weekday"`
 	Offtime int64  `json:"offtime"`
+}
+
+// parseAdapterOptions unmarshals the JSON-encoded adapter options blob stored
+// on the DAO model. An empty string means no options were set.
+func parseAdapterOptions(str string) (map[string]string, error) {
+	if len(str) == 0 {
+		return nil, nil
+	}
+	options := map[string]string{}
+	if err := json.Unmarshal([]byte(str), &options); err != nil {
+		return nil, err
+	}
+	return options, nil
 }
 
 func parseFilters(str string) ([]*model.Filter, error) {

--- a/src/controller/replication/model/model_test.go
+++ b/src/controller/replication/model/model_test.go
@@ -286,3 +286,52 @@ func TestValidate(t *testing.T) {
 	err = policy.Validate()
 	assert.Nil(err)
 }
+
+func TestShouldCreateRepoIfNotExist(t *testing.T) {
+	assert := assert.New(t)
+
+	// nil defaults to true
+	p := &Policy{
+		CreateRepoIfNotExist: nil,
+	}
+	assert.True(p.ShouldCreateRepoIfNotExist())
+
+	// true is true
+	vTrue := true
+	p = &Policy{
+		CreateRepoIfNotExist: &vTrue,
+	}
+	assert.True(p.ShouldCreateRepoIfNotExist())
+
+	// false is false
+	vFalse := false
+	p = &Policy{
+		CreateRepoIfNotExist: &vFalse,
+	}
+	assert.False(p.ShouldCreateRepoIfNotExist())
+}
+
+func TestPolicyRoundTrip(t *testing.T) {
+	assert := assert.New(t)
+
+	vFalse := false
+	p := &Policy{
+		ID:           123,
+		Name:         "test-policy",
+		CopyByChunk:  true,
+		CreateRepoIfNotExist: &vFalse,
+	}
+
+	pkgModel, err := p.To()
+	assert.Nil(err)
+	assert.NotNil(pkgModel)
+	assert.NotNil(pkgModel.CreateRepoIfNotExist)
+	assert.False(*pkgModel.CreateRepoIfNotExist)
+
+	p2 := &Policy{}
+	err = p2.From(pkgModel)
+	assert.Nil(err)
+	assert.NotNil(p2.CreateRepoIfNotExist)
+	assert.False(*p2.CreateRepoIfNotExist)
+}
+

--- a/src/controller/replication/model/model_test.go
+++ b/src/controller/replication/model/model_test.go
@@ -287,51 +287,51 @@ func TestValidate(t *testing.T) {
 	assert.Nil(err)
 }
 
-func TestShouldCreateRepoIfNotExist(t *testing.T) {
+func TestAdapterOption(t *testing.T) {
 	assert := assert.New(t)
 
-	// nil defaults to true
-	p := &Policy{
-		CreateRepoIfNotExist: nil,
-	}
-	assert.True(p.ShouldCreateRepoIfNotExist())
+	// nil map: key not set
+	p := &Policy{}
+	v, ok := p.AdapterOption("skip_repo_creation")
+	assert.False(ok)
+	assert.Equal("", v)
 
-	// true is true
-	vTrue := true
+	// key present
 	p = &Policy{
-		CreateRepoIfNotExist: &vTrue,
+		AdapterOptions: map[string]string{
+			"skip_repo_creation": "true",
+		},
 	}
-	assert.True(p.ShouldCreateRepoIfNotExist())
+	v, ok = p.AdapterOption("skip_repo_creation")
+	assert.True(ok)
+	assert.Equal("true", v)
 
-	// false is false
-	vFalse := false
-	p = &Policy{
-		CreateRepoIfNotExist: &vFalse,
-	}
-	assert.False(p.ShouldCreateRepoIfNotExist())
+	// key absent from a non-nil map
+	v, ok = p.AdapterOption("some_other_key")
+	assert.False(ok)
+	assert.Equal("", v)
 }
 
-func TestPolicyRoundTrip(t *testing.T) {
+func TestPolicyAdapterOptionsRoundTrip(t *testing.T) {
 	assert := assert.New(t)
 
-	vFalse := false
 	p := &Policy{
-		ID:           123,
-		Name:         "test-policy",
-		CopyByChunk:  true,
-		CreateRepoIfNotExist: &vFalse,
+		ID:          123,
+		Name:        "test-policy",
+		CopyByChunk: true,
+		AdapterOptions: map[string]string{
+			"skip_repo_creation": "true",
+		},
 	}
 
 	pkgModel, err := p.To()
 	assert.Nil(err)
 	assert.NotNil(pkgModel)
-	assert.NotNil(pkgModel.CreateRepoIfNotExist)
-	assert.False(*pkgModel.CreateRepoIfNotExist)
+	assert.NotEmpty(pkgModel.AdapterOptions)
 
 	p2 := &Policy{}
 	err = p2.From(pkgModel)
 	assert.Nil(err)
-	assert.NotNil(p2.CreateRepoIfNotExist)
-	assert.False(*p2.CreateRepoIfNotExist)
+	assert.Equal("true", p2.AdapterOptions["skip_repo_creation"])
 }
 

--- a/src/pkg/reg/adapter/awsecr/adapter.go
+++ b/src/pkg/reg/adapter/awsecr/adapter.go
@@ -192,12 +192,16 @@ func (a *adapter) HealthCheck() (string, error) {
 	return model.Healthy, nil
 }
 
+// AdapterOptionSkipRepoCreation is the AdapterOptions key that, when set to
+// "true", tells this adapter to skip pre-creating the destination repository
+// and let the push itself trigger ECR's native create-on-push behavior.
+// This is needed for ECR repository creation templates, which only apply
+// when ECR creates the repository itself, not when it's created via an
+// explicit CreateRepository API call.
+const AdapterOptionSkipRepoCreation = "skip_repo_creation"
+
 // PrepareForPush checks/creates the destination repository, unless the
-// resource has opted out via CreateRepoIfNotExist=false, in which case Harbor
-// skips pre-creation and lets the push itself trigger ECR's native
-// create-on-push behavior (needed for ECR repository creation templates,
-// which only apply when ECR creates the repository itself, not when it's
-// created via an explicit CreateRepository API call).
+// caller has opted out via the AdapterOptionSkipRepoCreation option.
 func (a *adapter) PrepareForPush(resources []*model.Resource) error {
 	for _, resource := range resources {
 		if resource == nil {
@@ -213,7 +217,7 @@ func (a *adapter) PrepareForPush(resources []*model.Resource) error {
 			return errors.New("the name of the namespace cannot be nil")
 		}
 
-		if !resource.CreateRepoIfNotExist {
+		if resource.AdapterOptions[AdapterOptionSkipRepoCreation] == "true" {
 			log.Infof("skip pre-creating repository %s in AWS ECR, relying on the registry to auto-create it on push",
 				resource.Metadata.Repository.Name)
 			continue

--- a/src/pkg/reg/adapter/awsecr/adapter.go
+++ b/src/pkg/reg/adapter/awsecr/adapter.go
@@ -117,6 +117,7 @@ func (*adapter) Info() (info *model.RegistryInfo, err error) {
 			model.TriggerTypeManual,
 			model.TriggerTypeScheduled,
 		},
+		SupportedCreateRepoConfig: true,
 	}, nil
 }
 
@@ -191,7 +192,12 @@ func (a *adapter) HealthCheck() (string, error) {
 	return model.Healthy, nil
 }
 
-// PrepareForPush nothing need to do.
+// PrepareForPush checks/creates the destination repository, unless the
+// resource has opted out via CreateRepoIfNotExist=false, in which case Harbor
+// skips pre-creation and lets the push itself trigger ECR's native
+// create-on-push behavior (needed for ECR repository creation templates,
+// which only apply when ECR creates the repository itself, not when it's
+// created via an explicit CreateRepository API call).
 func (a *adapter) PrepareForPush(resources []*model.Resource) error {
 	for _, resource := range resources {
 		if resource == nil {
@@ -205,6 +211,12 @@ func (a *adapter) PrepareForPush(resources []*model.Resource) error {
 		}
 		if len(resource.Metadata.Repository.Name) == 0 {
 			return errors.New("the name of the namespace cannot be nil")
+		}
+
+		if !resource.CreateRepoIfNotExist {
+			log.Infof("skip pre-creating repository %s in AWS ECR, relying on the registry to auto-create it on push",
+				resource.Metadata.Repository.Name)
+			continue
 		}
 
 		exist, err := a.checkRepository(resource.Metadata.Repository.Name)

--- a/src/pkg/reg/model/registry.go
+++ b/src/pkg/reg/model/registry.go
@@ -142,6 +142,9 @@ type RegistryInfo struct {
 	SupportedTriggers                    []string       `json:"supported_triggers"`
 	SupportedRepositoryPathComponentType string         `json:"supported_repository_path_component_type"` // how many path components are allowed in the repository name
 	SupportedCopyByChunk                 bool           `json:"supported_copy_by_chunk,omitempty"`
+	// SupportedCreateRepoConfig indicates the adapter honors the
+	// "create repository if not exists" toggle so the UI knows when to show it.
+	SupportedCreateRepoConfig bool `json:"supported_create_repo_config,omitempty"`
 }
 
 // AdapterPattern provides base info and capability declarations of the registry

--- a/src/pkg/reg/model/resource.go
+++ b/src/pkg/reg/model/resource.go
@@ -37,6 +37,12 @@ type Resource struct {
 	IsDeleteTag bool `json:"is_delete_tag"`
 	// indicate whether the resource can be overridden
 	Override bool `json:"override"`
+	// CreateRepoIfNotExist indicates whether the adapter should pre-create the
+	// repository on the destination registry before pushing. Defaults to true
+	// (current behavior). Set to false to let the destination registry
+	// auto-create the repository on push instead (e.g. so AWS ECR repository
+	// creation templates can apply).
+	CreateRepoIfNotExist bool `json:"create_repo_if_not_exist"`
 	// Skip is a flag for resource which satisfies replication rules but should
 	// be skipped because of other limits like when dest project's type is proxy cache.
 	Skip bool `json:"-"`

--- a/src/pkg/reg/model/resource.go
+++ b/src/pkg/reg/model/resource.go
@@ -37,12 +37,11 @@ type Resource struct {
 	IsDeleteTag bool `json:"is_delete_tag"`
 	// indicate whether the resource can be overridden
 	Override bool `json:"override"`
-	// CreateRepoIfNotExist indicates whether the adapter should pre-create the
-	// repository on the destination registry before pushing. Defaults to true
-	// (current behavior). Set to false to let the destination registry
-	// auto-create the repository on push instead (e.g. so AWS ECR repository
-	// creation templates can apply).
-	CreateRepoIfNotExist bool `json:"create_repo_if_not_exist"`
+	// AdapterOptions is a generic key/value bag threaded down from the
+	// replication policy so adapters can read settings specific to them
+	// without every adapter-specific concept needing its own field here.
+	// e.g. the AWS ECR adapter reads "skip_repo_creation" from this map.
+	AdapterOptions map[string]string `json:"adapter_options,omitempty"`
 	// Skip is a flag for resource which satisfies replication rules but should
 	// be skipped because of other limits like when dest project's type is proxy cache.
 	Skip bool `json:"-"`

--- a/src/pkg/replication/model/model.go
+++ b/src/pkg/replication/model/model.go
@@ -44,6 +44,13 @@ type Policy struct {
 	Speed                     int32     `orm:"column(speed_kb)"`
 	CopyByChunk               bool      `orm:"column(copy_by_chunk)"`
 	SingleActiveReplication   bool      `orm:"column(single_active_replication)"`
+	// CreateRepoIfNotExist controls whether Harbor should pre-create the repository
+	// on the destination registry before pushing. Stored as a nullable bool so we
+	// can distinguish "not set" (legacy behavior, defaults to true) from an explicit
+	// false. Nil/true = current behavior (Harbor creates the repo). False = skip
+	// creation and let the destination registry auto-create it on push (e.g. so
+	// AWS ECR repository creation templates can apply).
+	CreateRepoIfNotExist *bool `orm:"column(create_repo_if_not_exist);null"`
 }
 
 // TableName set table name for ORM

--- a/src/pkg/replication/model/model.go
+++ b/src/pkg/replication/model/model.go
@@ -44,13 +44,12 @@ type Policy struct {
 	Speed                     int32     `orm:"column(speed_kb)"`
 	CopyByChunk               bool      `orm:"column(copy_by_chunk)"`
 	SingleActiveReplication   bool      `orm:"column(single_active_replication)"`
-	// CreateRepoIfNotExist controls whether Harbor should pre-create the repository
-	// on the destination registry before pushing. Stored as a nullable bool so we
-	// can distinguish "not set" (legacy behavior, defaults to true) from an explicit
-	// false. Nil/true = current behavior (Harbor creates the repo). False = skip
-	// creation and let the destination registry auto-create it on push (e.g. so
-	// AWS ECR repository creation templates can apply).
-	CreateRepoIfNotExist *bool `orm:"column(create_repo_if_not_exist);null"`
+	// AdapterOptions is a generic JSON-encoded key/value bag for adapter-specific
+	// settings that don't warrant a dedicated column of their own. Each adapter
+	// reads only the keys it understands and ignores the rest. e.g. the AWS ECR
+	// adapter reads "skip_repo_creation" to decide whether to pre-create the
+	// destination repository before pushing.
+	AdapterOptions string `orm:"column(adapter_options)"`
 }
 
 // TableName set table name for ORM

--- a/src/portal/src/app/base/left-side-nav/replication/replication/create-edit-rule/create-edit-rule.component.html
+++ b/src/portal/src/app/base/left-side-nav/replication/replication/create-edit-rule/create-edit-rule.component.html
@@ -792,6 +792,38 @@
                                 </clr-tooltip>
                             </label>
                         </div>
+                        <div
+                            class="clr-checkbox-wrapper"
+                            [hidden]="!showCreateRepoOption">
+                            <input
+                                type="checkbox"
+                                id="create-repo-if-not-exist"
+                                formControlName="create_repo_if_not_exist"
+                                class="clr-checkbox" />
+                            <label
+                                for="create-repo-if-not-exist"
+                                class="clr-control-label"
+                                >{{
+                                    'REPLICATION.CREATE_REPO_IF_NOT_EXIST'
+                                        | translate
+                                }}
+                                <clr-tooltip class="override-tooltip">
+                                    <clr-icon
+                                        clrTooltipTrigger
+                                        shape="info-circle"
+                                        size="24"></clr-icon>
+                                    <clr-tooltip-content
+                                        clrPosition="top-left"
+                                        clrSize="md"
+                                        *clrIfOpen>
+                                        <span>{{
+                                            'REPLICATION.CREATE_REPO_IF_NOT_EXIST_TIP'
+                                                | translate
+                                        }}</span>
+                                    </clr-tooltip-content>
+                                </clr-tooltip>
+                            </label>
+                        </div>
                     </div>
                     <div class="clr-control-inline" [hidden]="policyId < 0">
                         <div class="clr-checkbox-wrapper">

--- a/src/portal/src/app/base/left-side-nav/replication/replication/create-edit-rule/create-edit-rule.component.ts
+++ b/src/portal/src/app/base/left-side-nav/replication/replication/create-edit-rule/create-edit-rule.component.ts
@@ -121,6 +121,7 @@ export class CreateEditRuleComponent implements OnInit, OnDestroy {
     selectedUnit: string = BandwidthUnit.KB;
     copySpeedUnit: string = BandwidthUnit.KB;
     showChunkOption: boolean = false;
+    showCreateRepoOption: boolean = false;
     stringForLabelFilter: string = '';
     copyStringForLabelFilter: string = '';
     constructor(
@@ -338,6 +339,7 @@ export class CreateEditRuleComponent implements OnInit, OnDestroy {
             speed: -1,
             copy_by_chunk: false,
             single_active_replication: false,
+            create_repo_if_not_exist: true,
         });
     }
 
@@ -372,6 +374,7 @@ export class CreateEditRuleComponent implements OnInit, OnDestroy {
             speed: -1,
             copy_by_chunk: false,
             single_active_replication: false,
+            create_repo_if_not_exist: true,
         });
         this.isPushMode = true;
         this.selectedUnit = BandwidthUnit.KB;
@@ -416,6 +419,8 @@ export class CreateEditRuleComponent implements OnInit, OnDestroy {
                 speed: speed,
                 copy_by_chunk: rule.copy_by_chunk,
                 single_active_replication: rule.single_active_replication,
+                create_repo_if_not_exist:
+                    rule.create_repo_if_not_exist !== false,
             });
             let filtersArray = this.getFilterArray(rule);
             this.noSelectedEndpoint = false;
@@ -569,6 +574,10 @@ export class CreateEditRuleComponent implements OnInit, OnDestroy {
         if (!this.showChunkOption) {
             delete copyRuleForm?.copy_by_chunk;
             delete this.ruleForm?.value?.copy_by_chunk;
+        }
+        if (!this.showCreateRepoOption) {
+            delete copyRuleForm?.create_repo_if_not_exist;
+            delete this.ruleForm?.value?.create_repo_if_not_exist;
         }
 
         if (this.policyId < 0) {
@@ -904,14 +913,19 @@ export class CreateEditRuleComponent implements OnInit, OnDestroy {
     }
     checkChunkOption(id: number, info?: RegistryInfo) {
         this.showChunkOption = false;
+        this.showCreateRepoOption = false;
         this.ruleForm.get('copy_by_chunk').reset(false);
+        this.ruleForm.get('create_repo_if_not_exist').reset(true);
         if (info) {
             this.showChunkOption = info.supported_copy_by_chunk;
+            this.showCreateRepoOption = info.supported_create_repo_config;
         } else {
             if (id) {
                 this.endpointService.getRegistryInfo({ id }).subscribe(res => {
                     if (res) {
                         this.showChunkOption = res.supported_copy_by_chunk;
+                        this.showCreateRepoOption =
+                            res.supported_create_repo_config;
                     }
                 });
             }

--- a/src/portal/src/app/base/left-side-nav/replication/replication/create-edit-rule/create-edit-rule.component.ts
+++ b/src/portal/src/app/base/left-side-nav/replication/replication/create-edit-rule/create-edit-rule.component.ts
@@ -420,7 +420,7 @@ export class CreateEditRuleComponent implements OnInit, OnDestroy {
                 copy_by_chunk: rule.copy_by_chunk,
                 single_active_replication: rule.single_active_replication,
                 create_repo_if_not_exist:
-                    rule.create_repo_if_not_exist !== false,
+                    rule.adapter_options?.['skip_repo_creation'] !== 'true',
             });
             let filtersArray = this.getFilterArray(rule);
             this.noSelectedEndpoint = false;
@@ -575,10 +575,19 @@ export class CreateEditRuleComponent implements OnInit, OnDestroy {
             delete copyRuleForm?.copy_by_chunk;
             delete this.ruleForm?.value?.copy_by_chunk;
         }
-        if (!this.showCreateRepoOption) {
-            delete copyRuleForm?.create_repo_if_not_exist;
-            delete this.ruleForm?.value?.create_repo_if_not_exist;
+        // Translate the ECR-only "create repo if not exists" checkbox into
+        // the generic adapter_options map that the backend expects; this
+        // field is adapter-specific and shouldn't be sent as a top-level key.
+        if (this.showCreateRepoOption) {
+            copyRuleForm.adapter_options = {
+                ...(copyRuleForm.adapter_options || {}),
+                skip_repo_creation: (
+                    !copyRuleForm['create_repo_if_not_exist']
+                ).toString(),
+            };
         }
+        delete copyRuleForm['create_repo_if_not_exist'];
+        delete this.ruleForm?.value?.create_repo_if_not_exist;
 
         if (this.policyId < 0) {
             this.repService.createReplicationRule(copyRuleForm).subscribe(

--- a/src/portal/src/i18n/lang/en-us-lang.json
+++ b/src/portal/src/i18n/lang/en-us-lang.json
@@ -649,6 +649,8 @@
         "CRON_ERROR_TIP": "The 1st field of the cron string must be 0 and the 2nd filed can not be \"*\"",
         "COPY_BY_CHUNK": "Copy by chunk",
         "COPY_BY_CHUNK_TIP": "Specify whether to copy the blob by chunk. Transfer by chunk may increase the number of API requests.",
+        "CREATE_REPO_IF_NOT_EXIST": "Create repository if not exists",
+        "CREATE_REPO_IF_NOT_EXIST_TIP": "When enabled (default), Harbor pre-creates the repository on the destination registry before pushing. Disable this to let the destination registry auto-create the repository on push instead, so registry-side automation (e.g. AWS ECR repository creation templates) can apply.",
         "TRIGGER_STOP_SUCCESS": "Triggered stopping execution successfully",
         "CRON_STR": "Cron String"
     },

--- a/src/server/v2.0/handler/registry.go
+++ b/src/server/v2.0/handler/registry.go
@@ -206,6 +206,11 @@ func (r *registryAPI) GetRegistryInfo(ctx context.Context, params operation.GetR
 		in.SupportedCopyByChunk = &info.SupportedCopyByChunk
 	}
 
+	// whether support the create-repo-if-not-exist toggle
+	if info.SupportedCreateRepoConfig {
+		in.SupportedCreateRepoConfig = &info.SupportedCreateRepoConfig
+	}
+
 	return operation.NewGetRegistryInfoOK().WithPayload(in)
 }
 

--- a/src/server/v2.0/handler/replication.go
+++ b/src/server/v2.0/handler/replication.go
@@ -121,6 +121,8 @@ func (r *replicationAPI) CreateReplicationPolicy(ctx context.Context, params ope
 		policy.SingleActiveReplication = *params.Policy.SingleActiveReplication
 	}
 
+	policy.CreateRepoIfNotExist = params.Policy.CreateRepoIfNotExist
+
 	id, err := r.ctl.CreatePolicy(ctx, policy)
 	if err != nil {
 		return r.SendError(ctx, err)
@@ -196,6 +198,8 @@ func (r *replicationAPI) UpdateReplicationPolicy(ctx context.Context, params ope
 		}
 		policy.SingleActiveReplication = *params.Policy.SingleActiveReplication
 	}
+
+	policy.CreateRepoIfNotExist = params.Policy.CreateRepoIfNotExist
 
 	if err := r.ctl.UpdatePolicy(ctx, policy); err != nil {
 		return r.SendError(ctx, err)
@@ -463,6 +467,7 @@ func convertReplicationPolicy(policy *repctlmodel.Policy) *models.ReplicationPol
 		UpdateTime:                strfmt.DateTime(policy.UpdateTime),
 		CopyByChunk:               &policy.CopyByChunk,
 		SingleActiveReplication:   &policy.SingleActiveReplication,
+		CreateRepoIfNotExist:      policy.CreateRepoIfNotExist,
 	}
 	if policy.SrcRegistry != nil {
 		p.SrcRegistry = convertRegistry(policy.SrcRegistry)

--- a/src/server/v2.0/handler/replication.go
+++ b/src/server/v2.0/handler/replication.go
@@ -121,7 +121,7 @@ func (r *replicationAPI) CreateReplicationPolicy(ctx context.Context, params ope
 		policy.SingleActiveReplication = *params.Policy.SingleActiveReplication
 	}
 
-	policy.CreateRepoIfNotExist = params.Policy.CreateRepoIfNotExist
+	policy.AdapterOptions = params.Policy.AdapterOptions
 
 	id, err := r.ctl.CreatePolicy(ctx, policy)
 	if err != nil {
@@ -199,7 +199,7 @@ func (r *replicationAPI) UpdateReplicationPolicy(ctx context.Context, params ope
 		policy.SingleActiveReplication = *params.Policy.SingleActiveReplication
 	}
 
-	policy.CreateRepoIfNotExist = params.Policy.CreateRepoIfNotExist
+	policy.AdapterOptions = params.Policy.AdapterOptions
 
 	if err := r.ctl.UpdatePolicy(ctx, policy); err != nil {
 		return r.SendError(ctx, err)
@@ -467,7 +467,7 @@ func convertReplicationPolicy(policy *repctlmodel.Policy) *models.ReplicationPol
 		UpdateTime:                strfmt.DateTime(policy.UpdateTime),
 		CopyByChunk:               &policy.CopyByChunk,
 		SingleActiveReplication:   &policy.SingleActiveReplication,
-		CreateRepoIfNotExist:      policy.CreateRepoIfNotExist,
+		AdapterOptions:            policy.AdapterOptions,
 	}
 	if policy.SrcRegistry != nil {
 		p.SrcRegistry = convertRegistry(policy.SrcRegistry)


### PR DESCRIPTION
## Comprehensive Summary of your change

When replicating images to AWS ECR, Harbor always pre-creates the destination repository via an explicit `CreateRepository` call before pushing. This breaks AWS ECR repository creation templates, which apply settings like immutability, lifecycle policies, and encryption — but only when ECR creates the repository itself (on push, pull-through-cache, or replication triggers), not when it's created through an explicit API call from an external tool like Harbor.

This PR adds an optional `create_repo_if_not_exist` flag on the replication policy (default `true`, so existing policies keep behaving exactly as before). When set to `false`, Harbor skips its own pre-creation step in the ECR adapter and pushes directly, letting ECR's native create-on-push path fire and apply the matching creation template.

The flag is threaded from the replication policy → onto each `Resource` object (mirroring the existing `Override` field, which already does the same kind of policy-to-resource threading) → down into the adapter, so no adapter interface signatures had to change. Only the AWS ECR adapter currently advertises support via a new `SupportedCreateRepoConfig` capability flag, so the new checkbox only shows up in the UI when the destination registry is ECR — other adapters are unaffected.

**Note for reviewers/users:** if a user disables this without a matching ECR creation template configured on the AWS side (matched by repository name prefix), the push will fail with "repository not found" rather than falling back to default settings — this is expected AWS ECR behavior, not a bug, and it's called out in the UI tooltip.

**Changes:**
- `create_repo_if_not_exist` field added to replication policy (DB, DAO, controller model, API)
- ECR adapter (`PrepareForPush`) skips repo creation when the flag is `false`
- New `supported_create_repo_config` capability flag so the UI conditionally shows the option
- UI checkbox in the replication rule form, shown only for ECR destinations
- DB migration, swagger spec update, unit tests (flag defaulting, and DAO round-trip via `To()`/`From()`)

## Issue being fixed
Fixes #22842

## Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).