### PR TITLE
fix: safely handle missing dry_run in retention executions

### DIFF
--- a/src/controller/retention/controller.go
+++ b/src/controller/retention/controller.go
@@ -336,6 +336,7 @@ func (r *defaultController) ListRetentionExecs(ctx context.Context, policyID int
 }
 
 func convertExecution(exec *task.Execution) *retention.Execution {
+	dryRun, _ := exec.ExtraAttrs["dry_run"].(bool)
 	retentionExec := &retention.Execution{
 		ID:        exec.ID,
 		PolicyID:  exec.VendorID,
@@ -343,7 +344,7 @@ func convertExecution(exec *task.Execution) *retention.Execution {
 		EndTime:   exec.EndTime,
 		Status:    exec.Status,
 		Trigger:   exec.Trigger,
-		DryRun:    exec.ExtraAttrs["dry_run"].(bool),
+		DryRun:    dryRun,
 		Type:      exec.VendorType,
 	}
 


### PR DESCRIPTION
## **SUMMARY**

This PR prevents a runtime panic when converting retention execution records that do not contain the `dry_run` attribute in `ExtraAttrs`. The change updates `src/controller/retention/controller.go` to safely read the optional field while preserving the existing behavior for valid execution records.

## **FIX**

```go
dryRun, _ := exec.ExtraAttrs["dry_run"].(bool)
```
  
