### PR TITLE
fix: avoid panic in retention execution conversion on missing dry_run

### DIFF
--- a/src/controller/retention/controller.go
+++ b/src/controller/retention/controller.go
@@ -343,12 +343,17 @@ func convertExecution(exec *task.Execution) *retention.Execution {
 		EndTime:   exec.EndTime,
 		Status:    exec.Status,
 		Trigger:   exec.Trigger,
-		DryRun:    exec.ExtraAttrs["dry_run"].(bool),
+		DryRun:    false,
 		Type:      exec.VendorType,
 	}
 
-	if operator, ok := exec.ExtraAttrs["operator"].(string); ok {
-		retentionExec.Operator = operator
+	if exec.ExtraAttrs != nil {
+		if dryRun, ok := exec.ExtraAttrs["dry_run"].(bool); ok {
+			retentionExec.DryRun = dryRun
+		}
+		if operator, ok := exec.ExtraAttrs["operator"].(string); ok {
+			retentionExec.Operator = operator
+		}
 	}
 
 	return retentionExec

--- a/src/controller/retention/controller_test.go
+++ b/src/controller/retention/controller_test.go
@@ -344,3 +344,66 @@ func (f *fakeLauncher) Stop(ctx context.Context, executionID int64) error {
 func (f *fakeLauncher) Launch(ctx context.Context, policy *policy.Metadata, executionID int64, isDryRun bool) (int64, error) {
 	return 0, nil
 }
+
+func (s *ControllerTestSuite) TestConvertExecution() {
+	// Case 1: ExtraAttrs is nil
+	e1 := &task.Execution{
+		ID:         1,
+		VendorID:   10,
+		Status:     "Success",
+		VendorType: "RETENTION",
+		ExtraAttrs: nil,
+	}
+	r1 := convertExecution(e1)
+	s.Equal(int64(1), r1.ID)
+	s.Equal(int64(10), r1.PolicyID)
+	s.Equal("Success", r1.Status)
+	s.False(r1.DryRun)
+	s.Empty(r1.Operator)
+
+	// Case 2: ExtraAttrs is empty
+	e2 := &task.Execution{
+		ID:         2,
+		VendorID:   10,
+		Status:     "Success",
+		VendorType: "RETENTION",
+		ExtraAttrs: map[string]any{},
+	}
+	r2 := convertExecution(e2)
+	s.Equal(int64(2), r2.ID)
+	s.False(r2.DryRun)
+	s.Empty(r2.Operator)
+
+	// Case 3: ExtraAttrs has invalid types
+	e3 := &task.Execution{
+		ID:         3,
+		VendorID:   10,
+		Status:     "Success",
+		VendorType: "RETENTION",
+		ExtraAttrs: map[string]any{
+			"dry_run":  "not-a-bool",
+			"operator": 12345,
+		},
+	}
+	r3 := convertExecution(e3)
+	s.Equal(int64(3), r3.ID)
+	s.False(r3.DryRun)
+	s.Empty(r3.Operator)
+
+	// Case 4: ExtraAttrs has valid types
+	e4 := &task.Execution{
+		ID:         4,
+		VendorID:   10,
+		Status:     "Success",
+		VendorType: "RETENTION",
+		ExtraAttrs: map[string]any{
+			"dry_run":  true,
+			"operator": "admin",
+		},
+	}
+	r4 := convertExecution(e4)
+	s.Equal(int64(4), r4.ID)
+	s.True(r4.DryRun)
+	s.Equal("admin", r4.Operator)
+}
+


### PR DESCRIPTION
# Comprehensive Summary of your change

This PR prevents a service panic (HTTP 500) in the retention controller by introducing safety checks when converting task executions to retention executions. 

Previously, `convertExecution` in `src/controller/retention/controller.go` directly asserted `exec.ExtraAttrs["dry_run"].(bool)`. If `extra_attrs` was nil, missing the `"dry_run"` key, or if the value was not a boolean, this triggered a runtime panic (`interface conversion: interface {} is nil, not bool`), failing the entire execution history listing request.

**Changes introduced:**
1. **Safety guards in `convertExecution`:** Default `DryRun` to `false` and safely extract `dry_run` and `operator` only if `ExtraAttrs` is non-nil and the keys contain the expected types (`bool` and `string`).
2. **Regression tests in `controller_test.go`:** Added `TestConvertExecution` validating execution object conversion under 4 distinct scenarios:
   - `ExtraAttrs` is `nil`
   - `ExtraAttrs` is empty (`map[string]any{}`)
   - `ExtraAttrs` contains invalid type assignments (gracefully fallback to defaults)
   - `ExtraAttrs` contains valid entries

# Issue being fixed
Fixes #23506

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed: `release-note/ignore-for-release`
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in website repository.