### PR TITLE
fix: use LEFT JOIN in projectBasicSQL to include projects without quota records

### DIFF
--- a/src/pkg/exporter/project_collector.go
+++ b/src/pkg/exporter/project_collector.go
@@ -32,11 +32,11 @@ var (
 	FROM project INNER JOIN project_metadata ON project.project_id=project_metadata.project_id
 	WHERE project.deleted=FALSE AND project_metadata.name='public'
 	GROUP BY project_metadata.value;`
-	projectBasicSQL = `SELECT project.project_id, project.name, project_metadata.value AS public, quota.hard AS quota, quota_usage.used AS usage FROM project
-	INNER JOIN project_metadata ON (project.project_id = project_metadata.project_id)
-	INNER JOIN quota ON project.project_id = CAST(quota.reference_id AS Integer)
-	INNER JOIN quota_usage ON project.project_id = CAST(quota_usage.reference_id AS Integer)
-	WHERE quota.reference='project' AND quota_usage.reference='project' AND project.deleted=FALSE AND project_metadata.name='public';`
+	projectBasicSQL = `SELECT project.project_id, project.name, COALESCE(project_metadata.value, 'false') AS public, COALESCE(quota.hard, '{}') AS quota, COALESCE(quota_usage.used, '{}') AS usage FROM project
+	LEFT JOIN project_metadata ON (project.project_id = project_metadata.project_id AND project_metadata.name='public')
+	LEFT JOIN quota ON (project.project_id::text = quota.reference_id AND quota.reference='project')
+	LEFT JOIN quota_usage ON (project.project_id::text = quota_usage.reference_id AND quota_usage.reference='project')
+	WHERE project.deleted=FALSE;`
 	projectMemberSQL = `SELECT project.project_id, COUNT(project.project_id) AS member_total
 	FROM project INNER JOIN project_member ON project.project_id=project_member.project_id
 	WHERE project.deleted=FALSE AND project_member.entity_type='u'

--- a/src/pkg/exporter/project_collector_test.go
+++ b/src/pkg/exporter/project_collector_test.go
@@ -29,6 +29,7 @@ var (
 	eve      = models.User{Username: "eve", Password: "password", Email: "eve@test.com"}
 	testPro1 = proModels.Project{OwnerID: 1, Name: "test1", Metadata: map[string]string{"public": "true"}}
 	testPro2 = proModels.Project{OwnerID: 1, Name: "test2", Metadata: map[string]string{"public": "false"}}
+	testPro3 = proModels.Project{OwnerID: 1, Name: "test3", Metadata: map[string]string{"public": "false"}}
 	rs1      = qtypes.ResourceList{qtypes.ResourceStorage: 100}
 	rs2      = qtypes.ResourceList{qtypes.ResourceStorage: 200}
 	repo1    = model.RepoRecord{Name: "repo1"}
@@ -65,8 +66,14 @@ func setupTest(t *testing.T) {
 	if err != nil {
 		t.Errorf("project creating %v", err)
 	}
+	// testPro3 has no quota records — simulates quota_per_project_enable=false
+	proID3, err := proctl.Ctl.Create(ctx, &testPro3)
+	if err != nil {
+		t.Errorf("project creating %v", err)
+	}
 	testPro1.ProjectID = proID1
 	testPro2.ProjectID = proID2
+	testPro3.ProjectID = proID3
 
 	// Create quota for project
 	quotactl.Ctl.Create(ctx, "project", strconv.Itoa(int(testPro1.ProjectID)), rs1)
@@ -125,14 +132,14 @@ func setupTest(t *testing.T) {
 }
 
 func tearDownTest(t *testing.T) {
-	dao.GetOrmer().Raw("delete from project_member where project_id in (?, ?)", []int64{testPro1.ProjectID, testPro2.ProjectID}).Exec()
-	dao.GetOrmer().Raw("delete from project_metadata where project_id in (?, ?)", []int64{testPro1.ProjectID, testPro2.ProjectID}).Exec()
-	dao.GetOrmer().Raw("delete from quota where reference=\"project\" and reference_id in (?, ?)", []int64{testPro1.ProjectID, testPro2.ProjectID}).Exec()
-	dao.GetOrmer().Raw("delete from quota_usage where reference=\"project\" and reference_id in (?, ?)", []int64{testPro1.ProjectID, testPro2.ProjectID}).Exec()
-	dao.GetOrmer().Raw("delete from project where project_id in (?, ?)", []int64{testPro1.ProjectID, testPro2.ProjectID}).Exec()
-	dao.GetOrmer().Raw("delete from artifact where project_id in (?, ?)", []int64{testPro1.ProjectID, testPro2.ProjectID}).Exec()
-	dao.GetOrmer().Raw("delete from repository where project_id in (?, ?)", []int64{testPro1.ProjectID, testPro2.ProjectID}).Exec()
-	dao.GetOrmer().Raw("delete from cve_allowlist where project_id in (?, ?)", []int64{testPro1.ProjectID, testPro2.ProjectID}).Exec()
+	dao.GetOrmer().Raw("delete from project_member where project_id in (?, ?, ?)", []int64{testPro1.ProjectID, testPro2.ProjectID, testPro3.ProjectID}).Exec()
+	dao.GetOrmer().Raw("delete from project_metadata where project_id in (?, ?, ?)", []int64{testPro1.ProjectID, testPro2.ProjectID, testPro3.ProjectID}).Exec()
+	dao.GetOrmer().Raw("delete from quota where reference=\"project\" and reference_id in (?, ?, ?)", []int64{testPro1.ProjectID, testPro2.ProjectID, testPro3.ProjectID}).Exec()
+	dao.GetOrmer().Raw("delete from quota_usage where reference=\"project\" and reference_id in (?, ?, ?)", []int64{testPro1.ProjectID, testPro2.ProjectID, testPro3.ProjectID}).Exec()
+	dao.GetOrmer().Raw("delete from project where project_id in (?, ?, ?)", []int64{testPro1.ProjectID, testPro2.ProjectID, testPro3.ProjectID}).Exec()
+	dao.GetOrmer().Raw("delete from artifact where project_id in (?, ?, ?)", []int64{testPro1.ProjectID, testPro2.ProjectID, testPro3.ProjectID}).Exec()
+	dao.GetOrmer().Raw("delete from repository where project_id in (?, ?, ?)", []int64{testPro1.ProjectID, testPro2.ProjectID, testPro3.ProjectID}).Exec()
+	dao.GetOrmer().Raw("delete from cve_allowlist where project_id in (?, ?, ?)", []int64{testPro1.ProjectID, testPro2.ProjectID, testPro3.ProjectID}).Exec()
 	dao.GetOrmer().Raw("delete from harbor_user where user_id in (?, ?, ?)", []int{alice.UserID, bob.UserID, eve.UserID}).Exec()
 }
 
@@ -166,5 +173,14 @@ func (c *ProjectCollectorTestSuite) TestProjectCollector() {
 	c.Equalf(pMap[testPro2.ProjectID].MemberTotal, float64(3), "pMap %v", pMap)
 	c.Equalf(pMap[testPro2.ProjectID].PullTotal, float64(0), "pMap %v", pMap)
 	c.Equalf(pMap[testPro2.ProjectID].Artifact["IMAGE"].ArtifactTotal, float64(1), "pMap %v", pMap)
+
+	// testPro3 has no quota records (simulates quota_per_project_enable=false).
+	// Verify it is still included in the map with zero quota/usage rather than
+	// being silently dropped and logged as "project not found".
+	c.Containsf(pMap, testPro3.ProjectID, "project without quota records should appear in pMap")
+	c.Equalf(pMap[testPro3.ProjectID].Name, testPro3.Name, "pMap %v", pMap)
+	c.Equalf(strconv.FormatBool(pMap[testPro3.ProjectID].Public), testPro3.Metadata["public"], "pMap %v", pMap)
+	c.Equalf(pMap[testPro3.ProjectID].Quota, "{}", "project without quota record should have empty quota")
+	c.Equalf(pMap[testPro3.ProjectID].Usage, "{}", "project without quota record should have empty usage")
 
 }


### PR DESCRIPTION
## What does this PR fix?

When `quota_per_project_enable` is `false`, Harbor does not create rows in the `quota` or `quota_usage` tables for new projects. The exporter's `projectBasicSQL` used `INNER JOIN` on both tables, so any project missing those rows was silently excluded from the in-memory project map built on each scrape.

The three subsequent collector functions (`updateProjectMemberInfo`, `updateProjectRepoInfo`, `updateProjectArtifactInfo`) query those same projects via independent JOINs on the `project` table directly, and call `log.Errorf` for each project ID not found in the map. With a large number of projects missing quota records this produces hundreds of error log writes per scrape, increasing scrape latency and risking Prometheus timeouts that drop all Harbor metrics.

## Changes

- **`src/pkg/exporter/project_collector.go`**: Convert `projectBasicSQL` from `INNER JOIN` to `LEFT JOIN` on `quota`, `quota_usage`, and `project_metadata`. Join-condition filtering (e.g. `quota.reference='project'`, `project_metadata.name='public'`) is moved into the `ON` clause as required for correct `LEFT JOIN` semantics. `COALESCE` defaults ensure projects without quota records emit `{}` (storage = 0) rather than being dropped. The quota join now casts `project_id` to text rather than casting `reference_id` to integer, which is safer if the quota table ever contains non-integer reference IDs.

- **`src/pkg/exporter/project_collector_test.go`**: Add `testPro3`, a project created without quota records, and assert it appears in the collector map with empty quota/usage values — covering the previously broken path.

## Testing

Existing unit tests continue to pass for projects with quota records. The new `testPro3` case verifies the fix.

Tested against a live Harbor instance where `quota_per_project_enable=false` and 529 of 611 projects had no quota rows — after the fix, all 611 projects appear in the map and the `project not found` error flood is eliminated.

## Notes

- No database schema changes.
- No behavioural change for projects that have quota records.
- A GitHub issue will be filed to track this; the branch will be renamed once an issue number is assigned.

Signed-off-by: cdarninsuang <cdarninsuang@bamfunds.com>