### PR TITLE
fix: avoid session fallback when Authorization header is present

### DIFF
--- a/src/server/middleware/security/security.go
+++ b/src/server/middleware/security/security.go
@@ -53,7 +53,16 @@ func Middleware(skippers ...middleware.Skipper) func(http.Handler) http.Handler 
 		} else {
 			log.Warningf("failed to get auth mode: %v", err)
 		}
+		// When Authorization is provided (e.g. Swagger UI "Authorize"), do not
+		// fall back to the portal session. Failed credentials must not silently
+		// use the logged-in user (https://github.com/goharbor/harbor/issues/7704).
+		hasAuthorization := r.Header.Get("Authorization") != ""
 		for _, generator := range generators {
+			if hasAuthorization {
+				if _, ok := generator.(*session); ok {
+					continue
+				}
+			}
 			if ctx := generator.Generate(r); ctx != nil {
 				r = r.WithContext(security.NewContext(r.Context(), ctx))
 				break

--- a/src/server/middleware/security/security.go
+++ b/src/server/middleware/security/security.go
@@ -16,6 +16,7 @@ package security
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/goharbor/harbor/src/common/security"
 	"github.com/goharbor/harbor/src/lib"
@@ -53,10 +54,14 @@ func Middleware(skippers ...middleware.Skipper) func(http.Handler) http.Handler 
 		} else {
 			log.Warningf("failed to get auth mode: %v", err)
 		}
-		// When Authorization is provided (e.g. Swagger UI "Authorize"), do not
-		// fall back to the portal session. Failed credentials must not silently
-		// use the logged-in user (https://github.com/goharbor/harbor/issues/7704).
-		hasAuthorization := r.Header.Get("Authorization") != ""
+		// When Basic/Bearer Authorization is provided (e.g. Swagger UI "Authorize"),
+		// do not fall back to the portal session. Failed credentials must not
+		// silently use the logged-in user (https://github.com/goharbor/harbor/issues/7704).
+		// Only Harbor-supported schemes skip session; non-standard Authorization
+		// values (e.g. injected by proxies) must not disable session auth.
+		authHeader := strings.ToLower(r.Header.Get("Authorization"))
+		hasAuthorization := strings.HasPrefix(authHeader, "basic ") ||
+			strings.HasPrefix(authHeader, "bearer ")
 		for _, generator := range generators {
 			if hasAuthorization {
 				if _, ok := generator.(*session); ok {

--- a/src/server/middleware/security/security_test.go
+++ b/src/server/middleware/security/security_test.go
@@ -137,3 +137,76 @@ func TestSecurityUsesSessionWhenNoAuthorization(t *testing.T) {
 	require.NotNil(t, ctx)
 	assert.Equal(t, "admin", ctx.GetUsername())
 }
+
+// TestSecurityAuthorizationTakesPrecedenceOverSession verifies that when both a
+// valid Authorization header and a portal session are present, the identity from
+// the header wins.
+func TestSecurityAuthorizationTakesPrecedenceOverSession(t *testing.T) {
+	initMemorySessionManager(t)
+
+	orig := generators
+	defer func() { generators = orig }()
+	generators = []generator{&basicAuth{}, &session{}}
+
+	sessionUser := models.User{
+		Username:     "session-user",
+		UserID:       2,
+		Email:        "session-user@example.com",
+		SysAdminFlag: false,
+	}
+	req, err := http.NewRequest(http.MethodGet, "http://127.0.0.1/api/projects/", nil)
+	require.Nil(t, err)
+	req = req.WithContext(orm.Context())
+	store, err := web.GlobalSessions.SessionStart(httptest.NewRecorder(), req)
+	require.Nil(t, err)
+	require.Nil(t, store.Set(req.Context(), "user", sessionUser))
+
+	// Valid Basic auth for admin (User A) while session holds session-user (User B).
+	req.SetBasicAuth("admin", "Harbor12345")
+
+	var ctx security.Context
+	var exist bool
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx, exist = security.FromContext(r.Context())
+	})
+	Middleware()(handler).ServeHTTP(httptest.NewRecorder(), req)
+
+	require.True(t, exist)
+	require.NotNil(t, ctx)
+	assert.Equal(t, "admin", ctx.GetUsername(), "Authorization identity must take precedence over session")
+}
+
+// TestSecurityUsesSessionWhenNonStandardAuthorization ensures a non-Basic/Bearer
+// Authorization value does not disable session auth (e.g. proxy-injected headers).
+func TestSecurityUsesSessionWhenNonStandardAuthorization(t *testing.T) {
+	initMemorySessionManager(t)
+
+	orig := generators
+	defer func() { generators = orig }()
+	generators = []generator{&basicAuth{}, &session{}}
+
+	user := models.User{
+		Username:     "admin",
+		UserID:       1,
+		Email:        "admin@example.com",
+		SysAdminFlag: true,
+	}
+	req, err := http.NewRequest(http.MethodGet, "http://127.0.0.1/api/projects/", nil)
+	require.Nil(t, err)
+	store, err := web.GlobalSessions.SessionStart(httptest.NewRecorder(), req)
+	require.Nil(t, err)
+	require.Nil(t, store.Set(req.Context(), "user", user))
+
+	req.Header.Set("Authorization", "Negotiate abc123")
+
+	var ctx security.Context
+	var exist bool
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx, exist = security.FromContext(r.Context())
+	})
+	Middleware()(handler).ServeHTTP(httptest.NewRecorder(), req)
+
+	require.True(t, exist)
+	require.NotNil(t, ctx)
+	assert.Equal(t, "admin", ctx.GetUsername())
+}

--- a/src/server/middleware/security/security_test.go
+++ b/src/server/middleware/security/security_test.go
@@ -16,14 +16,21 @@ package security
 
 import (
 	"net/http"
+	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/beego/beego/v2/server/web"
+	beegosession "github.com/beego/beego/v2/server/web/session"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/goharbor/harbor/src/common/models"
 	"github.com/goharbor/harbor/src/common/security"
 	"github.com/goharbor/harbor/src/common/utils/test"
+	_ "github.com/goharbor/harbor/src/core/auth/db"
+	"github.com/goharbor/harbor/src/lib/orm"
 )
 
 func TestMain(m *testing.M) {
@@ -32,6 +39,9 @@ func TestMain(m *testing.M) {
 }
 
 func TestSecurity(t *testing.T) {
+	orig := generators
+	defer func() { generators = orig }()
+
 	var ctx security.Context
 	var exist bool
 	generators = []generator{&unauthorized{}}
@@ -43,4 +53,87 @@ func TestSecurity(t *testing.T) {
 	Middleware()(handler).ServeHTTP(nil, req)
 	require.True(t, exist)
 	assert.NotNil(t, ctx)
+}
+
+func initMemorySessionManager(t *testing.T) {
+	t.Helper()
+	conf := &beegosession.ManagerConfig{
+		CookieName:      web.BConfig.WebConfig.Session.SessionName,
+		Gclifetime:      web.BConfig.WebConfig.Session.SessionGCMaxLifetime,
+		ProviderConfig:  filepath.ToSlash(web.BConfig.WebConfig.Session.SessionProviderConfig),
+		Secure:          web.BConfig.Listen.EnableHTTPS,
+		EnableSetCookie: web.BConfig.WebConfig.Session.SessionAutoSetCookie,
+		Domain:          web.BConfig.WebConfig.Session.SessionDomain,
+		CookieLifeTime:  web.BConfig.WebConfig.Session.SessionCookieLifeTime,
+	}
+	var err error
+	web.GlobalSessions, err = beegosession.NewManager("memory", conf)
+	require.Nil(t, err)
+}
+
+// TestSecuritySkipsSessionWhenAuthorizationPresent covers goharbor/harbor#7704:
+// invalid Basic auth must not fall back to the portal session user.
+func TestSecuritySkipsSessionWhenAuthorizationPresent(t *testing.T) {
+	initMemorySessionManager(t)
+
+	orig := generators
+	defer func() { generators = orig }()
+	generators = []generator{&basicAuth{}, &session{}}
+
+	user := models.User{
+		Username:     "admin",
+		UserID:       1,
+		Email:        "admin@example.com",
+		SysAdminFlag: true,
+	}
+	req, err := http.NewRequest(http.MethodGet, "http://127.0.0.1/api/projects/", nil)
+	require.Nil(t, err)
+	req = req.WithContext(orm.Context())
+	store, err := web.GlobalSessions.SessionStart(httptest.NewRecorder(), req)
+	require.Nil(t, err)
+	require.Nil(t, store.Set(req.Context(), "user", user))
+
+	// Fake credentials with an active portal session — Authorization is present.
+	req.SetBasicAuth("fake-user", "wrong-password")
+
+	var ctx security.Context
+	var exist bool
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx, exist = security.FromContext(r.Context())
+	})
+	Middleware()(handler).ServeHTTP(httptest.NewRecorder(), req)
+
+	assert.False(t, exist, "security context must not fall back to session when Authorization fails")
+	assert.Nil(t, ctx)
+}
+
+func TestSecurityUsesSessionWhenNoAuthorization(t *testing.T) {
+	initMemorySessionManager(t)
+
+	orig := generators
+	defer func() { generators = orig }()
+	generators = []generator{&basicAuth{}, &session{}}
+
+	user := models.User{
+		Username:     "admin",
+		UserID:       1,
+		Email:        "admin@example.com",
+		SysAdminFlag: true,
+	}
+	req, err := http.NewRequest(http.MethodGet, "http://127.0.0.1/api/projects/", nil)
+	require.Nil(t, err)
+	store, err := web.GlobalSessions.SessionStart(httptest.NewRecorder(), req)
+	require.Nil(t, err)
+	require.Nil(t, store.Set(req.Context(), "user", user))
+
+	var ctx security.Context
+	var exist bool
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx, exist = security.FromContext(r.Context())
+	})
+	Middleware()(handler).ServeHTTP(httptest.NewRecorder(), req)
+
+	require.True(t, exist)
+	require.NotNil(t, ctx)
+	assert.Equal(t, "admin", ctx.GetUsername())
 }


### PR DESCRIPTION
## Summary
- Fixes fallback behavior in security middleware when an `Authorization` header is present.
- Prevents invalid Basic credentials (e.g. from API Explorer/Swagger) from silently falling back to the logged-in session user.
- Adds middleware tests for both cases:
  - `Authorization` present + invalid credentials => no session fallback
  - no `Authorization` header => existing session auth behavior remains

## Why
Issue #7704 reports that API Explorer can appear “authorized” with fake credentials while requests are still executed as the current portal session user.  
This change makes auth behavior explicit: when `Authorization` is provided, failed auth does not downgrade to session auth.

## Test Plan
- Added unit tests in `src/server/middleware/security/security_test.go`:
  - `TestSecuritySkipsSessionWhenAuthorizationPresent`
  - `TestSecurityUsesSessionWhenNoAuthorization`
- Local full test run is limited on native Windows due to Harbor Linux-specific dependencies (`syslog`); CI should validate on Linux.

## Related
- Fixes #7704