### PR TITLE
(cherry-pick): fix race condition in log rotation test by polling job status

### DIFF
--- a/tests/apitests/python/test_log_rotation.py
+++ b/tests/apitests/python/test_log_rotation.py
@@ -43,12 +43,17 @@ class TestLogRotation(unittest.TestCase, object):
         # 2. Stop this purge audit log job
         latest_job = self.purge.get_latest_purge_job()
         self.purge.stop_purge_execution(latest_job.id)
-        # 3. Verify purge audit log job status is Stopped
-        # wait more 5s for status update after stop
-        time.sleep(5)
-        job_status = self.purge.get_purge_job(latest_job.id).job_status
+        # 3. Verify purge audit log job status is Stopped or Success
+        job_status = None
+        for i in range(20):
+            job_status = self.purge.get_purge_job(latest_job.id).job_status
+            if job_status in ["Stopped", "Success"]:
+                break
+            time.sleep(2)
         # The dry-run job can finish before the stop request is processed; in
         # that case Harbor keeps the final status as Success instead of Stopped.
+        # Also, the execution status might be updated asynchronously (default interval is 30s),
+        # so we wait in a loop.
         self.assertIn(job_status, ["Stopped", "Success"])
         # 4. Create a purge audit log job
         self.purge.create_purge_schedule(type="Manual", cron=None, dry_run=False, audit_retention_hour=1)


### PR DESCRIPTION
…b status

The dry-run job can finish before the stop request is processed, and the execution status might be updated asynchronously. This change replaces a fixed sleep with a polling loop to wait for the job to reach a terminal state (Stopped or Success).

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [ ] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [ ] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
