### PR TITLE
feat(backend): implement proxy cache repository filter API

### DIFF
--- a/api/v2.0/swagger.yaml
+++ b/api/v2.0/swagger.yaml
@@ -7534,6 +7534,14 @@ definitions:
         type: string
         description: 'Whether the proxy cache project should proxy OCI 1.1 referrer API requests to the upstream registry. The valid values are "true", "false".'
         x-nullable: true
+      proxy_cache_filter_pattern:
+        type: string
+        description: 'Repository filter pattern for proxy cache project. Only repositories matching the pattern will be proxied. Empty means allow all. Only has value when the current project is a proxy cache project.'
+        x-nullable: true
+      proxy_cache_filter_kind:
+        type: string
+        description: 'Matching mode for proxy_cache_filter_pattern: "doublestar" (default, glob-style with ** support) or "regex". Only has value when the current project is a proxy cache project.'
+        x-nullable: true
   ProjectSummary:
     type: object
     properties:

--- a/src/core/main.go
+++ b/src/core/main.go
@@ -69,6 +69,7 @@ import (
 	_ "github.com/goharbor/harbor/src/pkg/auditext/event/config"
 	_ "github.com/goharbor/harbor/src/pkg/auditext/event/login"
 	_ "github.com/goharbor/harbor/src/pkg/auditext/event/member"
+	_ "github.com/goharbor/harbor/src/pkg/auditext/event/project"
 	_ "github.com/goharbor/harbor/src/pkg/auditext/event/user"
 	dbCfg "github.com/goharbor/harbor/src/pkg/config/db"
 	_ "github.com/goharbor/harbor/src/pkg/config/inmemory"

--- a/src/lib/pattern/matcher.go
+++ b/src/lib/pattern/matcher.go
@@ -1,0 +1,118 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pattern
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/bmatcuk/doublestar"
+
+	"github.com/goharbor/harbor/src/lib/errors"
+)
+
+const (
+	// KindRegex indicates regular expression pattern matching
+	KindRegex = "regex"
+	// KindDoublestar indicates doublestar (glob) pattern matching
+	KindDoublestar = "doublestar"
+)
+
+// ValidateRepositoryFilter validates the repository filter kind and pattern.
+// Empty pattern is valid and means all repositories are allowed.
+func ValidateRepositoryFilter(filterPattern, kind string) error {
+	_, err := Match("", filterPattern, kind)
+	return err
+}
+
+// Match returns true if the value matches the pattern according to the kind.
+// Empty pattern matches all (returns true).
+func Match(value, filterPattern, kind string) (bool, error) {
+	filterPattern = strings.TrimSpace(filterPattern)
+	if filterPattern == "" {
+		return true, nil
+	}
+	switch kind {
+	case KindRegex:
+		re, err := regexp.Compile("^(?:" + filterPattern + ")$")
+		if err != nil {
+			return false, err
+		}
+		return re.MatchString(value), nil
+	case KindDoublestar, "":
+		if !validateDoublestarPattern(filterPattern) {
+			return false, doublestar.ErrBadPattern
+		}
+		return doublestar.Match(filterPattern, value)
+	default:
+		return false, errors.Errorf("unsupported repository filter kind %q", kind)
+	}
+}
+
+func validateDoublestarPattern(s string) bool {
+	altDepth := 0
+	l := len(s)
+VALIDATE:
+	for i := 0; i < l; i++ {
+		switch s[i] {
+		case '\\':
+			// skip the next byte - return false if there is no next byte
+			if i++; i >= l {
+				return false
+			}
+			continue
+
+		case '[':
+			if i++; i >= l {
+				// class didn't end
+				return false
+			}
+			if s[i] == '^' || s[i] == '!' {
+				i++
+			}
+			if i >= l || s[i] == ']' {
+				// class didn't end or empty character class
+				return false
+			}
+
+			for ; i < l; i++ {
+				if s[i] == '\\' {
+					i++
+				} else if s[i] == ']' {
+					// looks good
+					continue VALIDATE
+				}
+			}
+
+			// class didn't end
+			return false
+
+		case '{':
+			altDepth++
+			continue
+
+		case '}':
+			if altDepth == 0 {
+				// alt end without a corresponding start
+				return false
+			}
+			altDepth--
+			continue
+		}
+	}
+
+	// valid as long as all alts are closed
+	return altDepth == 0
+}

--- a/src/lib/pattern/matcher_test.go
+++ b/src/lib/pattern/matcher_test.go
@@ -1,0 +1,225 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pattern
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateRepositoryFilter(t *testing.T) {
+	cases := []struct {
+		name          string
+		filterPattern string
+		kind          string
+		expectErr     bool
+	}{
+		{
+			name:          "empty pattern",
+			filterPattern: "",
+			kind:          KindRegex,
+			expectErr:     false,
+		},
+		{
+			name:          "whitespace pattern",
+			filterPattern: "   ",
+			kind:          KindDoublestar,
+			expectErr:     false,
+		},
+		{
+			name:          "valid regex pattern",
+			filterPattern: "library/.*",
+			kind:          KindRegex,
+			expectErr:     false,
+		},
+		{
+			name:          "invalid regex pattern",
+			filterPattern: "[a-z",
+			kind:          KindRegex,
+			expectErr:     true,
+		},
+		{
+			name:          "valid doublestar pattern",
+			filterPattern: "library/**",
+			kind:          KindDoublestar,
+			expectErr:     false,
+		},
+		{
+			name:          "invalid doublestar pattern",
+			filterPattern: "library/[a-z",
+			kind:          KindDoublestar,
+			expectErr:     true,
+		},
+		{
+			name:          "valid doublestar pattern with empty kind",
+			filterPattern: "library/**",
+			kind:          "",
+			expectErr:     false,
+		},
+		{
+			name:          "invalid doublestar pattern with empty kind",
+			filterPattern: "library/[a-z",
+			kind:          "",
+			expectErr:     true,
+		},
+		{
+			name:          "unsupported kind",
+			filterPattern: "library/**",
+			kind:          "invalid_kind",
+			expectErr:     true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateRepositoryFilter(tc.filterPattern, tc.kind)
+			if tc.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestMatch(t *testing.T) {
+	cases := []struct {
+		name          string
+		value         string
+		filterPattern string
+		kind          string
+		want          bool
+		expectErr     bool
+	}{
+		{
+			name:          "empty pattern matches all",
+			value:         "library/nginx",
+			filterPattern: "",
+			kind:          KindRegex,
+			want:          true,
+		},
+		{
+			name:          "whitespace pattern matches all",
+			value:         "library/nginx",
+			filterPattern: "   ",
+			kind:          KindDoublestar,
+			want:          true,
+		},
+		{
+			name:          "regex exact match",
+			value:         "library/nginx",
+			filterPattern: "library/nginx",
+			kind:          KindRegex,
+			want:          true,
+		},
+		{
+			name:          "regex partial match is anchored",
+			value:         "library/nginx",
+			filterPattern: "nginx",
+			kind:          KindRegex,
+			want:          false,
+		},
+		{
+			name:          "regex prefix match is anchored",
+			value:         "library/nginx",
+			filterPattern: "library/",
+			kind:          KindRegex,
+			want:          false,
+		},
+		{
+			name:          "regex wildcard match",
+			value:         "library/nginx",
+			filterPattern: "library/.*",
+			kind:          KindRegex,
+			want:          true,
+		},
+		{
+			name:          "regex invalid pattern returns error",
+			value:         "library/nginx",
+			filterPattern: "[a-z",
+			kind:          KindRegex,
+			expectErr:     true,
+		},
+		{
+			name:          "doublestar exact match",
+			value:         "library/nginx",
+			filterPattern: "library/nginx",
+			kind:          KindDoublestar,
+			want:          true,
+		},
+		{
+			name:          "doublestar single star",
+			value:         "library/nginx",
+			filterPattern: "library/*",
+			kind:          KindDoublestar,
+			want:          true,
+		},
+		{
+			name:          "doublestar double star",
+			value:         "org/team/repo",
+			filterPattern: "org/**",
+			kind:          KindDoublestar,
+			want:          true,
+		},
+		{
+			name:          "doublestar match all",
+			value:         "library/nginx",
+			filterPattern: "**",
+			kind:          KindDoublestar,
+			want:          true,
+		},
+		{
+			name:          "doublestar no match",
+			value:         "library/nginx",
+			filterPattern: "other/*",
+			kind:          KindDoublestar,
+			want:          false,
+		},
+		{
+			name:          "doublestar alternation",
+			value:         "library/nginx",
+			filterPattern: "library/{nginx,alpine}",
+			kind:          KindDoublestar,
+			want:          true,
+		},
+		{
+			name:          "empty kind defaults to doublestar",
+			value:         "library/nginx",
+			filterPattern: "library/**",
+			kind:          "",
+			want:          true,
+		},
+		{
+			name:          "unsupported kind returns error",
+			value:         "library/nginx",
+			filterPattern: "library/**",
+			kind:          "invalid_kind",
+			expectErr:     true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := Match(tc.value, tc.filterPattern, tc.kind)
+			if tc.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.want, got)
+			}
+		})
+	}
+}

--- a/src/pkg/auditext/event/project/project.go
+++ b/src/pkg/auditext/event/project/project.go
@@ -1,0 +1,118 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package project
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"regexp"
+	"strconv"
+	"time"
+
+	ctlevent "github.com/goharbor/harbor/src/controller/event"
+	"github.com/goharbor/harbor/src/controller/event/metadata/commonevent"
+	"github.com/goharbor/harbor/src/controller/event/model"
+	"github.com/goharbor/harbor/src/controller/project"
+	"github.com/goharbor/harbor/src/lib/config"
+	"github.com/goharbor/harbor/src/lib/orm"
+	"github.com/goharbor/harbor/src/pkg/notifier/event"
+	"github.com/goharbor/harbor/src/pkg/project/models"
+)
+
+var (
+	projectReg        = regexp.MustCompile(`^/api/v2.0/projects/([^/?]+)(?:\?.*)?$`)
+	projectMetaReg    = regexp.MustCompile(`^/api/v2.0/projects/([^/?]+)/metadatas/(?:\?.*)?$`)
+	projectMetaKeyReg = regexp.MustCompile(`^/api/v2.0/projects/([^/?]+)/metadatas/([^/?]+)(?:\?.*)?$`)
+)
+
+func init() {
+	var projectEventResolver = &resolver{}
+	commonevent.RegisterResolver(`^/api/v2.0/projects/[^/?]+(?:\?.*)?$`, projectEventResolver)
+	commonevent.RegisterResolver(`^/api/v2.0/projects/[^/?]+/metadatas/(?:\?.*)?$`, projectEventResolver)
+	commonevent.RegisterResolver(`^/api/v2.0/projects/[^/?]+/metadatas/[^/?]+(?:\?.*)?$`, projectEventResolver)
+}
+
+type resolver struct {
+}
+
+func (r *resolver) Resolve(ce *commonevent.Metadata, evt *event.Event) error {
+	projStr := getProjectNameOrID(ce.RequestURL)
+	if projStr == "" {
+		return fmt.Errorf("failed to parse project name or ID from URL: %s", ce.RequestURL)
+	}
+
+	ctx := ce.Ctx
+	if _, err := orm.FromContext(ctx); err == nil {
+		ctx = orm.Clone(ctx)
+	}
+
+	proj, err := getProject(ctx, projStr)
+	if err != nil {
+		return fmt.Errorf("failed to get project: %v", err)
+	}
+
+	e := &model.CommonEvent{}
+	e.Operation = "update"
+	e.Operator = ce.Username
+	e.ResourceType = "project"
+	e.ResourceName = proj.Name
+	e.ProjectID = proj.ProjectID
+	e.OcurrAt = time.Now()
+	e.OperationDescription = fmt.Sprintf("update project: %s", proj.Name)
+
+	if ce.ResponseCode == http.StatusOK {
+		e.IsSuccessful = true
+	}
+	evt.Topic = ctlevent.TopicCommonEvent
+	evt.Data = e
+	return nil
+}
+
+func (r *resolver) PreCheck(ctx context.Context, url string, method string) (bool, string) {
+	if method != http.MethodPut && method != http.MethodPost && method != http.MethodDelete {
+		return false, ""
+	}
+
+	if method == http.MethodDelete && projectReg.MatchString(url) {
+		return false, ""
+	}
+
+	return config.AuditLogEventEnabled(ctx, "update_project"), ""
+}
+
+func getProjectNameOrID(url string) string {
+	if m := projectMetaKeyReg.FindStringSubmatch(url); len(m) > 1 {
+		return m[1]
+	}
+	if m := projectMetaReg.FindStringSubmatch(url); len(m) > 1 {
+		return m[1]
+	}
+	if m := projectReg.FindStringSubmatch(url); len(m) > 1 {
+		return m[1]
+	}
+	return ""
+}
+
+func getProject(ctx context.Context, str string) (*models.Project, error) {
+	var projectNameOrID any
+	v, err := strconv.ParseInt(str, 10, 64)
+	if err != nil {
+		projectNameOrID = str
+	} else {
+		projectNameOrID = v
+	}
+	return project.Ctl.Get(ctx, projectNameOrID)
+}

--- a/src/pkg/auditext/event/project/project_test.go
+++ b/src/pkg/auditext/event/project/project_test.go
@@ -1,0 +1,139 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package project
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/goharbor/harbor/src/controller/event/metadata/commonevent"
+	"github.com/goharbor/harbor/src/controller/event/model"
+	"github.com/goharbor/harbor/src/controller/project"
+	"github.com/goharbor/harbor/src/pkg/notifier/event"
+	proModels "github.com/goharbor/harbor/src/pkg/project/models"
+	mockproject "github.com/goharbor/harbor/src/testing/controller/project"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestProjectEventResolver_PreCheck(t *testing.T) {
+	c := &resolver{}
+
+	tests := []struct {
+		name   string
+		url    string
+		method string
+		want   bool
+	}{
+		{"test PUT", "/api/v2.0/projects/1", "PUT", true},
+		{"test POST", "/api/v2.0/projects/1/metadatas/", "POST", true},
+		{"test DELETE project metadata", "/api/v2.0/projects/1/metadatas/proxy_cache_filter_pattern", "DELETE", true},
+		{"test DELETE project", "/api/v2.0/projects/1", "DELETE", false},
+		{"test GET", "/api/v2.0/projects/1", "GET", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, _ := c.PreCheck(context.Background(), tt.url, tt.method)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestGetProjectNameOrID(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		want string
+	}{
+		{"normal project url", "/api/v2.0/projects/myproj", "myproj"},
+		{"normal project url with query", "/api/v2.0/projects/myproj?x_is_resource_name=true", "myproj"},
+		{"metadatas url", "/api/v2.0/projects/myproj/metadatas/", "myproj"},
+		{"metadatas url with query", "/api/v2.0/projects/myproj/metadatas/?x_is_resource_name=true", "myproj"},
+		{"metadata key url", "/api/v2.0/projects/myproj/metadatas/proxy_cache_filter_pattern", "myproj"},
+		{"metadata key url with query", "/api/v2.0/projects/myproj/metadatas/proxy_cache_filter_pattern?x_is_resource_name=true", "myproj"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getProjectNameOrID(tt.url)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestProjectEventResolver_Resolve(t *testing.T) {
+	mockCtrl := &mockproject.Controller{}
+	oldCtrl := project.Ctl
+	project.Ctl = mockCtrl
+	defer func() { project.Ctl = oldCtrl }()
+
+	proj := &proModels.Project{
+		ProjectID: 123,
+		Name:      "test-proj",
+	}
+
+	mockCtrl.On("Get", mock.Anything, int64(123)).Return(proj, nil)
+	mockCtrl.On("Get", mock.Anything, "test-proj").Return(proj, nil)
+
+	r := &resolver{}
+
+	t.Run("Resolve project update by ID", func(t *testing.T) {
+		ce := &commonevent.Metadata{
+			Ctx:           context.Background(),
+			Username:      "admin",
+			RequestURL:    "/api/v2.0/projects/123",
+			RequestMethod: "PUT",
+			ResponseCode:  http.StatusOK,
+		}
+		evt := &event.Event{}
+		err := r.Resolve(ce, evt)
+		assert.NoError(t, err)
+
+		data, ok := evt.Data.(*model.CommonEvent)
+		assert.True(t, ok)
+		assert.Equal(t, "update", data.Operation)
+		assert.Equal(t, "admin", data.Operator)
+		assert.Equal(t, "project", data.ResourceType)
+		assert.Equal(t, "test-proj", data.ResourceName)
+		assert.Equal(t, int64(123), data.ProjectID)
+		assert.Equal(t, "update project: test-proj", data.OperationDescription)
+		assert.True(t, data.IsSuccessful)
+	})
+
+	t.Run("Resolve project update by Name", func(t *testing.T) {
+		ce := &commonevent.Metadata{
+			Ctx:           context.Background(),
+			Username:      "admin",
+			RequestURL:    "/api/v2.0/projects/test-proj/metadatas/",
+			RequestMethod: "POST",
+			ResponseCode:  http.StatusOK,
+		}
+		evt := &event.Event{}
+		err := r.Resolve(ce, evt)
+		assert.NoError(t, err)
+
+		data, ok := evt.Data.(*model.CommonEvent)
+		assert.True(t, ok)
+		assert.Equal(t, "update", data.Operation)
+		assert.Equal(t, "admin", data.Operator)
+		assert.Equal(t, "project", data.ResourceType)
+		assert.Equal(t, "test-proj", data.ResourceName)
+		assert.Equal(t, int64(123), data.ProjectID)
+		assert.Equal(t, "update project: test-proj", data.OperationDescription)
+		assert.True(t, data.IsSuccessful)
+	})
+}

--- a/src/pkg/auditext/model/model.go
+++ b/src/pkg/auditext/model/model.go
@@ -64,6 +64,7 @@ var EventTypes = []string{
 	"create_member",
 	"delete_member",
 	"update_member",
+	"update_project",
 }
 
 // OtherEventTypes defines the types of other audit log event types excludes previous EventTypes: create_artifact, delete_artifact, pull_artifact

--- a/src/pkg/project/models/pro_meta.go
+++ b/src/pkg/project/models/pro_meta.go
@@ -26,6 +26,8 @@ const (
 	ProMetaAutoSBOMGen               = "auto_sbom_generation"
 	ProMetaProxySpeed                = "proxy_speed_kb"
 	ProMetaMaxUpstreamConn           = "max_upstream_conn"
+	ProMetaProxyCacheFilterPattern   = "proxy_cache_filter_pattern" // plain string pattern for proxy cache repository filter
+	ProMetaProxyCacheFilterKind      = "proxy_cache_filter_kind"    // "doublestar" (default) or "regex"
 	ProMetaProxyReferrerAPI          = "proxy_referrer_api"
 	ProMetaProxyCacheLocalOnNotFound = "proxy_cache_local_on_not_found"
 )

--- a/src/server/middleware/repoproxy/proxy.go
+++ b/src/server/middleware/repoproxy/proxy.go
@@ -44,6 +44,7 @@ import (
 	"github.com/goharbor/harbor/src/lib/log"
 	"github.com/goharbor/harbor/src/lib/metric"
 	"github.com/goharbor/harbor/src/lib/orm"
+	"github.com/goharbor/harbor/src/lib/pattern"
 	"github.com/goharbor/harbor/src/lib/q"
 	"github.com/goharbor/harbor/src/lib/redis"
 	"github.com/goharbor/harbor/src/pkg"
@@ -120,6 +121,11 @@ func handleBlob(w http.ResponseWriter, r *http.Request, next http.Handler) error
 	if isDefault {
 		http.Redirect(w, r, defaultBlobURL(p.Name, name, art.Digest), http.StatusMovedPermanently)
 		return nil
+	}
+
+	// Apply repository filter: if proxy_cache_filter_pattern is set, the repository must match
+	if err := checkRepositoryFilter(p, art); err != nil {
+		return err
 	}
 
 	if p.IsProxy() && config.Metric().Enabled {
@@ -241,6 +247,44 @@ func defaultBlobURL(projectName string, name string, digest string) string {
 	return fmt.Sprintf("/v2/%s/library/%s/blobs/%s", projectName, name, digest)
 }
 
+// defaultTagURL return the real url for request with default project
+func defaultTagURL(projectName string, name string) string {
+	return fmt.Sprintf("/v2/%s/library/%s/tags/list", projectName, name)
+}
+
+// matchRepositoryFilter returns true if repository matches the filter.
+// filterPattern is the plain pattern string; filterKind is "doublestar" or "regex" (defaults to doublestar when empty).
+// If filterPattern is empty, all repositories are allowed.
+// An invalid pattern is treated as no match.
+func matchRepositoryFilter(repository, filterPattern, filterKind string) bool {
+	log.Debugf("matching repository %q against filter pattern: %q (kind: %s)", repository, filterPattern, filterKind)
+	matched, err := pattern.Match(repository, filterPattern, filterKind)
+	if err != nil {
+		log.Warningf("invalid proxy_cache_filter_pattern %q (kind: %s): %v", filterPattern, filterKind, err)
+		return false
+	}
+	log.Debugf("repository %q match result: %v (filter: %q, kind: %s)", repository, matched, filterPattern, filterKind)
+	return matched
+}
+
+// checkRepositoryFilter returns a NotFoundError if the project has a proxy_cache_filter_pattern
+// set and the artifact's repository does not match it. It is enforced for both manifest and
+// blob requests so the filter acts as an access boundary rather than a manifest-only convenience,
+// since a client that knows a blob digest out-of-band could otherwise bypass the filter.
+func checkRepositoryFilter(p *proModels.Project, art lib.ArtifactInfo) error {
+	filterPattern, ok := p.GetMetadata(proModels.ProMetaProxyCacheFilterPattern)
+	if !ok || filterPattern == "" {
+		return nil
+	}
+	filterKind, _ := p.GetMetadata(proModels.ProMetaProxyCacheFilterKind)
+	remoteRepo := strings.TrimPrefix(art.Repository, art.ProjectName+"/")
+	if !matchRepositoryFilter(remoteRepo, filterPattern, filterKind) {
+		log.Debugf("blocked proxy cache pull for project %q repository %q: repository does not match filter %q (kind: %s)", p.Name, remoteRepo, filterPattern, filterKind)
+		return errors.NotFoundError(fmt.Errorf("repository %q does not match project repository filter", remoteRepo))
+	}
+	return nil
+}
+
 // upstreamRegistryConnectionKey get upstream registry connection key
 func upstreamRegistryConnectionKey(art lib.ArtifactInfo) string {
 	limitOnProject := os.Getenv(upstreamRegistryLimitOnProject)
@@ -265,6 +309,11 @@ func handleManifest(w http.ResponseWriter, r *http.Request, next http.Handler) e
 	if defaultProj {
 		http.Redirect(w, r, defaultManifestURL(p.Name, name, art), http.StatusMovedPermanently)
 		return nil
+	}
+
+	// Apply repository filter: if proxy_cache_filter_pattern is set, the repository must match
+	if err := checkRepositoryFilter(p, art); err != nil {
+		return err
 	}
 
 	if p.IsProxy() && config.Metric().Enabled {
@@ -448,7 +497,7 @@ func ProxyReferrerMiddleware() func(http.Handler) http.Handler {
 	return middleware.New(func(w http.ResponseWriter, r *http.Request, next http.Handler) {
 		ctx := r.Context()
 		art := lib.GetArtifactInfo(ctx)
-		p, err := project.Ctl.GetByName(ctx, art.ProjectName)
+		p, err := project.Ctl.GetByName(ctx, art.ProjectName, project.Metadata(true))
 		if err != nil {
 			httpLib.SendError(w, err)
 			return
@@ -461,6 +510,12 @@ func ProxyReferrerMiddleware() func(http.Handler) http.Handler {
 		if !p.ProxyReferrerAPI() {
 			log.Debug("the proxy referrer API is not enabled for current project, fallback to local registry")
 			next.ServeHTTP(w, r)
+			return
+		}
+
+		// Apply repository filter: if proxy_cache_filter_pattern is set, the repository must match
+		if err := checkRepositoryFilter(p, art); err != nil {
+			httpLib.SendError(w, err)
 			return
 		}
 

--- a/src/server/middleware/repoproxy/proxy_test.go
+++ b/src/server/middleware/repoproxy/proxy_test.go
@@ -46,6 +46,7 @@ import (
 	"github.com/goharbor/harbor/src/pkg/reg/model"
 	projecttesting "github.com/goharbor/harbor/src/testing/controller/project"
 	proxytesting "github.com/goharbor/harbor/src/testing/controller/proxy"
+	registrytesting "github.com/goharbor/harbor/src/testing/controller/registry"
 	testingcache "github.com/goharbor/harbor/src/testing/lib/cache"
 	testingmock "github.com/goharbor/harbor/src/testing/mock"
 )
@@ -341,6 +342,26 @@ func (s *ProxyReferrerMiddlewareSuite) TestProxyReferrerAPIDisabled() {
 	s.True(s.nextCalled, "next handler should be called when proxy referrer API is disabled")
 }
 
+func (s *ProxyReferrerMiddlewareSuite) TestProxyReferrerAPIBlockedByFilter() {
+	proj := &proModels.Project{
+		ProjectID:  3,
+		Name:       "testproject",
+		RegistryID: 1,
+		Metadata: map[string]string{
+			proModels.ProMetaProxyReferrerAPI:        "true",
+			proModels.ProMetaProxyCacheFilterPattern: "allow-*",
+			proModels.ProMetaProxyCacheFilterKind:    "doublestar",
+		},
+	}
+	testingmock.OnAnything(s.projectCtl, "GetByName").Return(proj, nil)
+
+	w := httptest.NewRecorder()
+	ProxyReferrerMiddleware()(s.next).ServeHTTP(w, s.makeRequest())
+
+	s.False(s.nextCalled, "next handler should not be called when repository is blocked by filter")
+	s.Equal(http.StatusNotFound, w.Code)
+}
+
 func TestProxyReferrerMiddlewareSuite(t *testing.T) {
 	suite.Run(t, new(ProxyReferrerMiddlewareSuite))
 }
@@ -633,5 +654,277 @@ func TestWriteProxyHeaders(t *testing.T) {
 				require.Empty(t, actualValue, fmt.Sprintf("header %s should not be present", header))
 			}
 		})
+	}
+}
+
+func TestMatchRepositoryFilter(t *testing.T) {
+	cases := []struct {
+		name          string
+		repository    string
+		filterPattern string
+		filterKind    string
+		want          bool
+	}{
+		{
+			name:          "empty pattern matches all",
+			repository:    "library/nginx",
+			filterPattern: "",
+			filterKind:    "",
+			want:          true,
+		},
+		{
+			name:          "regex exact match",
+			repository:    "library/nginx",
+			filterPattern: "^library/nginx$",
+			filterKind:    "regex",
+			want:          true,
+		},
+		{
+			name:          "regex partial match is anchored",
+			repository:    "library/nginx",
+			filterPattern: "nginx",
+			filterKind:    "regex",
+			want:          false,
+		},
+		{
+			name:          "regex prefix match is anchored",
+			repository:    "library/nginx",
+			filterPattern: "^library/",
+			filterKind:    "regex",
+			want:          false,
+		},
+		{
+			name:          "regex wildcard match",
+			repository:    "library/nginx",
+			filterPattern: "^library/.*",
+			filterKind:    "regex",
+			want:          true,
+		},
+		{
+			name:          "regex no match",
+			repository:    "library/nginx",
+			filterPattern: "^other/",
+			filterKind:    "regex",
+			want:          false,
+		},
+		{
+			name:          "regex invalid pattern treated as no match",
+			repository:    "library/nginx",
+			filterPattern: "[invalid",
+			filterKind:    "regex",
+			want:          false,
+		},
+		{
+			name:          "doublestar exact match",
+			repository:    "library/nginx",
+			filterPattern: "library/nginx",
+			filterKind:    "doublestar",
+			want:          true,
+		},
+		{
+			name:          "doublestar single star",
+			repository:    "library/nginx",
+			filterPattern: "library/*",
+			filterKind:    "doublestar",
+			want:          true,
+		},
+		{
+			name:          "doublestar double star",
+			repository:    "org/team/repo",
+			filterPattern: "org/**",
+			filterKind:    "doublestar",
+			want:          true,
+		},
+		{
+			name:          "doublestar match all",
+			repository:    "library/nginx",
+			filterPattern: "**",
+			filterKind:    "doublestar",
+			want:          true,
+		},
+		{
+			name:          "doublestar no match",
+			repository:    "library/nginx",
+			filterPattern: "other/*",
+			filterKind:    "doublestar",
+			want:          false,
+		},
+		{
+			name:          "doublestar alternation",
+			repository:    "library/nginx",
+			filterPattern: "library/{nginx,alpine}",
+			filterKind:    "doublestar",
+			want:          true,
+		},
+		{
+			name:          "empty kind defaults to doublestar",
+			repository:    "library/nginx",
+			filterPattern: "library/**",
+			filterKind:    "",
+			want:          true,
+		},
+		{
+			name:          "empty pattern with kind set matches all",
+			repository:    "library/nginx",
+			filterPattern: "",
+			filterKind:    "regex",
+			want:          true,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			got := matchRepositoryFilter(tt.repository, tt.filterPattern, tt.filterKind)
+			if got != tt.want {
+				t.Errorf("matchRepositoryFilter(%q, %q, %q) = %v; want %v",
+					tt.repository, tt.filterPattern, tt.filterKind, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestCheckRepositoryFilterAppliesToBlobAndManifest ensures the repository filter
+// is enforced regardless of whether the request is for a manifest or a blob, so
+// a blob digest known out-of-band can't be used to bypass the project's filter.
+func TestCheckRepositoryFilterAppliesToBlobAndManifest(t *testing.T) {
+	art := lib.ArtifactInfo{ProjectName: "proxy_project", Repository: "proxy_project/other/nginx"}
+
+	cases := []struct {
+		name      string
+		metadata  map[string]string
+		wantBlock bool
+	}{
+		{
+			name:      "no filter configured",
+			metadata:  map[string]string{},
+			wantBlock: false,
+		},
+		{
+			name:      "matching filter allows",
+			metadata:  map[string]string{proModels.ProMetaProxyCacheFilterPattern: "other/**"},
+			wantBlock: false,
+		},
+		{
+			name:      "non-matching filter blocks",
+			metadata:  map[string]string{proModels.ProMetaProxyCacheFilterPattern: "library/**"},
+			wantBlock: true,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &proModels.Project{Name: art.ProjectName, Metadata: tt.metadata}
+			err := checkRepositoryFilter(p, art)
+			if tt.wantBlock {
+				if err == nil || !liberrors.IsNotFoundErr(err) {
+					t.Errorf("checkRepositoryFilter() = %v; want NotFoundError", err)
+				}
+			} else if err != nil {
+				t.Errorf("checkRepositoryFilter() = %v; want nil", err)
+			}
+		})
+	}
+}
+
+func TestTagsListMiddlewareRepositoryFilter(t *testing.T) {
+	// Mock project.Ctl
+	originalProjectController := project.Ctl
+	projectController := &projecttesting.Controller{}
+	project.Ctl = projectController
+	defer func() {
+		project.Ctl = originalProjectController
+	}()
+
+	art := lib.ArtifactInfo{
+		ProjectName: "proxy_project",
+		Repository:  "proxy_project/other/nginx",
+	}
+
+	p := &proModels.Project{
+		Name: art.ProjectName,
+		Metadata: map[string]string{
+			proModels.ProMetaProxyCacheFilterPattern: "library/**",
+		},
+	}
+
+	testingmock.OnAnything(projectController, "GetByName").Return(p, nil)
+
+	req := httptest.NewRequest("GET", "/v2/proxy_project/other/nginx/tags/list", nil)
+	req = req.WithContext(lib.WithArtifactInfo(req.Context(), art))
+	rec := httptest.NewRecorder()
+
+	nextCalled := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		nextCalled = true
+	})
+
+	TagsListMiddleware()(next).ServeHTTP(rec, req)
+
+	if nextCalled {
+		t.Error("expected next handler not to be called, but it was")
+	}
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("expected status code %d, got %d", http.StatusNotFound, rec.Code)
+	}
+}
+
+func TestTagsListMiddlewareDefaultLibrary(t *testing.T) {
+	// Mock project.Ctl
+	originalProjectController := project.Ctl
+	projectController := &projecttesting.Controller{}
+	project.Ctl = projectController
+	defer func() {
+		project.Ctl = originalProjectController
+	}()
+
+	// Mock registry.Ctl
+	originalRegistryController := registryCtl.Ctl
+	registryController := &registrytesting.Controller{}
+	registryCtl.Ctl = registryController
+	defer func() {
+		registryCtl.Ctl = originalRegistryController
+	}()
+
+	art := lib.ArtifactInfo{
+		ProjectName: "proxy_project",
+		Repository:  "proxy_project/nginx",
+	}
+
+	p := &proModels.Project{
+		Name:       art.ProjectName,
+		RegistryID: 1,
+	}
+
+	reg := &model.Registry{
+		ID:   1,
+		Type: model.RegistryTypeDockerHub,
+	}
+
+	testingmock.OnAnything(projectController, "GetByName").Return(p, nil)
+	testingmock.OnAnything(registryController, "Get").Return(reg, nil)
+
+	req := httptest.NewRequest("GET", "/v2/proxy_project/nginx/tags/list", nil)
+	req = req.WithContext(lib.WithArtifactInfo(req.Context(), art))
+	rec := httptest.NewRecorder()
+
+	nextCalled := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		nextCalled = true
+	})
+
+	TagsListMiddleware()(next).ServeHTTP(rec, req)
+
+	if nextCalled {
+		t.Error("expected next handler not to be called, but it was")
+	}
+
+	if rec.Code != http.StatusMovedPermanently {
+		t.Errorf("expected status code %d, got %d", http.StatusMovedPermanently, rec.Code)
+	}
+
+	expectedLocation := "/v2/proxy_project/library/nginx/tags/list"
+	if location := rec.Header().Get("Location"); location != expectedLocation {
+		t.Errorf("expected Location header %q, got %q", expectedLocation, location)
 	}
 }

--- a/src/server/middleware/repoproxy/tag.go
+++ b/src/server/middleware/repoproxy/tag.go
@@ -35,8 +35,25 @@ func TagsListMiddleware() func(http.Handler) http.Handler {
 	return middleware.New(func(w http.ResponseWriter, r *http.Request, next http.Handler) {
 		ctx := r.Context()
 
-		art, p, _, err := preCheck(ctx, false)
+		art, p, _, err := preCheck(ctx, true)
 		if err != nil {
+			libhttp.SendError(w, err)
+			return
+		}
+
+		// Handle dockerhub request without library prefix
+		isDefault, name, err := defaultLibrary(ctx, p.RegistryID, art)
+		if err != nil {
+			libhttp.SendError(w, err)
+			return
+		}
+		if isDefault {
+			http.Redirect(w, r, defaultTagURL(p.Name, name), http.StatusMovedPermanently)
+			return
+		}
+
+		// Apply repository filter: if proxy_cache_filter_pattern is set, the repository must match
+		if err := checkRepositoryFilter(p, art); err != nil {
 			libhttp.SendError(w, err)
 			return
 		}

--- a/src/server/v2.0/handler/model/project.go
+++ b/src/server/v2.0/handler/model/project.go
@@ -52,6 +52,12 @@ func (p *Project) ToSwagger() *models.Project {
 			m.Severity = &severity
 		}
 
+		// proxy_cache_filter_pattern and proxy_cache_filter_kind are only for proxy cache projects
+		if !p.IsProxy() {
+			m.ProxyCacheFilterPattern = nil
+			m.ProxyCacheFilterKind = nil
+		}
+
 		md = &m
 	}
 

--- a/src/server/v2.0/handler/project.go
+++ b/src/server/v2.0/handler/project.go
@@ -44,6 +44,7 @@ import (
 	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/lib/log"
 	"github.com/goharbor/harbor/src/lib/orm"
+	"github.com/goharbor/harbor/src/lib/pattern"
 	"github.com/goharbor/harbor/src/lib/q"
 	"github.com/goharbor/harbor/src/pkg"
 	"github.com/goharbor/harbor/src/pkg/audit"
@@ -163,10 +164,12 @@ func (a *projectAPI) CreateProject(ctx context.Context, params operation.CreateP
 		}
 	}
 
-	// ignore metadata.proxy_speed_kb and metadata.max_upstream_conn for non-proxy-cache project
+	// ignore metadata.proxy_speed_kb, metadata.max_upstream_conn, proxy_cache_filter_pattern and proxy_cache_filter_kind for non-proxy-cache project
 	if req.RegistryID == nil {
 		req.Metadata.ProxySpeedKb = nil
 		req.Metadata.MaxUpstreamConn = nil
+		req.Metadata.ProxyCacheFilterPattern = nil
+		req.Metadata.ProxyCacheFilterKind = nil
 	}
 
 	// ignore enable_content_trust metadata for proxy cache project
@@ -567,16 +570,21 @@ func (a *projectAPI) UpdateProject(ctx context.Context, params operation.UpdateP
 		}
 	}
 
-	// ignore metadata.proxy_speed_kb and metadata.max_upstream_conn for non-proxy-cache project
+	// ignore metadata.proxy_speed_kb, metadata.max_upstream_conn, proxy_cache_filter_pattern and proxy_cache_filter_kind for non-proxy-cache project
 	if params.Project.Metadata != nil && !p.IsProxy() {
 		params.Project.Metadata.ProxySpeedKb = nil
 		params.Project.Metadata.MaxUpstreamConn = nil
+		params.Project.Metadata.ProxyCacheFilterPattern = nil
+		params.Project.Metadata.ProxyCacheFilterKind = nil
 	}
 
 	// ignore enable_content_trust metadata for proxy cache project
 	// see https://github.com/goharbor/harbor/issues/12940 to get more info
 	if params.Project.Metadata != nil && p.IsProxy() {
 		params.Project.Metadata.EnableContentTrust = nil
+		if err := validateProxyCacheRepositoryFilter(params.Project.Metadata); err != nil {
+			return a.SendError(ctx, err)
+		}
 	}
 	if err := lib.JSONCopy(&p.Metadata, params.Project.Metadata); err != nil {
 		log.Warningf("failed to call JSONCopy on project metadata when UpdateProject, error: %v", err)
@@ -826,6 +834,10 @@ func (a *projectAPI) validateProjectReq(ctx context.Context, req *models.Project
 				return errors.BadRequestError(nil).WithMessagef("metadata.max_upstream_conn should be an int, but got '%s', err: %s", *cnt, err)
 			}
 		}
+
+		if err := validateProxyCacheRepositoryFilter(req.Metadata); err != nil {
+			return err
+		}
 	}
 
 	if req.StorageLimit != nil {
@@ -835,6 +847,31 @@ func (a *projectAPI) validateProjectReq(ctx context.Context, req *models.Project
 		}
 	}
 
+	return nil
+}
+
+func validateProxyCacheRepositoryFilter(metadata *models.ProjectMetadata) error {
+	if metadata == nil {
+		return nil
+	}
+
+	filterPattern := lib.StringValue(metadata.ProxyCacheFilterPattern)
+	filterKind := lib.StringValue(metadata.ProxyCacheFilterKind)
+
+	// If both pattern and kind are empty, allow it and skip further validation
+	if filterPattern == "" && filterKind == "" {
+		return nil
+	}
+
+	if filterKind != pattern.KindRegex && filterKind != pattern.KindDoublestar {
+		return errors.BadRequestError(nil).
+			WithMessagef("metadata.proxy_cache_filter_kind should be %q or %q, but got: %q", pattern.KindDoublestar, pattern.KindRegex, filterKind)
+	}
+
+	if err := pattern.ValidateRepositoryFilter(filterPattern, filterKind); err != nil {
+		return errors.BadRequestError(nil).
+			WithMessagef("metadata.proxy_cache_filter_pattern is invalid for kind %q: %v", filterKind, err)
+	}
 	return nil
 }
 

--- a/src/server/v2.0/handler/project_metadata.go
+++ b/src/server/v2.0/handler/project_metadata.go
@@ -25,6 +25,7 @@ import (
 	"github.com/goharbor/harbor/src/controller/project"
 	"github.com/goharbor/harbor/src/controller/project/metadata"
 	"github.com/goharbor/harbor/src/lib/errors"
+	"github.com/goharbor/harbor/src/lib/pattern"
 	proModels "github.com/goharbor/harbor/src/pkg/project/models"
 	"github.com/goharbor/harbor/src/pkg/scan/vuln"
 	operation "github.com/goharbor/harbor/src/server/v2.0/restapi/operations/project_metadata"
@@ -48,12 +49,12 @@ func (p *projectMetadataAPI) AddProjectMetadatas(ctx context.Context, params ope
 	if err := p.RequireProjectAccess(ctx, projectNameOrID, rbac.ActionCreate, rbac.ResourceMetadata); err != nil {
 		return p.SendError(ctx, err)
 	}
-	metadata := params.Metadata
-	metadata, err := p.validate(metadata)
+	project, err := p.proCtl.Get(ctx, projectNameOrID)
 	if err != nil {
 		return p.SendError(ctx, err)
 	}
-	project, err := p.proCtl.Get(ctx, projectNameOrID)
+	metadata := params.Metadata
+	metadata, err = p.validate(ctx, project.ProjectID, metadata)
 	if err != nil {
 		return p.SendError(ctx, err)
 	}
@@ -88,6 +89,19 @@ func (p *projectMetadataAPI) DeleteProjectMetadata(ctx context.Context, params o
 	if err != nil {
 		return p.SendError(ctx, err)
 	}
+	if params.MetaName == proModels.ProMetaProxyCacheFilterKind {
+		if p.ctl != nil {
+			existing, err := p.ctl.Get(ctx, project.ProjectID, proModels.ProMetaProxyCacheFilterPattern)
+			if err != nil {
+				return p.SendError(ctx, err)
+			}
+			if patVal, ok := existing[proModels.ProMetaProxyCacheFilterPattern]; ok && patVal != "" {
+				return p.SendError(ctx, errors.New(nil).WithCode(errors.BadRequestCode).
+					WithMessagef("cannot delete %s when %s is not empty, please clear the pattern first",
+						proModels.ProMetaProxyCacheFilterKind, proModels.ProMetaProxyCacheFilterPattern))
+			}
+		}
+	}
 	if err = p.ctl.Delete(ctx, project.ProjectID, params.MetaName); err != nil {
 		return p.SendError(ctx, err)
 	}
@@ -115,14 +129,14 @@ func (p *projectMetadataAPI) UpdateProjectMetadata(ctx context.Context, params o
 	if err := p.RequireProjectAccess(ctx, projectNameOrID, rbac.ActionUpdate, rbac.ResourceMetadata); err != nil {
 		return p.SendError(ctx, err)
 	}
-	metadata := map[string]string{
-		params.MetaName: params.Metadata[params.MetaName],
-	}
-	metadata, err := p.validate(metadata)
+	project, err := p.proCtl.Get(ctx, projectNameOrID)
 	if err != nil {
 		return p.SendError(ctx, err)
 	}
-	project, err := p.proCtl.Get(ctx, projectNameOrID)
+	metadata := map[string]string{
+		params.MetaName: params.Metadata[params.MetaName],
+	}
+	metadata, err = p.validate(ctx, project.ProjectID, metadata)
 	if err != nil {
 		return p.SendError(ctx, err)
 	}
@@ -132,7 +146,7 @@ func (p *projectMetadataAPI) UpdateProjectMetadata(ctx context.Context, params o
 	return operation.NewUpdateProjectMetadataOK()
 }
 
-func (p *projectMetadataAPI) validate(metas map[string]string) (map[string]string, error) {
+func (p *projectMetadataAPI) validate(ctx context.Context, projectID int64, metas map[string]string) (map[string]string, error) {
 	if len(metas) != 1 {
 		return nil, errors.New(nil).WithCode(errors.BadRequestCode).WithMessage("only allow one key/value pair")
 	}
@@ -176,6 +190,73 @@ func (p *projectMetadataAPI) validate(metas map[string]string) (map[string]strin
 				WithMessagef("invalid value for %s: %d", key, v)
 		}
 		metas[proModels.ProMetaMaxUpstreamConn] = strconv.FormatInt(v, 10)
+	case proModels.ProMetaProxyCacheFilterPattern:
+		if p.proCtl != nil {
+			pro, err := p.proCtl.Get(ctx, projectID)
+			if err != nil {
+				return nil, err
+			}
+			if !pro.IsProxy() {
+				return nil, errors.New(nil).WithCode(errors.BadRequestCode).WithMessage("can not update the normal project with proxy cache filter metadata")
+			}
+		}
+		// plain pattern string; empty means match all — no further validation needed at metadata level
+		kind := pattern.KindDoublestar
+		if k, ok := metas[proModels.ProMetaProxyCacheFilterKind]; ok && k != "" {
+			kind = k
+		} else if p.ctl != nil {
+			existing, err := p.ctl.Get(ctx, projectID, proModels.ProMetaProxyCacheFilterKind)
+			if err != nil {
+				return nil, err
+			}
+			if k, ok := existing[proModels.ProMetaProxyCacheFilterKind]; ok && k != "" {
+				kind = k
+			}
+		}
+		if err := pattern.ValidateRepositoryFilter(value, kind); err != nil {
+			return nil, errors.New(nil).WithCode(errors.BadRequestCode).
+				WithMessagef("invalid proxy_cache_filter_pattern: %q, err: %v", value, err)
+		}
+		metas[proModels.ProMetaProxyCacheFilterPattern] = value
+	case proModels.ProMetaProxyCacheFilterKind:
+		if p.proCtl != nil {
+			pro, err := p.proCtl.Get(ctx, projectID)
+			if err != nil {
+				return nil, err
+			}
+			if !pro.IsProxy() {
+				return nil, errors.New(nil).WithCode(errors.BadRequestCode).WithMessage("can not update the normal project with proxy cache filter metadata")
+			}
+		}
+		// must be "doublestar" or "regex" when specified
+		if value != "" && value != pattern.KindRegex && value != pattern.KindDoublestar {
+			return nil, errors.New(nil).WithCode(errors.BadRequestCode).
+				WithMessagef("invalid proxy_cache_filter_kind: %q, must be %q or %q", value, pattern.KindDoublestar, pattern.KindRegex)
+		}
+		var pat string
+		hasPat := false
+		if patVal, ok := metas[proModels.ProMetaProxyCacheFilterPattern]; ok {
+			pat = patVal
+			hasPat = true
+		} else if p.ctl != nil {
+			if existing, err := p.ctl.Get(ctx, projectID, proModels.ProMetaProxyCacheFilterPattern); err == nil {
+				if patVal, ok := existing[proModels.ProMetaProxyCacheFilterPattern]; ok {
+					pat = patVal
+					hasPat = true
+				}
+			}
+		}
+		if hasPat && pat != "" {
+			kind := value
+			if kind == "" {
+				kind = pattern.KindDoublestar
+			}
+			if err := pattern.ValidateRepositoryFilter(pat, kind); err != nil {
+				return nil, errors.New(nil).WithCode(errors.BadRequestCode).
+					WithMessagef("existing proxy_cache_filter_pattern %q is invalid for new kind %q: %v", pat, kind, err)
+			}
+		}
+		metas[proModels.ProMetaProxyCacheFilterKind] = value
 	default:
 		return nil, errors.New(nil).WithCode(errors.BadRequestCode).WithMessagef("invalid key: %s", key)
 	}

--- a/src/server/v2.0/handler/project_metadata_test.go
+++ b/src/server/v2.0/handler/project_metadata_test.go
@@ -15,19 +15,65 @@
 package handler
 
 import (
+	"context"
 	"testing"
 
+	"github.com/goharbor/harbor/src/common/security"
+	"github.com/goharbor/harbor/src/controller/project"
+	"github.com/goharbor/harbor/src/controller/project/metadata"
+	"github.com/goharbor/harbor/src/lib/pattern"
 	proModels "github.com/goharbor/harbor/src/pkg/project/models"
+	operation "github.com/goharbor/harbor/src/server/v2.0/restapi/operations/project_metadata"
+	securitytesting "github.com/goharbor/harbor/src/testing/common/security"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
+type fakeMetadataController struct {
+	metadata.Controller
+	getFunc func(ctx context.Context, projectID int64, meta ...string) (map[string]string, error)
+	deleteFunc func(ctx context.Context, projectID int64, meta ...string) error
+}
+
+func (f *fakeMetadataController) Get(ctx context.Context, projectID int64, meta ...string) (map[string]string, error) {
+	if f.getFunc != nil {
+		return f.getFunc(ctx, projectID, meta...)
+	}
+	return nil, nil
+}
+
+func (f *fakeMetadataController) Delete(ctx context.Context, projectID int64, meta ...string) error {
+	if f.deleteFunc != nil {
+		return f.deleteFunc(ctx, projectID, meta...)
+	}
+	return nil
+}
+
+type fakeProjectController struct {
+	project.Controller
+	getFunc func(ctx context.Context, projectIDOrName any, options ...project.Option) (*proModels.Project, error)
+}
+
+func (f *fakeProjectController) Get(ctx context.Context, projectIDOrName any, options ...project.Option) (*proModels.Project, error) {
+	if f.getFunc != nil {
+		return f.getFunc(ctx, projectIDOrName, options...)
+	}
+	return nil, nil
+}
+
 func TestValidate(t *testing.T) {
-	api := &projectMetadataAPI{}
+	fakeCtl := &fakeMetadataController{}
+	fakeProCtl := &fakeProjectController{}
+	api := &projectMetadataAPI{
+		ctl:    fakeCtl,
+		proCtl: fakeProCtl,
+	}
 
 	tests := []struct {
 		name      string
 		metas     map[string]string
 		expectErr bool
+		setup     func()
 	}{
 		{
 			name:      "Invalid max upstream conn value",
@@ -64,11 +110,115 @@ func TestValidate(t *testing.T) {
 			metas:     map[string]string{},
 			expectErr: true,
 		},
+		{
+			name:      "ProxyCacheFilterPattern with KindDoublestar (valid)",
+			metas:     map[string]string{proModels.ProMetaProxyCacheFilterPattern: "**"},
+			expectErr: false,
+			setup: func() {
+				fakeProCtl.getFunc = func(ctx context.Context, projectIDOrName any, options ...project.Option) (*proModels.Project, error) {
+					return &proModels.Project{RegistryID: 1}, nil
+				}
+				fakeCtl.getFunc = func(ctx context.Context, projectID int64, meta ...string) (map[string]string, error) {
+					return map[string]string{proModels.ProMetaProxyCacheFilterKind: pattern.KindDoublestar}, nil
+				}
+			},
+		},
+		{
+			name:      "ProxyCacheFilterPattern with KindDoublestar (invalid)",
+			metas:     map[string]string{proModels.ProMetaProxyCacheFilterPattern: "[invalid"},
+			expectErr: true,
+			setup: func() {
+				fakeProCtl.getFunc = func(ctx context.Context, projectIDOrName any, options ...project.Option) (*proModels.Project, error) {
+					return &proModels.Project{RegistryID: 1}, nil
+				}
+				fakeCtl.getFunc = func(ctx context.Context, projectID int64, meta ...string) (map[string]string, error) {
+					return map[string]string{proModels.ProMetaProxyCacheFilterKind: pattern.KindDoublestar}, nil
+				}
+			},
+		},
+		{
+			name:      "ProxyCacheFilterPattern with KindRegex (valid)",
+			metas:     map[string]string{proModels.ProMetaProxyCacheFilterPattern: "^foo/.*$"},
+			expectErr: false,
+			setup: func() {
+				fakeProCtl.getFunc = func(ctx context.Context, projectIDOrName any, options ...project.Option) (*proModels.Project, error) {
+					return &proModels.Project{RegistryID: 1}, nil
+				}
+				fakeCtl.getFunc = func(ctx context.Context, projectID int64, meta ...string) (map[string]string, error) {
+					return map[string]string{proModels.ProMetaProxyCacheFilterKind: pattern.KindRegex}, nil
+				}
+			},
+		},
+		{
+			name:      "ProxyCacheFilterPattern with KindRegex (invalid)",
+			metas:     map[string]string{proModels.ProMetaProxyCacheFilterPattern: "[invalid"},
+			expectErr: true,
+			setup: func() {
+				fakeProCtl.getFunc = func(ctx context.Context, projectIDOrName any, options ...project.Option) (*proModels.Project, error) {
+					return &proModels.Project{RegistryID: 1}, nil
+				}
+				fakeCtl.getFunc = func(ctx context.Context, projectID int64, meta ...string) (map[string]string, error) {
+					return map[string]string{proModels.ProMetaProxyCacheFilterKind: pattern.KindRegex}, nil
+				}
+			},
+		},
+		{
+			name:      "ProxyCacheFilterKind with valid existing pattern",
+			metas:     map[string]string{proModels.ProMetaProxyCacheFilterKind: pattern.KindRegex},
+			expectErr: false,
+			setup: func() {
+				fakeProCtl.getFunc = func(ctx context.Context, projectIDOrName any, options ...project.Option) (*proModels.Project, error) {
+					return &proModels.Project{RegistryID: 1}, nil
+				}
+				fakeCtl.getFunc = func(ctx context.Context, projectID int64, meta ...string) (map[string]string, error) {
+					return map[string]string{proModels.ProMetaProxyCacheFilterPattern: "^foo/.*$"}, nil
+				}
+			},
+		},
+		{
+			name:      "ProxyCacheFilterKind with invalid existing pattern for doublestar",
+			metas:     map[string]string{proModels.ProMetaProxyCacheFilterKind: pattern.KindDoublestar},
+			expectErr: true,
+			setup: func() {
+				fakeProCtl.getFunc = func(ctx context.Context, projectIDOrName any, options ...project.Option) (*proModels.Project, error) {
+					return &proModels.Project{RegistryID: 1}, nil
+				}
+				fakeCtl.getFunc = func(ctx context.Context, projectID int64, meta ...string) (map[string]string, error) {
+					return map[string]string{proModels.ProMetaProxyCacheFilterPattern: "[invalid"}, nil
+				}
+			},
+		},
+		{
+			name:      "ProxyCacheFilterPattern on normal project (invalid)",
+			metas:     map[string]string{proModels.ProMetaProxyCacheFilterPattern: "**"},
+			expectErr: true,
+			setup: func() {
+				fakeProCtl.getFunc = func(ctx context.Context, projectIDOrName any, options ...project.Option) (*proModels.Project, error) {
+					return &proModels.Project{RegistryID: 0}, nil
+				}
+			},
+		},
+		{
+			name:      "ProxyCacheFilterKind on normal project (invalid)",
+			metas:     map[string]string{proModels.ProMetaProxyCacheFilterKind: pattern.KindDoublestar},
+			expectErr: true,
+			setup: func() {
+				fakeProCtl.getFunc = func(ctx context.Context, projectIDOrName any, options ...project.Option) (*proModels.Project, error) {
+					return &proModels.Project{RegistryID: 0}, nil
+				}
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := api.validate(tt.metas)
+			if tt.setup != nil {
+				tt.setup()
+			} else {
+				fakeCtl.getFunc = nil
+				fakeProCtl.getFunc = nil
+			}
+			result, err := api.validate(context.TODO(), int64(1), tt.metas)
 			if tt.expectErr {
 				assert.Error(t, err)
 				assert.Nil(t, result)
@@ -78,4 +228,91 @@ func TestValidate(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDeleteProjectMetadata(t *testing.T) {
+	fakeCtl := &fakeMetadataController{}
+	fakeProCtl := &fakeProjectController{}
+	api := &projectMetadataAPI{
+		ctl:    fakeCtl,
+		proCtl: fakeProCtl,
+	}
+
+	mockSecCtx := &securitytesting.Context{}
+	mockSecCtx.On("IsAuthenticated").Return(true)
+	mockSecCtx.On("Can", mock.Anything, mock.Anything, mock.Anything).Return(true)
+	ctx := security.NewContext(context.TODO(), mockSecCtx)
+
+	fakeProCtl.getFunc = func(ctx context.Context, projectIDOrName any, options ...project.Option) (*proModels.Project, error) {
+		return &proModels.Project{
+			ProjectID: 1,
+			Name:      "library",
+		}, nil
+	}
+
+	// 1. Delete proxy_cache_filter_kind when pattern is present and not empty -> expect 400
+	fakeCtl.getFunc = func(ctx context.Context, projectID int64, meta ...string) (map[string]string, error) {
+		assert.Equal(t, int64(1), projectID)
+		assert.Contains(t, meta, proModels.ProMetaProxyCacheFilterPattern)
+		return map[string]string{
+			proModels.ProMetaProxyCacheFilterPattern: "^library/(nginx|redis)$",
+		}, nil
+	}
+
+	params := operation.DeleteProjectMetadataParams{
+		ProjectNameOrID: "1",
+		MetaName:        proModels.ProMetaProxyCacheFilterKind,
+	}
+
+	resp := api.DeleteProjectMetadata(ctx, params)
+	assert.NotNil(t, resp)
+	_, ok := resp.(*operation.DeleteProjectMetadataOK)
+	assert.False(t, ok, "expected error responder when deleting proxy_cache_filter_kind while a non-empty pattern exists")
+
+	// 2. Delete proxy_cache_filter_kind when pattern is empty -> expect success
+	fakeCtl.getFunc = func(ctx context.Context, projectID int64, meta ...string) (map[string]string, error) {
+		return map[string]string{
+			proModels.ProMetaProxyCacheFilterPattern: "",
+		}, nil
+	}
+
+	calledDelete := false
+	fakeCtl.deleteFunc = func(ctx context.Context, projectID int64, meta ...string) error {
+		assert.Equal(t, int64(1), projectID)
+		assert.Contains(t, meta, proModels.ProMetaProxyCacheFilterKind)
+		calledDelete = true
+		return nil
+	}
+
+	respOK := api.DeleteProjectMetadata(ctx, params)
+	assert.NotNil(t, respOK)
+	_, ok = respOK.(*operation.DeleteProjectMetadataOK)
+	assert.True(t, ok, "expected OK responder when deleting proxy_cache_filter_kind while pattern is empty")
+	assert.True(t, calledDelete)
+
+	// 3. Delete another key (e.g. public) even if pattern is not empty -> expect success
+	fakeCtl.getFunc = func(ctx context.Context, projectID int64, meta ...string) (map[string]string, error) {
+		return map[string]string{
+			proModels.ProMetaProxyCacheFilterPattern: "^library/(nginx|redis)$",
+		}, nil
+	}
+
+	calledDeleteOther := false
+	fakeCtl.deleteFunc = func(ctx context.Context, projectID int64, meta ...string) error {
+		assert.Equal(t, int64(1), projectID)
+		assert.Contains(t, meta, "public")
+		calledDeleteOther = true
+		return nil
+	}
+
+	paramsOther := operation.DeleteProjectMetadataParams{
+		ProjectNameOrID: "1",
+		MetaName:        "public",
+	}
+
+	respOtherOK := api.DeleteProjectMetadata(ctx, paramsOther)
+	assert.NotNil(t, respOtherOK)
+	_, ok = respOtherOK.(*operation.DeleteProjectMetadataOK)
+	assert.True(t, ok, "expected OK responder when deleting other key than proxy_cache_filter_kind")
+	assert.True(t, calledDeleteOther)
 }


### PR DESCRIPTION
Introduce repository filter pattern and kind on proxy cache projects to explicitly allow selected repositories. Requests that do not match the filter are denied before Harbor proxies content from upstream.

Fixes #13231

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [ ] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [ ] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
