### PR TITLE
fix(ui): use dark login background in dark mode

### DIFF
--- a/src/portal/src/app/account/sign-in/sign-in.component.html
+++ b/src/portal/src/app/account/sign-in/sign-in.component.html
@@ -4,11 +4,13 @@
     <search-result></search-result>
     <div
         class="login-wrapper"
-        [ngStyle]="{
-            'background-image': customLoginBgImg
-                ? 'url(/images/' + customLoginBgImg + ')'
-                : ''
-        }">
+        [style.background-image]="
+            customLoginBgImg ? 'url(/images/' + customLoginBgImg + ')' : null
+        "
+        [style.background-color]="
+            customLoginBgImg ? null : 'var(--clr-login-background-color)'
+        "
+        [style.background-blend-mode]="customLoginBgImg ? null : 'multiply'">
         <form #signInForm="ngForm" class="login">
             @if (isOidcLoginMode && steps === 2) {
             <span (click)="steps = 1" class="back-icon">

--- a/src/portal/src/app/account/sign-in/sign-in.component.spec.ts
+++ b/src/portal/src/app/account/sign-in/sign-in.component.spec.ts
@@ -103,6 +103,28 @@ describe('SignInComponent', () => {
         expect(component).toBeTruthy();
     });
 
+    it('should apply the theme color to the default login background', () => {
+        component.customLoginBgImg = '';
+        fixture.detectChanges();
+
+        const loginWrapper: HTMLDivElement =
+            fixture.nativeElement.querySelector('.login-wrapper');
+        expect(loginWrapper.style.backgroundColor).toBe(
+            'var(--clr-login-background-color)'
+        );
+        expect(loginWrapper.style.backgroundBlendMode).toBe('multiply');
+    });
+
+    it('should not apply theme blending to a custom login background', () => {
+        const loginWrapper: HTMLDivElement =
+            fixture.nativeElement.querySelector('.login-wrapper');
+        expect(loginWrapper.style.backgroundImage).toContain(
+            'url("/images/abc")'
+        );
+        expect(loginWrapper.style.backgroundColor).toBe('');
+        expect(loginWrapper.style.backgroundBlendMode).toBe('');
+    });
+
     it('should show core service is not available', async () => {
         expect(component).toBeTruthy();
         const sessionService = TestBed.inject<SessionService>(SessionService);


### PR DESCRIPTION
Thank you for contributing to Harbor!

# Comprehensive Summary of your change

Clarity's built-in login illustration uses a fixed light palette, so switching Harbor to dark mode only updated the login form and left the illustration bright.

This change blends the built-in illustration with Clarity's theme-aware login background color. The light theme remains unchanged, the dark theme gets a matching dark illustration, and custom branded login backgrounds are left untouched.

Regression tests cover both the default and custom-background paths.

### Fixed UI Screenshot
<img width="396" height="394" alt="image" src="https://github.com/user-attachments/assets/8d735a9f-9a43-4ee2-8b24-dded058f8b9b" />


# Issue being fixed

Fixes #23533

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website). No documentation changes are needed for this UI-only fix.

## Validation

- `npm run test:headless` — 522 tests passed
- `npx ng lint`
- `npx prettier --check src/app/account/sign-in/sign-in.component.html src/app/account/sign-in/sign-in.component.spec.ts`
- `npm run release`
- Chromium visual validation in light and dark themes
