### PR TITLE
cherry-pick: fix(ui): use dark login background in dark mode

### DIFF
--- a/src/portal/src/app/account/sign-in/sign-in.component.html
+++ b/src/portal/src/app/account/sign-in/sign-in.component.html
@@ -4,11 +4,13 @@
     <search-result></search-result>
     <div
         class="login-wrapper"
-        [ngStyle]="{
-            'background-image': customLoginBgImg
-                ? 'url(/images/' + customLoginBgImg + ')'
-                : ''
-        }">
+        [style.background-image]="
+            customLoginBgImg ? 'url(/images/' + customLoginBgImg + ')' : null
+        "
+        [style.background-color]="
+            customLoginBgImg ? null : 'var(--clr-login-background-color)'
+        "
+        [style.background-blend-mode]="customLoginBgImg ? null : 'multiply'">
         <form #signInForm="ngForm" class="login">
             @if (isOidcLoginMode && steps === 2) {
             <span (click)="steps = 1" class="back-icon">

--- a/src/portal/src/app/account/sign-in/sign-in.component.spec.ts
+++ b/src/portal/src/app/account/sign-in/sign-in.component.spec.ts
@@ -103,6 +103,28 @@ describe('SignInComponent', () => {
         expect(component).toBeTruthy();
     });
 
+    it('should apply the theme color to the default login background', () => {
+        component.customLoginBgImg = '';
+        fixture.detectChanges();
+
+        const loginWrapper: HTMLDivElement =
+            fixture.nativeElement.querySelector('.login-wrapper');
+        expect(loginWrapper.style.backgroundColor).toBe(
+            'var(--clr-login-background-color)'
+        );
+        expect(loginWrapper.style.backgroundBlendMode).toBe('multiply');
+    });
+
+    it('should not apply theme blending to a custom login background', () => {
+        const loginWrapper: HTMLDivElement =
+            fixture.nativeElement.querySelector('.login-wrapper');
+        expect(loginWrapper.style.backgroundImage).toContain(
+            'url("/images/abc")'
+        );
+        expect(loginWrapper.style.backgroundColor).toBe('');
+        expect(loginWrapper.style.backgroundBlendMode).toBe('');
+    });
+
     it('should show core service is not available', async () => {
         expect(component).toBeTruthy();
         const sessionService = TestBed.inject<SessionService>(SessionService);


### PR DESCRIPTION
## Fixes

- [x] Addresses the login dark-mode background mismatch on the sign-in screen.
Cherry-pick of #23535 

- Fixes #23533 
