### PR TITLE
Fix grammar: 'can not be override' -> 'cannot be overridden' in comment

### DIFF
--- a/src/jobservice/common/rds/utils.go
+++ b/src/jobservice/common/rds/utils.go
@@ -116,7 +116,7 @@ func AcquireLock(conn redis.Conn, lockerKey string, lockerID string, expireTime 
 	if err != nil {
 		return err
 	}
-	// Existing, the value can not be override
+	// Existing, the value cannot be overridden
 	if res == nil {
 		return fmt.Errorf("key %s is already set with value %v", lockerKey, lockerID)
 	}


### PR DESCRIPTION
Fix grammar in a source code comment in utils.go: 'can not be override' should be 'cannot be overridden'.