### PR TITLE
fix(ui): UI displays OIDC/LDAP Administrator

### DIFF
--- a/api/v2.0/swagger.yaml
+++ b/api/v2.0/swagger.yaml
@@ -9793,6 +9793,9 @@ definitions:
       sysadmin_flag:
         type: boolean
         x-omitempty: false
+      sysadmin_flag_source:
+        type: string
+        description: how sysadmin_flag was last set - "manual" for an explicit operator action, "sync" for the LDAP/OIDC admin-group sync, or empty if never set for a non-DB-auth user.
       admin_role_in_auth:
         type: boolean
         x-omitempty: false

--- a/make/migrations/postgresql/0191_track_sysadmin_flag_source_schema.up.sql
+++ b/make/migrations/postgresql/0191_track_sysadmin_flag_source_schema.up.sql
@@ -1,0 +1,11 @@
+/* track whether sysadmin_flag was set by an operator or synced from the IdP admin group,
+   so that LDAP/OIDC group-based admin sync never silently overrides an explicit manual decision */
+ALTER TABLE harbor_user ADD COLUMN IF NOT EXISTS sysadmin_flag_source varchar(16) DEFAULT NULL;
+
+/* preserve existing admins as-is, so this migration can never auto-revoke one on next login.
+   Existing non-admins are deliberately left with a NULL (sync-eligible) source instead, even
+   though a few may have been manually demoted in the past and could get re-synced to admin:
+   that's accepted, since IsSysAdmin() already ORs in the live LDAP/OIDC role, so a stale false
+   flag never actually revoked their real access anyway. Only future manual changes are immune
+   to sync, via the 'manual' tag SetSysAdminFlag now always sets. */
+UPDATE harbor_user SET sysadmin_flag_source = 'manual' WHERE sysadmin_flag = true AND sysadmin_flag_source IS NULL;

--- a/src/common/models/user.go
+++ b/src/common/models/user.go
@@ -31,6 +31,11 @@ type User struct {
 	Rolename        string `json:"role_name"`
 	Role            int    `json:"role_id"`
 	SysAdminFlag    bool   `json:"sysadmin_flag"`
+	// SysAdminFlagSource records who last set SysAdminFlag: "manual" for an explicit operator
+	// action, "sync" for the LDAP/OIDC admin-group sync, or "" if never set. Auth sync only
+	// ever changes the flag when the source is not "manual", so it never overrides an
+	// operator's explicit grant or revocation.
+	SysAdminFlagSource string `json:"-"`
 	// AdminRoleInAuth to store the admin privilege granted by external authentication provider
 	AdminRoleInAuth bool      `json:"admin_role_in_auth"`
 	ResetUUID       string    `json:"reset_uuid"`

--- a/src/controller/user/controller.go
+++ b/src/controller/user/controller.go
@@ -43,6 +43,9 @@ var (
 type Controller interface {
 	// SetSysAdmin ...
 	SetSysAdmin(ctx context.Context, id int, adminFlag bool) error
+	// SyncSysAdmin reconciles the sysadmin flag with the admin role granted by the LDAP/OIDC
+	// admin group at login time. It never overrides a flag that was explicitly set by an operator.
+	SyncSysAdmin(ctx context.Context, id int, adminRoleInAuth bool) error
 	// VerifyPassword ...
 	VerifyPassword(ctx context.Context, usernameOrEmail string, password string) (bool, error)
 	// UpdatePassword ...
@@ -242,6 +245,10 @@ func (c *controller) VerifyPassword(ctx context.Context, usernameOrEmail, passwo
 
 func (c *controller) SetSysAdmin(ctx context.Context, id int, adminFlag bool) error {
 	return c.mgr.SetSysAdminFlag(ctx, id, adminFlag)
+}
+
+func (c *controller) SyncSysAdmin(ctx context.Context, id int, adminRoleInAuth bool) error {
+	return c.mgr.SyncSysAdminFlagFromAuth(ctx, id, adminRoleInAuth)
 }
 
 func (c *controller) SearchByName(ctx context.Context, name string, limitSize int) ([]*commonmodels.User, error) {

--- a/src/core/auth/ldap/ldap.go
+++ b/src/core/auth/ldap/ldap.go
@@ -350,6 +350,7 @@ func (l *Auth) PostAuthenticate(ctx context.Context, u *models.User) error {
 			}
 		}
 
+		l.syncSysAdminFlag(ctx, u)
 		return nil
 	}
 
@@ -360,7 +361,18 @@ func (l *Auth) PostAuthenticate(ctx context.Context, u *models.User) error {
 	if u.UserID <= 0 {
 		return fmt.Errorf("cannot OnBoardUser %v", u)
 	}
+	l.syncSysAdminFlag(ctx, u)
 	return nil
+}
+
+// syncSysAdminFlag persists the admin role granted by the LDAP admin group at this login, so
+// the Users list can report it accurately. It never overrides a flag an operator set manually,
+// and any failure is only logged - this is a best-effort reporting improvement, not something
+// that should ever fail a login.
+func (l *Auth) syncSysAdminFlag(ctx context.Context, u *models.User) {
+	if err := l.userMgr.SyncSysAdminFlagFromAuth(ctx, u.UserID, u.AdminRoleInAuth); err != nil {
+		log.Warningf("failed to sync sysadmin flag from LDAP group for user %s: %v", u.Username, err)
+	}
 }
 
 func init() {

--- a/src/core/controllers/oidc.go
+++ b/src/core/controllers/oidc.go
@@ -209,6 +209,13 @@ func (oc *OIDCController) Callback() {
 		return
 	}
 	oidc.InjectGroupsToUser(info, u)
+	// persist the admin role granted by the OIDC admin group at this login, so the Users list
+	// can report it accurately. Never overrides a flag an operator set manually, and any
+	// failure is only logged - this is a best-effort reporting improvement, not something that
+	// should ever fail a login.
+	if err := ctluser.Ctl.SyncSysAdmin(ctx, u.UserID, u.AdminRoleInAuth); err != nil {
+		log.Warningf("failed to sync sysadmin flag from OIDC group for user %s: %v", u.Username, err)
+	}
 	um, err := ctluser.Ctl.Get(ctx, u.UserID, &ctluser.Option{WithOIDCInfo: true})
 	if err != nil {
 		oc.SendError(err)

--- a/src/pkg/user/dao/user.go
+++ b/src/pkg/user/dao/user.go
@@ -38,10 +38,12 @@ type User struct {
 	Comment         string         `orm:"column(comment)" json:"comment"`
 	Deleted         bool           `orm:"column(deleted)" json:"deleted"`
 	SysAdminFlag    bool           `orm:"column(sysadmin_flag)" json:"sysadmin_flag"`
-	ResetUUID       string         `orm:"column(reset_uuid)" json:"reset_uuid"`
-	Salt            string         `orm:"column(salt)" filter:"false" json:"-"`
-	CreationTime    time.Time      `orm:"column(creation_time);auto_now_add" json:"creation_time"`
-	UpdateTime      time.Time      `orm:"column(update_time);auto_now" json:"update_time"`
+	// SysAdminFlagSource is "manual", "sync" or "" (see common/models.User for details)
+	SysAdminFlagSource string    `orm:"column(sysadmin_flag_source)" filter:"false" json:"-"`
+	ResetUUID          string    `orm:"column(reset_uuid)" json:"reset_uuid"`
+	Salt               string    `orm:"column(salt)" filter:"false" json:"-"`
+	CreationTime       time.Time `orm:"column(creation_time);auto_now_add" json:"creation_time"`
+	UpdateTime         time.Time `orm:"column(update_time);auto_now" json:"update_time"`
 }
 
 // TableName ...
@@ -65,6 +67,7 @@ func toDBUser(u *commonmodels.User) *User {
 	user.Comment = u.Comment
 	user.Deleted = u.Deleted
 	user.SysAdminFlag = u.SysAdminFlag
+	user.SysAdminFlagSource = u.SysAdminFlagSource
 	user.ResetUUID = u.ResetUUID
 	user.Salt = u.Salt
 	user.CreationTime = u.CreationTime
@@ -85,6 +88,7 @@ func toCommonUser(u *User) *commonmodels.User {
 	user.Comment = u.Comment
 	user.Deleted = u.Deleted
 	user.SysAdminFlag = u.SysAdminFlag
+	user.SysAdminFlagSource = u.SysAdminFlagSource
 	user.ResetUUID = u.ResetUUID
 	user.Salt = u.Salt
 	user.CreationTime = u.CreationTime

--- a/src/pkg/user/manager.go
+++ b/src/pkg/user/manager.go
@@ -24,6 +24,7 @@ import (
 	"github.com/goharbor/harbor/src/common/utils"
 	"github.com/goharbor/harbor/src/lib"
 	"github.com/goharbor/harbor/src/lib/errors"
+	"github.com/goharbor/harbor/src/lib/log"
 	"github.com/goharbor/harbor/src/lib/q"
 	"github.com/goharbor/harbor/src/pkg/user/dao"
 	"github.com/goharbor/harbor/src/pkg/user/models"
@@ -32,6 +33,15 @@ import (
 var (
 	// Mgr is the global project manager
 	Mgr = New()
+)
+
+const (
+	// sysAdminFlagSourceManual marks sysadmin_flag as set by an explicit operator action;
+	// auth sync must never override a manually set flag.
+	sysAdminFlagSourceManual = "manual"
+	// sysAdminFlagSourceSync marks sysadmin_flag as set by the LDAP/OIDC admin-group sync;
+	// auth sync remains free to update it again on a later login.
+	sysAdminFlagSourceSync = "sync"
 )
 
 // Manager is used for user management
@@ -50,8 +60,17 @@ type Manager interface {
 	Delete(ctx context.Context, id int) error
 	// DeleteGDPR deletes the user by updating user's delete flag and replace identifiable data with its crc
 	DeleteGDPR(ctx context.Context, id int) error
-	// SetSysAdminFlag sets the system admin flag of the user in local DB
+	// SetSysAdminFlag sets the system admin flag of the user in local DB. This is an explicit
+	// operator action: it marks the flag as manually-owned, so SyncSysAdminFlagFromAuth will
+	// never override it on a later login.
 	SetSysAdminFlag(ctx context.Context, id int, admin bool) error
+	// SyncSysAdminFlagFromAuth reconciles the persisted sysadmin_flag (used for reporting, e.g.
+	// the Users list) with the admin role granted by the LDAP/OIDC admin group at login time
+	// (adminRoleInAuth). Real admin authorization is unaffected either way - it already checks
+	// the live admin role independently of this flag. This is a no-op if the flag was last set
+	// manually by an operator, so it only ever updates the stored flag for users whose admin
+	// status has never been explicitly decided by a human.
+	SyncSysAdminFlagFromAuth(ctx context.Context, id int, adminRoleInAuth bool) error
 	// UpdateProfile updates the user's profile
 	UpdateProfile(ctx context.Context, user *commonmodels.User, col ...string) error
 	// UpdatePassword updates user's password
@@ -161,10 +180,45 @@ func (m *manager) UpdatePassword(ctx context.Context, id int, newPassword string
 
 func (m *manager) SetSysAdminFlag(ctx context.Context, id int, admin bool) error {
 	u := &commonmodels.User{
-		UserID:       id,
-		SysAdminFlag: admin,
+		UserID:             id,
+		SysAdminFlag:       admin,
+		SysAdminFlagSource: sysAdminFlagSourceManual,
 	}
-	return m.dao.Update(ctx, u, "sysadmin_flag")
+	return m.dao.Update(ctx, u, "sysadmin_flag", "sysadmin_flag_source")
+}
+
+func (m *manager) SyncSysAdminFlagFromAuth(ctx context.Context, id int, adminRoleInAuth bool) error {
+	cur, err := m.Get(ctx, id)
+	if err != nil {
+		return err
+	}
+	// an operator has explicitly set this user's flag, auth sync must not overwrite it
+	if cur.SysAdminFlagSource == sysAdminFlagSourceManual {
+		return nil
+	}
+	// already confirmed in sync with the current auth-provider role, nothing to do. Note this
+	// only skips when the source is already "sync" - a matching value with an empty source
+	// (never yet confirmed live, e.g. an ordinary non-admin user) still needs the write below so
+	// the source gets stamped, letting the Users list report "No" instead of "Unknown" for them.
+	if cur.SysAdminFlag == adminRoleInAuth && cur.SysAdminFlagSource == sysAdminFlagSourceSync {
+		return nil
+	}
+	u := &commonmodels.User{
+		UserID:             id,
+		SysAdminFlag:       adminRoleInAuth,
+		SysAdminFlagSource: sysAdminFlagSourceSync,
+	}
+	if err := m.dao.Update(ctx, u, "sysadmin_flag", "sysadmin_flag_source"); err != nil {
+		if cur.SysAdminFlag && !adminRoleInAuth {
+			// demotion write failed: sysadmin_flag alone still grants real admin access
+			// (see IsSysAdmin), so this user may keep it via any already-active session or
+			// token until the next successful sync - unlike a failed promotion, this is worth
+			// surfacing as an error, not just a warning
+			log.Errorf("failed to revoke stale sysadmin flag for user %d after IdP admin group removal: %v", id, err)
+		}
+		return err
+	}
+	return nil
 }
 
 func (m *manager) Create(ctx context.Context, user *commonmodels.User) (int, error) {

--- a/src/pkg/user/manager_test.go
+++ b/src/pkg/user/manager_test.go
@@ -42,9 +42,88 @@ func (m *mgrTestSuite) TestSetAdminFlag() {
 	id := 9
 	m.dao.On("Update", mock.Anything, testifymock.MatchedBy(
 		func(u *models.User) bool {
-			return u.UserID == 9 && u.SysAdminFlag
-		}), "sysadmin_flag").Return(nil)
+			return u.UserID == 9 && u.SysAdminFlag && u.SysAdminFlagSource == sysAdminFlagSourceManual
+		}), "sysadmin_flag", "sysadmin_flag_source").Return(nil)
 	err := m.mgr.SetSysAdminFlag(context.Background(), id, true)
+	m.Nil(err)
+	m.dao.AssertExpectations(m.T())
+}
+
+func (m *mgrTestSuite) TestSyncSysAdminFlagFromAuth_PromotesWhenNotManual() {
+	id := 10
+	m.dao.On("List", mock.Anything, mock.Anything).Return([]*models.User{
+		{UserID: id, SysAdminFlag: false, SysAdminFlagSource: ""},
+	}, nil)
+	m.dao.On("Update", mock.Anything, testifymock.MatchedBy(
+		func(u *models.User) bool {
+			return u.UserID == id && u.SysAdminFlag && u.SysAdminFlagSource == sysAdminFlagSourceSync
+		}), "sysadmin_flag", "sysadmin_flag_source").Return(nil)
+	err := m.mgr.SyncSysAdminFlagFromAuth(context.Background(), id, true)
+	m.Nil(err)
+	m.dao.AssertExpectations(m.T())
+}
+
+func (m *mgrTestSuite) TestSyncSysAdminFlagFromAuth_RevokesWhenSyncOwnedAndNoLongerInGroup() {
+	id := 11
+	m.dao.On("List", mock.Anything, mock.Anything).Return([]*models.User{
+		{UserID: id, SysAdminFlag: true, SysAdminFlagSource: sysAdminFlagSourceSync},
+	}, nil)
+	m.dao.On("Update", mock.Anything, testifymock.MatchedBy(
+		func(u *models.User) bool {
+			return u.UserID == id && !u.SysAdminFlag && u.SysAdminFlagSource == sysAdminFlagSourceSync
+		}), "sysadmin_flag", "sysadmin_flag_source").Return(nil)
+	err := m.mgr.SyncSysAdminFlagFromAuth(context.Background(), id, false)
+	m.Nil(err)
+	m.dao.AssertExpectations(m.T())
+}
+
+func (m *mgrTestSuite) TestSyncSysAdminFlagFromAuth_NeverOverridesManualGrant() {
+	id := 12
+	m.dao.On("List", mock.Anything, mock.Anything).Return([]*models.User{
+		{UserID: id, SysAdminFlag: true, SysAdminFlagSource: sysAdminFlagSourceManual},
+	}, nil)
+	// no Update call expected: a manual decision must never be touched by auth sync,
+	// regardless of the live admin-group membership
+	err := m.mgr.SyncSysAdminFlagFromAuth(context.Background(), id, false)
+	m.Nil(err)
+	m.dao.AssertExpectations(m.T())
+}
+
+func (m *mgrTestSuite) TestSyncSysAdminFlagFromAuth_NeverOverridesManualRevocation() {
+	id := 13
+	m.dao.On("List", mock.Anything, mock.Anything).Return([]*models.User{
+		{UserID: id, SysAdminFlag: false, SysAdminFlagSource: sysAdminFlagSourceManual},
+	}, nil)
+	// still in the admin group, but an operator explicitly revoked it manually - must stick
+	err := m.mgr.SyncSysAdminFlagFromAuth(context.Background(), id, true)
+	m.Nil(err)
+	m.dao.AssertExpectations(m.T())
+}
+
+func (m *mgrTestSuite) TestSyncSysAdminFlagFromAuth_NoOpWhenAlreadyInSync() {
+	id := 14
+	m.dao.On("List", mock.Anything, mock.Anything).Return([]*models.User{
+		{UserID: id, SysAdminFlag: true, SysAdminFlagSource: sysAdminFlagSourceSync},
+	}, nil)
+	// already true and already sync-owned: no Update call expected
+	err := m.mgr.SyncSysAdminFlagFromAuth(context.Background(), id, true)
+	m.Nil(err)
+	m.dao.AssertExpectations(m.T())
+}
+
+func (m *mgrTestSuite) TestSyncSysAdminFlagFromAuth_StampsSourceEvenWhenValueUnchanged() {
+	id := 15
+	// an ordinary non-admin user: value already matches, but source was never confirmed live
+	// (empty). The write must still happen so the source becomes "sync", letting the Users
+	// list report a confirmed "No" instead of "Unknown" for them going forward.
+	m.dao.On("List", mock.Anything, mock.Anything).Return([]*models.User{
+		{UserID: id, SysAdminFlag: false, SysAdminFlagSource: ""},
+	}, nil)
+	m.dao.On("Update", mock.Anything, testifymock.MatchedBy(
+		func(u *models.User) bool {
+			return u.UserID == id && !u.SysAdminFlag && u.SysAdminFlagSource == sysAdminFlagSourceSync
+		}), "sysadmin_flag", "sysadmin_flag_source").Return(nil)
+	err := m.mgr.SyncSysAdminFlagFromAuth(context.Background(), id, false)
 	m.Nil(err)
 	m.dao.AssertExpectations(m.T())
 }

--- a/src/portal/src/app/base/left-side-nav/user/user.component.ts
+++ b/src/portal/src/app/base/left-side-nav/user/user.component.ts
@@ -172,8 +172,11 @@ export class UserComponent implements OnDestroy {
         if (
             appConfig &&
             appConfig.auth_mode !== CONFIG_AUTH_MODE.DB_AUTH &&
-            !u.sysadmin_flag
+            !u.sysadmin_flag &&
+            !u.sysadmin_flag_source
         ) {
+            // never confirmed via a real login sync (or a manual grant/revocation) - we
+            // genuinely don't know this user's admin status, unlike a confirmed "No"
             key = 'USER.UNKNOWN';
         }
         this.translate

--- a/src/portal/src/app/base/left-side-nav/user/user.ts
+++ b/src/portal/src/app/base/left-side-nav/user/user.ts
@@ -29,6 +29,7 @@ export class User {
     role_name?: string;
     role_id?: number;
     sysadmin_flag?: boolean;
+    sysadmin_flag_source?: string;
     reset_uuid?: string;
     creation_time?: string;
     update_time?: string;

--- a/src/server/v2.0/handler/model/user.go
+++ b/src/server/v2.0/handler/model/user.go
@@ -46,15 +46,16 @@ func (u *User) ToUserProfile() *svrmodels.UserProfile {
 // ToUserResp ...
 func (u *User) ToUserResp() *svrmodels.UserResp {
 	res := &svrmodels.UserResp{
-		Email:           u.Email,
-		Realname:        u.Realname,
-		Comment:         u.Comment,
-		UserID:          int64(u.UserID),
-		Username:        u.Username,
-		SysadminFlag:    u.SysAdminFlag,
-		AdminRoleInAuth: u.AdminRoleInAuth,
-		CreationTime:    strfmt.DateTime(u.CreationTime),
-		UpdateTime:      strfmt.DateTime(u.UpdateTime),
+		Email:              u.Email,
+		Realname:           u.Realname,
+		Comment:            u.Comment,
+		UserID:             int64(u.UserID),
+		Username:           u.Username,
+		SysadminFlag:       u.SysAdminFlag,
+		SysadminFlagSource: u.SysAdminFlagSource,
+		AdminRoleInAuth:    u.AdminRoleInAuth,
+		CreationTime:       strfmt.DateTime(u.CreationTime),
+		UpdateTime:         strfmt.DateTime(u.UpdateTime),
 	}
 	if u.OIDCUserMeta != nil {
 		res.OIDCUserMeta = &svrmodels.OIDCUserInfo{

--- a/src/testing/controller/user/controller.go
+++ b/src/testing/controller/user/controller.go
@@ -302,6 +302,24 @@ func (_m *Controller) SetSysAdmin(ctx context.Context, id int, adminFlag bool) e
 	return r0
 }
 
+// SyncSysAdmin provides a mock function with given fields: ctx, id, adminRoleInAuth
+func (_m *Controller) SyncSysAdmin(ctx context.Context, id int, adminRoleInAuth bool) error {
+	ret := _m.Called(ctx, id, adminRoleInAuth)
+
+	if len(ret) == 0 {
+		panic("no return value specified for SyncSysAdmin")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, int, bool) error); ok {
+		r0 = rf(ctx, id, adminRoleInAuth)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // UpdateOIDCMeta provides a mock function with given fields: ctx, ou, cols
 func (_m *Controller) UpdateOIDCMeta(ctx context.Context, ou *models.OIDCUser, cols ...string) error {
 	_va := make([]interface{}, len(cols))

--- a/src/testing/pkg/user/manager.go
+++ b/src/testing/pkg/user/manager.go
@@ -326,6 +326,24 @@ func (_m *Manager) SetSysAdminFlag(ctx context.Context, id int, admin bool) erro
 	return r0
 }
 
+// SyncSysAdminFlagFromAuth provides a mock function with given fields: ctx, id, adminRoleInAuth
+func (_m *Manager) SyncSysAdminFlagFromAuth(ctx context.Context, id int, adminRoleInAuth bool) error {
+	ret := _m.Called(ctx, id, adminRoleInAuth)
+
+	if len(ret) == 0 {
+		panic("no return value specified for SyncSysAdminFlagFromAuth")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, int, bool) error); ok {
+		r0 = rf(ctx, id, adminRoleInAuth)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // UpdatePassword provides a mock function with given fields: ctx, id, newPassword
 func (_m *Manager) UpdatePassword(ctx context.Context, id int, newPassword string) error {
 	ret := _m.Called(ctx, id, newPassword)

--- a/tests/apitests/python/test_ldap_admin_role.py
+++ b/tests/apitests/python/test_ldap_admin_role.py
@@ -28,7 +28,8 @@ class TestLdapAdminRole(unittest.TestCase):
             1. Set LDAP Auth configurations;
             2. Create a new public project(PA) by LDAP user mike;
             3. Check project is created successfully;
-            4. Check mike's SysAdminFlag is false, but AdminRoleInAuth should be true
+            4. Check mike's SysAdminFlag is synced to true since mike is an LDAP admin-group
+               member, and AdminRoleInAuth should be true
             5. Delete project(PA);
         """
 
@@ -41,7 +42,7 @@ class TestLdapAdminRole(unittest.TestCase):
 
         _user = self.user.get_user_current(**self.USER_MIKE)
         print( _user)
-        self.assertFalse(_user.sysadmin_flag)
+        self.assertTrue(_user.sysadmin_flag)
         self.assertTrue(_user.admin_role_in_auth)
 
 


### PR DESCRIPTION
Thank you for contributing to Harbor!

# Comprehensive Summary of your change

Fixes Harbor not reporting OIDC/LDAP admin-group members as Administrators in the Users list (always showed "Unknown") as well as non-admin users.

Root cause: the live role granted by LDAP/OIDC group membership was only ever session-scoped, never persisted to the DB sysadmin_flag column that the Users list reads.

## Changes

- Add `harbor_user.sysadmin_flag_source` column, backfills existing admins as manual
- In `pkg/user/manager.go`, add `SetSysAdminFlag` now marks manual and new `SyncSysAdminFlagFromAuth` reconciles flag from live IdP role, skips if manually set.
- `core/auth/ldap/ldap.go`: calls sync in `PostAuthenticate`.
- `core/controllers/oidc.go`: calls sync in `Callback`.
- `controller/user/controller.go`: new `SyncSysAdmin` wrapper.
- `common/models/user.go`, `pkg/user/dao/user.go`: new field + DB mapping.
- `testing/pkg/user/manager.go`, `testing/controller/user/controller.go`: mock updates
- Add new tests in `pkg/user/manager_test.go` (promote/demote/no-op/manual-override).
- Exposed `sysadmin_flag_source` via the API response.
- Users list shows "No" instead of "Unknown" once a non-admin's status has been confirmed via a real login sync, not just for admins.
- `tests/apitests/python/test_ldap_admin_role.py` updated to assert the corrected behavior.


# Issue being fixed
Fixes #([19051](https://github.com/goharbor/harbor/issues/19051))
Fixes #([23544](https://github.com/goharbor/harbor/issues/23544))

Please indicate you've done the following:
- [ ] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [ ] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
