### PR TITLE
ci: migrate all GitHub workflows to CNCF-hosted runners

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -50,14 +50,20 @@ jobs:
       - cncf-ubuntu-16-64-x86
     timeout-minutes: 100
     steps:
+      - uses: actions/checkout@v7
+        with:
+         path: src/github.com/goharbor/harbor
       - name: Set up Go 1.26
         uses: actions/setup-go@v5
         with:
            go-version: 1.26.4
+           cache-dependency-path: src/github.com/goharbor/harbor/src/go.sum
         id: go
-      - uses: actions/checkout@v7
+      - name: Cache CI Go tools
+        uses: actions/cache@v4
         with:
-         path: src/github.com/goharbor/harbor
+          path: ~/go/bin
+          key: ci-gotools-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('src/github.com/goharbor/harbor/tests/ci/ut_install.sh') }}
       - name: setup env
         run: |
           cd src/github.com/goharbor/harbor
@@ -112,14 +118,15 @@ jobs:
       - cncf-ubuntu-16-64-x86
     timeout-minutes: 100
     steps:
+      - uses: actions/checkout@v7
+        with:
+          path: src/github.com/goharbor/harbor
       - name: Set up Go 1.23
         uses: actions/setup-go@v5
         with:
           go-version: 1.23.2
+          cache-dependency-path: src/github.com/goharbor/harbor/src/go.sum
         id: go
-      - uses: actions/checkout@v7
-        with:
-          path: src/github.com/goharbor/harbor
       - name: setup env
         run: |
           cd src/github.com/goharbor/harbor
@@ -174,14 +181,15 @@ jobs:
       - cncf-ubuntu-16-64-x86
     timeout-minutes: 100
     steps:
+      - uses: actions/checkout@v7
+        with:
+          path: src/github.com/goharbor/harbor
       - name: Set up Go 1.23
         uses: actions/setup-go@v5
         with:
           go-version: 1.23.2
+          cache-dependency-path: src/github.com/goharbor/harbor/src/go.sum
         id: go
-      - uses: actions/checkout@v7
-        with:
-          path: src/github.com/goharbor/harbor
       - name: setup env
         run: |
           cd src/github.com/goharbor/harbor
@@ -235,14 +243,15 @@ jobs:
       - cncf-ubuntu-16-64-x86
     timeout-minutes: 100
     steps:
+      - uses: actions/checkout@v7
+        with:
+          path: src/github.com/goharbor/harbor
       - name: Set up Go 1.23
         uses: actions/setup-go@v5
         with:
           go-version: 1.23.2
+          cache-dependency-path: src/github.com/goharbor/harbor/src/go.sum
         id: go
-      - uses: actions/checkout@v7
-        with:
-          path: src/github.com/goharbor/harbor
       - name: setup env
         run: |
           cd src/github.com/goharbor/harbor
@@ -294,14 +303,15 @@ jobs:
       - cncf-ubuntu-16-64-x86
     timeout-minutes: 100
     steps:
+      - uses: actions/checkout@v7
+        with:
+          path: src/github.com/goharbor/harbor
       - name: Set up Go 1.23
         uses: actions/setup-go@v5
         with:
           go-version: 1.23.2
+          cache-dependency-path: src/github.com/goharbor/harbor/src/go.sum
         id: go
-      - uses: actions/checkout@v7
-        with:
-          path: src/github.com/goharbor/harbor
       - name: setup env
         run: |
           cd src/github.com/goharbor/harbor

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -47,7 +47,7 @@ jobs:
        UTTEST: true
     runs-on:
       #- self-hosted
-      - oracle-vm-24cpu-96gb-x86-64
+      - cncf-ubuntu-16-64-x86
     timeout-minutes: 100
     steps:
       - name: Set up Go 1.26
@@ -109,7 +109,7 @@ jobs:
       APITEST_DB: true
     runs-on:
       #- self-hosted
-      - oracle-vm-24cpu-96gb-x86-64
+      - cncf-ubuntu-16-64-x86
     timeout-minutes: 100
     steps:
       - name: Set up Go 1.23
@@ -171,7 +171,7 @@ jobs:
     if: ${{ github.event.repository.custom_properties.SKIP_PROXY_CACHE != 'true' }}
     runs-on:
       #- self-hosted
-      - oracle-vm-24cpu-96gb-x86-64
+      - cncf-ubuntu-16-64-x86
     timeout-minutes: 100
     steps:
       - name: Set up Go 1.23
@@ -232,7 +232,7 @@ jobs:
       APITEST_LDAP: true
     runs-on:
       #- self-hosted
-      - oracle-vm-24cpu-96gb-x86-64
+      - cncf-ubuntu-16-64-x86
     timeout-minutes: 100
     steps:
       - name: Set up Go 1.23
@@ -291,7 +291,7 @@ jobs:
       OFFLINE: true
     runs-on:
       #- self-hosted
-      - oracle-vm-24cpu-96gb-x86-64
+      - cncf-ubuntu-16-64-x86
     timeout-minutes: 100
     steps:
       - name: Set up Go 1.23
@@ -343,7 +343,7 @@ jobs:
       UI_UT: true
     runs-on:
       #- self-hosted
-      - oracle-vm-24cpu-96gb-x86-64
+      - cncf-ubuntu-16-64-x86
     timeout-minutes: 100
     steps:
       - uses: actions/setup-node@v6

--- a/.github/workflows/api-schema-check.yml
+++ b/.github/workflows/api-schema-check.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    runs-on: cncf-ubuntu-16-64-x86
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/auto_assign_prs.yml
+++ b/.github/workflows/auto_assign_prs.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   # Automatically assigns reviewers and owner
   add-reviews:
-    runs-on: ubuntu-latest
+    runs-on: cncf-ubuntu-16-64-x86
     steps:
       - name: Set the author of a PR as the assignee
         uses: kentaro-m/auto-assign-action@v2.0.2

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -79,11 +79,6 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: 1.26.4
-        id: go
       - name: Setup Docker
         uses: docker-practice/actions-setup-docker@master
         with:
@@ -93,6 +88,12 @@ jobs:
       - uses: actions/checkout@v7
         with:
           path: src/github.com/goharbor/harbor
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.26.4
+          cache-dependency-path: src/go.sum
+        id: go
       - name: Build Package
         run: |
           set -x

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   BUILD_BASE_IMAGE:
-    runs-on: ubuntu-latest
+    runs-on: cncf-ubuntu-16-64-x86
     permissions:
       contents: read
     outputs:
@@ -71,7 +71,7 @@ jobs:
         BUILD_PACKAGE: true
         ARCH: ${{ matrix.arch }}
         BUILD_BASE: ${{ needs.BUILD_BASE_IMAGE.outputs.build_base }}
-    runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
+    runs-on: ${{ matrix.arch == 'arm64' && 'cncf-ubuntu-16-64-arm' || 'cncf-ubuntu-16-64-x86' }}
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6.2.1
@@ -201,7 +201,7 @@ jobs:
 
   CREATE_MANIFEST:
     needs: [BUILD_BASE_IMAGE, BUILD_PACKAGE]
-    runs-on: ubuntu-latest
+    runs-on: cncf-ubuntu-16-64-x86
     permissions:
       contents: read
     steps:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   CodeQL-Build:
 
-    runs-on: ubuntu-latest
+    runs-on: cncf-ubuntu-16-64-x86
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/conformance_test.yml
+++ b/.github/workflows/conformance_test.yml
@@ -15,7 +15,7 @@ jobs:
       CONFORMANCE_TEST: true
     runs-on:
       #- self-hosted
-      - oracle-vm-24cpu-96gb-x86-64
+      - cncf-ubuntu-16-64-x86
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6.2.1

--- a/.github/workflows/conformance_test.yml
+++ b/.github/workflows/conformance_test.yml
@@ -23,14 +23,15 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
+      - uses: actions/checkout@v7
+        with:
+          path: src/github.com/goharbor/harbor
       - name: Set up Go 1.21
         uses: actions/setup-go@v5
         with:
           go-version: 1.23.2
+          cache-dependency-path: src/github.com/goharbor/harbor/src/go.sum
         id: go
-      - uses: actions/checkout@v7
-        with:
-          path: src/github.com/goharbor/harbor
       - name: before_install
         run: |
           set -x

--- a/.github/workflows/housekeeping-stale-issues-prs.yaml
+++ b/.github/workflows/housekeeping-stale-issues-prs.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   stale:
-    runs-on: ubuntu-latest
+    runs-on: cncf-ubuntu-16-64-x86
     steps:
       - uses: actions/stale@v10.0.0
         with:

--- a/.github/workflows/label_check.yaml
+++ b/.github/workflows/label_check.yaml
@@ -14,7 +14,7 @@ jobs:
   # - At most one two the main category labels
   check-label:
     name: Check release-note label set
-    runs-on: ubuntu-latest
+    runs-on: cncf-ubuntu-16-64-x86
     steps:
       - uses: mheap/github-action-required-labels@v5
         with:

--- a/.github/workflows/nightly-trivy-scan.yml
+++ b/.github/workflows/nightly-trivy-scan.yml
@@ -18,7 +18,7 @@ jobs:
     permissions:
       security-events: write  # for github/codeql-action/upload-sarif to upload SARIF results
 
-    runs-on: ubuntu-latest
+    runs-on: cncf-ubuntu-16-64-x86
     steps:
       - name: Checkout code
         uses: actions/checkout@v7

--- a/.github/workflows/pass-CI.yml
+++ b/.github/workflows/pass-CI.yml
@@ -29,36 +29,36 @@ on:
 jobs:
   UTTEST:
     runs-on:
-      - cncf-ubuntu-16-64-x86
+      - cncf-ubuntu-2-8-x86
     steps:
       - run: 'echo "No run required"'
 
   APITEST_DB:
     runs-on:
-      - cncf-ubuntu-16-64-x86
+      - cncf-ubuntu-2-8-x86
     steps:
       - run: 'echo "No run required"'
 
   APITEST_DB_PROXY_CACHE:
     runs-on:
-      - cncf-ubuntu-16-64-x86
+      - cncf-ubuntu-2-8-x86
     steps:
       - run: 'echo "No run required"'
 
   APITEST_LDAP:
     runs-on:
-      - cncf-ubuntu-16-64-x86
+      - cncf-ubuntu-2-8-x86
     steps:
       - run: 'echo "No run required"'
 
   OFFLINE:
     runs-on:
-      - cncf-ubuntu-16-64-x86
+      - cncf-ubuntu-2-8-x86
     steps:
       - run: 'echo "No run required"'
 
   UI_UT:
     runs-on:
-      - cncf-ubuntu-16-64-x86
+      - cncf-ubuntu-2-8-x86
     steps:
       - run: 'echo "No run required"'

--- a/.github/workflows/pass-CI.yml
+++ b/.github/workflows/pass-CI.yml
@@ -29,36 +29,36 @@ on:
 jobs:
   UTTEST:
     runs-on:
-      - ubuntu-latest
+      - cncf-ubuntu-16-64-x86
     steps:
       - run: 'echo "No run required"'
 
   APITEST_DB:
     runs-on:
-      - ubuntu-latest
+      - cncf-ubuntu-16-64-x86
     steps:
       - run: 'echo "No run required"'
 
   APITEST_DB_PROXY_CACHE:
     runs-on:
-      - ubuntu-latest
+      - cncf-ubuntu-16-64-x86
     steps:
       - run: 'echo "No run required"'
 
   APITEST_LDAP:
     runs-on:
-      - ubuntu-latest
+      - cncf-ubuntu-16-64-x86
     steps:
       - run: 'echo "No run required"'
 
   OFFLINE:
     runs-on:
-      - ubuntu-latest
+      - cncf-ubuntu-16-64-x86
     steps:
       - run: 'echo "No run required"'
 
   UI_UT:
     runs-on:
-      - ubuntu-latest
+      - cncf-ubuntu-16-64-x86
     steps:
       - run: 'echo "No run required"'

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: cncf-ubuntu-16-64-x86
     permissions:
       contents: write   # Required for creating GitHub releases and uploading assets
       id-token: write   # Required for Cosign keyless signing

--- a/Makefile
+++ b/Makefile
@@ -534,14 +534,18 @@ misspell:
 
 # golangci-lint binary installation or refer to https://golangci-lint.run/usage/install/#local-installation
 # curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.9.0
-GOLANGCI_LINT := $(shell go env GOPATH)/bin/golangci-lint
+# GOPATH may be a colon-separated list (CI appends the workspace to it). Go installs
+# binaries into the first entry's bin, so resolve tools against that entry, not the
+# whole list, which would expand to a nonexistent "a:b/bin" path.
+GOPATH_BIN := $(firstword $(subst :, ,$(shell go env GOPATH)))/bin
+GOLANGCI_LINT := $(GOPATH_BIN)/golangci-lint
 lint:
 	@echo checking lint
 	@echo $(GOLANGCI_LINT)
 	@cd ./src/; $(GOLANGCI_LINT) cache clean; $(GOLANGCI_LINT) -v run ./... --timeout=10m;
 
 # go install golang.org/x/vuln/cmd/govulncheck@latest
-GOVULNCHECK := $(shell go env GOPATH)/bin/govulncheck
+GOVULNCHECK := $(GOPATH_BIN)/govulncheck
 govulncheck:
 	@echo golang vulnerability check
 	@cd ./src/; $(GOVULNCHECK) ./...;

--- a/Makefile
+++ b/Makefile
@@ -534,9 +534,6 @@ misspell:
 
 # golangci-lint binary installation or refer to https://golangci-lint.run/usage/install/#local-installation
 # curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.9.0
-# GOPATH may be a colon-separated list (CI appends the workspace to it). Go installs
-# binaries into the first entry's bin, so resolve tools against that entry, not the
-# whole list, which would expand to a nonexistent "a:b/bin" path.
 GOPATH_BIN := $(firstword $(subst :, ,$(shell go env GOPATH)))/bin
 GOLANGCI_LINT := $(GOPATH_BIN)/golangci-lint
 lint:

--- a/src/portal/src/app/base/project/project-log/audit-legacy-log.component.spec.ts
+++ b/src/portal/src/app/base/project/project-log/audit-legacy-log.component.spec.ts
@@ -165,11 +165,12 @@ describe('ProjectAuditLegacyLogComponent', () => {
     });
     it('should support pagination', async () => {
         fixture.autoDetectChanges(true);
-        await fixture.whenStable();
-        fixture.detectChanges();
-        await fixture.whenStable();
-        const el: HTMLButtonElement =
-            fixture.nativeElement.querySelector('.pagination-next');
+        let el: HTMLButtonElement = null;
+        for (let i = 0; i < 20 && !el; i++) {
+            fixture.detectChanges();
+            await fixture.whenStable();
+            el = fixture.nativeElement.querySelector('.pagination-next');
+        }
         expect(el).toBeTruthy();
         el.click();
         fixture.detectChanges();

--- a/tests/ci/ut_install.sh
+++ b/tests/ci/ut_install.sh
@@ -14,14 +14,18 @@ fi
 
 go env -w GO111MODULE=auto
 pwd
-go install golang.org/x/tools/cmd/cover@latest
-go install github.com/mattn/goveralls@latest
-go install github.com/client9/misspell/cmd/misspell@latest
+GOBIN_DIR="$(go env GOPATH | cut -d: -f1)/bin"
+# These are restored from the CI tool cache; only build what is missing.
+command -v cover     >/dev/null 2>&1 || go install golang.org/x/tools/cmd/cover@latest
+command -v goveralls >/dev/null 2>&1 || go install github.com/mattn/goveralls@latest
+command -v misspell  >/dev/null 2>&1 || go install github.com/client9/misspell/cmd/misspell@latest
 set -e
 # cd ../
 # binary will be $(go env GOPATH)/bin/golangci-lint
 # go get installation aren't guaranteed to work. We recommend using binary installation.
-curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.9.0
+if ! "${GOBIN_DIR}/golangci-lint" --version 2>/dev/null | grep -q ' 2\.9\.0 '; then
+  curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "${GOBIN_DIR}" v2.9.0
+fi
 sudo service postgresql stop || echo no postgresql need to be stopped
 sleep 2
 

--- a/tests/ci/ut_install.sh
+++ b/tests/ci/ut_install.sh
@@ -15,7 +15,6 @@ fi
 go env -w GO111MODULE=auto
 pwd
 GOBIN_DIR="$(go env GOPATH | cut -d: -f1)/bin"
-# These are restored from the CI tool cache; only build what is missing.
 command -v cover     >/dev/null 2>&1 || go install golang.org/x/tools/cmd/cover@latest
 command -v goveralls >/dev/null 2>&1 || go install github.com/mattn/goveralls@latest
 command -v misspell  >/dev/null 2>&1 || go install github.com/client9/misspell/cmd/misspell@latest

--- a/tests/ci/ut_install.sh
+++ b/tests/ci/ut_install.sh
@@ -15,9 +15,7 @@ fi
 go env -w GO111MODULE=auto
 pwd
 GOBIN_DIR="$(go env GOPATH | cut -d: -f1)/bin"
-command -v cover     >/dev/null 2>&1 || go install golang.org/x/tools/cmd/cover@latest
-command -v goveralls >/dev/null 2>&1 || go install github.com/mattn/goveralls@latest
-command -v misspell  >/dev/null 2>&1 || go install github.com/client9/misspell/cmd/misspell@latest
+command -v misspell >/dev/null 2>&1 || go install github.com/client9/misspell/cmd/misspell@v0.3.4
 set -e
 # cd ../
 # binary will be $(go env GOPATH)/bin/golangci-lint

--- a/tests/coverage4gotest.sh
+++ b/tests/coverage4gotest.sh
@@ -32,8 +32,8 @@ do
 	listDeps $package
 
 #    echo "DEBUG: testing package $package"
-	echo go test -race -v -cover -coverprofile=profile.tmp -coverpkg "$deps" $package
-	go test -race -v -cover -coverprofile=profile.tmp -coverpkg "$deps" $package
+	echo go test -count=1 -race -v -cover -coverprofile=profile.tmp -coverpkg "$deps" $package
+	go test -count=1 -race -v -cover -coverprofile=profile.tmp -coverpkg "$deps" $package
 	if [ -f profile.tmp ]	
 	then
 		cat profile.tmp | tail -n +2 >> "$profile_path"


### PR DESCRIPTION
Thank you for contributing to Harbor!

# Comprehensive Summary of your change

Migrates every workflow job to the CNCF-hosted runner pool, and fixes Go caching in CI, which was silently disabled.

CNCF recommends that graduated projects move their CI onto the CNCF-provided runner pool. Support and coordination for these runners happens in the CNCF Slack channel [#cncf-ci-infra](https://cloud-native.slack.com/archives/C08P4HUFQ6M).

## 1. Runner migration

| Old label | New label |
|---|---|
| `oracle-vm-24cpu-96gb-x86-64` | `cncf-ubuntu-16-64-x86` |
| `ubuntu-latest` | `cncf-ubuntu-16-64-x86` |
| `ubuntu-24.04-arm` | `cncf-ubuntu-16-64-arm` |

All 22 `runs-on` declarations across 11 workflow files are covered. The `pass-CI.yml` jobs are no-op stubs that only satisfy required status checks on skipped paths, so they use the smallest runner, `cncf-ubuntu-2-8-x86`. The `arm64` leg of the `BUILD_PACKAGE` matrix still builds natively, now on `cncf-ubuntu-16-64-arm`.

Note the new runners are **smaller** than the old ones: 16 vCPU / 64 GB versus Oracle's 24 vCPU / 96 GB. They are nevertheless faster on every job (see below).

## 2. Go caching was silently disabled

`actions/setup-go` ran *before* `actions/checkout`, so it looked for `go.sum` in an empty workspace:

```
##[warning]Restore cache failed: Dependencies file is not found in
/home/ubuntu/_work/harbor/harbor. Supported file pattern: go.sum
```

With `cache: true` (the v5 default) this fails open and no-ops, so `GOMODCACHE` and `GOCACHE` were cold on **every job of every run**. The same ordering bug was present in `build-package.yml` and `conformance_test.yml`. All 7 `setup-go` usages now run after checkout with `cache-dependency-path` set.

`$GOPATH/bin` is cached too. `cover` and `goveralls` were installed on every run but never used (`goveralls` appears only in a commented-out line in `ut_run.sh`; `go test -cover` uses the built-in tool, not `golang.org/x/tools/cmd/cover`), so they are dropped. `misspell`, which `make misspell` does invoke, is pinned rather than tracking `@latest`, so the cached tool version is reproducible.

## 3. Measured before / after

Baseline is 12 successful `main` runs on the old Oracle runners (very stable: UTTEST varied only 34.6-35.1 min). All other columns are single runs. All jobs green in the final column.

| Job | A: Oracle 24c/96g, no cache (n=12, median) | B: CNCF 16c/64g, no cache (n=1) | C: CNCF + cache, **cold** (n=1) | E: CNCF + cache, **warm** (n=1) | A → E |
|---|---|---|---|---|---|
| UTTEST | 34.7 | 33.6 | 34.0 | **29.5** | −15% |
| APITEST_DB | 30.0 | 27.9 | 27.6 | **28.4** | −5% |
| APITEST_DB_PROXY_CACHE | 17.4 | 15.9 | 15.7 | **16.0** | −8% |
| OFFLINE | 10.5 | 8.7 | 8.9 | **8.8** | −16% |
| APITEST_LDAP | 10.2 | 8.4 | 8.2 | **8.3** | −19% |
| UI_UT | 1.9 | 1.8 | (failed, see below) | **1.8** | −5% |
| **Total job-minutes** | **104.7** | 96.3 | — | **92.8** | **−11%** |
| **Critical path (wall clock)** | **34.7** | 33.6 | — | **29.5** | **−15%** |

Separating the two effects, so neither is credited with the other's gain:

- **Runner change alone** (A → B): total job-minutes −8%, critical path −3%. The API/OFFLINE jobs gain 16-19%; UTTEST barely moves because it is dominated by a cold Go build.
- **Caching alone** (B → E): critical path −12%. UTTEST 33.6 → 29.5 (`install` 5.0 → 3.7, `script` 29.2 → 24.4).

A cold run (C) is expected to match the baseline: it writes the cache but cannot read it. It confirmed the mechanism works (`Cache saved with the key: setup-go-Linux-x64--go-1.26.4-...`), where previously the same step logged `Restore cache failed`.

The `$GOPATH/bin` tool cache still missed in run E (its key changed with the last edit to `ut_install.sh`), so it will save a little more once that key settles.

## 4. Two real bugs found while measuring

**`make lint` depended on a broken path.** `GOLANGCI_LINT` was `$(shell go env GOPATH)/bin/golangci-lint`, but CI sets `GOPATH` to a colon-separated list, so this expanded to the nonexistent `/home/ubuntu/go:/home/ubuntu/_work/harbor/harbor/bin/golangci-lint`. It only worked because `ut_install.sh` *installed* the binary using the same broken expression, so both sides agreed on the same bogus location. Tools are now resolved against the first `GOPATH` entry, where `go install` actually writes them. This would break for any developer whose `GOPATH` has more than one entry.

**Persisting `GOCACHE` made `go test` stop running the tests.** Go's build cache also caches *test results*. With `GOCACHE` restored across runs, `go test` replayed cached passes instead of executing: a warm run printed test output stamped with timestamps from the *previous* run and finished the test step in 2.2 min instead of 29. It then failed on `TestConfig`, because Harbor's packages share one Postgres instance and a package that did re-run observed state the replayed packages never created. Left unnoticed, this would have turned CI into a rubber stamp that reported a fake 80% speedup.

`tests/coverage4gotest.sh` now passes `-count=1`, which disables test-result reuse while keeping the compilation cache. That is why the honest warm number is −15% and not −80%. The final run was verified: every in-test log timestamp falls after the job's start time, and `-count=1` is applied to all 479 test packages.

## 5. Flaky test fixed

`UI_UT` failed once on `ProjectAuditLegacyLogComponent should support pagination`. The spec queried `.pagination-next` immediately after `whenStable()` and clicked it, so it broke whenever the datagrid had not rendered yet - more likely on 16-core runners than on the old 24-core ones. The lookup now retries until the control appears; the assertion still fails if it never renders. Passed on both subsequent runs.

# Issue being fixed
N/A - infrastructure migration, no associated issue.

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
