### PR TITLE
fix(retention): avoid stripping repository path twice

### DIFF
--- a/src/pkg/retention/policy/action/performer.go
+++ b/src/pkg/retention/policy/action/performer.go
@@ -17,7 +17,6 @@ package action
 import (
 	"context"
 
-	"github.com/goharbor/harbor/src/common/utils"
 	"github.com/goharbor/harbor/src/lib/log"
 	"github.com/goharbor/harbor/src/lib/selector"
 	"github.com/goharbor/harbor/src/pkg/immutable/match/rule"
@@ -95,10 +94,8 @@ func (ra *retainAction) Perform(ctx context.Context, candidates []*selector.Cand
 
 func isImmutable(ctx context.Context, c *selector.Candidate) bool {
 	projectID := c.NamespaceID
-	repo := c.Repository
-	_, repoName := utils.ParseRepository(repo)
 	matched, err := rule.NewRuleMatcher().Match(ctx, projectID, selector.Candidate{
-		Repository:  repoName,
+		Repository:  c.Repository,
 		Tags:        c.Tags,
 		NamespaceID: projectID,
 	})

--- a/src/pkg/retention/policy/action/performer_test.go
+++ b/src/pkg/retention/policy/action/performer_test.go
@@ -222,8 +222,8 @@ func (suite *TestPerformerSuite) TestPerformImmutableRepositoryExclusion() {
 		TagSelectors: []*immumodel.Selector{
 			{
 				Kind:       "doublestar",
-				Decoration: "excludes",
-				Pattern:    "latest",
+				Decoration: "matches",
+				Pattern:    "**",
 			},
 		},
 		ScopeSelectors: map[string][]*immumodel.Selector{
@@ -250,7 +250,7 @@ func (suite *TestPerformerSuite) TestPerformImmutableRepositoryExclusion() {
 				Repository:  "qa/team/component/backend",
 				Kind:        selector.Image,
 				Tags:        []string{"build-42"},
-				Digest:      "qa-build",
+				Digest:      "d0",
 			},
 			{
 				NamespaceID: projectID,
@@ -258,25 +258,16 @@ func (suite *TestPerformerSuite) TestPerformImmutableRepositoryExclusion() {
 				Repository:  "prod/team/component/backend",
 				Kind:        selector.Image,
 				Tags:        []string{"build-42"},
-				Digest:      "prod-build",
-			},
-			{
-				NamespaceID: projectID,
-				Namespace:   "example",
-				Repository:  "prod/team/component/backend",
-				Kind:        selector.Image,
-				Tags:        []string{"latest"},
-				Digest:      "prod-latest",
+				Digest:      "d1",
 			},
 		},
 	}
 
 	results, err := p.Perform(orm.Context(), nil)
 	require.NoError(suite.T(), err)
-	require.Len(suite.T(), results, 3)
+	require.Len(suite.T(), results, 2)
 	assert.NoError(suite.T(), results[0].Error)
 	assert.IsType(suite.T(), (*selector.ImmutableError)(nil), results[1].Error)
-	assert.NoError(suite.T(), results[2].Error)
 }
 
 type fakeRetentionClient struct{}

--- a/src/pkg/retention/policy/action/performer_test.go
+++ b/src/pkg/retention/policy/action/performer_test.go
@@ -212,6 +212,73 @@ func (suite *TestPerformerSuite) TestPerformImmutable() {
 	assert.Equal(suite.T(), "dev", results[0].Target.Tags[0])
 }
 
+func (suite *TestPerformerSuite) TestPerformImmutableRepositoryExclusion() {
+	const projectID int64 = 987654321
+	rule := &immumodel.Metadata{
+		ProjectID: projectID,
+		Priority:  1,
+		Action:    "immutable",
+		Template:  "immutable_template",
+		TagSelectors: []*immumodel.Selector{
+			{
+				Kind:       "doublestar",
+				Decoration: "excludes",
+				Pattern:    "latest",
+			},
+		},
+		ScopeSelectors: map[string][]*immumodel.Selector{
+			"repository": {
+				{
+					Kind:       "doublestar",
+					Decoration: "repoExcludes",
+					Pattern:    "qa/**",
+				},
+			},
+		},
+	}
+	ruleID, err := immutable.Ctr.CreateImmutableRule(orm.Context(), rule)
+	require.NoError(suite.T(), err)
+	defer func() {
+		require.NoError(suite.T(), immutable.Ctr.DeleteImmutableRule(orm.Context(), ruleID))
+	}()
+
+	p := &retainAction{
+		all: []*selector.Candidate{
+			{
+				NamespaceID: projectID,
+				Namespace:   "example",
+				Repository:  "qa/team/component/backend",
+				Kind:        selector.Image,
+				Tags:        []string{"build-42"},
+				Digest:      "qa-build",
+			},
+			{
+				NamespaceID: projectID,
+				Namespace:   "example",
+				Repository:  "prod/team/component/backend",
+				Kind:        selector.Image,
+				Tags:        []string{"build-42"},
+				Digest:      "prod-build",
+			},
+			{
+				NamespaceID: projectID,
+				Namespace:   "example",
+				Repository:  "prod/team/component/backend",
+				Kind:        selector.Image,
+				Tags:        []string{"latest"},
+				Digest:      "prod-latest",
+			},
+		},
+	}
+
+	results, err := p.Perform(orm.Context(), nil)
+	require.NoError(suite.T(), err)
+	require.Len(suite.T(), results, 3)
+	assert.NoError(suite.T(), results[0].Error)
+	assert.IsType(suite.T(), (*selector.ImmutableError)(nil), results[1].Error)
+	assert.NoError(suite.T(), results[2].Error)
+}
+
 type fakeRetentionClient struct{}
 
 // GetCandidates ...


### PR DESCRIPTION
  Thank you for contributing to Harbor!

  # Comprehensive Summary of your change

  Retention parsed an already project-stripped repository name again, causing nested repository exclusions such as `qa/**` to fail.

  This change passes `Candidate.Repository` directly to the immutable matcher and adds tests covering repository and tag exclusions.

  # Issue being fixed

  Fixes #23530

  Please indicate you've done the following:

  - [x] Well Written Title and Summary of the PR
  - [x] Label the PR as needed.
  - [x] Accepted the DCO.
  - [x] Made sure tests are passing and test coverage is added if needed.
  - [x] Considered the docs impact. No documentation changes are required.