### PR TITLE
fix: allow no-op update for retention policies with manual trigger

### DIFF
--- a/src/controller/retention/controller.go
+++ b/src/controller/retention/controller.go
@@ -166,7 +166,7 @@ func (r *defaultController) UpdateRetention(ctx context.Context, p *policy.Metad
 					needSch = true
 				}
 			}
-		case "":
+		case "", policy.TriggerKindManual:
 
 		default:
 			return fmt.Errorf("not support Trigger %s", p.Trigger.Kind)

--- a/src/controller/retention/controller_test.go
+++ b/src/controller/retention/controller_test.go
@@ -194,6 +194,59 @@ func (s *ControllerTestSuite) TestPolicy() {
 	s.Require().NotNil(err)
 	s.Require().True(strings.Contains(err.Error(), "no such Retention policy"))
 	s.Require().Nil(p1)
+
+	// Test Manual Trigger
+	p2 := &policy.Metadata{
+		Algorithm: "or",
+		Rules: []rule.Metadata{
+			{
+				ID:       1,
+				Priority: 1,
+				Template: "always",
+				TagSelectors: []*rule.Selector{
+					{
+						Kind:       "doublestar",
+						Decoration: "matches",
+						Pattern:    "**",
+					},
+				},
+				ScopeSelectors: map[string][]*rule.Selector{
+					"repository": {
+						{
+							Kind:       "doublestar",
+							Decoration: "matches",
+							Pattern:    "**",
+						},
+					},
+				},
+			},
+		},
+		Trigger: &policy.Trigger{
+			Kind: "Manual",
+		},
+		Scope: &policy.Scope{
+			Level:     "project",
+			Reference: 1,
+		},
+	}
+
+	id2, err := c.CreateRetention(ctx, p2)
+	s.Require().Nil(err)
+	s.Require().True(id2 > 0)
+
+	p2, err = c.GetRetention(ctx, id2)
+	s.Require().Nil(err)
+	s.Require().EqualValues("project", p2.Scope.Level)
+
+	p2.Scope.Level = "test-manual"
+	err = c.UpdateRetention(ctx, p2)
+	s.Require().Nil(err)
+	p2, err = c.GetRetention(ctx, id2)
+	s.Require().Nil(err)
+	s.Require().EqualValues("test-manual", p2.Scope.Level)
+
+	err = c.DeleteRetention(ctx, id2)
+	s.Require().Nil(err)
 }
 
 func (s *ControllerTestSuite) TestExecution() {

--- a/src/pkg/retention/policy/models.go
+++ b/src/pkg/retention/policy/models.go
@@ -31,6 +31,9 @@ const (
 	// TriggerKindSchedule Schedule
 	TriggerKindSchedule = "Schedule"
 
+	// TriggerKindManual Manual
+	TriggerKindManual = "Manual"
+
 	// TriggerSettingsCron cron
 	TriggerSettingsCron = "cron"
 


### PR DESCRIPTION
# Comprehensive Summary of your change

This PR allows users to update existing retention policies that were created with a "Manual" trigger. 

Previously, `UpdateRetention` in `src/controller/retention/controller.go` only checked for `TriggerKindSchedule` (or an empty kind) when the trigger kind hadn't changed during an update. If the existing policy had a `Manual` trigger, it fell through to the `default` case, returning an `unknown: not support Trigger Manual` error (HTTP 500). This prevented any updates (e.g., changing rules, algorithms, or scope) to policies that used manual triggers.

Changes introduced:
1. Added `TriggerKindManual` constant to `src/pkg/retention/policy/models.go` to avoid hardcoded strings.
2. Handled `policy.TriggerKindManual` as a valid no-op scenario in `UpdateRetention` so updates don't error out.
3. Added a unit test in `src/controller/retention/controller_test.go` covering unchanged manual trigger updates.

# Issue being fixed

Fixes #23278

Please indicate you've done the following:

- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed: `release-note/ignore-for-release` (Note: I do not have permission to apply labels, could a maintainer please apply this?)
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in website repository.
