### PR TITLE
fix: safely type assert cron string in retention manager

### DIFF
--- a/src/pkg/retention/manager.go
+++ b/src/pkg/retention/manager.go
@@ -99,8 +99,10 @@ func (d *DefaultManager) GetPolicy(ctx context.Context, id int64) (*policy.Metad
 	p.ID = id
 	if p.Trigger.Kind == policy.TriggerKindSchedule {
 		cron, ok := p.Trigger.Settings[policy.TriggerSettingsCron]
-		if ok && len(cron.(string)) > 0 {
-			p.Trigger.Settings[policy.TriggerSettingNextScheduledTime] = strfmt.DateTime(utils.NextSchedule(cron.(string), time.Now()))
+		if ok {
+			if cronStr, isStr := cron.(string); isStr && len(cronStr) > 0 {
+				p.Trigger.Settings[policy.TriggerSettingNextScheduledTime] = strfmt.DateTime(utils.NextSchedule(cronStr, time.Now()))
+			}
 		}
 	}
 	return p, nil


### PR DESCRIPTION
# Comprehensive Summary of your change

This PR prevents a service panic (HTTP 500) in the retention manager when reading policy data from the database.

Previously, `manager.go` directly asserted `cron.(string)` when extracting the cron string from a policy's settings. If a retention policy somehow contained a non-string value for the cron setting (e.g. from an API anomaly or DB tampering), this unchecked assertion would trigger a runtime panic, permanently failing the retrieval of that retention policy.

Changes introduced:
- Added a safe type assertion `cronStr, isStr := cron.(string)` before evaluating its length or calculating the next schedule time.

# Issue being fixed

Fixes potential runtime panic in retention policy retrieval.

Please indicate you've done the following:

- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed: `release-note/ignore-for-release`
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in website repository.
