### PR TITLE
fix: safely type assert cvss score in scan report converter

### DIFF
--- a/src/pkg/scan/postprocessors/report_converters.go
+++ b/src/pkg/scan/postprocessors/report_converters.go
@@ -373,12 +373,16 @@ func parseScoreFromVendorAttribute(ctx context.Context, vendorAttribute string) 
 
 	// set the nvd as the first priority, if it's unavailable, return the first V3Score available.
 	if val, ok := data.CVSS["nvd"]["V3Score"]; ok {
-		return val.(float64)
+		if f, ok := val.(float64); ok {
+			return f
+		}
 	}
 
 	for vendor := range data.CVSS {
 		if val, ok := data.CVSS[vendor]["V3Score"]; ok {
-			return val.(float64)
+			if f, ok := val.(float64); ok {
+				return f
+			}
 		}
 	}
 	return 0


### PR DESCRIPTION
# Comprehensive Summary of your change

This PR prevents a service panic in the vulnerability scan report post-processor.

Previously, when converting the CVSS scores from a raw scan report into Harbor's model, `report_converters.go` directly asserted that the V3Score extracted from a generic JSON map was a `float64`:
`return val.(float64)`

If a vulnerability scanner or proxy returns the V3Score as another type (e.g., an integer like `10` or a string like `"9.8"`), this unchecked type assertion triggers a runtime panic. This causes the post-processor to crash, permanently halting the processing of the vulnerability report and leaving the scan job in a failed or hung state.

Changes introduced:
- Safely verify that the interface underlying `val` is actually a `float64` before returning it. 

# Issue being fixed

Fixes potential runtime panic during vulnerability report processing.

Please indicate you've done the following:

- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed: `release-note/ignore-for-release`
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in website repository.
