### PR TITLE
fix: safely type assert cron string in retention policy validation

### DIFF
--- a/src/pkg/retention/policy/models.go
+++ b/src/pkg/retention/policy/models.go
@@ -66,10 +66,17 @@ func (m *Metadata) ValidateRetentionPolicy() error {
 	if m.Trigger != nil {
 		if m.Trigger.Kind == TriggerKindSchedule && m.Trigger.Settings != nil {
 			cronItem, ok := m.Trigger.Settings[TriggerSettingsCron]
-			if ok && len(cronItem.(string)) > 0 {
-				if err := utils.ValidateCronString(cronItem.(string)); err != nil {
+			if ok {
+				if cronStr, isStr := cronItem.(string); isStr {
+					if len(cronStr) > 0 {
+						if err := utils.ValidateCronString(cronStr); err != nil {
+							return errors.New(nil).WithCode(errors.BadRequestCode).
+								WithMessagef("invalid cron string for scheduled tag retention: %s, error: %v", cronStr, err)
+						}
+					}
+				} else {
 					return errors.New(nil).WithCode(errors.BadRequestCode).
-						WithMessagef("invalid cron string for scheduled tag retention: %s, error: %v", cronItem.(string), err)
+						WithMessage("invalid cron type for scheduled tag retention: must be a string")
 				}
 			}
 		}


### PR DESCRIPTION
# Comprehensive Summary of your change

This PR prevents a service panic in the retention policy validation function.

Previously, `ValidateRetentionPolicy` directly asserted `cronItem.(string)` when checking the length and validity of a policy's cron schedule. If a retention policy payload contained a non-string value for the cron setting (e.g. from an API anomaly), this unchecked assertion would trigger a runtime panic (HTTP 500) rather than gracefully rejecting the payload.

Changes introduced:
- Added a safe type assertion `cronStr, isStr := cronItem.(string)` before evaluating its length or validating it.
- Return an HTTP 400 Bad Request error if the cron setting is not a string, matching the expected API validation behavior.

# Issue being fixed

Fixes potential runtime panic in retention policy validation.

Please indicate you've done the following:

- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed: `release-note/ignore-for-release`
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in website repository.
