### PR TITLE
fix: safely type assert int64 when fetching project roles

### DIFF
--- a/src/pkg/project/dao/dao.go
+++ b/src/pkg/project/dao/dao.go
@@ -197,7 +197,9 @@ func (d *dao) ListRoles(ctx context.Context, projectID int64, userID int, groupI
 
 	var roles []int
 	for _, value := range values {
-		roles = append(roles, int(value.(int64)))
+		if roleInt64, ok := value.(int64); ok {
+			roles = append(roles, int(roleInt64))
+		}
 	}
 
 	return roles, nil


### PR DESCRIPTION
# Comprehensive Summary of your change

This PR prevents a potential runtime panic (HTTP 500) when retrieving project roles from the database.

Previously, `GetRoles` in the project DAO used Beego ORM's `ValuesFlat` function to retrieve a list of roles as `interface{}` values, and then directly asserted each value as `int64`:
`roles = append(roles, int(value.(int64)))`

While the default database driver typically maps these integers to `int64`, any anomaly (such as a caching layer returning a different numeric type, a mock implementation during testing, or a driver update) would cause this unchecked assertion to trigger a fatal panic. 

Changes introduced:
- Implemented a safe type assertion `if roleInt64, ok := value.(int64); ok` to gracefully handle the returned values and prevent panics.

# Issue being fixed

Fixes potential runtime panic in project role retrieval.

Please indicate you've done the following:

- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed: `release-note/ignore-for-release`
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in website repository.
