### PR TITLE
Allow configuring PERMITTED_REGISTRY_TYPES_FOR_PROXY_CACHE and REPLIC…

### DIFF
--- a/make/harbor.yml.tmpl
+++ b/make/harbor.yml.tmpl
@@ -327,3 +327,36 @@ cache:
 #   # suggest switch provider to redis if you were ran into the db connections spike around
 #   # the scenario of high concurrent pushing to same project, no improvement for other scenes.
 #   quota_update_provider: redis # Or db
+#
+#   # The registry types that are permitted to be used as proxy cache targets.
+#   # NOTE: this list is curated by the Harbor maintainers because these are the
+#   # adapters that are actively maintained and tested. Adding adapters that are
+#   # unmaintained or scheduled for deprecation is not officially supported;
+#   # override this at your own risk.
+#   permitted_registry_types_for_proxy_cache:
+#     - docker-hub
+#     - harbor
+#     - azure-acr
+#     - ali-acr
+#     - aws-ecr
+#     - google-gcr
+#     - docker-registry
+#     - github-ghcr
+#     - jfrog-artifactory
+#
+#   # The registry adapter types that are permitted to be used as replication
+#   # targets. Same caveat as above: overriding this to include unmaintained or
+#   # deprecated adapters is not officially supported.
+#   replication_adapter_whitelist:
+#     - ali-acr
+#     - aws-ecr
+#     - azure-acr
+#     - docker-hub
+#     - docker-registry
+#     - github-ghcr
+#     - google-gcr
+#     - harbor
+#     - huawei-SWR
+#     - jfrog-artifactory
+#     - tencent-tcr
+#     - volcengine-cr

--- a/make/photon/prepare/models.py
+++ b/make/photon/prepare/models.py
@@ -243,8 +243,35 @@ class Cache:
         return
 
 class Core:
+    # keep these two defaults in sync with the historical hardcoded values that
+    # used to live directly in templates/core/env.jinja
+    default_permitted_registry_types_for_proxy_cache = [
+        'docker-hub', 'harbor', 'azure-acr', 'ali-acr', 'aws-ecr', 'google-gcr',
+        'docker-registry', 'github-ghcr', 'jfrog-artifactory',
+    ]
+    default_replication_adapter_whitelist = [
+        'ali-acr', 'aws-ecr', 'azure-acr', 'docker-hub', 'docker-registry',
+        'github-ghcr', 'google-gcr', 'harbor', 'huawei-SWR', 'jfrog-artifactory',
+        'tencent-tcr', 'volcengine-cr',
+    ]
+
     def __init__(self, config: dict):
         self.quota_update_provider = config.get('quota_update_provider') or 'db'
+        self.permitted_registry_types_for_proxy_cache = self._to_csv(
+            config.get('permitted_registry_types_for_proxy_cache'),
+            self.default_permitted_registry_types_for_proxy_cache)
+        self.replication_adapter_whitelist = self._to_csv(
+            config.get('replication_adapter_whitelist'),
+            self.default_replication_adapter_whitelist)
+
+    @staticmethod
+    def _to_csv(value, default_list):
+        if not value:
+            return ','.join(default_list)
+        if isinstance(value, (list, tuple)):
+            return ','.join(str(v).strip() for v in value)
+        # allow a plain comma separated string as well
+        return ','.join(v.strip() for v in str(value).split(',') if v.strip())
 
     def validate(self):
         if not self.quota_update_provider:

--- a/make/photon/prepare/templates/core/env.jinja
+++ b/make/photon/prepare/templates/core/env.jinja
@@ -39,8 +39,8 @@ REGISTRY_CREDENTIAL_USERNAME={{registry_username}}
 REGISTRY_CREDENTIAL_PASSWORD={{registry_password}}
 CSRF_KEY={{csrf_key}}
 ROBOT_SCANNER_NAME_PREFIX={{scan_robot_prefix}}
-PERMITTED_REGISTRY_TYPES_FOR_PROXY_CACHE=docker-hub,harbor,azure-acr,ali-acr,aws-ecr,google-gcr,docker-registry,github-ghcr,jfrog-artifactory
-REPLICATION_ADAPTER_WHITELIST=ali-acr,aws-ecr,azure-acr,docker-hub,docker-registry,github-ghcr,google-gcr,harbor,huawei-SWR,jfrog-artifactory,tencent-tcr,volcengine-cr
+PERMITTED_REGISTRY_TYPES_FOR_PROXY_CACHE={{core.permitted_registry_types_for_proxy_cache}}
+REPLICATION_ADAPTER_WHITELIST={{core.replication_adapter_whitelist}}
 
 HTTP_PROXY={{core_http_proxy}}
 HTTPS_PROXY={{core_https_proxy}}


### PR DESCRIPTION
Closes #22957

Adds optional core.permitted_registry_types_for_proxy_cache and core.replication_adapter_whitelist keys to harbor.yml, defaulting to the previously hardcoded values in env.jinja when unset. Includes a disclaimer in harbor.yml.tmpl that overriding beyond the curated list is not officially supported, per maintainer feedback in the issue.

# Comprehensive Summary of your change
Currently `PERMITTED_REGISTRY_TYPES_FOR_PROXY_CACHE` and `REPLICATION_ADAPTER_WHITELIST` are hardcoded in `make/photon/prepare/templates/core/env.jinja`, so the only way to add an adapter (e.g. Quay, GitLab) is to manually edit the generated env file and restart core — which doesn't survive `helm upgrade` / re-running `prepare`.

This PR:
- Extends the `Core` config model (`make/photon/prepare/models.py`) with two new optional fields, each defaulting to the exact original hardcoded list when unset.
- Updates `env.jinja` to render these values from config instead of hardcoding them.
- Documents the new keys in `harbor.yml.tmpl` with a disclaimer that adapters outside the default curated list are not officially supported (per maintainer discussion in the issue).

Backward compatible: verified that running `prepare` with no `core:` override in harbor.yml produces a byte-for-byte identical `core/env` file to before this change.

# Issue being fixed
Fixes #22957

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).