### PR TITLE
fix: safely type assert filter values when building artifact filters

### DIFF
--- a/src/pkg/reg/filter/artifact.go
+++ b/src/pkg/reg/filter/artifact.go
@@ -15,6 +15,7 @@
 package filter
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/goharbor/harbor/src/pkg/reg/model"
@@ -37,14 +38,22 @@ func BuildArtifactFilters(filters []*model.Filter) (ArtifactFilters, error) {
 		var f ArtifactFilter
 		switch filter.Type {
 		case model.FilterTypeLabel:
-			f = &artifactLabelFilter{
-				labels:     filter.Value.([]string),
-				decoration: filter.Decoration,
+			if labels, ok := filter.Value.([]string); ok {
+				f = &artifactLabelFilter{
+					labels:     labels,
+					decoration: filter.Decoration,
+				}
+			} else {
+				return nil, fmt.Errorf("invalid filter value type for label filter, expecting []string")
 			}
 		case model.FilterTypeTag:
-			f = &artifactTagFilter{
-				pattern:    filter.Value.(string),
-				decoration: filter.Decoration,
+			if pattern, ok := filter.Value.(string); ok {
+				f = &artifactTagFilter{
+					pattern:    pattern,
+					decoration: filter.Decoration,
+				}
+			} else {
+				return nil, fmt.Errorf("invalid filter value type for tag filter, expecting string")
 			}
 		}
 		if f != nil {


### PR DESCRIPTION
# Comprehensive Summary of your change

This PR prevents a potential runtime panic when building artifact filters in the registry adapter.

Previously, `BuildArtifactFilters` blindly asserted the filter value to a specific type without checking if the underlying interface actually matched:
- `filter.Value.([]string)` for label filters
- `filter.Value.(string)` for tag filters

If an invalid filter payload was supplied, these unchecked assertions would trigger a fatal panic (HTTP 500) rather than failing gracefully.

Changes introduced:
- Added safe type assertions (`if val, ok := ...; ok`) before assigning the filter values.
- Return an error gracefully if the filter value type is invalid, matching expected API validation behavior.

# Issue being fixed

Fixes potential runtime panic during artifact filter construction.

Please indicate you've done the following:

- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed: `release-note/ignore-for-release`
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in website repository.
