### PR TITLE
fix: safely type assert filter values when building repository filters

### DIFF
--- a/src/pkg/reg/filter/repository.go
+++ b/src/pkg/reg/filter/repository.go
@@ -15,6 +15,8 @@
 package filter
 
 import (
+	"fmt"
+
 	"github.com/goharbor/harbor/src/pkg/reg/model"
 	"github.com/goharbor/harbor/src/pkg/reg/util"
 )
@@ -35,8 +37,12 @@ func BuildRepositoryFilters(filters []*model.Filter) (RepositoryFilters, error) 
 		var f RepositoryFilter
 		switch filter.Type {
 		case model.FilterTypeName:
-			f = &repositoryNameFilter{
-				pattern: filter.Value.(string),
+			if pattern, ok := filter.Value.(string); ok {
+				f = &repositoryNameFilter{
+					pattern: pattern,
+				}
+			} else {
+				return nil, fmt.Errorf("invalid filter value type for repository name filter, expecting string")
 			}
 		}
 		if f != nil {


### PR DESCRIPTION
# Comprehensive Summary of your change

This PR prevents a potential runtime panic when building repository filters in the registry adapter.

Previously, `BuildRepositoryFilters` blindly asserted the filter value for a repository name filter to a string:
`filter.Value.(string)`

If a malformed or invalid filter payload is supplied that contains a non-string value, this unchecked assertion will trigger a fatal panic (HTTP 500) rather than failing gracefully.

Changes introduced:
- Added a safe type assertion (`if pattern, ok := filter.Value.(string); ok`) before assigning the filter value.
- Return an error gracefully if the filter value type is invalid, matching expected API validation behavior.

# Issue being fixed

Fixes potential runtime panic during repository filter construction.

Please indicate you've done the following:

- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed: `release-note/ignore-for-release`
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in website repository.
