### PR TITLE
fix(replication): fix incorrect error propagation in getAccessoryArts

### DIFF
--- a/src/pkg/reg/adapter/harbor/v2/client.go
+++ b/src/pkg/reg/adapter/harbor/v2/client.go
@@ -125,7 +125,7 @@ func (c *client) getAccessoryArts(project, repo string, art *artifact.Artifact, 
 			accArt.Tags = append(accArt.Tags, tag.Name)
 		}
 		*accArts = append(*accArts, accArt)
-		if err != c.getAccessoryArts(project, repo, art, labels, tags, accArts) {
+		if err := c.getAccessoryArts(project, repo, art, labels, tags, accArts); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
PR Description
## Summary
This PR fixes a critical error-handling bug in the recursive `getAccessoryArts` function within the Harbor v2 registry adapter.
### The Bug
In the original code:
```go
if err != c.getAccessoryArts(project, repo, art, labels, tags, accArts) {
    return err
}
```
At this point in execution, the local variable err is guaranteed to be nil (due to the successful getArtifact check right above it).

If the recursive call c.getAccessoryArts failed and returned a non-nil error, the comparison nil != error evaluated to true.
The function then entered the if block and returned err (which is nil), effectively swallowing the actual recursive error and falsely indicating success to the caller.
The Fix
Corrected the statement to use the standard Go error-handling pattern:
```
if err := c.getAccessoryArts(project, repo, art, labels, tags, accArts); err != nil {
    return err
}
```
This ensures that any error occurring during the recursive retrieval of accessory artifacts is correctly propagated up the call stack.