### PR TITLE
fix: guard against division by zero when merging scan report summaries

### DIFF
--- a/src/pkg/scan/vuln/summary.go
+++ b/src/pkg/scan/vuln/summary.go
@@ -63,7 +63,9 @@ func (sum *NativeReportSummary) Merge(another *NativeReportSummary) *NativeRepor
 
 	r.TotalCount = sum.TotalCount + another.TotalCount
 	r.CompleteCount = sum.CompleteCount + another.CompleteCount
-	r.CompletePercent = r.CompleteCount * 100 / r.TotalCount
+	if r.TotalCount > 0 {
+		r.CompletePercent = r.CompleteCount * 100 / r.TotalCount
+	}
 	r.ReportID = mergeReportID(sum.ReportID, another.ReportID)
 	r.ScanStatus = MergeScanStatus(sum.ScanStatus, another.ScanStatus)
 


### PR DESCRIPTION
# Summary

This PR fixes a potential integer **division by zero panic** in the `NativeReportSummary.Merge` function in `src/pkg/scan/vuln/summary.go`.

## The Bug

When two scan report summaries are merged (e.g. for a multi-architecture image), the merged `CompletePercent` is calculated as:

```go
r.TotalCount = sum.TotalCount + another.TotalCount
r.CompleteCount = sum.CompleteCount + another.CompleteCount
r.CompletePercent = r.CompleteCount * 100 / r.TotalCount  // <-- PANIC if TotalCount == 0
```

If both input summaries have a `TotalCount` of `0` (which can happen when a scan is just starting, has no scannable layers, or uses a scanner that does not report total counts), the integer division `/ r.TotalCount` will cause a **runtime panic**, crashing the goroutine handling that scan summary merge.

## The Fix

Added a zero-guard before the division:

```go
if r.TotalCount > 0 {
    r.CompletePercent = r.CompleteCount * 100 / r.TotalCount
}
```

This ensures `CompletePercent` stays at its zero-value (0%) when there is nothing to divide by, which is the correct and safe behaviour.

## Issue being fixed

Fixes a potential integer division by zero panic when merging scan report summaries with no reported total artifact count.

Please indicate you've done the following:

- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed: `release-note/ignore-for-release`
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in website repository.
