### PR TITLE
fix: safely type assert context value in SetMetricOpID to avoid panic

### DIFF
--- a/src/server/middleware/metric/metric.go
+++ b/src/server/middleware/metric/metric.go
@@ -48,8 +48,9 @@ const (
 // SetMetricOpID used to set operation ID for metrics
 func SetMetricOpID(ctx context.Context, value string) {
 	if config.Metric().Enabled {
-		v := ctx.Value(contextOpIDKey{}).(*string)
-		*v = value
+		if v, ok := ctx.Value(contextOpIDKey{}).(*string); ok && v != nil {
+			*v = value
+		}
 	}
 }
 


### PR DESCRIPTION
# Summary

This PR fixes a potential **nil pointer panic** in `SetMetricOpID` in `src/server/middleware/metric/metric.go`.

## The Bug

`SetMetricOpID` retrieves a context value and directly asserts it to `*string` without a nil or type check:

```go
func SetMetricOpID(ctx context.Context, value string) {
    if config.Metric().Enabled {
        v := ctx.Value(contextOpIDKey{}).(*string) // <-- PANIC if key not in context
        *v = value
    }
}
```

`ctx.Value()` returns `nil` if the key was never injected into the context (e.g. if `SetMetricOpID` is called from a code path that does not go through the `instrumentHandler` middleware). The direct assertion `nil.(*string)` causes a **runtime panic**.

## The Fix

Replace the bare assertion with a safe two-value type assertion:

```go
func SetMetricOpID(ctx context.Context, value string) {
    if config.Metric().Enabled {
        if v, ok := ctx.Value(contextOpIDKey{}).(*string); ok && v != nil {
            *v = value
        }
    }
}
```

This ensures that if the context key is absent or holds an unexpected type, the function silently no-ops instead of panicking, which is the correct defensive behaviour for a metrics helper.

## Issue being fixed

Fixes a potential runtime panic in the metrics middleware when `SetMetricOpID` is called outside of the `instrumentHandler` context.

Please indicate you've done the following:

- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed: `release-note/ignore-for-release`
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in website repository.
