### PR TITLE
fix(scan): fix validation bypass and ignored authorization error in scan job

### DIFF
--- a/src/pkg/scan/job.go
+++ b/src/pkg/scan/job.go
@@ -134,7 +134,7 @@ func (j *Job) Validate(params job.Parameters) error {
 	}
 
 	if authType != authorizationBearer && authType != authorizationBasic {
-		return errors.Wrapf(err, "job validate: not support auth type %s", authType)
+		return errors.Errorf("job validate: not support auth type %s", authType)
 	}
 
 	return nil
@@ -200,7 +200,7 @@ func (j *Job) Run(ctx job.Context, params job.Parameters) error {
 		authorization, err = makeBasicAuthorization(robotAccount)
 	}
 	if err != nil {
-		_ = logAndWrapError(myLogger, err, "scan job: make authorization")
+		return logAndWrapError(myLogger, err, "scan job: make authorization")
 	}
 
 	if shouldStop() {


### PR DESCRIPTION
## Summary

Two bugs in `src/pkg/scan/job.go`:

### 1. Validation bypass: `errors.Wrapf(nil, ...)` returns nil (line 137)

In `Validate()`, the unsupported auth type error was reported using `errors.Wrapf(err, ...)`. But at that point, `err` is guaranteed `nil` (the `if err != nil` check above already returned). The harbor errors library's `Wrapf` function explicitly returns `nil` when `err == nil`:

```go
func Wrapf(err error, format string, args ...any) *Error {
    if err == nil {
        return nil
    }
    ...
}
```

This means `Validate()` returned nil for **any** unsupported auth type, completely defeating the validation.

**Fix**: Changed to `errors.Errorf(...)` which always returns an error.

### 2. Ignored authorization error causes scan with empty credentials (line 202)

In `Run()`, when `makeBearerAuthorization` or `makeBasicAuthorization` fails, the error was explicitly discarded with `_ =`:

```go
if err != nil {
    _ = logAndWrapError(myLogger, err, "scan job: make authorization")
}
```

Execution continued to submit the scan request with an empty `authorization` string, wasting resources on a request guaranteed to fail at the scanner adapter.

**Fix**: Changed to `return logAndWrapError(...)` to propagate the error.