### PR TITLE
fix: close leaked file handle in scan data export and use embedded HTTP client in exporter

### DIFF
--- a/src/jobservice/job/impl/scandataexport/scan_data_export.go
+++ b/src/jobservice/job/impl/scandataexport/scan_data_export.go
@@ -117,6 +117,7 @@ func (sde *ScanDataExport) Run(ctx job.Context, params job.Parameters) error {
 			"Export Job Id = %s. Error when moving report file %s to persistent storage: %v", params[export.JobID], fileName, err)
 		return err
 	}
+	defer csvFile.Close()
 	baseFileName := filepath.Base(fileName)
 	repositoryName := strings.TrimSuffix(baseFileName, filepath.Ext(baseFileName))
 	logger.Infof("Creating repository for CSV file with blob : %s", repositoryName)

--- a/src/pkg/exporter/harbor_cli.go
+++ b/src/pkg/exporter/harbor_cli.go
@@ -42,7 +42,7 @@ func (hc HarborClient) harborURL(p string) url.URL {
 // Get ...
 func (hc HarborClient) Get(p string) (*http.Response, error) {
 	hbrURL := hc.harborURL(p)
-	res, err := http.Get(hbrURL.String())
+	res, err := hc.Client.Get(hbrURL.String())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

### 1. File handle leak in scan data export (`src/jobservice/job/impl/scandataexport/scan_data_export.go:114`)

`csvFile` is opened but not closed on two early-return paths:
- Line 126: when `os.Stat` fails
- Line 140: when the file is empty

Under sustained export workloads, this leaks file descriptors until the process hits its ulimit, causing cascading failures.

**Fix**: Added `defer csvFile.Close()` immediately after the successful open.

### 2. Embedded HTTP client bypassed in exporter (`src/pkg/exporter/harbor_cli.go:45`)

`HarborClient.Get()` calls the package-level `http.Get()`, which uses `http.DefaultClient` instead of the embedded `*http.Client` initialized with a custom transport. This means:

- Custom TLS configuration is silently ignored
- `http.DefaultClient` has no timeout, so connections can hang indefinitely
- The `HarborClient` struct's embedded `*http.Client` field is completely unused

**Fix**: Changed to `hc.Client.Get()` to use the properly configured client.