### PR TITLE
fix: safeguard against nil Trigger when getting retention policy

### DIFF
--- a/src/pkg/retention/manager.go
+++ b/src/pkg/retention/manager.go
@@ -97,7 +97,7 @@ func (d *DefaultManager) GetPolicy(ctx context.Context, id int64) (*policy.Metad
 		return nil, err
 	}
 	p.ID = id
-	if p.Trigger.Kind == policy.TriggerKindSchedule {
+	if p.Trigger != nil && p.Trigger.Kind == policy.TriggerKindSchedule {
 		cron, ok := p.Trigger.Settings[policy.TriggerSettingsCron]
 		if ok {
 			if cronStr, isStr := cron.(string); isStr && len(cronStr) > 0 {


### PR DESCRIPTION
# Summary

This PR fixes a potential **nil pointer panic** in the `GetPolicy` function in `src/pkg/retention/manager.go`.

## The Bug

In `src/pkg/retention/manager.go`, `GetPolicy` retrieves the policy from the database and unmarshals it into `policy.Metadata`:

```go
	p := &policy.Metadata{}
	if err = json.Unmarshal([]byte(p1.Data), p); err != nil {
		return nil, err
	}
	p.ID = id
	if p.Trigger.Kind == policy.TriggerKindSchedule { // <-- PANIC if Trigger is nil
```

`Trigger` is a pointer field in the `policy.Metadata` struct (`*Trigger`). If the database JSON doesn't contain a trigger, `json.Unmarshal` leaves `p.Trigger` as `nil`. Accessing `p.Trigger.Kind` without checking for nil causes a runtime panic.

Other functions in the codebase (like `ValidateRetentionPolicy`) correctly check `if p.Trigger != nil` before accessing its fields, but this check was missing in `GetPolicy`.

## The Fix

Added a nil check before accessing `p.Trigger.Kind`:

```go
	if p.Trigger != nil && p.Trigger.Kind == policy.TriggerKindSchedule {
		cron, ok := p.Trigger.Settings[policy.TriggerSettingsCron]
```

## Issue being fixed

Fixes a potential nil pointer dereference panic when retrieving a retention policy without a trigger.

Please indicate you've done the following:

- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed: `release-note/ignore-for-release`
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in website repository.
