### PR TITLE
fix: safely type assert ExtraAttrs in scan data export

### DIFF
--- a/src/controller/scandataexport/execution.go
+++ b/src/controller/scandataexport/execution.go
@@ -183,22 +183,24 @@ func (c *controller) convertToExportExecStatus(ctx context.Context, exec *task.E
 		StartTime:     exec.StartTime,
 		EndTime:       exec.EndTime,
 	}
-	if pids, ok := exec.ExtraAttrs[export.ProjectIDsAttribute]; ok {
-		for _, pid := range pids.([]any) {
-			execStatus.ProjectIDs = append(execStatus.ProjectIDs, int64(pid.(float64)))
+	if pids, ok := exec.ExtraAttrs[export.ProjectIDsAttribute].([]any); ok {
+		for _, pid := range pids {
+			if floatPid, ok := pid.(float64); ok {
+				execStatus.ProjectIDs = append(execStatus.ProjectIDs, int64(floatPid))
+			}
 		}
 	}
-	if digest, ok := exec.ExtraAttrs[export.DigestKey]; ok {
-		execStatus.ExportDataDigest = digest.(string)
+	if digest, ok := exec.ExtraAttrs[export.DigestKey].(string); ok {
+		execStatus.ExportDataDigest = digest
 	}
-	if jobName, ok := exec.ExtraAttrs[export.JobNameAttribute]; ok {
-		execStatus.JobName = jobName.(string)
+	if jobName, ok := exec.ExtraAttrs[export.JobNameAttribute].(string); ok {
+		execStatus.JobName = jobName
 	}
-	if userName, ok := exec.ExtraAttrs[export.UserNameAttribute]; ok {
-		execStatus.UserName = userName.(string)
+	if userName, ok := exec.ExtraAttrs[export.UserNameAttribute].(string); ok {
+		execStatus.UserName = userName
 	}
-	if statusMessage, ok := exec.ExtraAttrs[export.StatusMessageAttribute]; ok {
-		execStatus.StatusMessage = statusMessage.(string)
+	if statusMessage, ok := exec.ExtraAttrs[export.StatusMessageAttribute].(string); ok {
+		execStatus.StatusMessage = statusMessage
 	}
 
 	if len(execStatus.ExportDataDigest) > 0 {


### PR DESCRIPTION
# Summary

This PR fixes a set of unsafe type assertions when reading `ExtraAttrs` in the scan data export execution logic.

## The Bug

In `src/controller/scandataexport/execution.go`, values extracted from the `ExtraAttrs` map (such as `export.ProjectIDsAttribute`, `export.DigestKey`, etc.) are type-asserted directly to strings or arrays without verifying that the underlying interface actually holds that type.

For example:
```go
	if digest, ok := exec.ExtraAttrs[export.DigestKey]; ok {
		execStatus.ExportDataDigest = digest.(string)
	}
```

If the `digest` is somehow corrupted in the database or present as a different type due to JSON unmarshalling (or if `ProjectIDs` doesn't match exactly `[]any` containing `float64`), this direct type assertion will cause a runtime panic.

## The Fix

Changed the type assertions to the safe comma-ok idiom for `ExtraAttrs` access. For example:
```go
	if digest, ok := exec.ExtraAttrs[export.DigestKey].(string); ok {
		execStatus.ExportDataDigest = digest
	}
```

This prevents the panic and safely ignores fields that do not match the expected type.

## Issue being fixed

Fixes potential runtime panics when processing scan data export executions with corrupted or unexpectedly typed `ExtraAttrs`.

Please indicate you've done the following:

- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed: `release-note/ignore-for-release`
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in website repository.
