### PR TITLE
Add proxy cache hit/miss metrics

### DIFF
--- a/src/lib/metric/collector.go
+++ b/src/lib/metric/collector.go
@@ -26,6 +26,8 @@ func RegisterCollectors() {
 		TotalInFlightGauge,
 		TotalReqCnt,
 		TotalReqDurSummary,
+		TotalProxyReq,
+		TotalProxyUpstreamReq,
 	}...)
 }
 
@@ -61,4 +63,24 @@ var (
 			Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
 		},
 		[]string{"method", "operation"})
+
+	// TotalProxyReq used to collect total proxy cache requests
+	TotalProxyReq = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: os.Getenv(NamespaceEnvKey),
+			Subsystem: os.Getenv(SubsystemEnvKey),
+			Name:      "http_registry_proxy_requests_total",
+			Help:      "The total number of requests sent to the proxy cache",
+		},
+		[]string{"project", "method"})
+
+	// TotalProxyUpstreamReq used to collect total requests sent to the upstream
+	TotalProxyUpstreamReq = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: os.Getenv(NamespaceEnvKey),
+			Subsystem: os.Getenv(SubsystemEnvKey),
+			Name:      "http_registry_proxy_upstream_requests_total",
+			Help:      "The total number of proxy cache requests that fetched from the upstream registry (cache miss)",
+		},
+		[]string{"project", "method"})
 )

--- a/src/server/middleware/repoproxy/proxy.go
+++ b/src/server/middleware/repoproxy/proxy.go
@@ -33,6 +33,7 @@ import (
 	"github.com/goharbor/harbor/src/lib/errors"
 	httpLib "github.com/goharbor/harbor/src/lib/http"
 	"github.com/goharbor/harbor/src/lib/log"
+	"github.com/goharbor/harbor/src/lib/metric"
 	"github.com/goharbor/harbor/src/lib/orm"
 	"github.com/goharbor/harbor/src/lib/redis"
 	proModels "github.com/goharbor/harbor/src/pkg/project/models"
@@ -99,6 +100,9 @@ func handleBlob(w http.ResponseWriter, r *http.Request, next http.Handler) error
 		return nil
 	}
 
+	if p.IsProxy() && config.Metric().Enabled {
+		metric.TotalProxyReq.WithLabelValues(p.Name, r.Method).Inc()
+	}
 	if !canProxy(r.Context(), p) || proxyCtl.UseLocalBlob(ctx, art) {
 		next.ServeHTTP(w, r)
 		return nil
@@ -119,6 +123,9 @@ func handleBlob(w http.ResponseWriter, r *http.Request, next http.Handler) error
 		defer connection.Limiter.Release(context.Background(), client, key) // use background context in defer to avoid been canceled
 	}
 
+	if config.Metric().Enabled {
+		metric.TotalProxyUpstreamReq.WithLabelValues(p.Name, r.Method).Inc()
+	}
 	size, reader, err := proxyCtl.ProxyBlob(ctx, p, art)
 	if err != nil {
 		return err
@@ -239,6 +246,9 @@ func handleManifest(w http.ResponseWriter, r *http.Request, next http.Handler) e
 		return nil
 	}
 
+	if p.IsProxy() && config.Metric().Enabled {
+		metric.TotalProxyReq.WithLabelValues(p.Name, r.Method).Inc()
+	}
 	if !canProxy(r.Context(), p) {
 		next.ServeHTTP(w, r)
 		return nil
@@ -283,6 +293,9 @@ func handleManifest(w http.ResponseWriter, r *http.Request, next http.Handler) e
 		defer connection.Limiter.Release(context.Background(), client, key) // use background context in defer to avoid been canceled
 	}
 
+	if config.Metric().Enabled {
+		metric.TotalProxyUpstreamReq.WithLabelValues(p.Name, r.Method).Inc()
+	}
 	log.Debugf("the tag is %v, digest is %v", art.Tag, art.Digest)
 	if r.Method == http.MethodHead {
 		err = proxyManifestHead(ctx, w, proxyCtl, p, art, remote)


### PR DESCRIPTION
# Comprehensive Summary of your change

Added `http_registry_proxy_requests_total` and `http_registry_proxy_upstream_requests_total` metrics to monitor proxy cache hit/miss ratio.

# Issue being fixed
Fixes https://github.com/goharbor/harbor/issues/22799


Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
