### PR TITLE
fix: safeguard against nil context value in scan data export

### DIFF
--- a/src/controller/scandataexport/execution.go
+++ b/src/controller/scandataexport/execution.go
@@ -124,7 +124,11 @@ func (c *controller) DeleteExecution(ctx context.Context, executionID int64) err
 
 func (c *controller) Start(ctx context.Context, request export.Request) (executionID int64, err error) {
 	logger := log.GetLogger(ctx)
-	vendorID := int64(ctx.Value(export.CsvJobVendorIDKey).(int))
+	vID, ok := ctx.Value(export.CsvJobVendorIDKey).(int)
+	if !ok {
+		return 0, fmt.Errorf("failed to get vendor ID from context")
+	}
+	vendorID := int64(vID)
 	extraAttrs := make(map[string]any)
 	extraAttrs[export.ProjectIDsAttribute] = request.Projects
 	extraAttrs[export.JobNameAttribute] = request.JobName


### PR DESCRIPTION
# Summary

This PR fixes an unsafe type assertion in the scan data export execution flow which can cause a runtime panic.

## The Bug

In `src/controller/scandataexport/execution.go`, when starting an execution, the vendor ID is extracted from the context using an unsafe type assertion:

```go
vendorID := int64(ctx.Value(export.CsvJobVendorIDKey).(int))
```

If the context does not contain the `CsvJobVendorIDKey`, `ctx.Value()` returns `nil`, and the type assertion `.(int)` directly on `nil` results in a panic.

## The Fix

Introduced the safe type-assertion idiom (`ok` check) for `ctx.Value(export.CsvJobVendorIDKey)`. If it is not present or invalid, it gracefully returns a formatted error instead of crashing the process.

## Issue being fixed

Fixes a potential runtime panic when processing scan data export executions without a valid vendor ID in the context.

Please indicate you've done the following:

- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed: `release-note/ignore-for-release`
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in website repository.
