### PR TITLE
fix: safely type assert LDAP group config values

### DIFF
--- a/src/pkg/config/validate/ldapgroup.go
+++ b/src/pkg/config/validate/ldapgroup.go
@@ -37,16 +37,28 @@ func (l LdapGroupValidateRule) Validate(ctx context.Context, cfgMgr config.Manag
 	updated := false
 	// Merge the cfgs and the cfgMgr to get the final GroupConf
 	if val, exist := cfgs[common.LDAPGroupSearchFilter]; exist {
-		cfg.Filter = val.(string)
-		updated = true
+		if v, ok := val.(string); ok {
+			cfg.Filter = v
+			updated = true
+		} else {
+			return errors.New("ldap group search filter must be a string")
+		}
 	}
 	if val, exist := cfgs[common.LDAPGroupAttributeName]; exist {
-		cfg.NameAttribute = val.(string)
-		updated = true
+		if v, ok := val.(string); ok {
+			cfg.NameAttribute = v
+			updated = true
+		} else {
+			return errors.New("ldap group attribute name must be a string")
+		}
 	}
 	if val, exist := cfgs[common.LDAPGroupMembershipAttribute]; exist {
-		cfg.MembershipAttribute = val.(string)
-		updated = true
+		if v, ok := val.(string); ok {
+			cfg.MembershipAttribute = v
+			updated = true
+		} else {
+			return errors.New("ldap group membership attribute must be a string")
+		}
 	}
 	if !updated {
 		return nil


### PR DESCRIPTION
# Summary

This PR introduces safe type assertions for LDAP group configurations during validation to prevent runtime panics.

## The Bug

In `src/pkg/config/validate/ldapgroup.go`, the configuration values for LDAP groups are unmarshaled into `map[string]any` via API input. The code previously assumed that certain fields were strings and forcefully cast them without checking:

```go
	if val, exist := cfgs[common.LDAPGroupSearchFilter]; exist {
		cfg.Filter = val.(string)
```

If a user maliciously or accidentally submitted a boolean, integer, or array for these fields, `val.(string)` would trigger a panic, crashing the Harbor core process.

## The Fix

Introduced the safe type-assertion idiom (`v, ok := val.(string)`) for LDAP group string configuration fields. If the provided value is not a string, a descriptive validation error is returned instead of panicking.

## Issue being fixed

Fixes potential runtime panics when processing incorrectly typed LDAP group configurations via the API.

Please indicate you've done the following:

- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed: `release-note/ignore-for-release`
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in website repository.
