### PR TITLE
fix: safeguard against panics in Casbin keyMatch2Func

### DIFF
--- a/src/pkg/permission/evaluator/rbac/casbin_match.go
+++ b/src/pkg/permission/evaluator/rbac/casbin_match.go
@@ -15,6 +15,7 @@
 package rbac
 
 import (
+	"fmt"
 	"math/rand"
 	"regexp"
 	"strings"
@@ -95,8 +96,14 @@ func keyMatch2(key1 string, key2 string) bool {
 }
 
 func keyMatch2Func(args ...any) (any, error) {
-	name1 := args[0].(string)
-	name2 := args[1].(string)
+	if len(args) != 2 {
+		return false, fmt.Errorf("keyMatch2Func expects 2 arguments, got %d", len(args))
+	}
+	name1, ok1 := args[0].(string)
+	name2, ok2 := args[1].(string)
+	if !ok1 || !ok2 {
+		return false, fmt.Errorf("keyMatch2Func expects 2 string arguments")
+	}
 
 	return keyMatch2(name1, name2), nil
 }


### PR DESCRIPTION
# Summary

This PR fixes unsafe type assertions in the Casbin matcher (`keyMatch2Func`), which could cause a runtime panic if invalid arguments are passed from the RBAC policy evaluator.

## The Bug

In `src/pkg/permission/evaluator/rbac/casbin_match.go`, the custom Casbin matcher function blindly asserted its arguments as strings:

```go
func keyMatch2Func(args ...any) (any, error) {
	name1 := args[0].(string)
	name2 := args[1].(string)
	...
```

If the Casbin policy engine passes fewer than two arguments or arguments of different types (e.g. `nil`), this will trigger an immediate runtime panic, crashing the Harbor core server instead of gracefully returning an error.

## The Fix

Introduced standard bounds checking (`len(args) != 2`) and safe type assertions (`ok1`, `ok2`) for the arguments. If the check fails, it now safely returns a formatted error instead of crashing.

## Issue being fixed

Fixes potential runtime panics during RBAC policy evaluation when the Casbin matcher is invoked with malformed arguments.

Please indicate you've done the following:

- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed: `release-note/ignore-for-release`
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in website repository.
