### PR TITLE
fix: safeguard against missing id_token in OIDC auth

### DIFF
--- a/src/pkg/oidc/helper.go
+++ b/src/pkg/oidc/helper.go
@@ -211,7 +211,11 @@ func ExchangeToken(ctx context.Context, code string, pkceCode pkce.Code) (*Token
 	if err != nil {
 		return nil, err
 	}
-	return &Token{Token: *oauthToken, RawIDToken: oauthToken.Extra("id_token").(string)}, nil
+	idToken, ok := oauthToken.Extra("id_token").(string)
+	if !ok {
+		return nil, fmt.Errorf("id_token is missing or not a string in the oauth token")
+	}
+	return &Token{Token: *oauthToken, RawIDToken: idToken}, nil
 }
 
 func parseIDToken(ctx context.Context, rawIDToken string) (*gooidc.IDToken, error) {


### PR DESCRIPTION
# Summary

This PR fixes an unsafe type assertion in the OIDC helper logic that could cause a runtime panic during user authentication.

## The Bug

In `src/pkg/oidc/helper.go`, the `id_token` is extracted from the `oauthToken.Extra` properties and blindly cast to a string:

```go
RawIDToken: oauthToken.Extra("id_token").(string)
```

If the OIDC identity provider fails to return an `id_token`, or returns it in an unexpected type (e.g. `nil`), this type assertion will trigger a panic and crash the Harbor core instance during login flows.

## The Fix

Introduced the safe type-assertion idiom (`ok` check) when extracting the `id_token`. If it is missing or invalid, it gracefully returns a formatted error rather than crashing.

## Issue being fixed

Fixes potential runtime panics during OIDC authentication when the identity provider responds with malformed tokens.

Please indicate you've done the following:

- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed: `release-note/ignore-for-release`
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in website repository.
