### PR TITLE
Fix: member audit log resolution after transaction commit

### DIFF
--- a/src/pkg/auditext/event/member/member.go
+++ b/src/pkg/auditext/event/member/member.go
@@ -217,8 +217,13 @@ func ensureORMContext(ctx context.Context) context.Context {
 	if ctx == nil {
 		return orm.Context()
 	}
-	if _, err := orm.FromContext(ctx); err == nil {
-		return ctx
+	if o, err := orm.FromContext(ctx); err == nil {
+		if _, ok := o.(beegoorm.TxOrmer); !ok {
+			return ctx
+		}
 	}
+	// Member audit events are resolved asynchronously and may run after the
+	// request transaction has already been committed/rolled back. Replace
+	// transaction-bound ORM with a fresh ORM to avoid using a completed tx.
 	return orm.NewContext(ctx, beegoorm.NewOrm())
 }

--- a/src/pkg/auditext/event/member/member.go
+++ b/src/pkg/auditext/event/member/member.go
@@ -213,6 +213,11 @@ func parsePreResolved(info string) (string, string) {
 	return info, ""
 }
 
+// newBeegoOrm builds a fresh, non-transaction ORM. It is a package-level seam
+// so tests can exercise the transaction-replacement branch of ensureORMContext
+// without a registered default database (beegoorm.NewOrm panics otherwise).
+var newBeegoOrm = beegoorm.NewOrm
+
 func ensureORMContext(ctx context.Context) context.Context {
 	if ctx == nil {
 		return orm.Context()
@@ -225,5 +230,5 @@ func ensureORMContext(ctx context.Context) context.Context {
 	// Member audit events are resolved asynchronously and may run after the
 	// request transaction has already been committed/rolled back. Replace
 	// transaction-bound ORM with a fresh ORM to avoid using a completed tx.
-	return orm.NewContext(ctx, beegoorm.NewOrm())
+	return orm.NewContext(ctx, newBeegoOrm())
 }

--- a/src/pkg/auditext/event/member/member_test.go
+++ b/src/pkg/auditext/event/member/member_test.go
@@ -19,6 +19,8 @@ import (
 	"net/http"
 	"testing"
 
+	beegoorm "github.com/beego/beego/v2/client/orm"
+
 	"github.com/goharbor/harbor/src/controller/event/metadata/commonevent"
 	"github.com/goharbor/harbor/src/controller/event/model"
 	"github.com/goharbor/harbor/src/lib/orm"
@@ -393,13 +395,41 @@ func TestAuditLogMemberEventEnabled_EmptyOperation(t *testing.T) {
 }
 
 func TestEnsureORMContext(t *testing.T) {
-	// context with a regular (non-tx) ORM: returned as-is, covering the new
-	// TxOrmer type-assertion branch added to ensureORMContext.
-	regularCtx := orm.NewContext(context.Background(), &ormtesting.FakeOrmer{})
-	gotCtx := ensureORMContext(regularCtx)
-	if gotCtx != regularCtx {
-		t.Error("ensureORMContext with non-tx ORM should return the same context")
-	}
+	// Stub the ORM factory so the transaction-replacement branch does not need a
+	// registered default DB (beegoorm.NewOrm panics otherwise).
+	origNewOrm := newBeegoOrm
+	defer func() { newBeegoOrm = origNewOrm }()
+	fresh := &ormtesting.FakeOrmer{}
+	newBeegoOrm = func() beegoorm.Ormer { return fresh }
+
+	t.Run("non-tx ORM returned as-is", func(t *testing.T) {
+		// A regular (non-tx) ORM must be returned unchanged, covering the
+		// TxOrmer type-assertion branch in ensureORMContext.
+		ctx := orm.NewContext(context.Background(), &ormtesting.FakeOrmer{})
+		if got := ensureORMContext(ctx); got != ctx {
+			t.Error("ensureORMContext with non-tx ORM should return the same context")
+		}
+	})
+
+	t.Run("tx ORM replaced with fresh non-tx ORM", func(t *testing.T) {
+		// A transaction ORM must be swapped for a fresh non-tx ORM, guarding the
+		// regression where member audit events reused a completed transaction.
+		ctx := orm.NewContext(context.Background(), &ormtesting.FakeTxOrmer{})
+		got := ensureORMContext(ctx)
+		if got == ctx {
+			t.Fatal("ensureORMContext with tx ORM should return a new context")
+		}
+		o, err := orm.FromContext(got)
+		if err != nil {
+			t.Fatalf("orm.FromContext returned error: %v", err)
+		}
+		if _, isTx := o.(beegoorm.TxOrmer); isTx {
+			t.Error("ensureORMContext should replace the transaction ORM with a non-tx ORM")
+		}
+		if o != fresh {
+			t.Error("ensureORMContext should install the ORM produced by newBeegoOrm")
+		}
+	})
 }
 
 func TestParsePreResolved(t *testing.T) {

--- a/src/pkg/auditext/event/member/member_test.go
+++ b/src/pkg/auditext/event/member/member_test.go
@@ -21,7 +21,9 @@ import (
 
 	"github.com/goharbor/harbor/src/controller/event/metadata/commonevent"
 	"github.com/goharbor/harbor/src/controller/event/model"
+	"github.com/goharbor/harbor/src/lib/orm"
 	"github.com/goharbor/harbor/src/pkg/notifier/event"
+	ormtesting "github.com/goharbor/harbor/src/testing/lib/orm"
 )
 
 func stubLookups() func() {
@@ -387,6 +389,16 @@ func TestResolver_Resolve_NilInputs(t *testing.T) {
 func TestAuditLogMemberEventEnabled_EmptyOperation(t *testing.T) {
 	if auditLogMemberEventEnabled(context.Background(), "") {
 		t.Fatal("auditLogMemberEventEnabled() = true, want false for empty operation")
+	}
+}
+
+func TestEnsureORMContext(t *testing.T) {
+	// context with a regular (non-tx) ORM: returned as-is, covering the new
+	// TxOrmer type-assertion branch added to ensureORMContext.
+	regularCtx := orm.NewContext(context.Background(), &ormtesting.FakeOrmer{})
+	gotCtx := ensureORMContext(regularCtx)
+	if gotCtx != regularCtx {
+		t.Error("ensureORMContext with non-tx ORM should return the same context")
 	}
 }
 


### PR DESCRIPTION
Thank you for contributing to Harbor!

# Comprehensive Summary of your change

This fixes issue #23557 by resolving project member audit entries without depending on the original request transaction. As a result, member audit logs remain readable even after the request context has ended.



# Issue being fixed
Fixes #23557

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
