### PR TITLE
chore(deps): bump github actions to v6

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -193,7 +193,7 @@ jobs:
             : > "$GITHUB_WORKSPACE/_base_repos_${ARCH}.txt"
           fi
       - name: Upload repo list
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: repos-${{ matrix.arch }}
           path: |


### PR DESCRIPTION
## What this PR does / why we need it:
This PR bumps outdated GitHub Actions in `.github/workflows/api-schema-check.yml` and `.github/workflows/build-package.yml` (`actions/checkout`, `actions/upload-artifact`, and `actions/download-artifact`) from `@v4` to `@v6` to match the versions currently used in the primary `CI.yml` workflow.

This ensures consistency across all CI workflows and takes advantage of the latest features and security fixes in these actions.

## Which issue(s) this PR fixes:
N/A

## Special notes for your reviewer:
N/A
