### PR TITLE
fix: set MaxIdleConnsPerHost on internal HTTP transports

### DIFF
--- a/src/common/http/transport.go
+++ b/src/common/http/transport.go
@@ -67,8 +67,14 @@ func newDefaultTransport() *http.Transport {
 			KeepAlive: 30 * time.Second,
 			DualStack: true,
 		}).DialContext,
-		TLSClientConfig:       &tls.Config{},
-		MaxIdleConns:          100,
+		TLSClientConfig: &tls.Config{},
+		MaxIdleConns:    1000,
+		// The default value of MaxIdleConnsPerHost is 2, which is too small for
+		// high-concurrency scenarios (e.g. core/jobservice talking to the registry,
+		// or replicating to a single remote endpoint). Idle connections beyond the
+		// need are reaped by IdleConnTimeout, so a generous value is safe. Keeping
+		// it low causes connection churn and ephemeral port exhaustion (EADDRNOTAVAIL).
+		MaxIdleConnsPerHost:   200,
 		IdleConnTimeout:       90 * time.Second,
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,

--- a/src/jobservice/hook/hook_client.go
+++ b/src/jobservice/hook/hook_client.go
@@ -45,8 +45,12 @@ type basicClient struct {
 func NewClient(ctx context.Context) Client {
 	// Create transport
 	transport := &http.Transport{
-		MaxIdleConns:    20,
-		IdleConnTimeout: 30 * time.Second,
+		MaxIdleConns: 20,
+		// hooks only ever target the single core endpoint, so allow all idle
+		// connections to be kept for that host (default is 2, which causes
+		// connection churn and TIME_WAIT pile-up under heavy job activity)
+		MaxIdleConnsPerHost: 20,
+		IdleConnTimeout:     30 * time.Second,
 		DialContext: (&net.Dialer{
 			Timeout:   30 * time.Second,
 			KeepAlive: 30 * time.Second,

--- a/src/pkg/scan/rest/v1/client.go
+++ b/src/pkg/scan/rest/v1/client.go
@@ -83,6 +83,10 @@ func NewClient(url, authType, accessCredential string, skipCertVerify bool) (Cli
 	transport := &http.Transport{
 		Proxy:        http.ProxyFromEnvironment,
 		MaxIdleConns: 100,
+		// each client instance talks to a single scanner adapter endpoint, so
+		// allow all idle connections to be kept for that host (default is 2,
+		// which causes connection churn during scan-all bursts)
+		MaxIdleConnsPerHost: 100,
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: skipCertVerify,
 		},

--- a/src/server/registry/proxy.go
+++ b/src/server/registry/proxy.go
@@ -33,9 +33,21 @@ func newProxy() http.Handler {
 		panic(fmt.Sprintf("failed to parse the URL of registry: %v", err))
 	}
 	proxy := httputil.NewSingleHostReverseProxy(url)
-	if commonhttp.InternalTLSEnabled() {
-		proxy.Transport = commonhttp.GetHTTPTransport()
+	// The reverse proxy forwards all /v2/ traffic to a single host (the registry),
+	// so it deserves a dedicated transport with a large per-host idle connection
+	// pool. Relying on http.DefaultTransport (MaxIdleConnsPerHost=2) closes almost
+	// every connection after use under high concurrency, piling up TIME_WAIT
+	// sockets and eventually exhausting ephemeral ports (EADDRNOTAVAIL).
+	opts := []func(*http.Transport){
+		func(tr *http.Transport) {
+			tr.MaxIdleConns = 1024
+			tr.MaxIdleConnsPerHost = 1024
+		},
 	}
+	if commonhttp.InternalTLSEnabled() {
+		opts = append(opts, commonhttp.WithInternalTLSConfig())
+	}
+	proxy.Transport = commonhttp.NewTransport(opts...)
 
 	proxy.Director = basicAuthDirector(proxy.Director)
 	return proxy


### PR DESCRIPTION
### Comprehensive Summary

Go's `http.Transport` defaults `MaxIdleConnsPerHost` to 2. Harbor's internal traffic is dominated by single-host hotspots (core → registry reverse proxy, registry API client, jobservice → core hooks, scanner adapter client), so under high concurrency almost every connection is closed after use. The resulting churn piles up client-side `TIME_WAIT` sockets and eventually exhausts ephemeral ports:

```
http: proxy error: dial tcp 172.18.0.4:5000: connect: cannot assign requested address
```

Changes:

- `common/http/transport.go`: `newDefaultTransport()` now sets `MaxIdleConns=1000` / `MaxIdleConnsPerHost=200`, covering the registry client, core↔jobservice, webhook jobs and replication adapters.
- `server/registry/proxy.go`: the core → registry reverse proxy previously fell back to `http.DefaultTransport` when internal TLS is disabled; it now always gets a dedicated transport with `MaxIdleConns(PerHost)=1024`, as all `/v2/` data-plane traffic targets a single host.
- `jobservice/hook/hook_client.go` / `pkg/scan/rest/v1/client.go`: per-host idle pool now matches `MaxIdleConns` (20/100), since each client only talks to one endpoint.

These knobs only enable connection reuse — idle connections beyond actual need are still reaped by `IdleConnTimeout`, and peak connection count remains driven by concurrency. No behavior change.

### Issue being fixed

Observed on a docker-compose deployment under high-concurrency pulls; core floods `proxy error: context canceled` followed by `cannot assign requested address` on the core → registry hop.

