### PR TITLE
fix(portal): resolve missing OCI annotations in Annotations column

### DIFF
--- a/src/portal/src/app/base/project/repository/artifact/artifact-list-page/artifact-list/artifact-list-tab/artifact-list-tab.component.spec.ts
+++ b/src/portal/src/app/base/project/repository/artifact/artifact-list-page/artifact-list/artifact-list-tab/artifact-list-tab.component.spec.ts
@@ -531,6 +531,38 @@ describe('ArtifactListTabComponent', () => {
         expect(comp.hasEnabledSbom()).toBeTruthy();
         expect(comp.canAddLabel()).toBeFalsy();
     });
+
+    it('should format and populate annotationsArray', () => {
+        const artifactsWithAnnotations: ArtifactFront[] = [
+            {
+                id: 10,
+                type: 'image',
+                digest: 'sha256:111',
+                annotations: {
+                    'org.opencontainers.image.vendor': 'Harbor',
+                    'custom.key': 'custom-value',
+                },
+            },
+            {
+                id: 11,
+                type: 'image',
+                digest: 'sha256:222',
+            },
+        ];
+
+        comp.populateAnnotations(artifactsWithAnnotations);
+
+        expect(artifactsWithAnnotations[0].annotationsArray).toBeDefined();
+        expect(artifactsWithAnnotations[0].annotationsArray.length).toBe(2);
+        expect(artifactsWithAnnotations[0].annotationsArray).toContain(
+            'org.opencontainers.image.vendor: Harbor'
+        );
+        expect(artifactsWithAnnotations[0].annotationsArray).toContain(
+            'custom.key: custom-value'
+        );
+
+        expect(artifactsWithAnnotations[1].annotationsArray).toBeUndefined();
+    });
 });
 
 async function stepOpenAction(fixture, comp) {

--- a/src/portal/src/app/base/project/repository/artifact/artifact-list-page/artifact-list/artifact-list-tab/artifact-list-tab.component.ts
+++ b/src/portal/src/app/base/project/repository/artifact/artifact-list-page/artifact-list/artifact-list-tab/artifact-list-tab.component.ts
@@ -439,6 +439,7 @@ export class ArtifactListTabComponent implements OnInit, OnDestroy {
                                         platFormAttr[index].platform
                                     );
                                 });
+                                this.populateAnnotations(this.artifactList);
                                 this.getArtifactTagsAsync(this.artifactList);
                                 this.getAccessoriesAsync(this.artifactList);
                                 this.checkCosignAndSbomAsync(this.artifactList);
@@ -479,6 +480,7 @@ export class ArtifactListTabComponent implements OnInit, OnDestroy {
                             }
                         }
                         this.artifactList = res.body;
+                        this.populateAnnotations(this.artifactList);
                         this.getArtifactTagsAsync(this.artifactList);
                         this.getAccessoriesAsync(this.artifactList);
                         this.checkCosignAndSbomAsync(this.artifactList);
@@ -1271,5 +1273,19 @@ export class ArtifactListTabComponent implements OnInit, OnDestroy {
     }
     isEllipsisActive(ele: HTMLSpanElement): boolean {
         return ele?.offsetWidth < ele?.scrollWidth;
+    }
+    populateAnnotations(artifacts: ArtifactFront[]) {
+        if (artifacts && artifacts.length) {
+            artifacts.forEach(artifact => {
+                if (artifact.annotations) {
+                    artifact.annotationsArray = [];
+                    for (const key of Object.keys(artifact.annotations)) {
+                        artifact.annotationsArray.push(
+                            `${key}: ${artifact.annotations[key]}`
+                        );
+                    }
+                }
+            });
+        }
     }
 }

--- a/src/portal/src/app/base/project/repository/artifact/artifact.ts
+++ b/src/portal/src/app/base/project/repository/artifact/artifact.ts
@@ -21,7 +21,7 @@ export interface ArtifactFront extends Artifact {
     platform?: Platform;
     showImage?: string;
     pullCommand?: string;
-    annotationsArray?: Array<{ [key: string]: any }>;
+    annotationsArray?: string[];
     tagNumber?: number;
     signed?: string;
     sbomDigest?: string;


### PR DESCRIPTION


# Comprehensive Summary of your change
This PR resolves the issue where the "Annotations" column in the artifacts list view remains blank. 

### Root Cause:
In the UI template (`artifact-list-tab.component.html`), the **Annotations** column iterates over the `artifact.annotationsArray` property to render labels. However, this array was defined on the `ArtifactFront` model but was never populated from the `annotations` map returned by the backend API.

### Changes:
1. **Model Update**: Changed the type of `annotationsArray` from `Array<{ [key: string]: any }>` to `string[]` in `artifact.ts` to correctly align with how it is rendered in the HTML template.
2. **Data Mapping**: Implemented a helper function `populateAnnotations()` in `artifact-list-tab.component.ts` that converts the OCI `annotations` map into formatted `key: value` strings (e.g., `["org.opencontainers.image.vendor: Harbor"]`).
3. **Trigger**: Invoked the helper function when loading the artifact list and resolving index references.

# Issue being fixed
Fixes #23550

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. (e.g. `release-note/update`)
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.