### PR TITLE
fix(core): respect external endpoint protocol to set secure and samesite flags on session cookie

### DIFF
--- a/src/core/main.go
+++ b/src/core/main.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/beego/beego/v2/server/web"
+	beegosession "github.com/beego/beego/v2/server/web/session"
 
 	"github.com/goharbor/harbor/src/common"
 	"github.com/goharbor/harbor/src/common/dao"
@@ -324,6 +325,63 @@ func main() {
 			log.Errorf("failed to schedule system execution sweep job, error: %v", err)
 		}
 	}()
+
+	// Add start hook to override session manager settings after Beego initializes it
+	web.AddAPPStartHook(func() error {
+		if web.BConfig.WebConfig.Session.SessionOn {
+			secure := true
+			ep, err := config.ExtEndpoint()
+			if err != nil {
+				log.Warningf("Failed to get external endpoint: %v, set session cookie secure flag to true", err)
+			} else if strings.HasPrefix(strings.ToLower(ep), "http://") {
+				secure = false
+			}
+
+			sameSite := http.SameSiteLaxMode
+			if sameSiteStr := os.Getenv("SESSION_COOKIE_SAMESITE"); sameSiteStr != "" {
+				switch strings.ToLower(sameSiteStr) {
+				case "strict":
+					sameSite = http.SameSiteStrictMode
+				case "lax":
+					sameSite = http.SameSiteLaxMode
+				case "none":
+					sameSite = http.SameSiteNoneMode
+				case "default":
+					sameSite = http.SameSiteDefaultMode
+				}
+			}
+
+			if sameSite == http.SameSiteNoneMode && !secure {
+				log.Warning("SESSION_COOKIE_SAMESITE is set to None, but the external endpoint is HTTP. SameSite None requires a Secure cookie. Falling back to Lax mode.")
+				sameSite = http.SameSiteLaxMode
+			}
+
+			provider := web.BConfig.WebConfig.Session.SessionProvider
+			if provider == "" {
+				provider = "memory"
+			}
+
+			conf := &beegosession.ManagerConfig{
+				CookieName:      web.BConfig.WebConfig.Session.SessionName,
+				EnableSetCookie: web.BConfig.WebConfig.Session.SessionAutoSetCookie,
+				Gclifetime:      web.BConfig.WebConfig.Session.SessionGCMaxLifetime,
+				Secure:          secure,
+				CookieLifeTime:  web.BConfig.WebConfig.Session.SessionCookieLifeTime,
+				ProviderConfig:  web.BConfig.WebConfig.Session.SessionProviderConfig,
+				Domain:          web.BConfig.WebConfig.Session.SessionDomain,
+				DisableHTTPOnly: web.BConfig.WebConfig.Session.SessionDisableHTTPOnly,
+				CookieSameSite:  sameSite,
+			}
+
+			var errSession error
+			web.GlobalSessions, errSession = beegosession.NewManager(provider, conf)
+			if errSession != nil {
+				log.Fatalf("failed to initialize global sessions: %v", errSession)
+			}
+		}
+		return nil
+	})
+
 	web.RunWithMiddleWares("", middlewares.MiddleWares()...)
 }
 

--- a/src/server/middleware/session/session.go
+++ b/src/server/middleware/session/session.go
@@ -16,6 +16,7 @@ package session
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/goharbor/harbor/src/lib"
 	"github.com/goharbor/harbor/src/lib/config"
@@ -33,9 +34,19 @@ const (
 func Middleware() func(http.Handler) http.Handler {
 	return func(handler http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Determine if the external endpoint utilizes TLS (HTTPS)
+			secure := true
+			ep, err := config.ExtEndpoint()
+			if err == nil && strings.HasPrefix(strings.ToLower(ep), "http://") {
+				secure = false
+			}
+			if secure {
+				r.URL.Scheme = "https"
+			}
+
 			// We can check the cookie directly b/c the filter and controllerRegistry is executed after middleware, so no session
 			// cookie is added by beego.
-			_, err := r.Cookie(config.SessionCookieName)
+			_, err = r.Cookie(config.SessionCookieName)
 			if err == nil {
 				r = r.WithContext(lib.WithCarrySession(r.Context(), true))
 			}

--- a/src/server/middleware/session/session_test.go
+++ b/src/server/middleware/session/session_test.go
@@ -25,11 +25,14 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/goharbor/harbor/src/common"
 	"github.com/goharbor/harbor/src/lib"
 	"github.com/goharbor/harbor/src/lib/config"
+	_ "github.com/goharbor/harbor/src/pkg/config/inmemory"
 )
 
 func TestSession(t *testing.T) {
+	config.InitWithSettings(map[string]any{})
 	carrySession := false
 	skipRenewal := false
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -72,4 +75,110 @@ func TestSession(t *testing.T) {
 	req.Header.Del(HeaderNoSessionRenewal)
 	Middleware()(handler).ServeHTTP(nil, req)
 	assert.False(t, skipRenewal)
+}
+
+func TestSessionCookieFlags(t *testing.T) {
+	// Initialize in-memory config settings
+	conf := map[string]any{
+		common.ExtEndpoint: "https://harbor.test",
+	}
+	config.InitWithSettings(conf)
+
+	// Mock http request
+	req, err := http.NewRequest("GET", "http://127.0.0.1:8080/api/users", nil)
+	require.Nil(t, err)
+
+	// Call middleware on request
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify that Scheme has been updated to https
+		assert.Equal(t, "https", r.URL.Scheme)
+	})
+	Middleware()(handler).ServeHTTP(httptest.NewRecorder(), req)
+
+	// Switch to HTTP external endpoint
+	conf = map[string]any{
+		common.ExtEndpoint: "http://harbor.test",
+	}
+	config.InitWithSettings(conf)
+
+	req2, err := http.NewRequest("GET", "http://127.0.0.1:8080/api/users", nil)
+	require.Nil(t, err)
+
+	handler2 := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify that Scheme remains http (empty or http)
+		assert.Equal(t, "http", r.URL.Scheme)
+	})
+	Middleware()(handler2).ServeHTTP(httptest.NewRecorder(), req2)
+}
+
+func TestSessionCookieSecureSameSite(t *testing.T) {
+	// 1. Test HTTPS endpoint (Secure=true)
+	config.InitWithSettings(map[string]any{
+		common.ExtEndpoint: "https://harbor.test",
+	})
+
+	// Override/initialize using the production start hook logic
+	secure := true
+	sameSite := http.SameSiteLaxMode
+
+	conf := &beegosession.ManagerConfig{
+		CookieName:      "sid",
+		EnableSetCookie: true,
+		Gclifetime:      3600,
+		Secure:          secure,
+		CookieLifeTime:  3600,
+		CookieSameSite:  sameSite,
+	}
+
+	var err error
+	web.GlobalSessions, err = beegosession.NewManager("memory", conf)
+	require.Nil(t, err)
+
+	req, err := http.NewRequest("GET", "http://127.0.0.1:8080/api/users", nil)
+	require.Nil(t, err)
+
+	// Simulate session middleware scheme mutation
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Start session, which emits the cookie
+		_, err := web.GlobalSessions.SessionStart(w, r)
+		require.Nil(t, err)
+	})
+
+	rec := httptest.NewRecorder()
+	Middleware()(handler).ServeHTTP(rec, req)
+
+	cookies := rec.Result().Cookies()
+	require.Len(t, cookies, 1)
+	assert.Equal(t, "sid", cookies[0].Name)
+	assert.True(t, cookies[0].Secure)
+	assert.Equal(t, http.SameSiteLaxMode, cookies[0].SameSite)
+
+	// 2. Test HTTP endpoint (Secure=false)
+	config.InitWithSettings(map[string]any{
+		common.ExtEndpoint: "http://harbor.test",
+	})
+
+	confHTTP := &beegosession.ManagerConfig{
+		CookieName:      "sid",
+		EnableSetCookie: true,
+		Gclifetime:      3600,
+		Secure:          false,
+		CookieLifeTime:  3600,
+		CookieSameSite:  sameSite,
+	}
+
+	web.GlobalSessions, err = beegosession.NewManager("memory", confHTTP)
+	require.Nil(t, err)
+
+	reqHTTP, err := http.NewRequest("GET", "http://127.0.0.1:8080/api/users", nil)
+	require.Nil(t, err)
+
+	recHTTP := httptest.NewRecorder()
+	Middleware()(handler).ServeHTTP(recHTTP, reqHTTP)
+
+	cookiesHTTP := recHTTP.Result().Cookies()
+	require.Len(t, cookiesHTTP, 1)
+	assert.Equal(t, "sid", cookiesHTTP[0].Name)
+	assert.False(t, cookiesHTTP[0].Secure)
+	assert.Equal(t, http.SameSiteLaxMode, cookiesHTTP[0].SameSite)
 }


### PR DESCRIPTION


# Comprehensive Summary of your change
This PR resolves the issue where the `Secure` and `SameSite` flags are not properly configured for the Harbor session cookie (`SID`) when TLS termination is handled upstream (e.g. at an ingress or load balancer).

### Root Cause:
Beego's session manager internally binds the session cookie's `Secure` flag to `BConfig.Listen.EnableHTTPS`. Since Harbor core containers run internally on HTTP (port `8080`), this flag always evaluates to `false` in production, even if the public-facing external URL uses HTTPS.

### Changes:
1. Set the default session SameSite attribute to `Lax` (via `SessionCookieSameSite`).
2. Programmatically re-initialize the `web.GlobalSessions` manager in `main.go` after configurations are successfully loaded.
3. Automatically determine the session cookie's `Secure` flag based on the scheme of `config.ExtEndpoint()`. If it starts with `https://`, `Secure` is configured to `true`.
4. Support overriding the SameSite mode via the environment variable `SESSION_COOKIE_SAMESITE` (e.g., `Strict`, `Lax`, `None`, `Default`).

# Issue being fixed
Fixes #23229

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. (e.g. `release-note/update`)
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.