### PR TITLE
test(cache): stabilize and speed up cache expiration tests by polling

### DIFF
--- a/src/lib/cache/memory/memory_test.go
+++ b/src/lib/cache/memory/memory_test.go
@@ -49,8 +49,9 @@ func (suite *CacheTestSuite) TestContains() {
 	suite.cache.Save(suite.ctx, key, "value", time.Second*5)
 	suite.True(suite.cache.Contains(suite.ctx, key))
 
-	time.Sleep(time.Second * 8)
-	suite.False(suite.cache.Contains(suite.ctx, key))
+	suite.Eventually(func() bool {
+		return !suite.cache.Contains(suite.ctx, key)
+	}, 10*time.Second, 100*time.Millisecond, "cache item should eventually expire")
 }
 
 func (suite *CacheTestSuite) TestDelete() {
@@ -88,21 +89,19 @@ func (suite *CacheTestSuite) TestSave() {
 		suite.cache.Fetch(suite.ctx, key, &value)
 		suite.Equal("hello, save", value)
 
-		time.Sleep(time.Second * 8)
-
 		value = ""
-		suite.Error(suite.cache.Fetch(suite.ctx, key, &value))
-		suite.Equal("", value)
+		suite.Eventually(func() bool {
+			return suite.cache.Fetch(suite.ctx, key, &value) != nil
+		}, 10*time.Second, 100*time.Millisecond, "cache item should eventually expire")
 	}
 
 	{
 		suite.cache.Save(suite.ctx, key, "hello, save", time.Second)
 
-		time.Sleep(time.Second * 2)
-
 		var value string
-		suite.Error(suite.cache.Fetch(suite.ctx, key, &value))
-		suite.Equal("", value)
+		suite.Eventually(func() bool {
+			return suite.cache.Fetch(suite.ctx, key, &value) != nil
+		}, 10*time.Second, 100*time.Millisecond, "cache item should eventually expire")
 	}
 }
 

--- a/src/lib/cache/memory/memory_test.go
+++ b/src/lib/cache/memory/memory_test.go
@@ -89,10 +89,11 @@ func (suite *CacheTestSuite) TestSave() {
 		suite.cache.Fetch(suite.ctx, key, &value)
 		suite.Equal("hello, save", value)
 
-		value = ""
 		suite.Eventually(func() bool {
+			value = ""
 			return suite.cache.Fetch(suite.ctx, key, &value) != nil
 		}, 10*time.Second, 100*time.Millisecond, "cache item should eventually expire")
+		suite.Equal("", value)
 	}
 
 	{
@@ -100,8 +101,10 @@ func (suite *CacheTestSuite) TestSave() {
 
 		var value string
 		suite.Eventually(func() bool {
+			value = ""
 			return suite.cache.Fetch(suite.ctx, key, &value) != nil
 		}, 10*time.Second, 100*time.Millisecond, "cache item should eventually expire")
+		suite.Equal("", value)
 	}
 }
 

--- a/src/lib/cache/redis/redis_test.go
+++ b/src/lib/cache/redis/redis_test.go
@@ -49,8 +49,9 @@ func (suite *CacheTestSuite) TestContains() {
 	suite.cache.Save(suite.ctx, key, "value", time.Second*5)
 	suite.True(suite.cache.Contains(suite.ctx, key))
 
-	time.Sleep(time.Second * 8)
-	suite.False(suite.cache.Contains(suite.ctx, key))
+	suite.Eventually(func() bool {
+		return !suite.cache.Contains(suite.ctx, key)
+	}, 10*time.Second, 100*time.Millisecond, "cache item should eventually expire")
 }
 
 func (suite *CacheTestSuite) TestDelete() {
@@ -88,21 +89,19 @@ func (suite *CacheTestSuite) TestSave() {
 		suite.cache.Fetch(suite.ctx, key, &value)
 		suite.Equal("hello, save", value)
 
-		time.Sleep(time.Second * 8)
-
 		value = ""
-		suite.Error(suite.cache.Fetch(suite.ctx, key, &value))
-		suite.Equal("", value)
+		suite.Eventually(func() bool {
+			return suite.cache.Fetch(suite.ctx, key, &value) != nil
+		}, 10*time.Second, 100*time.Millisecond, "cache item should eventually expire")
 	}
 
 	{
 		suite.cache.Save(suite.ctx, key, "hello, save", time.Second)
 
-		time.Sleep(time.Second * 2)
-
 		var value string
-		suite.Error(suite.cache.Fetch(suite.ctx, key, &value))
-		suite.Equal("", value)
+		suite.Eventually(func() bool {
+			return suite.cache.Fetch(suite.ctx, key, &value) != nil
+		}, 10*time.Second, 100*time.Millisecond, "cache item should eventually expire")
 	}
 }
 

--- a/src/lib/cache/redis/redis_test.go
+++ b/src/lib/cache/redis/redis_test.go
@@ -89,10 +89,11 @@ func (suite *CacheTestSuite) TestSave() {
 		suite.cache.Fetch(suite.ctx, key, &value)
 		suite.Equal("hello, save", value)
 
-		value = ""
 		suite.Eventually(func() bool {
+			value = ""
 			return suite.cache.Fetch(suite.ctx, key, &value) != nil
 		}, 10*time.Second, 100*time.Millisecond, "cache item should eventually expire")
+		suite.Equal("", value)
 	}
 
 	{
@@ -100,8 +101,10 @@ func (suite *CacheTestSuite) TestSave() {
 
 		var value string
 		suite.Eventually(func() bool {
+			value = ""
 			return suite.cache.Fetch(suite.ctx, key, &value) != nil
 		}, 10*time.Second, 100*time.Millisecond, "cache item should eventually expire")
+		suite.Equal("", value)
 	}
 }
 


### PR DESCRIPTION
## What this PR does / why we need it:
This PR replaces rigid `time.Sleep` assertions in `src/lib/cache/memory/memory_test.go` and `src/lib/cache/redis/redis_test.go` with `suite.Eventually` deterministic polling. 
Previously, these tests relied on hard-coded 8-second and 2-second sleep timers to wait for cache items to expire, which unnecessarily slowed down the CI pipeline and was prone to race conditions if the runner was heavily loaded. Using `Eventually` makes the tests significantly faster and completely immune to flaky behavior.

## Which issue(s) this PR fixes:
Fixes flaky tests and speeds up CI.

## Special notes for your reviewer:
N/A

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. `release-note/ignore-for-release`
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).