### PR TITLE
test(proxy): fix flaky secret manager garbage collection tests by polling

### DIFF
--- a/src/pkg/proxy/secret/manager_test.go
+++ b/src/pkg/proxy/secret/manager_test.go
@@ -47,7 +47,8 @@ func TestGC(t *testing.T) {
 		manager.Generate(rn)
 	}
 	assert.Equal(t, uint64(1000), atomic.LoadUint64(&manager.size))
-	time.Sleep(4 * time.Second)
-	assert.Equal(t, uint64(0), atomic.LoadUint64(&manager.size))
+	assert.Eventually(t, func() bool {
+		return atomic.LoadUint64(&manager.size) == 0
+	}, 10*time.Second, 100*time.Millisecond, "secret manager GC should eventually clear expired items")
 
 }


### PR DESCRIPTION
## What this PR does / why we need it:
This PR replaces a rigid `time.Sleep` assertion in `src/pkg/proxy/secret/manager_test.go` with `assert.Eventually` deterministic polling. 
Previously, `TestGC` relied on a blind 4-second sleep to wait for the background garbage collection goroutine to clear expired secrets. This needlessly delayed CI and remained susceptible to race conditions. Using `Eventually` allows the test to pass immediately once the background GC executes, speeding up the test suite and completely eliminating flakiness.

## Which issue(s) this PR fixes:
Fixes flaky test and speeds up CI.

## Special notes for your reviewer:
N/A

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. `release-note/ignore-for-release`
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).