### PR TITLE
test(api_db): fix flaky scan_image and log_rotation test cases

### DIFF
--- a/tests/apitests/python/library/artifact.py
+++ b/tests/apitests/python/library/artifact.py
@@ -113,7 +113,7 @@ class Artifact(base.Base, object):
         return self._get_client(**kwargs).list_accessories(project_name, repo_name, reference)
 
     def check_image_scan_result(self, project_name, repo_name, reference, expected_scan_status = "Success", **kwargs):
-        timeout_count = 30
+        timeout_count = 60
         scan_status=""
         while True:
             time.sleep(5)
@@ -123,7 +123,7 @@ class Artifact(base.Base, object):
             artifact = self.get_reference_info(project_name, repo_name, reference, **kwargs)
             if expected_scan_status in ["Not Scanned", "No Scan Overview"]:
                 if artifact.scan_overview is None:
-                    if (timeout_count > 24):
+                    if (timeout_count > 54):
                         continue
                     print("artifact is not scanned.")
                     return
@@ -131,10 +131,11 @@ class Artifact(base.Base, object):
                     raise Exception("Artifact should not be scanned {}.".format(artifact.scan_overview))
 
             scan_status = ''
-            for mime_type in report_mime_types:
-                overview = artifact.scan_overview.get(mime_type)
-                if overview:
-                    scan_status = overview.scan_status
+            if artifact and artifact.scan_overview:
+                for mime_type in report_mime_types:
+                    overview = artifact.scan_overview.get(mime_type)
+                    if overview:
+                        scan_status = overview.scan_status
 
             if scan_status == expected_scan_status:
                 return

--- a/tests/apitests/python/test_log_rotation.py
+++ b/tests/apitests/python/test_log_rotation.py
@@ -56,16 +56,22 @@ class TestLogRotation(unittest.TestCase, object):
         # so we wait in a loop.
         self.assertIn(job_status, ["Stopped", "Success"])
         # 4. Create a purge audit log job
+        # Record previous job ID to avoid a race condition in the polling loop below.
+        # Without this check, get_latest_purge_job() might fetch the previously stopped dry-run job
+        # if the asynchronous creation of the new job is still in progress, causing the test to fail
+        # with 'Stopped' != 'Success'.
+        prev_job_id = latest_job.id if latest_job else 0
         self.purge.create_purge_schedule(type="Manual", cron=None, dry_run=False, audit_retention_hour=1)
         # 5. Verify purge audit log job status is Success
         job_status = None
         job_id = None
-        for i in range(20):
+        for i in range(30):
             print("wait for the job to finish:", i)
-            if job_id == None:
+            if job_id is None:
                 latest_job = self.purge.get_latest_purge_job()
-                job_status = latest_job.job_status
-                job_id = latest_job.id
+                if latest_job and latest_job.id != prev_job_id:
+                    job_status = latest_job.job_status
+                    job_id = latest_job.id
             else:
                 job_status = self.purge.get_purge_job(job_id).job_status
             if job_status == "Success":


### PR DESCRIPTION
Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

1. In check_image_scan_result, add a check for artifact.scan_overview being None to prevent AttributeError right after scan trigger, and increase timeout count from 30 to 60 (300s) for slower testbed environments.

2. In test_log_rotation, record previous job_id before creating a new purge job to avoid fetching the previous stopped job in a race condition, and increase retry count to 30.

Please indicate you've done the following:
- [ ] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [ ] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
