### PR TITLE
refactor: remove deprecated io/ioutil usage

### DIFF
--- a/src/pkg/reg/adapter/volcenginecr/adapter_test.go
+++ b/src/pkg/reg/adapter/volcenginecr/adapter_test.go
@@ -3,7 +3,6 @@ package volcenginecr
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -47,7 +46,7 @@ func getMockAdapter_withoutCred(t *testing.T, hasCred, health bool) (*adapter, *
 			Pattern: "/",
 			Handler: func(w http.ResponseWriter, r *http.Request) {
 				fmt.Println(r.Method, r.URL)
-				if buf, e := ioutil.ReadAll(&io.LimitedReader{R: r.Body, N: 80}); e == nil {
+				if buf, e := io.ReadAll(&io.LimitedReader{R: r.Body, N: 80}); e == nil {
 					fmt.Println("\t", string(buf))
 				}
 				w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
The `io/ioutil` package has been deprecated since Go 1.16. This PR replaces its usage with the modern `io` and `os` equivalents, keeping the codebase clean and up to date with modern Go standards.