### PR TITLE
test: remove deprecated rand.Seed usage

### DIFF
--- a/src/controller/quota/util_test.go
+++ b/src/controller/quota/util_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"math/rand"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/suite"
 
@@ -74,8 +73,6 @@ func (suite *RefreshForProjectsTestSuite) TearDownTest() {
 }
 
 func (suite *RefreshForProjectsTestSuite) TestRefreshForProjects() {
-	rand.Seed(time.Now().UnixNano())
-
 	startProjectID := rand.Int63()
 	var firstPageProjects, secondPageProjects []*models.Project
 	for i := range 50 {

--- a/src/testing/suite.go
+++ b/src/testing/suite.go
@@ -36,9 +36,6 @@ import (
 	proModels "github.com/goharbor/harbor/src/pkg/project/models"
 )
 
-func init() {
-	rand.Seed(time.Now().UnixNano())
-}
 
 var (
 	once sync.Once


### PR DESCRIPTION
The `math/rand.Seed` function was deprecated in Go 1.20, as the math/rand package now automatically seeds the global random number generator. This PR removes its usage in tests to keep the codebase clean and up to date with modern Go standards.