### PR TITLE
fix: address unkeyed fields in struct literals from go vet

### DIFF
--- a/src/pkg/securityhub/dao/security_test.go
+++ b/src/pkg/securityhub/dao/security_test.go
@@ -185,7 +185,7 @@ func (suite *SecurityDaoTestSuite) TestRangeFilter() {
 		wantSQLStr string
 		wantParams []any
 	}{
-		{"normal", args{suite.Context(), "cvss_score_v3", q.New(q.KeyWords{"cvss_score_v3": &q.Range{1.0, 2.0}})}, " and cvss_score_v3 between ? and ?", []any{1.0, 2.0}},
+		{"normal", args{suite.Context(), "cvss_score_v3", q.New(q.KeyWords{"cvss_score_v3": &q.Range{Min: 1.0, Max: 2.0}})}, " and cvss_score_v3 between ? and ?", []any{1.0, 2.0}},
 	}
 	for _, tt := range tests {
 		suite.Run(tt.name, func() {

--- a/src/testing/job/mock_client.go
+++ b/src/testing/job/mock_client.go
@@ -23,12 +23,12 @@ func (mjc *MockJobClient) GetJobServiceConfig() (*job.Config, error) {
 // GetJobLog ...
 func (mjc *MockJobClient) GetJobLog(uuid string) ([]byte, error) {
 	if uuid == "500" {
-		return nil, &http.Error{500, "server side error"}
+		return nil, &http.Error{Code: 500, Message: "server side error"}
 	}
 	if mjc.validUUID(uuid) {
 		return []byte("some log"), nil
 	}
-	return nil, &http.Error{404, "not Found"}
+	return nil, &http.Error{Code: 404, Message: "not Found"}
 }
 
 // SubmitJob ...
@@ -41,10 +41,10 @@ func (mjc *MockJobClient) SubmitJob(data *models.JobData) (string, error) {
 // PostAction ...
 func (mjc *MockJobClient) PostAction(uuid, action string) error {
 	if "500" == uuid {
-		return &http.Error{500, "server side error"}
+		return &http.Error{Code: 500, Message: "server side error"}
 	}
 	if !mjc.validUUID(uuid) {
-		return &http.Error{404, "not Found"}
+		return &http.Error{Code: 404, Message: "not Found"}
 	}
 	return nil
 }


### PR DESCRIPTION
Running `go vet` on the codebase surfaces several warnings about unkeyed fields in struct literals. This PR updates these structs to use keyed fields, ensuring compliance with standard Go practices and preventing potential breakages if the underlying struct definitions are modified in the future.