### PR TITLE
fix: use errors.Is for sentinel error checks in usergroup controller

### DIFF
--- a/src/controller/usergroup/controller.go
+++ b/src/controller/usergroup/controller.go
@@ -91,10 +91,10 @@ func (c *controller) Update(ctx context.Context, id int, groupName string) error
 func (c *controller) Create(ctx context.Context, group model.UserGroup) (int, error) {
 	if group.GroupType == common.LDAPGroupType {
 		ldapGroup, err := auth.SearchGroup(ctx, group.LdapGroupDN)
-		if err == ldap.ErrNotFound || ldapGroup == nil {
+		if errors.Is(err, ldap.ErrNotFound) || ldapGroup == nil {
 			return 0, errors.BadRequestError(nil).WithMessagef("LDAP Group DN is not found: DN:%v", group.LdapGroupDN)
 		}
-		if err == ldap.ErrDNSyntax {
+		if errors.Is(err, ldap.ErrDNSyntax) {
 			return 0, errors.BadRequestError(nil).WithMessagef("invalid DN syntax. DN: %v", group.LdapGroupDN)
 		}
 		if err != nil {
@@ -102,7 +102,7 @@ func (c *controller) Create(ctx context.Context, group model.UserGroup) (int, er
 		}
 	}
 	id, err := c.mgr.Create(ctx, group)
-	if err != nil && err == usergroup.ErrDupUserGroup {
+	if errors.Is(err, usergroup.ErrDupUserGroup) {
 		return 0, errors.ConflictError(nil).
 			WithMessagef("duplicate user group, group name:%v, group type: %v, ldap group DN: %v",
 				group.GroupName, group.GroupType, group.LdapGroupDN)


### PR DESCRIPTION
## Summary

Replace direct error equality comparisons (`==`) with `errors.Is()` in the usergroup controller to ensure correct behavior when sentinel errors are wrapped.

## Changes

| Before | After |
| :--- | :--- |
| `err == ldap.ErrNotFound` | `errors.Is(err, ldap.ErrNotFound)` |
| `err == ldap.ErrDNSyntax` | `errors.Is(err, ldap.ErrDNSyntax)` |
| `err != nil && err == usergroup.ErrDupUserGroup` | `errors.Is(err, usergroup.ErrDupUserGroup)` |

## Why

Per Go best practices (Go 1.13+), sentinel errors should be compared using `errors.Is()` instead of direct equality (`==`). This ensures the check works correctly even if the error has been wrapped via `fmt.Errorf("...: %w", err)`.

Harbor's own `lib/errors` package already re-exports `errors.Is`, so no new imports are needed.

## Verification

- `go vet ./controller/usergroup/...` ✅
- `go build ./controller/usergroup/...` ✅
- 1 file changed, 3 insertions, 3 deletions

cc @wy65701436 @chlins for review