### PR TITLE
fix: return MANIFEST_UNKNOWN for missing manifests

### DIFF
--- a/src/lib/errors/const.go
+++ b/src/lib/errors/const.go
@@ -45,6 +45,10 @@ const (
 	DIGESTINVALID = "DIGEST_INVALID"
 	// MANIFESTINVALID ...
 	MANIFESTINVALID = "MANIFEST_INVALID"
+	// MANIFESTUNKNOWN is the code the OCI distribution spec defines for a manifest
+	// that is unknown to the registry, it's only used by the manifest endpoints of
+	// the /v2/ API, NotFoundCode remains the general purpose code of the other APIs
+	MANIFESTUNKNOWN = "MANIFEST_UNKNOWN"
 	// UNSUPPORTED is for digest UNSUPPORTED error
 	UNSUPPORTED = "UNSUPPORTED"
 	// RequestEntityTooLargeCode is the error code for request entity too large error.
@@ -54,6 +58,21 @@ const (
 // NotFoundError is error for the case of object not found
 func NotFoundError(err error) *Error {
 	return New("resource not found").WithCode(NotFoundCode).WithCause(err)
+}
+
+// AsManifestUnknownError converts a not found error into a manifest unknown error,
+// any other error is returned unchanged.
+//
+// The error code of a /v2/ API response MUST be one of the codes the OCI distribution
+// spec defines, and NOT_FOUND isn't one of them, so clients cannot tell a missing
+// manifest from a server side failure. Only the manifest endpoints are converted,
+// the general purpose NOT_FOUND is kept for the Harbor APIs.
+// https://github.com/opencontainers/distribution-spec/blob/v1.1.1/spec.md#error-codes
+func AsManifestUnknownError(err error) error {
+	if !IsNotFoundErr(err) {
+		return err
+	}
+	return New("manifest unknown").WithCode(MANIFESTUNKNOWN).WithCause(err)
 }
 
 // ConflictError is error for the case of object conflict

--- a/src/lib/errors/errors_test.go
+++ b/src/lib/errors/errors_test.go
@@ -184,6 +184,17 @@ func (suite *ErrorTestSuite) TestIsNotFoundErr() {
 	suite.False(IsNotFoundErr(err))
 }
 
+func (suite *ErrorTestSuite) TestAsManifestUnknownError() {
+	// a not found error is converted and keeps the original message as the cause
+	err := AsManifestUnknownError(NotFoundError(nil).WithMessage("artifact library/hello-world:latest not found"))
+	suite.Equal(MANIFESTUNKNOWN, ErrCode(err))
+	suite.Equal("manifest unknown: artifact library/hello-world:latest not found", err.Error())
+
+	// any other error is returned unchanged
+	precondition := New(nil).WithCode(PreconditionCode)
+	suite.Equal(precondition, AsManifestUnknownError(precondition))
+}
+
 func (suite *ErrorTestSuite) TestIsConflictErrErr() {
 	err := New(nil).WithCode(ConflictCode)
 	suite.True(IsConflictErr(err))

--- a/src/lib/http/error.go
+++ b/src/lib/http/error.go
@@ -37,6 +37,7 @@ var (
 		errors.MethodNotAllowedCode:            http.StatusMethodNotAllowed,
 		errors.DENIED:                          http.StatusForbidden,
 		errors.NotFoundCode:                    http.StatusNotFound,
+		errors.MANIFESTUNKNOWN:                 http.StatusNotFound,
 		errors.RateLimitCode:                   http.StatusTooManyRequests,
 		errors.ConflictCode:                    http.StatusConflict,
 		errors.PreconditionCode:                http.StatusPreconditionFailed,

--- a/src/lib/http/error_test.go
+++ b/src/lib/http/error_test.go
@@ -48,6 +48,13 @@ func TestSendError(t *testing.T) {
 	SendError(rw, err)
 	assert.Equal(t, http.StatusNotFound, rw.Code)
 	assert.Equal(t, `{"errors":[{"code":"NOT_FOUND","message":"object not found"}]}`+"\n", rw.Body.String())
+
+	// manifest unknown error, the OCI distribution spec code for a missing manifest
+	rw = httptest.NewRecorder()
+	err = errors.New(nil).WithCode(errors.MANIFESTUNKNOWN).WithMessage("manifest unknown")
+	SendError(rw, err)
+	assert.Equal(t, http.StatusNotFound, rw.Code)
+	assert.Equal(t, `{"errors":[{"code":"MANIFEST_UNKNOWN","message":"manifest unknown"}]}`+"\n", rw.Body.String())
 }
 
 func TestAPIError(t *testing.T) {

--- a/src/server/middleware/repoproxy/proxy.go
+++ b/src/server/middleware/repoproxy/proxy.go
@@ -172,7 +172,7 @@ func ManifestMiddleware() func(http.Handler) http.Handler {
 	return middleware.New(func(w http.ResponseWriter, r *http.Request, next http.Handler) {
 		if err := handleManifest(w, r, next); err != nil {
 			if errors.IsNotFoundErr(err) {
-				httpLib.SendError(w, err)
+				httpLib.SendError(w, errors.AsManifestUnknownError(err))
 				return
 			}
 			if errors.IsRateLimitError(err) {

--- a/src/server/middleware/repoproxy/proxy_test.go
+++ b/src/server/middleware/repoproxy/proxy_test.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/goharbor/harbor/src/common/models"
@@ -83,6 +84,29 @@ func TestIsProxySession(t *testing.T) {
 				t.Errorf(`(%v) = %v; want "%v"`, tt.in, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestManifestMiddlewareNotFound(t *testing.T) {
+	// A manifest that is missing in a proxy cache project must be reported with the
+	// MANIFEST_UNKNOWN code defined by the OCI distribution spec. Harbor's general
+	// purpose NOT_FOUND code is not one of the codes the spec allows, so clients
+	// fall back to treating the response as an unknown server side failure.
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Error("a not found error must not fall through to the local repository")
+		w.WriteHeader(http.StatusOK)
+	})
+
+	// without artifact info in the context handleManifest fails with a not found error
+	req := httptest.NewRequest(http.MethodGet, "/v2/proxy/library/debian/manifests/badtag", nil)
+	rec := httptest.NewRecorder()
+	ManifestMiddleware()(next).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusNotFound)
+	}
+	if got := rec.Body.String(); !strings.Contains(got, `"code":"MANIFEST_UNKNOWN"`) {
+		t.Errorf("body = %s, want the MANIFEST_UNKNOWN error code", got)
 	}
 }
 

--- a/src/server/registry/manifest.go
+++ b/src/server/registry/manifest.go
@@ -54,7 +54,7 @@ func getManifest(w http.ResponseWriter, req *http.Request) {
 	reference := router.Param(req.Context(), ":reference")
 	art, err := artifact.Ctl.GetByReference(req.Context(), repository, reference, nil)
 	if err != nil {
-		lib_http.SendError(w, err)
+		lib_http.SendError(w, errors.AsManifestUnknownError(err))
 		return
 	}
 
@@ -155,7 +155,7 @@ func deleteManifest(w http.ResponseWriter, req *http.Request) {
 	}
 	art, err := artifact.Ctl.GetByReference(req.Context(), repository, reference, nil)
 	if err != nil {
-		lib_http.SendError(w, err)
+		lib_http.SendError(w, errors.AsManifestUnknownError(err))
 		return
 	}
 	if err = artifact.Ctl.Delete(req.Context(), art.ID); err != nil {

--- a/src/server/registry/manifest_test.go
+++ b/src/server/registry/manifest_test.go
@@ -76,11 +76,15 @@ func (m *manifestTestSuite) TearDownSuite() {
 }
 
 func (m *manifestTestSuite) TestGetManifest() {
+	// a missing manifest must be reported with the MANIFEST_UNKNOWN code defined by
+	// the OCI distribution spec rather than Harbor's general purpose NOT_FOUND
 	req := httptest.NewRequest(http.MethodGet, "/v2/library/hello-world/manifests/latest", nil)
-	w := &httptest.ResponseRecorder{}
-	mock.OnAnything(m.artCtl, "GetByReference").Return(nil, errors.New(nil).WithCode(errors.NotFoundCode))
+	w := httptest.NewRecorder()
+	mock.OnAnything(m.artCtl, "GetByReference").Return(nil, errors.New(nil).
+		WithCode(errors.NotFoundCode).WithMessage("artifact library/hello-world:latest not found"))
 	getManifest(w, req)
 	m.Equal(http.StatusNotFound, w.Code)
+	m.JSONEq(`{"errors":[{"code":"MANIFEST_UNKNOWN","message":"manifest unknown: artifact library/hello-world:latest not found"}]}`, w.Body.String())
 
 	m.SetupTest()
 
@@ -156,6 +160,20 @@ func (m *manifestTestSuite) TestDeleteManifest() {
 	deleteManifest(w, req)
 	m.Equal(http.StatusAccepted, w.Code)
 	m.cachedMgr.AssertCalled(m.T(), "Delete", mock.Anything, mock.Anything)
+}
+
+func (m *manifestTestSuite) TestDeleteManifestNotFound() {
+	dgt := "sha256:418fb88ec412e340cdbef913b8ca1bbe8f9e8dc705f9617414c1f2c8db980180"
+	req := httptest.NewRequest(http.MethodDelete, "/v2/library/hello-world/manifests/"+dgt, nil)
+	input := &beegocontext.BeegoInput{}
+	input.SetParam(":reference", dgt)
+	*req = *(req.WithContext(context.WithValue(req.Context(), router.ContextKeyInput{}, input)))
+	w := httptest.NewRecorder()
+	mock.OnAnything(m.artCtl, "GetByReference").Return(nil, errors.New(nil).
+		WithCode(errors.NotFoundCode).WithMessage("artifact not found"))
+	deleteManifest(w, req)
+	m.Equal(http.StatusNotFound, w.Code)
+	m.JSONEq(`{"errors":[{"code":"MANIFEST_UNKNOWN","message":"manifest unknown: artifact not found"}]}`, w.Body.String())
 }
 
 func (m *manifestTestSuite) TestPutManifest() {


### PR DESCRIPTION
## Summary

Return `MANIFEST_UNKNOWN` instead of `NOT_FOUND` when a manifest is missing on the
`/v2/*/manifests/:reference` endpoints, for both proxy cache and regular projects.
The HTTP status stays `404`; only the `code` field of the error body changes.

Fixes #20764 and #16515.

## Why

The OCI distribution spec is prescriptive about the permitted set:

> The `code` field MUST be one of the following: `BLOB_UNKNOWN`, `BLOB_UPLOAD_INVALID`,
> `BLOB_UPLOAD_UNKNOWN`, `DIGEST_INVALID`, `MANIFEST_BLOB_UNKNOWN`, `MANIFEST_INVALID`,
> `MANIFEST_UNKNOWN`, `NAME_INVALID`, `NAME_UNKNOWN`, `SIZE_INVALID`, `UNAUTHORIZED`,
> `DENIED`, `UNSUPPORTED`, `TOOMANYREQUESTS`

[distribution-spec v1.1.1, Error Codes](https://github.com/opencontainers/distribution-spec/blob/v1.1.1/spec.md#error-codes)

`NOT_FOUND` is not one of them. Clients built on `distribution`'s `errcode` package
resolve an unregistered code to `ErrorCodeUnknown`, whose descriptor carries HTTP 500.
So a plain "this image does not exist" is surfaced to users as a server failure:

```
docker.errors.APIError: 500 Server Error ... ("unknown: resource not found: repo docker.io/library/debian, tag badtag not found")
```

where Docker Hub gives the expected:

```
docker.errors.NotFound: 404 Client Error ... ("manifest for debian:badtag not found: manifest unknown: manifest unknown")
```

The existing behavior breaks anything that distinguishes "missing image" from "registry is broken":
`docker-compose pull --ignore-pull-failures`, docker-py, jib, and retry logic that
correctly retries 500s but not 404s.

In fairness, this is not caught by the OCI conformance suite: its pull tests assert
only the HTTP status for a missing manifest, not the error code, which is presumably
why it went unnoticed. The spec requirement is clear regardless.

## Relationship to rejected PR #16516

A previous attempt changed the value of `NotFoundCode` itself. That was rejected, and
the objection was right:

> This change does not make sense, as the NOT_FOUND_CODE is a general 404 failure for
> the API handlers. This code simply means that the object was not found, and is
> definitely not meant for manifest unknown errors. — @wy65701436

This PR does not touch `NotFoundCode` or any Harbor API response. It adds a separate
`MANIFESTUNKNOWN` code and converts to it at three `/v2/` manifest call sites only,
following the pattern already established for `MANIFEST_INVALID` (#11961).

## Compatibility

- The HTTP status is unchanged (404) on every affected path.
- Harbor's own registry client (`src/pkg/registry/client.go`) derives its error code
  from the HTTP status, not from the body, so replication, GC, scanning and proxy
  cache are unaffected.
- The portal only consumes `/api/v2.0`, which is untouched.
- The one visible change is the `code` string in `/v2/` manifest 404 bodies, moving
  from a non-conformant value to the spec-mandated one. Anyone who coded against
  Harbor's `NOT_FOUND` here would need to update — please tell me if you would rather
  label this `release-note/breaking-change` than `release-note/update`.

## Scope

Deliberately limited to the manifest endpoints, which is what the issue reports. The
blob endpoints (`BLOB_UNKNOWN`) and the tags list (`NAME_UNKNOWN`) have the same
problem; happy to follow up in a separate PR if you want those fixed too.

`MANIFEST_UNKNOWN` is returned when the repository does not exist as well as when only
the tag or digest is missing. This matches `distribution` and Docker Hub, and avoids
disclosing whether a repository exists to a client that cannot read it.

## Checklist
Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. Suggesting `release-note/update` (see Compatibility above if you consider this a breaking change)
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website). The `/v2/` error codes are not documented on the website, so no docs change appears to be needed — happy to open one if you disagree.