### PR TITLE
fix: allow resizing of the SBOM column in artifact table

### DIFF
--- a/src/portal/src/app/base/project/repository/artifact/artifact-list-page/artifact-list/artifact-list-tab/artifact-list-tab.component.scss
+++ b/src/portal/src/app/base/project/repository/artifact/artifact-list-page/artifact-list/artifact-list-tab/artifact-list-tab.component.scss
@@ -163,7 +163,7 @@
 }
 
 .sbom-column {
-  width: 7rem !important;
+  width: 7rem;
 }
 
 .annotations-column {

--- a/src/portal/src/app/base/project/repository/artifact/artifact-list-page/artifact-list/artifact-list-tab/artifact-list-tab.component.scss
+++ b/src/portal/src/app/base/project/repository/artifact/artifact-list-page/artifact-list/artifact-list-tab/artifact-list-tab.component.scss
@@ -147,19 +147,19 @@
 }
 
 .pull-command-column {
-  width: 6rem !important;
+  width: 6rem;
 }
 
 .co-signed-column {
-  width: 7rem !important;
+  width: 7rem;
 }
 
 .size-column {
-  width: 6rem !important;
+  width: 6rem;
 }
 
 .vul-column {
-  width: 11rem !important;
+  width: 11rem;
 }
 
 .sbom-column {
@@ -167,7 +167,7 @@
 }
 
 .annotations-column {
-  width: 5rem !important;
+  width: 5rem;
 }
 
 .signed {


### PR DESCRIPTION
i have  removed the `!important` modifier from the `.sbom-column` width rule in the artifact list table

The SBOM column width is currently defined with `!important`, which overrides the inline width applied by Clarity' s datagrid during column resizing.  As a result, the SBOM column cannot be resized correctly, causing the header and data columns to become misaligned.

Removing " !important " preserves the default width while allowing Clarity's resize logic to update the column width as expected.

## Issue being fixed

Fixes #23634
