### PR TITLE
Refactor manifest abstraction into a registry

### DIFF
--- a/src/controller/artifact/abstractor.go
+++ b/src/controller/artifact/abstractor.go
@@ -16,21 +16,10 @@ package artifact
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
 
-	"github.com/docker/distribution/manifest/manifestlist"
-	"github.com/docker/distribution/manifest/schema1"
-	"github.com/docker/distribution/manifest/schema2"
-	v1 "github.com/opencontainers/image-spec/specs-go/v1"
-
+	"github.com/goharbor/harbor/src/controller/artifact/manifest"
 	"github.com/goharbor/harbor/src/controller/artifact/processor"
-	"github.com/goharbor/harbor/src/controller/artifact/processor/wasm"
-	"github.com/goharbor/harbor/src/lib/log"
-	"github.com/goharbor/harbor/src/lib/q"
-	"github.com/goharbor/harbor/src/pkg"
 	"github.com/goharbor/harbor/src/pkg/artifact"
-	"github.com/goharbor/harbor/src/pkg/blob"
 	"github.com/goharbor/harbor/src/pkg/registry"
 )
 
@@ -43,164 +32,33 @@ type Abstractor interface {
 // NewAbstractor creates a new abstractor
 func NewAbstractor() Abstractor {
 	return &abstractor{
-		artMgr:  pkg.ArtifactMgr,
-		blobMgr: blob.Mgr,
-		regCli:  registry.Cli,
+		regCli: registry.Cli,
 	}
 }
 
 type abstractor struct {
-	artMgr  artifact.Manager
-	blobMgr blob.Manager
-	regCli  registry.Client
+	regCli registry.Client
 }
 
-func (a *abstractor) AbstractMetadata(ctx context.Context, artifact *artifact.Artifact) error {
+func (a *abstractor) AbstractMetadata(ctx context.Context, art *artifact.Artifact) error {
 	// read manifest content
-	manifest, _, err := a.regCli.PullManifest(artifact.RepositoryName, artifact.Digest)
+	mf, _, err := a.regCli.PullManifest(art.RepositoryName, art.Digest)
 	if err != nil {
 		return err
 	}
-	manifestMediaType, content, err := manifest.Payload()
+	manifestMediaType, content, err := mf.Payload()
 	if err != nil {
 		return err
 	}
-	artifact.ManifestMediaType = manifestMediaType
+	art.ManifestMediaType = manifestMediaType
 
-	switch artifact.ManifestMediaType {
-	case "", "application/json", schema1.MediaTypeSignedManifest:
-		if err := a.abstractManifestV1Metadata(ctx, artifact, content); err != nil {
-			return err
-		}
-	case v1.MediaTypeImageManifest, schema2.MediaTypeManifest:
-		if err = a.abstractManifestV2Metadata(artifact, content); err != nil {
-			return err
-		}
-	case v1.MediaTypeImageIndex, manifestlist.MediaTypeManifestList:
-		if err = a.abstractIndexMetadata(ctx, artifact, content); err != nil {
-			return err
-		}
-	default:
-		return fmt.Errorf("unsupported manifest media type: %s", artifact.ManifestMediaType)
-	}
-	return processor.Get(artifact.ResolveArtifactType()).AbstractMetadata(ctx, artifact, content)
-}
-
-// the artifact is enveloped by docker manifest v1
-func (a *abstractor) abstractManifestV1Metadata(ctx context.Context, artifact *artifact.Artifact, content []byte) error {
-	// unify the media type of v1 manifest to "schema1.MediaTypeSignedManifest"
-	artifact.ManifestMediaType = schema1.MediaTypeSignedManifest
-	// as no config layer in the docker v1 manifest, use the "schema1.MediaTypeSignedManifest"
-	// as the media type of artifact
-	artifact.MediaType = schema1.MediaTypeSignedManifest
-
-	manifest := &schema1.Manifest{}
-	if err := json.Unmarshal(content, manifest); err != nil {
-		return err
-	}
-
-	var ol q.OrList
-	for _, fsLayer := range manifest.FSLayers {
-		ol.Values = append(ol.Values, fsLayer.BlobSum.String())
-	}
-
-	// there is no layer size in v1 manifest, compute the artifact size from the blobs
-	blobs, err := a.blobMgr.List(ctx, q.New(q.KeyWords{"digest": &ol}))
+	abs, err := manifest.Get(art.ManifestMediaType)
 	if err != nil {
-		log.G(ctx).Errorf("failed to get blobs of the artifact %s, error %v", artifact.Digest, err)
+		return err
+	}
+	if err = abs.Abstract(ctx, art, content); err != nil {
 		return err
 	}
 
-	artifact.Size = int64(len(content))
-	for _, blob := range blobs {
-		artifact.Size += blob.Size
-	}
-
-	return nil
-}
-
-// the artifact is enveloped by OCI manifest or docker manifest v2
-func (a *abstractor) abstractManifestV2Metadata(artifact *artifact.Artifact, content []byte) error {
-	manifest := &v1.Manifest{}
-	if err := json.Unmarshal(content, manifest); err != nil {
-		return err
-	}
-	// use the "manifest.config.mediatype" as the media type of the artifact
-	artifact.MediaType = manifest.Config.MediaType
-	if manifest.Annotations[wasm.AnnotationVariantKey] == wasm.AnnotationVariantValue || manifest.Annotations[wasm.AnnotationHandlerKey] == wasm.AnnotationHandlerValue {
-		artifact.MediaType = wasm.MediaType
-	}
-	/*
-		https://github.com/opencontainers/distribution-spec/blob/v1.1.0/spec.md#listing-referrers
-		For referrers list, if the artifactType is empty or missing in the image manifest, the value of artifactType MUST be set to the config descriptor mediaType value
-	*/
-	if manifest.ArtifactType != "" {
-		artifact.ArtifactType = manifest.ArtifactType
-	} else {
-		artifact.ArtifactType = manifest.Config.MediaType
-	}
-
-	// set size
-	artifact.Size = int64(len(content)) + manifest.Config.Size
-	for _, layer := range manifest.Layers {
-		artifact.Size += layer.Size
-	}
-	// set annotations
-	artifact.Annotations = manifest.Annotations
-	return nil
-}
-
-// the artifact is enveloped by OCI index or docker manifest list
-func (a *abstractor) abstractIndexMetadata(ctx context.Context, art *artifact.Artifact, content []byte) error {
-	// the identity of index is still in progress, we use the manifest mediaType
-	// as the media type of artifact
-	art.MediaType = art.ManifestMediaType
-
-	index := &v1.Index{}
-	if err := json.Unmarshal(content, index); err != nil {
-		return err
-	}
-
-	/*
-		https://github.com/opencontainers/distribution-spec/blob/v1.1.0/spec.md#listing-referrers
-		For referrers list, If the artifactType is empty or missing in an index, the artifactType MUST be omitted.
-	*/
-	if index.ArtifactType != "" {
-		art.ArtifactType = index.ArtifactType
-	} else {
-		art.ArtifactType = ""
-	}
-
-	// set annotations
-	art.Annotations = index.Annotations
-
-	art.Size += int64(len(content))
-	// populate the referenced artifacts
-	for _, mani := range index.Manifests {
-		digest := mani.Digest.String()
-		// make sure the child artifact exist
-		ar, err := a.artMgr.GetByDigest(ctx, art.RepositoryName, digest)
-		if err != nil {
-			return err
-		}
-		art.Size += ar.Size
-		art.References = append(art.References, &artifact.Reference{
-			ChildID:     ar.ID,
-			ChildDigest: digest,
-			Platform:    mani.Platform,
-			URLs:        mani.URLs,
-			Annotations: mani.Annotations,
-		})
-	}
-
-	// Currently, CNAB put its media type inside the annotations
-	// try to parse the artifact media type from the annotations
-	if art.Annotations != nil {
-		mediaType := art.Annotations["org.opencontainers.artifactType"]
-		if len(mediaType) > 0 {
-			art.MediaType = mediaType
-		}
-	}
-
-	return nil
+	return processor.Get(art.ResolveArtifactType()).AbstractMetadata(ctx, art, content)
 }

--- a/src/controller/artifact/abstractor_test.go
+++ b/src/controller/artifact/abstractor_test.go
@@ -19,11 +19,13 @@ import (
 	"testing"
 
 	"github.com/docker/distribution"
+	"github.com/docker/distribution/manifest/manifestlist"
 	"github.com/docker/distribution/manifest/schema1"
 	"github.com/docker/distribution/manifest/schema2"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/goharbor/harbor/src/controller/artifact/manifest"
 	"github.com/goharbor/harbor/src/controller/artifact/processor"
 	"github.com/goharbor/harbor/src/pkg/artifact"
 	"github.com/goharbor/harbor/src/pkg/blob"
@@ -306,14 +308,22 @@ func (a *abstractorTestSuite) SetupTest() {
 	a.argMgr = &tart.Manager{}
 	a.blobMgr = &tblob.Manager{}
 	a.abstractor = &abstractor{
-		artMgr:  a.argMgr,
-		blobMgr: a.blobMgr,
-		regCli:  a.regCli,
+		regCli: a.regCli,
 	}
 	a.processor = &tpro.Processor{}
 	// clear all registered processors
 	processor.Registry = map[string]processor.Processor{}
 	processor.Registry[schema2.MediaTypeImageConfig] = a.processor
+	// replace the registered manifest abstractors with mock-backed ones so the
+	// suite exercises them against its own managers instead of the globals
+	// wired up by the manifest package's init()
+	manifest.Registry = map[string]manifest.Abstractor{}
+	a.Require().NoError(manifest.Register(manifest.NewV1(a.blobMgr),
+		"", "application/json", schema1.MediaTypeSignedManifest))
+	a.Require().NoError(manifest.Register(manifest.NewV2(),
+		v1.MediaTypeImageManifest, schema2.MediaTypeManifest))
+	a.Require().NoError(manifest.Register(manifest.NewIndex(a.argMgr),
+		v1.MediaTypeImageIndex, manifestlist.MediaTypeManifestList))
 }
 
 // docker manifest v1

--- a/src/controller/artifact/manifest/abstractor_test.go
+++ b/src/controller/artifact/manifest/abstractor_test.go
@@ -124,3 +124,60 @@ func TestIndexAbstractorPropagatesChildLookupError(t *testing.T) {
 	art := &artifact.Artifact{ID: 1, ManifestMediaType: v1.MediaTypeImageIndex}
 	assert.Error(t, NewIndex(artMgr).Abstract(context.Background(), art, []byte(indexContent)))
 }
+
+// CNAB carries its media type in an index annotation rather than in the
+// descriptor.
+func TestIndexAbstractorReadsMediaTypeFromAnnotations(t *testing.T) {
+	artMgr := &tart.Manager{}
+	art := &artifact.Artifact{ID: 1, ManifestMediaType: v1.MediaTypeImageIndex}
+	content := `{
+   "schemaVersion": 2,
+   "mediaType": "application/vnd.oci.image.index.v1+json",
+   "manifests": [],
+   "annotations": {"org.opencontainers.artifactType": "application/vnd.cnab.manifest.v1"}
+}`
+	require.NoError(t, NewIndex(artMgr).Abstract(context.Background(), art, []byte(content)))
+	assert.Equal(t, "application/vnd.cnab.manifest.v1", art.MediaType)
+}
+
+func TestIndexAbstractorReadsArtifactType(t *testing.T) {
+	artMgr := &tart.Manager{}
+	art := &artifact.Artifact{ID: 1, ManifestMediaType: v1.MediaTypeImageIndex}
+	content := `{
+   "schemaVersion": 2,
+   "mediaType": "application/vnd.oci.image.index.v1+json",
+   "artifactType": "application/vnd.example.sbom",
+   "manifests": []
+}`
+	require.NoError(t, NewIndex(artMgr).Abstract(context.Background(), art, []byte(content)))
+	assert.Equal(t, "application/vnd.example.sbom", art.ArtifactType)
+}
+
+func TestV2AbstractorReadsArtifactType(t *testing.T) {
+	art := &artifact.Artifact{ID: 1}
+	content := `{
+   "schemaVersion": 2,
+   "mediaType": "application/vnd.oci.image.manifest.v1+json",
+   "artifactType": "application/vnd.example.sbom",
+   "config": {"mediaType": "application/vnd.oci.image.config.v1+json", "size": 1, "digest": "sha256:b5b2b2c507a0944348e0303114d8d93aaaa081732b86451d9bce1f432a537bc7"},
+   "layers": []
+}`
+	require.NoError(t, NewV2().Abstract(context.Background(), art, []byte(content)))
+	assert.Equal(t, "application/vnd.example.sbom", art.ArtifactType)
+}
+
+func TestV1AbstractorPropagatesBlobListError(t *testing.T) {
+	blobMgr := &tblob.Manager{}
+	mock.OnAnything(blobMgr, "List").Return(nil, assert.AnError)
+
+	art := &artifact.Artifact{ID: 1}
+	assert.Error(t, NewV1(blobMgr).Abstract(context.Background(), art, []byte(v1ManifestContent)))
+}
+
+func TestAbstractorsRejectMalformedContent(t *testing.T) {
+	malformed := []byte("{not json")
+
+	assert.Error(t, NewV1(&tblob.Manager{}).Abstract(context.Background(), &artifact.Artifact{}, malformed))
+	assert.Error(t, NewV2().Abstract(context.Background(), &artifact.Artifact{}, malformed))
+	assert.Error(t, NewIndex(&tart.Manager{}).Abstract(context.Background(), &artifact.Artifact{}, malformed))
+}

--- a/src/controller/artifact/manifest/abstractor_test.go
+++ b/src/controller/artifact/manifest/abstractor_test.go
@@ -30,9 +30,7 @@ import (
 	tblob "github.com/goharbor/harbor/src/testing/pkg/blob"
 )
 
-// These tests exercise each abstractor directly with injected mocks, which is
-// what the exported constructors are for. Registration wires the same types up
-// from the package-level managers.
+// Driving each abstractor directly with mocks is what the exported constructors are for.
 
 const (
 	v1ManifestContent = `{
@@ -125,8 +123,7 @@ func TestIndexAbstractorPropagatesChildLookupError(t *testing.T) {
 	assert.Error(t, NewIndex(artMgr).Abstract(context.Background(), art, []byte(indexContent)))
 }
 
-// CNAB carries its media type in an index annotation rather than in the
-// descriptor.
+// CNAB carries its media type in an index annotation, not in the descriptor.
 func TestIndexAbstractorReadsMediaTypeFromAnnotations(t *testing.T) {
 	artMgr := &tart.Manager{}
 	art := &artifact.Artifact{ID: 1, ManifestMediaType: v1.MediaTypeImageIndex}

--- a/src/controller/artifact/manifest/abstractor_test.go
+++ b/src/controller/artifact/manifest/abstractor_test.go
@@ -1,0 +1,126 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package manifest
+
+import (
+	"context"
+	"testing"
+
+	"github.com/docker/distribution/manifest/schema1"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/goharbor/harbor/src/pkg/artifact"
+	"github.com/goharbor/harbor/src/pkg/blob"
+	"github.com/goharbor/harbor/src/testing/mock"
+	tart "github.com/goharbor/harbor/src/testing/pkg/artifact"
+	tblob "github.com/goharbor/harbor/src/testing/pkg/blob"
+)
+
+// These tests exercise each abstractor directly with injected mocks, which is
+// what the exported constructors are for. Registration wires the same types up
+// from the package-level managers.
+
+const (
+	v1ManifestContent = `{
+   "schemaVersion": 1,
+   "name": "library/hello-world",
+   "tag": "latest",
+   "architecture": "amd64",
+   "fsLayers": [
+      {"blobSum": "sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4"},
+      {"blobSum": "sha256:1b930d010525941c1d56ec53b97bd057a67ae1865eebf042686d2a2d18271ced"}
+   ],
+   "history": []
+}`
+
+	v2ManifestContent = `{
+   "schemaVersion": 2,
+   "mediaType": "application/vnd.oci.image.manifest.v1+json",
+   "config": {
+      "mediaType": "application/vnd.oci.image.config.v1+json",
+      "size": 7023,
+      "digest": "sha256:b5b2b2c507a0944348e0303114d8d93aaaa081732b86451d9bce1f432a537bc7"
+   },
+   "layers": [
+      {
+         "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+         "size": 32654,
+         "digest": "sha256:9834876dcfb05cb167a5c24953eba58c4ac89b1adf57f28f2f9d09af107ee8f0"
+      }
+   ],
+   "annotations": {"com.example.key1": "value1"}
+}`
+
+	indexContent = `{
+   "schemaVersion": 2,
+   "mediaType": "application/vnd.oci.image.index.v1+json",
+   "manifests": [
+      {
+         "mediaType": "application/vnd.oci.image.manifest.v1+json",
+         "size": 7143,
+         "digest": "sha256:e692418e4cbaf90ca69d05a66403747baa33ee08806650b51fab815ad7fc331f",
+         "platform": {"architecture": "ppc64le", "os": "linux"}
+      }
+   ]
+}`
+)
+
+func TestV1AbstractorUsesInjectedBlobManager(t *testing.T) {
+	blobMgr := &tblob.Manager{}
+	mock.OnAnything(blobMgr, "List").Return([]*blob.Blob{{Size: 10}, {Size: 20}}, nil)
+
+	art := &artifact.Artifact{ID: 1}
+	require.NoError(t, NewV1(blobMgr).Abstract(context.Background(), art, []byte(v1ManifestContent)))
+
+	assert.Equal(t, schema1.MediaTypeSignedManifest, art.ManifestMediaType)
+	assert.Equal(t, schema1.MediaTypeSignedManifest, art.MediaType)
+	// there is no layer size in a v1 manifest, so it is summed from the blobs
+	assert.Equal(t, int64(30+len(v1ManifestContent)), art.Size)
+}
+
+func TestV2Abstractor(t *testing.T) {
+	art := &artifact.Artifact{ID: 1}
+	require.NoError(t, NewV2().Abstract(context.Background(), art, []byte(v2ManifestContent)))
+
+	assert.Equal(t, v1.MediaTypeImageConfig, art.MediaType)
+	// artifactType is absent, so it falls back to the config media type
+	assert.Equal(t, v1.MediaTypeImageConfig, art.ArtifactType)
+	assert.Equal(t, int64(7023+32654+len(v2ManifestContent)), art.Size)
+	assert.Equal(t, "value1", art.Annotations["com.example.key1"])
+}
+
+func TestIndexAbstractorUsesInjectedArtifactManager(t *testing.T) {
+	artMgr := &tart.Manager{}
+	mock.OnAnything(artMgr, "GetByDigest").Return(&artifact.Artifact{ID: 2, Size: 100}, nil)
+
+	art := &artifact.Artifact{ID: 1, ManifestMediaType: v1.MediaTypeImageIndex}
+	require.NoError(t, NewIndex(artMgr).Abstract(context.Background(), art, []byte(indexContent)))
+
+	assert.Equal(t, v1.MediaTypeImageIndex, art.MediaType)
+	assert.Empty(t, art.ArtifactType)
+	require.Len(t, art.References, 1)
+	assert.Equal(t, int64(2), art.References[0].ChildID)
+	assert.Equal(t, int64(100+len(indexContent)), art.Size)
+}
+
+func TestIndexAbstractorPropagatesChildLookupError(t *testing.T) {
+	artMgr := &tart.Manager{}
+	mock.OnAnything(artMgr, "GetByDigest").Return(nil, assert.AnError)
+
+	art := &artifact.Artifact{ID: 1, ManifestMediaType: v1.MediaTypeImageIndex}
+	assert.Error(t, NewIndex(artMgr).Abstract(context.Background(), art, []byte(indexContent)))
+}

--- a/src/controller/artifact/manifest/index.go
+++ b/src/controller/artifact/manifest/index.go
@@ -1,0 +1,98 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package manifest
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/docker/distribution/manifest/manifestlist"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"github.com/goharbor/harbor/src/lib/log"
+	"github.com/goharbor/harbor/src/pkg"
+	"github.com/goharbor/harbor/src/pkg/artifact"
+)
+
+func init() {
+	mediaTypes := []string{v1.MediaTypeImageIndex, manifestlist.MediaTypeManifestList}
+	if err := Register(NewIndex(pkg.ArtifactMgr), mediaTypes...); err != nil {
+		log.Errorf("failed to register the abstractor for manifest media types %v: %v", mediaTypes, err)
+	}
+}
+
+// indexAbstractor abstracts artifacts enveloped by OCI index or docker manifest list.
+type indexAbstractor struct {
+	artMgr artifact.Manager
+}
+
+// NewIndex returns an abstractor for OCI indexes and docker manifest lists.
+func NewIndex(artMgr artifact.Manager) Abstractor {
+	return &indexAbstractor{artMgr: artMgr}
+}
+
+func (a *indexAbstractor) Abstract(ctx context.Context, art *artifact.Artifact, content []byte) error {
+	// the identity of index is still in progress, we use the manifest mediaType
+	// as the media type of artifact
+	art.MediaType = art.ManifestMediaType
+
+	index := &v1.Index{}
+	if err := json.Unmarshal(content, index); err != nil {
+		return err
+	}
+
+	/*
+		https://github.com/opencontainers/distribution-spec/blob/v1.1.0/spec.md#listing-referrers
+		For referrers list, If the artifactType is empty or missing in an index, the artifactType MUST be omitted.
+	*/
+	if index.ArtifactType != "" {
+		art.ArtifactType = index.ArtifactType
+	} else {
+		art.ArtifactType = ""
+	}
+
+	// set annotations
+	art.Annotations = index.Annotations
+
+	art.Size += int64(len(content))
+	// populate the referenced artifacts
+	for _, mani := range index.Manifests {
+		digest := mani.Digest.String()
+		// make sure the child artifact exist
+		ar, err := a.artMgr.GetByDigest(ctx, art.RepositoryName, digest)
+		if err != nil {
+			return err
+		}
+		art.Size += ar.Size
+		art.References = append(art.References, &artifact.Reference{
+			ChildID:     ar.ID,
+			ChildDigest: digest,
+			Platform:    mani.Platform,
+			URLs:        mani.URLs,
+			Annotations: mani.Annotations,
+		})
+	}
+
+	// Currently, CNAB put its media type inside the annotations
+	// try to parse the artifact media type from the annotations
+	if art.Annotations != nil {
+		mediaType := art.Annotations["org.opencontainers.artifactType"]
+		if len(mediaType) > 0 {
+			art.MediaType = mediaType
+		}
+	}
+
+	return nil
+}

--- a/src/controller/artifact/manifest/index.go
+++ b/src/controller/artifact/manifest/index.go
@@ -21,7 +21,6 @@ import (
 	"github.com/docker/distribution/manifest/manifestlist"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 
-	"github.com/goharbor/harbor/src/lib/log"
 	"github.com/goharbor/harbor/src/pkg"
 	"github.com/goharbor/harbor/src/pkg/artifact"
 )
@@ -29,7 +28,7 @@ import (
 func init() {
 	mediaTypes := []string{v1.MediaTypeImageIndex, manifestlist.MediaTypeManifestList}
 	if err := Register(NewIndex(pkg.ArtifactMgr), mediaTypes...); err != nil {
-		log.Errorf("failed to register the abstractor for manifest media types %v: %v", mediaTypes, err)
+		panic(err)
 	}
 }
 

--- a/src/controller/artifact/manifest/index.go
+++ b/src/controller/artifact/manifest/index.go
@@ -38,7 +38,6 @@ type indexAbstractor struct {
 	artMgr artifact.Manager
 }
 
-// NewIndex returns an abstractor for OCI indexes and docker manifest lists.
 func NewIndex(artMgr artifact.Manager) Abstractor {
 	return &indexAbstractor{artMgr: artMgr}
 }

--- a/src/controller/artifact/manifest/manifest.go
+++ b/src/controller/artifact/manifest/manifest.go
@@ -22,25 +22,18 @@ import (
 	"github.com/goharbor/harbor/src/pkg/artifact"
 )
 
-// Registry holds the registered manifest abstractors, keyed by manifest media
-// type. Exported so that tests can replace it, the same way processor.Registry
-// is replaced today.
+// Registry holds the registered manifest abstractors, keyed by manifest media type.
 var Registry = map[string]Abstractor{}
 
 // Abstractor abstracts the metadata carried by one manifest format into the
 // artifact model.
 type Abstractor interface {
-	// Abstract reads the manifest content and populates the artifact model.
 	Abstract(ctx context.Context, art *artifact.Artifact, content []byte) error
 }
 
-// Register an abstractor for one or more manifest media types. One abstractor
-// can serve multiple media types that share a wire format.
-//
-// The whole batch is validated before anything is written, so a rejected call
-// leaves the registry untouched. Callers only log registration errors, and a
-// half-applied batch would otherwise make dispatch depend on the order the
-// media types happened to be listed in.
+// Register an abstractor for one or more manifest media types. Callers only log
+// registration errors, so the batch is validated before anything is written: a
+// half-applied batch would make dispatch depend on the order of the media types.
 func Register(abstractor Abstractor, mediaTypes ...string) error {
 	seen := make(map[string]struct{}, len(mediaTypes))
 	for _, mediaType := range mediaTypes {
@@ -61,8 +54,7 @@ func Register(abstractor Abstractor, mediaTypes ...string) error {
 }
 
 // Get the abstractor for the manifest media type. Unlike processor.Get there is
-// no default fallback: an unknown manifest media type cannot be abstracted, and
-// silently guessing a format would corrupt the artifact model.
+// no default fallback: guessing at an unknown format would corrupt the artifact model.
 func Get(mediaType string) (Abstractor, error) {
 	abstractor, exist := Registry[mediaType]
 	if !exist {

--- a/src/controller/artifact/manifest/manifest.go
+++ b/src/controller/artifact/manifest/manifest.go
@@ -31,9 +31,11 @@ type Abstractor interface {
 	Abstract(ctx context.Context, art *artifact.Artifact, content []byte) error
 }
 
-// Register an abstractor for one or more manifest media types. Callers only log
-// registration errors, so the batch is validated before anything is written: a
-// half-applied batch would make dispatch depend on the order of the media types.
+// Register an abstractor for one or more manifest media types. Registration
+// failures are fatal at startup: an unregistered media type would fail every
+// push and pull of that manifest format at runtime, far from the actual cause.
+// The batch is validated before anything is written, since a half-applied batch
+// would make dispatch depend on the order of the media types.
 func Register(abstractor Abstractor, mediaTypes ...string) error {
 	seen := make(map[string]struct{}, len(mediaTypes))
 	for _, mediaType := range mediaTypes {

--- a/src/controller/artifact/manifest/manifest.go
+++ b/src/controller/artifact/manifest/manifest.go
@@ -1,0 +1,59 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package manifest
+
+import (
+	"context"
+
+	"github.com/goharbor/harbor/src/lib/errors"
+	"github.com/goharbor/harbor/src/lib/log"
+	"github.com/goharbor/harbor/src/pkg/artifact"
+)
+
+// Registry holds the registered manifest abstractors, keyed by manifest media
+// type. Exported so that tests can replace it, the same way processor.Registry
+// is replaced today.
+var Registry = map[string]Abstractor{}
+
+// Abstractor abstracts the metadata carried by one manifest format into the
+// artifact model.
+type Abstractor interface {
+	// Abstract reads the manifest content and populates the artifact model.
+	Abstract(ctx context.Context, art *artifact.Artifact, content []byte) error
+}
+
+// Register an abstractor for one or more manifest media types. One abstractor
+// can serve multiple media types that share a wire format.
+func Register(abstractor Abstractor, mediaTypes ...string) error {
+	for _, mediaType := range mediaTypes {
+		if _, exist := Registry[mediaType]; exist {
+			return errors.Errorf("the abstractor for manifest media type %s already exists", mediaType)
+		}
+		Registry[mediaType] = abstractor
+		log.Debugf("the abstractor for manifest media type %s registered", mediaType)
+	}
+	return nil
+}
+
+// Get the abstractor for the manifest media type. Unlike processor.Get there is
+// no default fallback: an unknown manifest media type cannot be abstracted, and
+// silently guessing a format would corrupt the artifact model.
+func Get(mediaType string) (Abstractor, error) {
+	abstractor, exist := Registry[mediaType]
+	if !exist {
+		return nil, errors.Errorf("unsupported manifest media type: %s", mediaType).WithCode(errors.UNSUPPORTED)
+	}
+	return abstractor, nil
+}

--- a/src/controller/artifact/manifest/manifest.go
+++ b/src/controller/artifact/manifest/manifest.go
@@ -36,11 +36,24 @@ type Abstractor interface {
 
 // Register an abstractor for one or more manifest media types. One abstractor
 // can serve multiple media types that share a wire format.
+//
+// The whole batch is validated before anything is written, so a rejected call
+// leaves the registry untouched. Callers only log registration errors, and a
+// half-applied batch would otherwise make dispatch depend on the order the
+// media types happened to be listed in.
 func Register(abstractor Abstractor, mediaTypes ...string) error {
+	seen := make(map[string]struct{}, len(mediaTypes))
 	for _, mediaType := range mediaTypes {
 		if _, exist := Registry[mediaType]; exist {
 			return errors.Errorf("the abstractor for manifest media type %s already exists", mediaType)
 		}
+		if _, duplicate := seen[mediaType]; duplicate {
+			return errors.Errorf("the manifest media type %s is listed twice", mediaType)
+		}
+		seen[mediaType] = struct{}{}
+	}
+
+	for _, mediaType := range mediaTypes {
 		Registry[mediaType] = abstractor
 		log.Debugf("the abstractor for manifest media type %s registered", mediaType)
 	}

--- a/src/controller/artifact/manifest/manifest_test.go
+++ b/src/controller/artifact/manifest/manifest_test.go
@@ -35,7 +35,6 @@ func (stubAbstractor) Abstract(_ context.Context, _ *artifact.Artifact, _ []byte
 	return nil
 }
 
-// withRegistry swaps the package registry for the duration of a test.
 func withRegistry(t *testing.T, registry map[string]Abstractor) {
 	t.Helper()
 	original := Registry
@@ -43,9 +42,7 @@ func withRegistry(t *testing.T, registry map[string]Abstractor) {
 	t.Cleanup(func() { Registry = original })
 }
 
-// TestDefaultRegistrations pins the bootstrap. An empty registry means no
-// artifact can be abstracted at all, so it is worth a test rather than a
-// convention.
+// An empty registry means no artifact can be abstracted at all, so pin the bootstrap.
 func TestDefaultRegistrations(t *testing.T) {
 	for _, mediaType := range []string{
 		"",
@@ -93,8 +90,7 @@ func TestRegisterDuplicate(t *testing.T) {
 	assert.Error(t, Register(stubAbstractor{}, "a"))
 }
 
-// A rejected batch must not leave part of itself registered, otherwise dispatch
-// would depend on the order the media types were listed in.
+// A partly applied batch would make dispatch depend on the order of the media types.
 func TestRegisterRejectedBatchIsNotApplied(t *testing.T) {
 	withRegistry(t, map[string]Abstractor{})
 

--- a/src/controller/artifact/manifest/manifest_test.go
+++ b/src/controller/artifact/manifest/manifest_test.go
@@ -92,3 +92,23 @@ func TestRegisterDuplicate(t *testing.T) {
 	require.NoError(t, Register(stubAbstractor{}, "a"))
 	assert.Error(t, Register(stubAbstractor{}, "a"))
 }
+
+// A rejected batch must not leave part of itself registered, otherwise dispatch
+// would depend on the order the media types were listed in.
+func TestRegisterRejectedBatchIsNotApplied(t *testing.T) {
+	withRegistry(t, map[string]Abstractor{})
+
+	require.NoError(t, Register(stubAbstractor{}, "existing"))
+	assert.Error(t, Register(stubAbstractor{}, "new", "existing"))
+
+	_, err := Get("new")
+	assert.Error(t, err, "the rest of the batch must not have been registered")
+	assert.Len(t, Registry, 1)
+}
+
+func TestRegisterDuplicateWithinBatch(t *testing.T) {
+	withRegistry(t, map[string]Abstractor{})
+
+	assert.Error(t, Register(stubAbstractor{}, "a", "a"))
+	assert.Empty(t, Registry)
+}

--- a/src/controller/artifact/manifest/manifest_test.go
+++ b/src/controller/artifact/manifest/manifest_test.go
@@ -1,0 +1,94 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package manifest
+
+import (
+	"context"
+	"testing"
+
+	"github.com/docker/distribution/manifest/manifestlist"
+	"github.com/docker/distribution/manifest/schema1"
+	"github.com/docker/distribution/manifest/schema2"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/goharbor/harbor/src/lib/errors"
+	"github.com/goharbor/harbor/src/pkg/artifact"
+)
+
+type stubAbstractor struct{}
+
+func (stubAbstractor) Abstract(_ context.Context, _ *artifact.Artifact, _ []byte) error {
+	return nil
+}
+
+// withRegistry swaps the package registry for the duration of a test.
+func withRegistry(t *testing.T, registry map[string]Abstractor) {
+	t.Helper()
+	original := Registry
+	Registry = registry
+	t.Cleanup(func() { Registry = original })
+}
+
+// TestDefaultRegistrations pins the bootstrap. An empty registry means no
+// artifact can be abstracted at all, so it is worth a test rather than a
+// convention.
+func TestDefaultRegistrations(t *testing.T) {
+	for _, mediaType := range []string{
+		"",
+		"application/json",
+		schema1.MediaTypeSignedManifest,
+		v1.MediaTypeImageManifest,
+		schema2.MediaTypeManifest,
+		v1.MediaTypeImageIndex,
+		manifestlist.MediaTypeManifestList,
+	} {
+		abstractor, err := Get(mediaType)
+		require.NoError(t, err, "no abstractor registered for %q", mediaType)
+		assert.NotNil(t, abstractor)
+	}
+}
+
+func TestGetUnsupportedMediaType(t *testing.T) {
+	abstractor, err := Get("application/vnd.example.unknown")
+	require.Error(t, err)
+	assert.Nil(t, abstractor)
+	assert.Equal(t, errors.UNSUPPORTED, errors.ErrCode(err))
+}
+
+// A layer media type must not resolve to the image manifest abstractor.
+func TestGetRejectsLayerMediaType(t *testing.T) {
+	_, err := Get(v1.MediaTypeImageLayerGzip)
+	assert.Error(t, err)
+}
+
+func TestRegister(t *testing.T) {
+	withRegistry(t, map[string]Abstractor{})
+
+	require.NoError(t, Register(stubAbstractor{}, "a", "b"))
+	assert.Len(t, Registry, 2)
+
+	abstractor, err := Get("a")
+	require.NoError(t, err)
+	assert.NotNil(t, abstractor)
+}
+
+func TestRegisterDuplicate(t *testing.T) {
+	withRegistry(t, map[string]Abstractor{})
+
+	require.NoError(t, Register(stubAbstractor{}, "a"))
+	assert.Error(t, Register(stubAbstractor{}, "a"))
+}

--- a/src/controller/artifact/manifest/v1.go
+++ b/src/controller/artifact/manifest/v1.go
@@ -1,0 +1,76 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package manifest
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/docker/distribution/manifest/schema1"
+
+	"github.com/goharbor/harbor/src/lib/log"
+	"github.com/goharbor/harbor/src/lib/q"
+	"github.com/goharbor/harbor/src/pkg/artifact"
+	"github.com/goharbor/harbor/src/pkg/blob"
+)
+
+func init() {
+	mediaTypes := []string{"", "application/json", schema1.MediaTypeSignedManifest}
+	if err := Register(NewV1(blob.Mgr), mediaTypes...); err != nil {
+		log.Errorf("failed to register the abstractor for manifest media types %v: %v", mediaTypes, err)
+	}
+}
+
+// v1Abstractor abstracts artifacts enveloped by docker manifest v1.
+type v1Abstractor struct {
+	blobMgr blob.Manager
+}
+
+// NewV1 returns an abstractor for docker manifest v1 / schema1.
+func NewV1(blobMgr blob.Manager) Abstractor {
+	return &v1Abstractor{blobMgr: blobMgr}
+}
+
+func (a *v1Abstractor) Abstract(ctx context.Context, art *artifact.Artifact, content []byte) error {
+	// unify the media type of v1 manifest to "schema1.MediaTypeSignedManifest"
+	art.ManifestMediaType = schema1.MediaTypeSignedManifest
+	// as no config layer in the docker v1 manifest, use the "schema1.MediaTypeSignedManifest"
+	// as the media type of artifact
+	art.MediaType = schema1.MediaTypeSignedManifest
+
+	mf := &schema1.Manifest{}
+	if err := json.Unmarshal(content, mf); err != nil {
+		return err
+	}
+
+	var ol q.OrList
+	for _, fsLayer := range mf.FSLayers {
+		ol.Values = append(ol.Values, fsLayer.BlobSum.String())
+	}
+
+	// there is no layer size in v1 manifest, compute the artifact size from the blobs
+	blobs, err := a.blobMgr.List(ctx, q.New(q.KeyWords{"digest": &ol}))
+	if err != nil {
+		log.G(ctx).Errorf("failed to get blobs of the artifact %s, error %v", art.Digest, err)
+		return err
+	}
+
+	art.Size = int64(len(content))
+	for _, b := range blobs {
+		art.Size += b.Size
+	}
+
+	return nil
+}

--- a/src/controller/artifact/manifest/v1.go
+++ b/src/controller/artifact/manifest/v1.go
@@ -38,7 +38,6 @@ type v1Abstractor struct {
 	blobMgr blob.Manager
 }
 
-// NewV1 returns an abstractor for docker manifest v1 / schema1.
 func NewV1(blobMgr blob.Manager) Abstractor {
 	return &v1Abstractor{blobMgr: blobMgr}
 }

--- a/src/controller/artifact/manifest/v1.go
+++ b/src/controller/artifact/manifest/v1.go
@@ -29,7 +29,7 @@ import (
 func init() {
 	mediaTypes := []string{"", "application/json", schema1.MediaTypeSignedManifest}
 	if err := Register(NewV1(blob.Mgr), mediaTypes...); err != nil {
-		log.Errorf("failed to register the abstractor for manifest media types %v: %v", mediaTypes, err)
+		panic(err)
 	}
 }
 

--- a/src/controller/artifact/manifest/v2.go
+++ b/src/controller/artifact/manifest/v2.go
@@ -1,0 +1,72 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package manifest
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/docker/distribution/manifest/schema2"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"github.com/goharbor/harbor/src/controller/artifact/processor/wasm"
+	"github.com/goharbor/harbor/src/lib/log"
+	"github.com/goharbor/harbor/src/pkg/artifact"
+)
+
+func init() {
+	mediaTypes := []string{v1.MediaTypeImageManifest, schema2.MediaTypeManifest}
+	if err := Register(NewV2(), mediaTypes...); err != nil {
+		log.Errorf("failed to register the abstractor for manifest media types %v: %v", mediaTypes, err)
+	}
+}
+
+// v2Abstractor abstracts artifacts enveloped by OCI manifest or docker manifest v2.
+type v2Abstractor struct{}
+
+// NewV2 returns an abstractor for OCI image manifests and docker manifest v2.
+func NewV2() Abstractor {
+	return &v2Abstractor{}
+}
+
+func (a *v2Abstractor) Abstract(_ context.Context, art *artifact.Artifact, content []byte) error {
+	mf := &v1.Manifest{}
+	if err := json.Unmarshal(content, mf); err != nil {
+		return err
+	}
+	// use the "manifest.config.mediatype" as the media type of the artifact
+	art.MediaType = mf.Config.MediaType
+	if mf.Annotations[wasm.AnnotationVariantKey] == wasm.AnnotationVariantValue || mf.Annotations[wasm.AnnotationHandlerKey] == wasm.AnnotationHandlerValue {
+		art.MediaType = wasm.MediaType
+	}
+	/*
+		https://github.com/opencontainers/distribution-spec/blob/v1.1.0/spec.md#listing-referrers
+		For referrers list, if the artifactType is empty or missing in the image manifest, the value of artifactType MUST be set to the config descriptor mediaType value
+	*/
+	if mf.ArtifactType != "" {
+		art.ArtifactType = mf.ArtifactType
+	} else {
+		art.ArtifactType = mf.Config.MediaType
+	}
+
+	// set size
+	art.Size = int64(len(content)) + mf.Config.Size
+	for _, layer := range mf.Layers {
+		art.Size += layer.Size
+	}
+	// set annotations
+	art.Annotations = mf.Annotations
+	return nil
+}

--- a/src/controller/artifact/manifest/v2.go
+++ b/src/controller/artifact/manifest/v2.go
@@ -22,14 +22,13 @@ import (
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 
 	"github.com/goharbor/harbor/src/controller/artifact/processor/wasm"
-	"github.com/goharbor/harbor/src/lib/log"
 	"github.com/goharbor/harbor/src/pkg/artifact"
 )
 
 func init() {
 	mediaTypes := []string{v1.MediaTypeImageManifest, schema2.MediaTypeManifest}
 	if err := Register(NewV2(), mediaTypes...); err != nil {
-		log.Errorf("failed to register the abstractor for manifest media types %v: %v", mediaTypes, err)
+		panic(err)
 	}
 }
 

--- a/src/controller/artifact/manifest/v2.go
+++ b/src/controller/artifact/manifest/v2.go
@@ -36,7 +36,6 @@ func init() {
 // v2Abstractor abstracts artifacts enveloped by OCI manifest or docker manifest v2.
 type v2Abstractor struct{}
 
-// NewV2 returns an abstractor for OCI image manifests and docker manifest v2.
 func NewV2() Abstractor {
 	return &v2Abstractor{}
 }


### PR DESCRIPTION
Fixes #22847

`AbstractMetadata()` dispatched on manifest media type through a hardcoded `switch`, with the three abstraction bodies as private methods on `abstractor`. Every new manifest format meant editing core dispatch logic, and the struct carried the union of every dependency: `blob.Manager` for schema1, `artifact.Manager` for indexes, neither for v2.

This moves the three formats behind an interface in a new `controller/artifact/manifest` package, keyed by media type, using the registry pattern the artifact processors already use.

```
manifest/
├── manifest.go  # Abstractor interface, Registry, Register, Get
├── v1.go        # docker manifest v1 / schema1     (blob.Manager)
├── v2.go        # OCI image manifest / docker v2   (no deps)
└── index.go     # OCI index / docker manifest list (artifact.Manager)
```

No behaviour change: the same media types are accepted and the same metadata is produced.

## What this opens up

- **New manifest formats become registrations, not edits.** Anything needing its own metadata extraction — future OCI additions, artifact/referrers handling, vendor-specific formats — registers an implementation instead of growing the switch and the dependency union on a single struct.
- **Each abstractor is independently testable.** Constructors are exported and take their dependencies, so an abstractor can be driven directly with mocks (see `manifest/abstractor_test.go`) instead of only through the full `AbstractMetadata` path.
- **Downstream can extend without patching core.** Distributions and forks can register their own abstractor rather than carrying a permanent diff on `abstractor.go`.

## Design notes

- `Get` returns an error instead of falling back to a default. `processor.Get` defaults, which is right for artifact types; guessing at an unknown manifest format would corrupt the artifact model. The error now carries `errors.UNSUPPORTED` rather than being untyped.
- Flat package, no sub-packages. `controller/artifact` imports `manifest` by name, so the `init()` registrations cannot be silently missed the way a forgotten blank import would leave the registry empty.
- `schema1.MediaTypeManifest` is left unregistered to match the current switch exactly. It is accepted elsewhere in the tree (`pkg/registry/client.go`, `replication/transfer/image/transfer.go`), so it may be a real gap — but that is a behaviour change and belongs in its own PR.

Supersedes #22862, with thanks to @vg006.

## Testing

`go test ./src/controller/artifact/...` green; the existing `abstractorTestSuite` is unchanged in behaviour and now populates `manifest.Registry` with mock-backed abstractors, mirroring how it already replaces `processor.Registry`. New tests cover the registry, each abstractor, and the bootstrap itself (an empty registry would break every push). 94.9% statement coverage on the new package. `golangci-lint`, `gofmt` and `go vet` clean.

---
Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
