### PR TITLE
fix: Add missing PII redaction to gdpr redaction job

### DIFF
--- a/src/jobservice/job/impl/gdpr/audit_logs_data_masking.go
+++ b/src/jobservice/job/impl/gdpr/audit_logs_data_masking.go
@@ -73,12 +73,17 @@ func (a AuditLogsDataMasking) Run(ctx job.Context, params job.Parameters) error 
 	if err != nil {
 		return err
 	}
-	logger.Infof("Masking log entries for a user: %s", username)
-	err = a.manager.UpdateUsername(ctx.SystemContext(), username, a.userManager.GenerateCheckSum(username))
+	maskedUsername := a.userManager.GenerateCheckSum(username)
+	logger.Infof("Masking log entries deleted user replacing the username with: %s", maskedUsername)
+	err = a.manager.UpdateUsername(ctx.SystemContext(), username, maskedUsername)
 	if err != nil {
 		return err
 	}
-	return a.extManager.UpdateUsername(ctx.SystemContext(), username, a.userManager.GenerateCheckSum(username))
+	err = a.extManager.UpdateUsername(ctx.SystemContext(), username, maskedUsername)
+	if err != nil {
+		return err
+	}
+	return a.extManager.UpdateUsernameForUserResource(ctx.SystemContext(), username, maskedUsername)
 }
 
 func (a AuditLogsDataMasking) parseParams(params job.Parameters) (string, error) {

--- a/src/jobservice/job/impl/gdpr/audit_logs_data_masking_test.go
+++ b/src/jobservice/job/impl/gdpr/audit_logs_data_masking_test.go
@@ -65,6 +65,7 @@ func TestAuditLogsCleanupJobValidateParams(t *testing.T) {
 	userManager.On("GenerateCheckSum", validUsername).Return("hash")
 	manager.On("UpdateUsername", context.TODO(), validUsername, "hash").Return(nil)
 	extManger.On("UpdateUsername", context.TODO(), validUsername, "hash").Return(nil)
+	extManger.On("UpdateUsernameForUserResource", context.TODO(), validUsername, "hash").Return(nil)
 
 	err = rep.Run(ctx, validParams)
 	assert.Nil(t, err)

--- a/src/pkg/auditext/dao/dao.go
+++ b/src/pkg/auditext/dao/dao.go
@@ -21,6 +21,7 @@ import (
 
 	beegorm "github.com/beego/beego/v2/client/orm"
 
+	"github.com/goharbor/harbor/src/common/rbac"
 	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/lib/log"
 	"github.com/goharbor/harbor/src/lib/orm"
@@ -44,6 +45,8 @@ type DAO interface {
 	Purge(ctx context.Context, retentionHour int, includeOperations []string, dryRun bool) (int64, error)
 	// UpdateUsername replaces username in matched records
 	UpdateUsername(ctx context.Context, username string, usernameReplace string) error
+	// UpdateUsernameForUserResource replaces the username in the resource and op_desc columns of user related records
+	UpdateUsernameForUserResource(ctx context.Context, username string, usernameReplace string) error
 }
 
 // New returns an instance of the default DAO
@@ -59,6 +62,16 @@ func (d *dao) UpdateUsername(ctx context.Context, username string, usernameRepla
 		return err
 	}
 	_, err = o.Raw("UPDATE audit_log_ext SET username = ? WHERE username = ?", usernameReplace, username).Exec()
+	return err
+}
+
+func (d *dao) UpdateUsernameForUserResource(ctx context.Context, username string, usernameReplace string) error {
+	o, err := orm.FromContext(ctx)
+	if err != nil {
+		return err
+	}
+	_, err = o.Raw("UPDATE audit_log_ext SET resource = ?, op_desc = REPLACE(op_desc, ?, ?) WHERE resource_type = ? AND resource = ?",
+		usernameReplace, username, usernameReplace, rbac.ResourceUser.String(), username).Exec()
 	return err
 }
 

--- a/src/pkg/auditext/manager.go
+++ b/src/pkg/auditext/manager.go
@@ -43,6 +43,8 @@ type Manager interface {
 	Purge(ctx context.Context, retentionHour int, includeOperations []string, dryRun bool) (int64, error)
 	// UpdateUsername Replace all log records username with its hash
 	UpdateUsername(ctx context.Context, username string, replaceWith string) error
+	// UpdateUsernameForUserResource Replace the username with its hash in the resource and op_desc of user related records
+	UpdateUsernameForUserResource(ctx context.Context, username string, replaceWith string) error
 }
 
 // New returns a default implementation of Manager
@@ -58,6 +60,10 @@ type manager struct {
 
 func (m *manager) UpdateUsername(ctx context.Context, username string, replaceWith string) error {
 	return m.dao.UpdateUsername(ctx, username, replaceWith)
+}
+
+func (m *manager) UpdateUsernameForUserResource(ctx context.Context, username string, replaceWith string) error {
+	return m.dao.UpdateUsernameForUserResource(ctx, username, replaceWith)
 }
 
 // Count ...

--- a/src/testing/pkg/auditext/dao/dao.go
+++ b/src/testing/pkg/auditext/dao/dao.go
@@ -195,6 +195,24 @@ func (_m *DAO) UpdateUsername(ctx context.Context, username string, usernameRepl
 	return r0
 }
 
+// UpdateUsernameForUserResource provides a mock function with given fields: ctx, username, usernameReplace
+func (_m *DAO) UpdateUsernameForUserResource(ctx context.Context, username string, usernameReplace string) error {
+	ret := _m.Called(ctx, username, usernameReplace)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateUsernameForUserResource")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) error); ok {
+		r0 = rf(ctx, username, usernameReplace)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // NewDAO creates a new instance of DAO. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewDAO(t interface {

--- a/src/testing/pkg/auditext/manager.go
+++ b/src/testing/pkg/auditext/manager.go
@@ -195,6 +195,24 @@ func (_m *Manager) UpdateUsername(ctx context.Context, username string, replaceW
 	return r0
 }
 
+// UpdateUsernameForUserResource provides a mock function with given fields: ctx, username, replaceWith
+func (_m *Manager) UpdateUsernameForUserResource(ctx context.Context, username string, replaceWith string) error {
+	ret := _m.Called(ctx, username, replaceWith)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateUsernameForUserResource")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) error); ok {
+		r0 = rf(ctx, username, replaceWith)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // NewManager creates a new instance of Manager. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewManager(t interface {


### PR DESCRIPTION
# Comprehensive Summary of your change

The GDPR masking job hashed a deleted user's name in the audit log username column but left it in plaintext in the `resource` and `op_desc` columns of user-related  records. This MR adds the logic to  redacts those columns too, and calls it from the masking job. It also logs the masked value instead of the real username and updates mocks and tests accordingly.

Please indicate you've done the following:
- [X] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [X] Accepted the DCO. Commits without the DCO will delay acceptance.
- [X] Made sure tests are passing and test coverage is added if needed.
- [X] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
