### PR TITLE
fix: system_cve testcase failing at end of month

### DIFF
--- a/tests/resources/Harbor-Pages/Configuration.robot
+++ b/tests/resources/Harbor-Pages/Configuration.robot
@@ -281,8 +281,13 @@ Delete Top Item In System CVE Allowlist
 Set CVE Allowlist Expires
     [Arguments]  ${expired}
     Retry Button Click  ${cve_allowlist_expires_btn}
-    ${element}=  Set Variable If  ${expired}  ${cve_allowlist_expires_yesterday}  ${cve_allowlist_expires_tomorrow}
-    Retry Element Click  ${element}
+    # The picker opens on the month of the previously selected date, so jump back to the current month first
+    Retry Element Click  ${datepicker_cur_month_btn}
+    # Clarity hides adjacent-month days, so yesterday/tomorrow can be unclickable at month boundaries;
+    # switch to the previous/next month and pick its 15th to get a date in the past/future
+    ${switcher}=  Set Variable If  ${expired}  ${datepicker_prev_month_btn}  ${datepicker_next_month_btn}
+    Retry Element Click  ${switcher}
+    Retry Element Click  ${datepicker_mid_month_day_btn}
     Retry Element Click  //button[contains(.,'SAVE')]
 
 Get Project Count Quota Text From Project Quotas List

--- a/tests/resources/Harbor-Pages/Configuration_Elements.robot
+++ b/tests/resources/Harbor-Pages/Configuration_Elements.robot
@@ -35,8 +35,10 @@ ${configuration_system_wl_add_confirm_btn}    //*[@id='add-to-system']
 ${configuration_system_wl_delete_a_cve_id_icon}    //app-security//form/section//ul/li[1]/a[2]/clr-icon
 ${configuration_sys_repo_readonly_chb_id}  //*[@id='repo_read_only_lbl']
 ${cve_allowlist_expires_btn}  //clr-date-container[.//div[@class='clr-input-group' and not(@hidden)]]//button
-${cve_allowlist_expires_yesterday}  //td[.//button[@class='day-btn is-today']]/preceding::td[1]
-${cve_allowlist_expires_tomorrow}  //td[.//button[@class='day-btn is-today']]/following::td[1]
+${datepicker_cur_month_btn}  //button[@class='calendar-btn switcher' and .//cds-icon[@shape='event']]
+${datepicker_prev_month_btn}  //button[@class='calendar-btn switcher' and .//cds-icon[@shape='angle' and @direction='left']]
+${datepicker_next_month_btn}  //button[@class='calendar-btn switcher' and .//cds-icon[@shape='angle' and @direction='right']]
+${datepicker_mid_month_day_btn}  //button[contains(@class,'day-btn') and not(contains(@class,'is-excluded')) and normalize-space()='15']
 ${cfg_auth_automatic_onboarding_checkbox}  (//input[@id='oidcAutoOnboard'])[1]
 ${cfg_auth_user_name_claim_input}  //*[@id='oidcUserClaim']
 


### PR DESCRIPTION
# Comprehensive Summary of your change
The system_cve nightly test failed at every month boundary because Set CVE Allowlist Expires clicked the calendar cell adjacent to today, which is an empty cell when yesterday/tomorrow falls in the adjacent month. So no date was selected and the `save` button never enabled. The keyword now normalizes the picker to the current month and steps one month back (expired) or forward (not expired), and clicks day 15.


# Issue being fixed
Fixes #23659 

Please indicate you've done the following:
- [X] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [X] Accepted the DCO. Commits without the DCO will delay acceptance.
- [X]  Made sure tests are passing and test coverage is added if needed.
- [X] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
