### PR TITLE
(cherry-pick)ci: pin docker-practice/actions-setup-docker to a full commit SHA (#23554)

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -25,7 +25,7 @@ jobs:
           go-version: 1.23.2
         id: go
       - name: Setup Docker
-        uses: docker-practice/actions-setup-docker@master
+        uses: docker-practice/actions-setup-docker@509de4a162d8fd24b2721a9fb3721131a6a4776b # master
         with:
           docker_version: 20.10
           docker_channel: stable

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -72,7 +72,7 @@ jobs:
             echo "ONLINE_SIGSTORE_PATH=./assets/harbor-online-installer-${{ env.CUR_TAG }}.tgz.sigstore.json" >> $GITHUB_ENV
           fi
       - name: Setup Docker
-        uses: docker-practice/actions-setup-docker@master
+        uses: docker-practice/actions-setup-docker@509de4a162d8fd24b2721a9fb3721131a6a4776b # master
         with:
           docker_version: 20.10
           docker_channel: stable


### PR DESCRIPTION

build-package.yml and publish_release.yml reference this third-party action by the mutable @master tag in jobs that hold AWS keys, Docker Hub push credentials (and, in publish_release, OIDC signing via id-token: write). A moved tag would run unreviewed code with those release credentials. Pin to the current master commit SHA. Behaviour unchanged; per GitHub's pin-to-SHA guidance.

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [ ] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [ ] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
