### PR TITLE
fix(registry): Refactor registry update handling to improve URL validation

### DIFF
--- a/src/server/v2.0/handler/registry.go
+++ b/src/server/v2.0/handler/registry.go
@@ -133,10 +133,14 @@ func (r *registryAPI) UpdateRegistry(ctx context.Context, params operation.Updat
 	if err := r.RequireSystemAccess(ctx, rbac.ActionUpdate, rbac.ResourceRegistry); err != nil {
 		return r.SendError(ctx, err)
 	}
+	if params.ID == 0 {
+		return r.SendError(ctx, errors.New(nil).WithCode(errors.NotFoundCode).WithMessage("registry 0 not found"))
+	}
 	registry, err := r.ctl.Get(ctx, params.ID)
 	if err != nil {
 		return r.SendError(ctx, err)
 	}
+	storedURL := registry.URL
 	if params.Registry != nil {
 		if params.Registry.Name != nil {
 			registry.Name = *params.Registry.Name
@@ -168,6 +172,15 @@ func (r *registryAPI) UpdateRegistry(ctx context.Context, params operation.Updat
 		}
 		if params.Registry.AccessSecret != nil {
 			registry.Credential.AccessSecret = *params.Registry.AccessSecret
+		}
+		if registry.URL != storedURL && params.Registry.AccessSecret == nil {
+			normalizedURL, err := lib.ValidateHTTPURL(registry.URL)
+			if err != nil {
+				return r.SendError(ctx, err)
+			}
+			if normalizedURL != storedURL && registry.Credential != nil {
+				registry.Credential.AccessSecret = ""
+			}
 		}
 	}
 	if err := r.ctl.Update(ctx, registry); err != nil {

--- a/src/server/v2.0/handler/registry_test.go
+++ b/src/server/v2.0/handler/registry_test.go
@@ -41,6 +41,13 @@ func (suite *RegistryTestSuite) SetupSuite() {
 	suite.Suite.SetupSuite()
 }
 
+func (suite *RegistryTestSuite) SetupTest() {
+	suite.regCtl.ExpectedCalls = nil
+	suite.regCtl.Calls = nil
+	suite.Security.ExpectedCalls = nil
+	suite.Security.Calls = nil
+}
+
 func (suite *RegistryTestSuite) ptrStr(s string) *string { return &s }
 
 // TestPingRegistryByIDIgnoresOverrides guards against CVE-class credential
@@ -93,6 +100,72 @@ func (suite *RegistryTestSuite) TestPingRegistryInlineUsesSuppliedURL() {
 	suite.Equal(200, res.StatusCode)
 	suite.Require().NotNil(pinged)
 	suite.Equal("https://inline.example.com", pinged.URL)
+}
+
+// TestUpdateRegistryID0ReturnsNotFound guards against updating synthetic local registry ID 0,
+// asserting the NotFound response and that controller's Get and Update methods are not called.
+func (suite *RegistryTestSuite) TestUpdateRegistryID0ReturnsNotFound() {
+	suite.Security.On("IsAuthenticated").Return(true).Once()
+	suite.Security.On("Can", mock.Anything, mock.Anything, mock.Anything).Return(true).Once()
+
+	res, err := suite.PutJSON("/registries/0", &models.RegistryUpdate{
+		URL: suite.ptrStr("https://attacker.example.com"),
+	})
+	suite.NoError(err)
+	suite.Equal(404, res.StatusCode)
+
+	suite.regCtl.AssertNotCalled(suite.T(), "Get", testifymock.Anything, testifymock.Anything)
+	suite.regCtl.AssertNotCalled(suite.T(), "Update", testifymock.Anything, testifymock.Anything)
+}
+
+// TestUpdateRegistryClearsAccessSecretOnURLChange tests that updating an existing registry's
+// URL without providing a new AccessSecret clears the stored AccessSecret.
+func (suite *RegistryTestSuite) TestUpdateRegistryClearsAccessSecretOnURLChange() {
+	suite.Security.On("IsAuthenticated").Return(true).Once()
+	suite.Security.On("Can", mock.Anything, mock.Anything, mock.Anything).Return(true).Once()
+
+	saved := &model.Registry{
+		ID:         1,
+		Type:       "harbor",
+		URL:        "https://registry.example.com",
+		Credential: &model.Credential{Type: "basic", AccessKey: "admin", AccessSecret: "secret123"},
+	}
+	mock.OnAnything(suite.regCtl, "Get").Return(saved, nil).Once()
+
+	var updated *model.Registry
+	suite.regCtl.On("Update", mock.Anything, mock.Anything).Return(nil).Once().
+		Run(func(args testifymock.Arguments) { updated = args.Get(1).(*model.Registry) })
+
+	res, err := suite.PutJSON("/registries/1", &models.RegistryUpdate{
+		URL: suite.ptrStr("https://new.example.com"),
+	})
+	suite.NoError(err)
+	suite.Equal(200, res.StatusCode)
+	suite.Require().NotNil(updated)
+	suite.Equal("https://new.example.com", updated.URL)
+	suite.Empty(updated.Credential.AccessSecret)
+}
+
+// TestUpdateRegistryInvalidURLReturnsError tests that updating a registry with an invalid
+// URL returns BadRequest error and does not update the registry.
+func (suite *RegistryTestSuite) TestUpdateRegistryInvalidURLReturnsError() {
+	suite.Security.On("IsAuthenticated").Return(true).Once()
+	suite.Security.On("Can", mock.Anything, mock.Anything, mock.Anything).Return(true).Once()
+
+	saved := &model.Registry{
+		ID:         1,
+		Type:       "harbor",
+		URL:        "https://registry.example.com",
+		Credential: &model.Credential{Type: "basic", AccessKey: "admin", AccessSecret: "secret123"},
+	}
+	mock.OnAnything(suite.regCtl, "Get").Return(saved, nil).Once()
+
+	res, err := suite.PutJSON("/registries/1", &models.RegistryUpdate{
+		URL: suite.ptrStr("ftp://invalid.example.com"),
+	})
+	suite.NoError(err)
+	suite.Equal(400, res.StatusCode)
+	suite.regCtl.AssertNotCalled(suite.T(), "Update", testifymock.Anything, testifymock.Anything)
 }
 
 func TestRegistryTestSuite(t *testing.T) {


### PR DESCRIPTION
Fix #23680 

When PingRegistry or UpdateRegistry fetches a registry by ID (including ID 0 for the local Harbor registry), updating params.Registry.URL to a caller-specified URL.

Please indicate you've done the following:
- [ ] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [ ] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
