### PR TITLE
fix(repoproxy): prevent proxy-cache poisoning via robot-name prefix

### DIFF
--- a/src/server/middleware/repoproxy/proxy.go
+++ b/src/server/middleware/repoproxy/proxy.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/goharbor/harbor/src/common/security"
 	"github.com/goharbor/harbor/src/common/security/proxycachesecret"
+	robotSc "github.com/goharbor/harbor/src/common/security/robot"
 	"github.com/goharbor/harbor/src/controller/project"
 	"github.com/goharbor/harbor/src/controller/proxy"
 	"github.com/goharbor/harbor/src/controller/registry"
@@ -434,6 +435,20 @@ func isProxySession(ctx context.Context, projectName string) bool {
 	username := sc.GetUsername()
 	if username == proxycachesecret.ProxyCacheService {
 		return true
+	}
+	// Verify that security context is a robot security context.
+	rSc, ok := sc.(*robotSc.SecurityContext)
+	if !ok {
+		return false
+	}
+	r := rSc.User()
+	if r == nil {
+		return false
+	}
+	// Scanner robot accounts created by system must be invisible and have CreatorRef == 0.
+	// User-created robot accounts created via API have Visible == true and CreatorRef > 0.
+	if r.Visible || r.CreatorRef != 0 {
+		return false
 	}
 	// it should include the auto generate SBOM session, so that it could generate SBOM accessory in proxy cache project
 	robotPrefix := config.RobotPrefix(ctx)

--- a/src/server/middleware/repoproxy/proxy_test.go
+++ b/src/server/middleware/repoproxy/proxy_test.go
@@ -30,13 +30,13 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
-	"github.com/goharbor/harbor/src/common/models"
 	"github.com/goharbor/harbor/src/common/security"
-	"github.com/goharbor/harbor/src/common/security/local"
 	"github.com/goharbor/harbor/src/common/security/proxycachesecret"
+	robotSc "github.com/goharbor/harbor/src/common/security/robot"
 	securitySecret "github.com/goharbor/harbor/src/common/security/secret"
 	"github.com/goharbor/harbor/src/controller/project"
 	registryCtl "github.com/goharbor/harbor/src/controller/registry"
+	"github.com/goharbor/harbor/src/controller/robot"
 	"github.com/goharbor/harbor/src/lib"
 	libCache "github.com/goharbor/harbor/src/lib/cache"
 	_ "github.com/goharbor/harbor/src/lib/cache/memory"
@@ -44,6 +44,7 @@ import (
 	"github.com/goharbor/harbor/src/lib/q"
 	proModels "github.com/goharbor/harbor/src/pkg/project/models"
 	"github.com/goharbor/harbor/src/pkg/reg/model"
+	pkgRobot "github.com/goharbor/harbor/src/pkg/robot/model"
 	projecttesting "github.com/goharbor/harbor/src/testing/controller/project"
 	proxytesting "github.com/goharbor/harbor/src/testing/controller/proxy"
 	registrytesting "github.com/goharbor/harbor/src/testing/controller/registry"
@@ -58,16 +59,37 @@ func TestIsProxySession(t *testing.T) {
 	sc2 := proxycachesecret.NewSecurityContext("library/hello-world")
 	proxyCtx := security.NewContext(context.Background(), sc2)
 
-	user := &models.User{
-		Username: "robot$library+scanner-8ec3b47a-fd29-11ee-9681-0242c0a87009",
+	// Valid system scanner robot account (invisible, CreatorRef == 0)
+	sysScannerRobot := &robot.Robot{
+		Robot: pkgRobot.Robot{
+			Name:       "robot$library+scanner-8ec3b47a-fd29-11ee-9681-0242c0a87009",
+			Visible:    false,
+			CreatorRef: 0,
+		},
 	}
-	userSc := local.NewSecurityContext(user)
-	scannerCtx := security.NewContext(context.Background(), userSc)
+	sysScannerSc := robotSc.NewSecurityContext(sysScannerRobot)
+	scannerCtx := security.NewContext(context.Background(), sysScannerSc)
 
-	otherRobot := &models.User{
-		Username: "robot$library+test-8ec3b47a-fd29-11ee-9681-0242c0a87009",
+	// User-created robot account attempting proxy cache poisoning (Visible == true, CreatorRef > 0)
+	poisoningRobot := &robot.Robot{
+		Robot: pkgRobot.Robot{
+			Name:       "robot$library+scanner-attacker",
+			Visible:    true,
+			CreatorRef: 1,
+		},
 	}
-	userSc2 := local.NewSecurityContext(otherRobot)
+	poisoningSc := robotSc.NewSecurityContext(poisoningRobot)
+	poisoningCtx := security.NewContext(context.Background(), poisoningSc)
+
+	// Non scanner robot account
+	otherRobot := &robot.Robot{
+		Robot: pkgRobot.Robot{
+			Name:       "robot$library+test-8ec3b47a-fd29-11ee-9681-0242c0a87009",
+			Visible:    true,
+			CreatorRef: 1,
+		},
+	}
+	userSc2 := robotSc.NewSecurityContext(otherRobot)
 	nonScannerCtx := security.NewContext(context.Background(), userSc2)
 
 	cases := []struct {
@@ -86,9 +108,14 @@ func TestIsProxySession(t *testing.T) {
 			want: true,
 		},
 		{
-			name: `robot account`,
+			name: `system scanner robot account`,
 			in:   scannerCtx,
 			want: true,
+		},
+		{
+			name: `user-created robot prefixed with scanner (poisoning attempt)`,
+			in:   poisoningCtx,
+			want: false,
 		},
 		{
 			name: `non scanner robot`,


### PR DESCRIPTION
User-created robot accounts could bypass DisableBlobAndManifestUploadMiddleware on proxy cache projects by naming the robot account with the scanner prefix (e.g., scanner-*), allowing unauthorized pushes and proxy-cache poisoning.

Update isProxySession to verify that the security context is a valid robot.SecurityContext and that the underlying robot account was system-created (Visible == false and CreatorRef == 0), in addition to checking the username prefix.

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

Fix #23681 

Please indicate you've done the following:
- [ ] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [ ] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
