### PR TITLE
feat(ui): allow to scroll through the result set of matching groups/users, when assigning to project

### DIFF
--- a/src/portal/src/app/base/project/member/add-group/add-group.component.html
+++ b/src/portal/src/app/base/project/member/add-group/add-group.component.html
@@ -38,6 +38,7 @@
                             [hidden]="!checkOnGoing"></span>
                         <div
                             class="selectBox"
+                            (scroll)="onGroupListScroll($event)"
                             [style.display]="
                                 searchedGroups.length ? 'block' : 'none'
                             ">
@@ -48,6 +49,11 @@
                                 </li>
                                 }
                             </ul>
+                            <div
+                                class="loading-more"
+                                [hidden]="!loadingMoreGroups">
+                                <span class="spinner spinner-inline"></span>
+                            </div>
                         </div>
                     </div>
                     @if ( (groupName.invalid && (groupName.touched ||

--- a/src/portal/src/app/base/project/member/add-group/add-group.component.scss
+++ b/src/portal/src/app/base/project/member/add-group/add-group.component.scss
@@ -6,7 +6,8 @@
 .selectBox{
   position: absolute;
   width: 173px;
-  height: auto;
+  max-height: 200px;
+  overflow-y: auto;
   background-color: white;
   border: 1px solid rgb(0 0 0 / 15%);
   border-right-width: 2px;
@@ -14,6 +15,11 @@
   border-radius: 6px;
   box-shadow: 0 5px 10px rgb(0 0 0 / 20%);
   z-index: 100;
+}
+
+.loading-more{
+  text-align: center;
+  padding: 4px 0;
 }
 
 .selectBox ul li{

--- a/src/portal/src/app/base/project/member/add-group/add-group.component.ts
+++ b/src/portal/src/app/base/project/member/add-group/add-group.component.ts
@@ -11,7 +11,13 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-import { debounceTime, finalize, switchMap } from 'rxjs/operators';
+import {
+    catchError,
+    debounceTime,
+    finalize,
+    switchMap,
+    takeUntil,
+} from 'rxjs/operators';
 import {
     Component,
     EventEmitter,
@@ -67,10 +73,16 @@ export class AddGroupComponent implements OnInit, OnDestroy {
     groupSearcher: Subject<string> = new Subject<string>();
     groupCheckerSub: Subscription;
     groupSearcherSub: Subscription;
+    groupSearchPageSize: number = 10;
+    groupSearchPage: number = 1;
+    groupSearchTotalCount: number = 0;
+    groupSearchName: string = '';
+    loadingMoreGroups: boolean = false;
     btnStatus: ClrLoadingState = ClrLoadingState.DEFAULT;
     isGroupNameValid: boolean = true;
     groupTooltip: string = 'MEMBER.GROUP_NAME_REQUIRED';
     isNameChecked: boolean = false; // this is only for LDAP mode
+    destroy$: Subject<void> = new Subject<void>();
     constructor(
         private memberService: MemberService,
         private appConfigService: AppConfigService,
@@ -101,6 +113,10 @@ export class AddGroupComponent implements OnInit, OnDestroy {
                         } else {
                             return of([]);
                         }
+                    }),
+                    catchError((err, caught) => {
+                        this.messageHandlerService.handleError(err);
+                        return caught;
                     })
                 )
                 .subscribe(res => {
@@ -123,20 +139,36 @@ export class AddGroupComponent implements OnInit, OnDestroy {
                 .pipe(
                     debounceTime(500),
                     switchMap(name => {
+                        this.groupSearchName = name;
+                        this.groupSearchPage = 1;
+                        this.searchedGroups = [];
+                        this.groupSearchTotalCount = 0;
                         if (name) {
-                            return this.userGroupService.searchUserGroups({
-                                page: 1,
-                                pageSize: 10,
-                                groupname: name,
-                            });
+                            return this.userGroupService.searchUserGroupsResponse(
+                                {
+                                    page: this.groupSearchPage,
+                                    pageSize: this.groupSearchPageSize,
+                                    groupname: name,
+                                }
+                            );
                         } else {
-                            return of([]);
+                            return of(null);
                         }
+                    }),
+                    catchError((err, caught) => {
+                        this.messageHandlerService.handleError(err);
+                        return caught;
                     })
                 )
                 .subscribe(res => {
                     if (res) {
-                        this.searchedGroups = res;
+                        this.searchedGroups = res.body || [];
+                        this.groupSearchTotalCount = Number(
+                            res.headers.get('X-Total-Count')
+                        );
+                    } else {
+                        this.searchedGroups = [];
+                        this.groupSearchTotalCount = 0;
                     }
                     // for LDAP mode, if input group name is not found from search result, then show "Group name does not exists" error
                     if (
@@ -171,6 +203,8 @@ export class AddGroupComponent implements OnInit, OnDestroy {
             this.groupSearcherSub.unsubscribe();
             this.groupSearcherSub = null;
         }
+        this.destroy$.next();
+        this.destroy$.complete();
     }
 
     createGroupAsMember() {
@@ -228,6 +262,9 @@ export class AddGroupComponent implements OnInit, OnDestroy {
         this.isGroupNameValid = true;
         this.groupTooltip = 'MEMBER.GROUP_NAME_REQUIRED';
         this.searchedGroups = [];
+        this.groupSearchPage = 1;
+        this.groupSearchTotalCount = 0;
+        this.groupSearchName = '';
     }
     isValid(): boolean {
         if (this.appConfigService.isLdapMode()) {
@@ -257,6 +294,46 @@ export class AddGroupComponent implements OnInit, OnDestroy {
         this.searchedGroups = [];
     }
 
+    loadNextGroupPage(): void {
+        if (this.loadingMoreGroups) {
+            return;
+        }
+        if (this.searchedGroups.length >= this.groupSearchTotalCount) {
+            return;
+        }
+        this.loadingMoreGroups = true;
+        this.userGroupService
+            .searchUserGroupsResponse({
+                page: this.groupSearchPage + 1,
+                pageSize: this.groupSearchPageSize,
+                groupname: this.groupSearchName,
+            })
+            .pipe(
+                finalize(() => (this.loadingMoreGroups = false)),
+                catchError((err, caught) => {
+                    this.messageHandlerService.handleError(err);
+                    return caught;
+                }),
+                takeUntil(this.destroy$)
+            )
+            .subscribe(res => {
+                this.groupSearchPage++;
+                this.searchedGroups = this.searchedGroups.concat(
+                    res.body || []
+                );
+                this.groupSearchTotalCount = Number(
+                    res.headers.get('X-Total-Count')
+                );
+            });
+    }
+
+    onGroupListScroll(event: Event): void {
+        const target = event.target as HTMLElement;
+        if (target.scrollHeight - target.scrollTop - target.clientHeight < 10) {
+            this.loadNextGroupPage();
+        }
+    }
+
     input() {
         if (this.appConfigService.isLdapMode()) {
             this.isNameChecked = false;
@@ -265,6 +342,8 @@ export class AddGroupComponent implements OnInit, OnDestroy {
         this.groupSearcher.next(this.memberGroup.group_name);
         if (!this.memberGroup.group_name) {
             this.searchedGroups = [];
+            this.groupSearchPage = 1;
+            this.groupSearchTotalCount = 0;
             this.isGroupNameValid = false;
             this.groupTooltip = 'MEMBER.GROUP_NAME_REQUIRED';
         } else {

--- a/src/portal/src/app/base/project/member/add-member/add-member.component.html
+++ b/src/portal/src/app/base/project/member/add-member/add-member.component.html
@@ -37,6 +37,7 @@
                             [hidden]="!checkOnGoing"></span>
                         <div
                             class="selectBox"
+                            (scroll)="onUserListScroll($event)"
                             [style.display]="
                                 searchedUserLists.length ? 'block' : 'none'
                             ">
@@ -47,6 +48,11 @@
                                 </li>
                                 }
                             </ul>
+                            <div
+                                class="loading-more"
+                                [hidden]="!loadingMoreUsers">
+                                <span class="spinner spinner-inline"></span>
+                            </div>
                         </div>
                     </div>
                     @if ( (memberName.invalid && (memberName.touched ||

--- a/src/portal/src/app/base/project/member/add-member/add-member.component.scss
+++ b/src/portal/src/app/base/project/member/add-member/add-member.component.scss
@@ -6,7 +6,8 @@
 .selectBox{
     position: absolute;
     width: 173px;
-    height: auto;
+    max-height: 200px;
+    overflow-y: auto;
     background-color: white;
     border: 1px solid rgb(0 0 0 / 15%);
     border-right-width: 2px;
@@ -14,6 +15,11 @@
     border-radius: 6px;
     box-shadow: 0 5px 10px rgb(0 0 0 / 20%);
     z-index: 100;
+}
+
+.loading-more{
+    text-align: center;
+    padding: 4px 0;
 }
 
 .selectBox ul li{

--- a/src/portal/src/app/base/project/member/add-member/add-member.component.spec.ts
+++ b/src/portal/src/app/base/project/member/add-member/add-member.component.spec.ts
@@ -14,7 +14,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { AddMemberComponent } from './add-member.component';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
-import { UserService } from '../../../left-side-nav/user/user.service';
+import { UserService } from 'ng-swagger-gen/services/user.service';
 import { of } from 'rxjs';
 import { MessageHandlerService } from '../../../../shared/services/message-handler.service';
 import { ActivatedRoute } from '@angular/router';
@@ -32,6 +32,9 @@ describe('AddMemberComponent', () => {
     const mockUserService = {
         searchUsers: () => {
             return of([[], []]);
+        },
+        searchUsersResponse: () => {
+            return of({ body: [], headers: { get: () => '0' } });
         },
     };
 

--- a/src/portal/src/app/base/project/member/add-member/add-member.component.ts
+++ b/src/portal/src/app/base/project/member/add-member/add-member.component.ts
@@ -11,7 +11,13 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-import { debounceTime, finalize, switchMap } from 'rxjs/operators';
+import {
+    catchError,
+    debounceTime,
+    finalize,
+    switchMap,
+    takeUntil,
+} from 'rxjs/operators';
 import {
     Component,
     EventEmitter,
@@ -32,6 +38,7 @@ import { MemberService } from 'ng-swagger-gen/services/member.service';
 import { UserService } from 'ng-swagger-gen/services/user.service';
 import { UserResp } from '../../../../../../ng-swagger-gen/models/user-resp';
 import { UserEntity } from '../../../../../../ng-swagger-gen/models/user-entity';
+import { calculatePage } from 'src/app/shared/units/utils';
 
 @Component({
     selector: 'add-member',
@@ -58,8 +65,14 @@ export class AddMemberComponent implements OnInit, OnDestroy {
     searcherSub: Subscription;
     checkOnGoing: boolean = false;
     searchedUserLists: UserResp[] = [];
+    userSearchPageSize: number = 10;
+    userSearchPage: number = 1;
+    userSearchTotalCount: number = 0;
+    userSearchName: string = '';
+    loadingMoreUsers: boolean = false;
     btnStatus: ClrLoadingState = ClrLoadingState.DEFAULT;
     roleId: number = 1; // default value is 1(project admin)
+    destroy$: Subject<void> = new Subject<void>();
 
     constructor(
         private memberService: MemberService,
@@ -81,20 +94,34 @@ export class AddMemberComponent implements OnInit, OnDestroy {
                     .pipe(
                         debounceTime(500),
                         switchMap(name => {
+                            this.userSearchName = name;
+                            this.userSearchPage = 1;
+                            this.searchedUserLists = [];
+                            this.userSearchTotalCount = 0;
                             if (name) {
-                                return this.userService.searchUsers({
-                                    page: 1,
-                                    pageSize: 10,
+                                return this.userService.searchUsersResponse({
+                                    page: this.userSearchPage,
+                                    pageSize: this.userSearchPageSize,
                                     username: name,
                                 });
                             } else {
-                                return of([]);
+                                return of(null);
                             }
+                        }),
+                        catchError((err, caught) => {
+                            this.messageHandlerService.handleError(err);
+                            return caught;
                         })
                     )
                     .subscribe(res => {
                         if (res) {
-                            this.searchedUserLists = res;
+                            this.searchedUserLists = res.body || [];
+                            this.userSearchTotalCount = Number(
+                                res.headers.get('X-Total-Count')
+                            );
+                        } else {
+                            this.searchedUserLists = [];
+                            this.userSearchTotalCount = 0;
                         }
                     });
             }
@@ -121,6 +148,10 @@ export class AddMemberComponent implements OnInit, OnDestroy {
                             } else {
                                 return of([]);
                             }
+                        }),
+                        catchError((err, caught) => {
+                            this.messageHandlerService.handleError(err);
+                            return caught;
                         })
                     )
                     .subscribe(res => {
@@ -149,6 +180,8 @@ export class AddMemberComponent implements OnInit, OnDestroy {
             this.searcherSub.unsubscribe();
             this.searcherSub = null;
         }
+        this.destroy$.next();
+        this.destroy$.complete();
     }
 
     onSubmit(): void {
@@ -204,6 +237,49 @@ export class AddMemberComponent implements OnInit, OnDestroy {
         this.isMemberNameValid = true;
         this.memberTooltip = 'MEMBER.USERNAME_IS_REQUIRED';
         this.searchedUserLists = [];
+        this.userSearchPage = 1;
+        this.userSearchTotalCount = 0;
+        this.userSearchName = '';
+    }
+
+    loadNextUserPage(): void {
+        if (this.loadingMoreUsers) {
+            return;
+        }
+        if (this.searchedUserLists.length >= this.userSearchTotalCount) {
+            return;
+        }
+        this.loadingMoreUsers = true;
+        this.userService
+            .searchUsersResponse({
+                page: this.userSearchPage + 1,
+                pageSize: this.userSearchPageSize,
+                username: this.userSearchName,
+            })
+            .pipe(
+                finalize(() => (this.loadingMoreUsers = false)),
+                catchError((err, caught) => {
+                    this.messageHandlerService.handleError(err);
+                    return caught;
+                }),
+                takeUntil(this.destroy$)
+            )
+            .subscribe(res => {
+                this.userSearchPage++;
+                this.searchedUserLists = this.searchedUserLists.concat(
+                    res.body || []
+                );
+                this.userSearchTotalCount = Number(
+                    res.headers.get('X-Total-Count')
+                );
+            });
+    }
+
+    onUserListScroll(event: Event): void {
+        const target = event.target as HTMLElement;
+        if (target.scrollHeight - target.scrollTop - target.clientHeight < 10) {
+            this.loadNextUserPage();
+        }
     }
 
     handleValidation(): void {
@@ -211,6 +287,8 @@ export class AddMemberComponent implements OnInit, OnDestroy {
         this.searcher.next(this.member.username);
         if (!this.member.username) {
             this.searchedUserLists = [];
+            this.userSearchPage = 1;
+            this.userSearchTotalCount = 0;
             this.isMemberNameValid = false;
             this.memberTooltip = 'MEMBER.USERNAME_IS_REQUIRED';
         } else {


### PR DESCRIPTION
Thank you for contributing to Harbor!

# Comprehensive Summary of your change

## Problem

When assigning users/groups to a project, the "add member" / "add group" search dropdowns only ever fetched the first page (10 results) of matches. If a search term matched more than 10 users or groups, the remaining ones were unreachable in the UI.

## Fix

Added infinite-scroll pagination to both dropdowns (add-member and add-group components):

- Switched from `searchUsers` / `searchUserGroups` (body-only) to `searchUsersResponse` / `searchUserGroupsResponse`, which expose response headers so `X-Total-Count` can be read.
- Added pagination state (`page`, `pageSize`, `totalCount`, current search name) and a `loadNextPage()` method that fetches the next page and appends results, guarded against concurrent/duplicate loads and fetching past the total count.
- Wired a (scroll) handler on the dropdown container that triggers loading the next page when the user scrolls near the bottom.
- Updated the SCSS to give the dropdown a fixed `max-height` with `overflow-y: auto` (previously `height: auto`, so scrolling wasn't even possible), plus a small spinner shown while loading more results.
- Updated the add-member spec's mock service to include `searchUsersResponse`.

## Net effect

Users can now scroll through the full result set of matching groups/users instead of being capped at 10.

# Issue being fixed
Fixes: #23684

Please indicate you've done the following:
- [ ] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [ ] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
