### PR TITLE
fix: Add missing validation when creating a rb account

### DIFF
--- a/src/server/v2.0/handler/robot.go
+++ b/src/server/v2.0/handler/robot.go
@@ -338,8 +338,16 @@ func (rAPI *robotAPI) validate(d int64, level string, permissions []*models.Robo
 	}
 
 	for _, perm := range permissions {
+		if perm == nil {
+			return errors.New(nil).WithMessage("bad request empty permission").WithCode(errors.BadRequestCode)
+		}
 		if len(perm.Access) == 0 {
 			return errors.New(nil).WithMessage("bad request empty access").WithCode(errors.BadRequestCode)
+		}
+		for _, acc := range perm.Access {
+			if acc == nil {
+				return errors.New(nil).WithMessage("bad request empty access").WithCode(errors.BadRequestCode)
+			}
 		}
 	}
 

--- a/src/server/v2.0/handler/robot_test.go
+++ b/src/server/v2.0/handler/robot_test.go
@@ -143,6 +143,23 @@ func TestValidateName(t *testing.T) {
 	}
 }
 
+func TestValidateNilPermissionElement(t *testing.T) {
+	rAPI := &robotAPI{}
+	err := rAPI.validate(-1, robot.LEVELSYSTEM, []*models.RobotPermission{nil})
+	assert.Error(t, err)
+}
+
+func TestValidateNilAccessElement(t *testing.T) {
+	rAPI := &robotAPI{}
+	err := rAPI.validate(-1, robot.LEVELSYSTEM, []*models.RobotPermission{
+		{
+			Kind:   robot.LEVELSYSTEM,
+			Access: []*models.Access{nil},
+		},
+	})
+	assert.Error(t, err)
+}
+
 func TestContainsAccess(t *testing.T) {
 	system := rbac.PoliciesMap["System"]
 	systests := []struct {


### PR DESCRIPTION
# Comprehensive Summary of your change
Added missing validation to return a error if a nil item is encountered in the perm or access array of the robot account. Before this resulted in the API returning a 500 due to the error not beeing handelt. 

Please indicate you've done the following:
- [X] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [X] Accepted the DCO. Commits without the DCO will delay acceptance.
- [X] Made sure tests are passing and test coverage is added if needed.
- [X] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
