### PR TITLE
(cherry-pick): add explicit permissions block to workflows

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,4 +1,7 @@
 name: CI
+permissions:
+  contents: read
+
 env:
    POSTGRESQL_HOST: localhost
    POSTGRESQL_PORT: 5432

--- a/.github/workflows/auto_assign_prs.yml
+++ b/.github/workflows/auto_assign_prs.yml
@@ -7,6 +7,11 @@ on:
   pull_request_target:
     types: [opened, reopened, ready_for_review]
 
+permissions:
+  pull-requests: write
+  issues: write
+  contents: read
+
 jobs:
   # Automatically assigns reviewers and owner
   add-reviews:

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -9,6 +9,8 @@ on:
       - release-*
 jobs:
   BUILD_PACKAGE:
+    permissions:
+      contents: read
     env:
         BUILD_PACKAGE: true
     runs-on: ubuntu-latest

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -6,6 +6,10 @@ on:
   schedule:
     - cron: '0 16 * * 6'
 
+permissions:
+  security-events: write
+  contents: read
+
 jobs:
   CodeQL-Build:
 

--- a/.github/workflows/conformance_test.yml
+++ b/.github/workflows/conformance_test.yml
@@ -1,4 +1,7 @@
 name: CONFORMANCE_TEST
+permissions:
+  contents: read
+
 env:
   DOCKER_COMPOSE_VERSION: 1.23.0
 

--- a/.github/workflows/housekeeping-stale-issues-prs.yaml
+++ b/.github/workflows/housekeeping-stale-issues-prs.yaml
@@ -3,6 +3,10 @@ on:
   schedule:
     - cron: '0 9 * * *'
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   stale:
     runs-on: ubuntu-latest

--- a/.github/workflows/label_check.yaml
+++ b/.github/workflows/label_check.yaml
@@ -5,6 +5,9 @@ on:
   pull_request:
     types: [opened, labeled, unlabeled, synchronize]
 
+permissions:
+  pull-requests: read
+
 env:
   GOPROXY: https://proxy.golang.org/
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/nightly-trivy-scan.yml
+++ b/.github/workflows/nightly-trivy-scan.yml
@@ -17,6 +17,7 @@ jobs:
         images: [harbor-core, harbor-db, harbor-exporter, harbor-jobservice, harbor-log, harbor-portal, harbor-registryctl, prepare, registry-photon, nginx-photon, valkey-photon, trivy-adapter-photon]
     permissions:
       security-events: write  # for github/codeql-action/upload-sarif to upload SARIF results
+      contents: read
 
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pass-CI.yml
+++ b/.github/workflows/pass-CI.yml
@@ -1,4 +1,5 @@
 name: CI
+permissions: {}
 
 on:
   pull_request:

--- a/tests/apitests/python/test_replication_from_dockerhub.py
+++ b/tests/apitests/python/test_replication_from_dockerhub.py
@@ -91,7 +91,7 @@ class TestProjects(unittest.TestCase):
         self.replication.trigger_replication_executions(TestProjects.rule_id, **ADMIN_CLIENT)
 
         #7. Wait for completion of this replication job;
-        self.replication.wait_until_jobs_finish(TestProjects.rule_id,interval=30, **ADMIN_CLIENT)
+        self.replication.wait_until_jobs_finish(TestProjects.rule_id, retry=20, interval=30, **ADMIN_CLIENT)
 
         #8. Check image is replicated into target project successfully.
         artifact = self.artifact.get_reference_info(TestProjects.project_name, self.image, self.tag, **ADMIN_CLIENT)


### PR DESCRIPTION
Add explicit least-privilege permissions block to GitHub Actions workflow files to secure pull_request_target and other workflows.

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [ ] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [ ] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
