### PR TITLE
test: replace arbitrary sleep delays in execution tests

### DIFF
--- a/src/controller/replication/execution_test.go
+++ b/src/controller/replication/execution_test.go
@@ -35,6 +35,12 @@ import (
 	testingTask "github.com/goharbor/harbor/src/testing/pkg/task"
 )
 
+type dummyTestingT struct{}
+
+func (d *dummyTestingT) Logf(format string, args ...interface{})   {}
+func (d *dummyTestingT) Errorf(format string, args ...interface{}) {}
+func (d *dummyTestingT) FailNow()                                  {}
+
 type replicationTestSuite struct {
 	suite.Suite
 	ctl        *controller
@@ -81,7 +87,10 @@ func (r *replicationTestSuite) TestStart() {
 	id, err = r.ctl.Start(context.Background(), &repctlmodel.Policy{Enabled: true}, nil, task.ExecutionTriggerManual)
 	r.Require().Nil(err)
 	r.Equal(int64(1), id)
-	time.Sleep(1 * time.Second) // wait the functions called in the goroutine
+	r.Eventually(func() bool {
+		dt := &dummyTestingT{}
+		return r.execMgr.AssertExpectations(dt) && r.flowCtl.AssertExpectations(dt) && r.ormCreator.AssertExpectations(dt)
+	}, 2*time.Second, 10*time.Millisecond)
 	r.execMgr.AssertExpectations(r.T())
 	r.flowCtl.AssertExpectations(r.T())
 	r.ormCreator.AssertExpectations(r.T())
@@ -97,7 +106,10 @@ func (r *replicationTestSuite) TestStart() {
 	id, err = r.ctl.Start(context.Background(), &repctlmodel.Policy{Enabled: true}, nil, task.ExecutionTriggerManual)
 	r.Require().Nil(err)
 	r.Equal(int64(1), id)
-	time.Sleep(1 * time.Second) // wait the functions called in the goroutine
+	r.Eventually(func() bool {
+		dt := &dummyTestingT{}
+		return r.execMgr.AssertExpectations(dt) && r.flowCtl.AssertExpectations(dt) && r.ormCreator.AssertExpectations(dt)
+	}, 2*time.Second, 10*time.Millisecond)
 	r.execMgr.AssertExpectations(r.T())
 	r.flowCtl.AssertExpectations(r.T())
 	r.ormCreator.AssertExpectations(r.T())
@@ -111,7 +123,10 @@ func (r *replicationTestSuite) TestStart() {
 	id, err = r.ctl.Start(context.Background(), &repctlmodel.Policy{Enabled: true, SingleActiveReplication: true}, nil, task.ExecutionTriggerManual)
 	r.Require().Nil(err)
 	r.Equal(int64(1), id)
-	time.Sleep(1 * time.Second) // wait the functions called in the goroutine
+	r.Eventually(func() bool {
+		dt := &dummyTestingT{}
+		return r.execMgr.AssertNumberOfCalls(dt, "MarkError", 1) && r.execMgr.AssertExpectations(dt)
+	}, 2*time.Second, 10*time.Millisecond)
 	r.flowCtl.AssertNumberOfCalls(r.T(), "Start", 0)
 	r.execMgr.AssertNumberOfCalls(r.T(), "MarkError", 1) // Ensure execution marked as final status error
 	r.execMgr.AssertExpectations(r.T())
@@ -129,7 +144,10 @@ func (r *replicationTestSuite) TestStart() {
 	id, err = r.ctl.Start(context.Background(), &repctlmodel.Policy{Enabled: true, SingleActiveReplication: true}, nil, task.ExecutionTriggerManual)
 	r.Require().Nil(err)
 	r.Equal(int64(1), id)
-	time.Sleep(1 * time.Second) // wait the functions called in the goroutine
+	r.Eventually(func() bool {
+		dt := &dummyTestingT{}
+		return r.execMgr.AssertExpectations(dt) && r.flowCtl.AssertExpectations(dt) && r.ormCreator.AssertExpectations(dt)
+	}, 2*time.Second, 10*time.Millisecond)
 	r.execMgr.AssertExpectations(r.T())
 	r.flowCtl.AssertExpectations(r.T())
 	r.ormCreator.AssertExpectations(r.T())

--- a/src/pkg/task/execution_test.go
+++ b/src/pkg/task/execution_test.go
@@ -30,6 +30,12 @@ import (
 	"github.com/goharbor/harbor/src/testing/lib/orm"
 )
 
+type dummyTestingT struct{}
+
+func (d *dummyTestingT) Logf(format string, args ...interface{})   {}
+func (d *dummyTestingT) Errorf(format string, args ...interface{}) {}
+func (d *dummyTestingT) FailNow()                                  {}
+
 type executionManagerTestSuite struct {
 	suite.Suite
 	execMgr    *executionManager
@@ -65,8 +71,10 @@ func (e *executionManagerTestSuite) TestCreate() {
 		map[string]any{"k": "v"})
 	e.Require().Nil(err)
 	e.Equal(int64(1), id)
-	// sleep to make sure the function in the goroutine run
-	time.Sleep(1 * time.Second)
+	e.Eventually(func() bool {
+		dt := &dummyTestingT{}
+		return e.execDAO.AssertExpectations(dt)
+	}, 2*time.Second, 10*time.Millisecond)
 	e.execDAO.AssertExpectations(e.T())
 }
 


### PR DESCRIPTION
## What does this PR do?

Reduces arbitrary test delays by replacing hardcoded `time.Sleep()` calls with deterministic mock polling.

Specifically:
1. `src/controller/replication/execution_test.go`: Replaced four 1-second sleeps with `suite.Eventually` blocks checking `AssertExpectations` on the relevant mocks.
2. `src/pkg/task/execution_test.go`: Replaced a 1-second sleep with a similar `suite.Eventually` block.

A `dummyTestingT` struct is used to safely check expectations inside the polling loop without triggering test failures prematurely.

## Why is this necessary?

Hardcoded `time.Sleep()` delays in tests are inherently flaky and slow down CI pipelines. Polling for the expected condition allows the test to complete exactly when the background work finishes.