### PR TITLE
ci: add zizmor security audit gated on High severity, and fix the High findings

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -53,17 +53,17 @@ jobs:
       - cncf-ubuntu-16-64-x86
     timeout-minutes: 100
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
          path: src/github.com/goharbor/harbor
       - name: Set up Go 1.26
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
            go-version: 1.26.4
            cache-dependency-path: src/github.com/goharbor/harbor/src/go.sum
         id: go
       - name: Cache CI Go tools
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/go/bin
           key: ci-gotools-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('src/github.com/goharbor/harbor/tests/ci/ut_install.sh') }}
@@ -107,7 +107,7 @@ jobs:
           bash ./tests/showtime.sh ./tests/ci/ut_run.sh $IP
           df -h
       - name: Codecov For BackEnd
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: ./src/github.com/goharbor/harbor/profile.cov
           flags: unittests
@@ -121,11 +121,11 @@ jobs:
       - cncf-ubuntu-16-64-x86
     timeout-minutes: 100
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           path: src/github.com/goharbor/harbor
       - name: Set up Go 1.23
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: 1.23.2
           cache-dependency-path: src/github.com/goharbor/harbor/src/go.sum
@@ -169,7 +169,7 @@ jobs:
           bash ./tests/showtime.sh ./tests/ci/api_run.sh DB $IP
           df -h
       - name: upload_logs
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         if: always()
         with:
           name: db-api-harbor-logs.tar.gz
@@ -184,11 +184,11 @@ jobs:
       - cncf-ubuntu-16-64-x86
     timeout-minutes: 100
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           path: src/github.com/goharbor/harbor
       - name: Set up Go 1.23
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: 1.23.2
           cache-dependency-path: src/github.com/goharbor/harbor/src/go.sum
@@ -233,7 +233,7 @@ jobs:
           df -h
       - name: upload_logs
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: proxy-api-harbor-logs.tar.gz
           path: /home/ubuntu/_work/harbor/harbor/src/github.com/goharbor/harbor/integration_logs.tar.gz
@@ -246,11 +246,11 @@ jobs:
       - cncf-ubuntu-16-64-x86
     timeout-minutes: 100
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           path: src/github.com/goharbor/harbor
       - name: Set up Go 1.23
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: 1.23.2
           cache-dependency-path: src/github.com/goharbor/harbor/src/go.sum
@@ -293,7 +293,7 @@ jobs:
           df -h
       - name: upload_logs
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: ldap-api-harbor-logs.tar.gz
           path: /home/ubuntu/_work/harbor/harbor/src/github.com/goharbor/harbor/integration_logs.tar.gz
@@ -306,11 +306,11 @@ jobs:
       - cncf-ubuntu-16-64-x86
     timeout-minutes: 100
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           path: src/github.com/goharbor/harbor
       - name: Set up Go 1.23
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: 1.23.2
           cache-dependency-path: src/github.com/goharbor/harbor/src/go.sum
@@ -359,10 +359,10 @@ jobs:
       - cncf-ubuntu-16-64-x86
     timeout-minutes: 100
     steps:
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: '22'
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           path: src/github.com/goharbor/harbor
       - name: script
@@ -373,7 +373,7 @@ jobs:
           bash ./tests/showtime.sh ./tests/ci/ui_ut_run.sh
           df -h
       - name: Codecov For UI
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: ./src/github.com/goharbor/harbor/src/portal/coverage/lcov.info
           flags: unittests

--- a/.github/workflows/api-schema-check.yml
+++ b/.github/workflows/api-schema-check.yml
@@ -13,9 +13,9 @@ jobs:
   check:
     runs-on: cncf-ubuntu-16-64-x86
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
-      - uses: delimit-ai/delimit-action@v1
+      - uses: delimit-ai/delimit-action@00900a3b45d9278400854f38ec0262bc07a62373 # v1.11.6
         with:
           spec: api/v2.0/swagger.yaml

--- a/.github/workflows/auto_assign_prs.yml
+++ b/.github/workflows/auto_assign_prs.yml
@@ -18,6 +18,6 @@ jobs:
     runs-on: cncf-ubuntu-16-64-x86
     steps:
       - name: Set the author of a PR as the assignee
-        uses: kentaro-m/auto-assign-action@v2.0.2
+        uses: kentaro-m/auto-assign-action@0a2c53d3721e4c5cfcce6afd4014aecc337979f6 # v2.0.2
         with:
           configuration-path: ".github/auto-assignees.yml"

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -23,8 +23,8 @@ jobs:
     outputs:
       build_base: ${{ steps.decide.outputs.build_base || 'false' }}
     steps:
-      - uses: actions/checkout@v7
-      - uses: jitterbit/get-changed-files@v1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: jitterbit/get-changed-files@b17fbb00bdc0c0f63fcf166580804b4d2cdc2a42 # v1
         id: changed-files
         continue-on-error: true
         with:
@@ -42,7 +42,7 @@ jobs:
         run: echo "build_base=true" >> "$GITHUB_OUTPUT"
       - name: Set up QEMU
         if: steps.decide.outputs.build_base == 'true'
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
         with:
           # Pin to a known-good binfmt image. The default "tonistiigi/binfmt:latest"
           # has shipped broken releases that fail arm64 emulation with
@@ -51,7 +51,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
       - name: Set up Docker Buildx
         if: steps.decide.outputs.build_base == 'true'
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
       - name: Build and push goharbor/photon:5.0 multi-arch manifest
         if: steps.decide.outputs.build_base == 'true'
         run: |
@@ -76,20 +76,21 @@ jobs:
     runs-on: ${{ matrix.arch == 'arm64' && 'cncf-ubuntu-16-64-arm' || 'cncf-ubuntu-16-64-x86' }}
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6.2.3
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
-      - uses: actions/checkout@v7
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           path: src/github.com/goharbor/harbor
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: 1.26.4
           cache-dependency-path: src/go.sum
+          cache: false
         id: go
       - name: Build Package
         run: |
@@ -190,7 +191,7 @@ jobs:
             : > "$GITHUB_WORKSPACE/_base_repos_${ARCH}.txt"
           fi
       - name: Upload repo list
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: repos-${{ matrix.arch }}
           path: |
@@ -203,13 +204,13 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/download-artifact@v8
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: repos-*
           merge-multiple: true
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
       - name: Determine image tag
         id: tag
         run: |

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         # We must fetch at least the immediate parents so that if this is
         # a pull request then we can checkout the head.
@@ -30,7 +30,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
       # Override language selection by uncommenting this and choosing your languages
       # with:
       #   languages: go, javascript, csharp, python, cpp, java
@@ -55,4 +55,4 @@ jobs:
     # https://github.com/github/codeql/issues/15647#issuecomment-2003768106
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6

--- a/.github/workflows/conformance_test.yml
+++ b/.github/workflows/conformance_test.yml
@@ -21,16 +21,16 @@ jobs:
       - cncf-ubuntu-16-64-x86
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6.2.3
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           path: src/github.com/goharbor/harbor
       - name: Set up Go 1.21
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: 1.23.2
           cache-dependency-path: src/github.com/goharbor/harbor/src/go.sum

--- a/.github/workflows/housekeeping-stale-issues-prs.yaml
+++ b/.github/workflows/housekeeping-stale-issues-prs.yaml
@@ -11,7 +11,7 @@ jobs:
   stale:
     runs-on: cncf-ubuntu-16-64-x86
     steps:
-      - uses: actions/stale@v10.0.0
+      - uses: actions/stale@3a9db7e6a41a89f618792c92c0e97cc736e1b13f # v10.0.0
         with:
           stale-issue-message: 'This issue is being marked stale due to a period of inactivity. If this issue is still relevant, please comment or remove the stale label. Otherwise, this issue will close in 30 days.'
           stale-pr-message: 'This PR is being marked stale due to a period of inactivty. If this PR is still relevant, please comment or remove the stale label. Otherwise, this PR will close in 30 days.'

--- a/.github/workflows/label_check.yaml
+++ b/.github/workflows/label_check.yaml
@@ -20,7 +20,7 @@ jobs:
     name: Check release-note label set
     runs-on: cncf-ubuntu-16-64-x86
     steps:
-      - uses: mheap/github-action-required-labels@v5
+      - uses: mheap/github-action-required-labels@23e10fde7e062233401931a0eece796cd9bf3177 # v5.6.0
         with:
           mode: minimum
           count: 1

--- a/.github/workflows/nightly-trivy-scan.yml
+++ b/.github/workflows/nightly-trivy-scan.yml
@@ -22,10 +22,10 @@ jobs:
     runs-on: cncf-ubuntu-16-64-x86
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Run Trivy vulnerability scanner
         # tag 0.35.0, get the commit hash from https://github.com/aquasecurity/trivy-action.git
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: 'docker.io/goharbor/${{ matrix.images }}:${{ matrix.tags }}'
           severity: 'CRITICAL,HIGH'
@@ -38,6 +38,6 @@ jobs:
           # Ref: https://github.com/aquasecurity/trivy-action/issues/389
           TRIVY_DB_REPOSITORY: 'public.ecr.aws/aquasecurity/trivy-db:2'
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -13,18 +13,18 @@ jobs:
       id-token: write   # Required for Cosign keyless signing
       packages: write   # Required for pushing images to ghcr.io
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Setup env
         run: |
-          echo "CUR_TAG=${{ github.ref_name }}" >> $GITHUB_ENV
+          echo "CUR_TAG=${GITHUB_REF_NAME}" >> $GITHUB_ENV
           echo "BASE_TAG=$(cat ./VERSION)" >> $GITHUB_ENV
-          release=$(curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/goharbor/harbor/releases/tags/${{ github.ref_name }})
+          release=$(curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/goharbor/harbor/releases/tags/${GITHUB_REF_NAME})
           echo "BUILD_NO=$(echo $release | jq -r '.body' | jq -r '.buildNo')" >> $GITHUB_ENV
           echo "PRE_TAG=$(echo $release | jq -r '.body' | jq -r '.preTag')" >> $GITHUB_ENV
           echo "BRANCH=$(echo $release | jq -r '.target_commitish')" >> $GITHUB_ENV
           echo "PRERELEASE=$(echo $release | jq -r '.prerelease')" >> $GITHUB_ENV
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6.2.3
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -63,7 +63,7 @@ jobs:
           echo "ASSETS_DIR=$assets_path" >> $GITHUB_ENV
           echo "MD5SUM_PATH=$assets_path/md5sum" >> $GITHUB_ENV
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v4.1.2
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
       - name: Sign Release Artifacts
         run: |
           cur=${{ env.CUR_TAG }}
@@ -84,7 +84,7 @@ jobs:
           docker_version: 20.10
           docker_channel: stable
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
       - name: Publish Images (amd64 + arm64)
         run: |
           set -euo pipefail
@@ -100,7 +100,7 @@ jobs:
             echo "$images" | tr ' ' '\n' >> "$GITHUB_WORKSPACE/_images_all.txt"
             source tools/release/release_utils.sh
             publishImages "$cur" "$base" "${{ secrets.DOCKER_HUB_USERNAME }}" "${{ secrets.DOCKER_HUB_PASSWORD }}" $images
-            publishPackages "$cur" "$base" "${{ github.actor }}" "${{ secrets.GITHUB_TOKEN }}" $images
+            publishPackages "$cur" "$base" "${GITHUB_ACTOR}" "${{ secrets.GITHUB_TOKEN }}" $images
             rm -rf harbor
           done
       - name: Create multi-arch manifests
@@ -108,7 +108,7 @@ jobs:
           set -euo pipefail
           cur=${{ env.CUR_TAG }}
           printf '%s\n' "${{ secrets.DOCKER_HUB_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_HUB_USERNAME }}" --password-stdin
-          printf '%s\n' "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+          printf '%s\n' "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${GITHUB_ACTOR}" --password-stdin
           sort -u "$GITHUB_WORKSPACE/_images_all.txt" | while IFS= read -r repo; do
             [ -z "$repo" ] && continue
             docker buildx imagetools create -t "${repo}:${cur}" \
@@ -126,7 +126,7 @@ jobs:
           source tools/release/release_utils.sh && generateReleaseNotes ${{ env.CUR_TAG }} ${{ env.PRE_TAG }} ${{ secrets.GITHUB_TOKEN }} $release_notes_path
           echo "RELEASE_NOTES_PATH=$release_notes_path" >> $GITHUB_ENV
       - name: RC Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         if: ${{ env.PRERELEASE == 'true' }}
         with:
           body_path: ${{ env.RELEASE_NOTES_PATH }}
@@ -137,7 +137,7 @@ jobs:
             ${{ env.ASSETS_DIR }}/harbor-offline-installer-*-arm64.tgz.sigstore.json
             ${{ env.MD5SUM_PATH }}
       - name: GA Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         if: ${{ env.PRERELEASE == 'false' }}
         with:
           body_path: ${{ env.RELEASE_NOTES_PATH }}

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,41 @@
+name: GitHub Actions Security Audit
+
+on:
+  push:
+    branches:
+      - main
+      - release-*
+    paths:
+      - '.github/workflows/**'
+      - '.github/actions/**'
+      - '.github/zizmor.yml'
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - '.github/actions/**'
+      - '.github/zizmor.yml'
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  zizmor:
+    name: zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2
+        with:
+          # Gate on High only. Low/informational findings still show as
+          # annotations but do not fail the check.
+          min-severity: high
+          advanced-security: false
+          annotations: true

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,13 @@
+# zizmor configuration — https://docs.zizmor.sh/configuration/
+#
+# CI gates on High severity only (see .github/workflows/zizmor.yml).
+# Everything listed here is a High finding that is either accepted or
+# tracked separately; nothing below silences a fixable issue.
+
+rules:
+  dangerous-triggers:
+    ignore:
+      # auto_assign_prs.yml needs pull_request_target to get a write token for
+      # PRs from forks. It never checks out or executes PR head content, so the
+      # usual pull_request_target escalation path does not apply.
+      - auto_assign_prs.yml


### PR DESCRIPTION
Follow-up to #23676 / #23694, which added explicit `permissions:` blocks. That
closed out zizmor's `excessive-permissions` class; this closes out the rest of
the High-severity ones and adds CI so they stay closed.

## What's added

**`.github/workflows/zizmor.yml`** — runs [zizmor](https://zizmor.sh) over
`.github/` on pushes and PRs that touch workflow files. It gates on **High
severity only**. Low and informational findings still surface as PR annotations
but do not block, so the check is actionable rather than noisy.

**`.github/zizmor.yml`** — records the single accepted High finding with its
justification, rather than hiding it with an inline suppression comment.

## What's fixed

**All 49 unpinned action references are now pinned to a commit SHA** with a
matching version comment. Every pin stays inside the major version already in
use, so no action behaviour changes here; Dependabot (already configured on
`main`) will propose major bumps separately.

**`publish_release.yml`** — four High-confidence template-injection sinks.
`${{ github.ref_name }}` and `${{ github.actor }}` expanded directly into `run:`
blocks are replaced with the equivalent runner environment variables
(`$GITHUB_REF_NAME`, `$GITHUB_ACTOR`). Same values, no expression expansion into
the shell.

**`build-package.yml`** — `cache-poisoning`. This workflow publishes release
artifacts, and `actions/setup-go` enables the module cache by default, so a
poisoned cache entry could reach published output. The cache is now disabled for
this workflow only; other workflows keep theirs.

## Accepted, not fixed

`auto_assign_prs.yml` uses `pull_request_target`, which zizmor flags as
`dangerous-triggers` (High). It needs that trigger to get a write token for PRs
from forks, and it never checks out or executes PR head content, so the usual
escalation path does not apply. This is recorded in `.github/zizmor.yml` with
that reasoning.

## Verification

```
$ zizmor --min-severity=high .github
No findings to report. Good job!
```

Remaining below the gate, not addressed here: 4 medium (`dependabot-cooldown`),
38 low (`template-injection` on non-attacker-controlled contexts, `artipacked`),
5 informational.
