### PR TITLE
fix(ci): remove contents read permission from label check workflow

### DIFF
--- a/.github/workflows/label_check.yaml
+++ b/.github/workflows/label_check.yaml
@@ -7,7 +7,6 @@ on:
 
 permissions:
   pull-requests: read
-  contents: read
 
 env:
   GOPROXY: https://proxy.golang.org/


### PR DESCRIPTION
Removed the explicit `contents: read` permission from `.github/workflows/label_check.yaml`.

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [ ] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [ ] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
