### PR TITLE
fix: copy only the requested tag, not the most recently pushed one on the same digest

### DIFF
--- a/src/controller/artifact/controller.go
+++ b/src/controller/artifact/controller.go
@@ -588,6 +588,14 @@ ensureArt:
 	for _, tag := range srcArt.Tags {
 		tags = append(tags, tag.Name)
 	}
+	// when the root copy reference is a tag name, only include that
+	// specific tag so the push event fires with the correct tag instead
+	// of the most recently pushed one on the same digest
+	if isRoot && !isAcc {
+		if _, err := digest.Parse(reference); err != nil {
+			tags = []string{reference}
+		}
+	}
 	// ensure the parent artifact exist in the database
 	artopt := &ArtOption{
 		Tags: tags,


### PR DESCRIPTION
## Description

Fixes #23706

When the copy artifact API is called with a specific tag reference (e.g. `:1.0.3`), if the source artifact's digest is also tagged with another tag that was pushed more recently (e.g. `:1.0.11`), the triggered replication job replicates the wrong tag (`1.0.11`) instead of the requested one (`1.0.3`).

### Root cause

In `copyDeeply`, `GetByReference` fetches the source artifact with all its tags sorted by `PushTime DESC`. The full tag list is passed to `Ensure`, which fires a single push event using `option.Tags[0]` — the most recently pushed tag, ignoring which tag was specified in the copy request.

### Fix

When the root copy reference is a tag name (not a digest), only include that specific tag in the list passed to `Ensure` so the push event fires with the correct tag.

### Testing

Existing test `TestCopy` passes with the fix (reference "latest" is a tag name, and the mocked tag list only contains "latest", so the behavior is unchanged).