### PR TITLE
Exclude replication from dockerhub in github action

### DIFF
--- a/tests/ci/api_run.sh
+++ b/tests/ci/api_run.sh
@@ -22,7 +22,7 @@ docker ps
 if [ "$1" = 'DB' ]; then
     docker run -i --privileged \
         -v $DIR/../../:/drone -v $DIR/../:/ca -w /drone $E2E_IMAGE \
-        robot --exclude proxy_cache_* \
+        robot --exclude proxy_cache_*  --exclude replic_dockerhub \
         -v DOCKER_USER:"${DOCKER_USER}" -v DOCKER_PWD:${DOCKER_PWD} -v ip:$2 -v ip1: \
         -v http_get_ca:false -v HARBOR_PASSWORD:${HARBOR_ADMIN_PASSWD} -v HARBOR_ADMIN:${HARBOR_ADMIN} \
         /drone/tests/robot-cases/Group1-Nightly/Setup.robot \


### PR DESCRIPTION
Previously dockerhub allow anonymous user to list the repository and the replication test in PR is using empty username password to create registry in Harbor, but recently it return 403 for this API. https://hub.docker.com/v2/repositories/library/?page_size=100 will return 403 error

Exclude replic_dockerhub in the github action, it is already covered in the nightly test.

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [ ] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [ ] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
