### PR TITLE
feat: serve cached images when upstream is unavailable

### DIFF
--- a/src/controller/proxy/controller.go
+++ b/src/controller/proxy/controller.go
@@ -42,10 +42,13 @@ const (
 	// wait more time than manifest (maxManifestWait) because manifest list depends on manifest ready
 	maxManifestListWait = 20
 	maxManifestWait     = 10
-	sleepIntervalSec    = 20
 	// keep manifest list in cache for one week
 	manifestListCacheInterval = 7 * 24 * 60 * 60 * time.Second
 )
+
+// sleepInterval is the delay between rounds while waiting for child manifests to
+// be cached locally. It is a var (not a const) so tests can shorten it.
+var sleepInterval = 20 * time.Second
 
 var (
 	// Ctl is a global proxy controller instance
@@ -182,7 +185,9 @@ func (c *controller) UseLocalManifest(ctx context.Context, art lib.ArtifactInfo,
 	remoteRepo := GetRemoteRepo(art)
 	exist, desc, err := remote.ManifestExist(remoteRepo, getReference(art)) // HEAD
 	if err != nil {
-		if errors.IsRateLimitError(err) && a != nil { // if rate limit, use local if it exists, otherwise return error
+		// when the upstream check fails (rate limited, unreachable, ...), use local if it exists, otherwise return the error
+		if a != nil {
+			log.Warningf("Failed to check the manifest in the remote registry, serving from local cache, repo: %v, ref: %v, error: %v", art.Repository, getReference(art), err)
 			return true, nil, nil
 		}
 		return false, nil, err

--- a/src/controller/proxy/controller_test.go
+++ b/src/controller/proxy/controller_test.go
@@ -152,6 +152,26 @@ func (p *proxyControllerTestSuite) TestUseLocalManifest_429ToLocal() {
 	p.Assert().True(result)
 }
 
+func (p *proxyControllerTestSuite) TestUseLocalManifestWithTag_UnreachableToLocal() {
+	ctx := context.Background()
+	art := lib.ArtifactInfo{Repository: "library/hello-world", Tag: "latest"}
+	p.remote.On("ManifestExist", mock.Anything, mock.Anything).Return(false, nil, errors.New("connection refused"))
+	p.local.On("GetManifest", mock.Anything, mock.Anything).Return(&artifact.Artifact{}, nil)
+	result, _, err := p.ctr.UseLocalManifest(ctx, art, p.remote, p.proj)
+	p.Assert().Nil(err)
+	p.Assert().True(result)
+}
+
+func (p *proxyControllerTestSuite) TestUseLocalManifestWithTag_UnreachableNoLocal() {
+	ctx := context.Background()
+	art := lib.ArtifactInfo{Repository: "library/hello-world", Tag: "latest"}
+	p.remote.On("ManifestExist", mock.Anything, mock.Anything).Return(false, nil, errors.New("connection refused"))
+	p.local.On("GetManifest", mock.Anything, mock.Anything).Return(nil, nil)
+	result, _, err := p.ctr.UseLocalManifest(ctx, art, p.remote, p.proj)
+	p.Assert().NotNil(err)
+	p.Assert().False(result)
+}
+
 func (p *proxyControllerTestSuite) TestUseLocalManifestWithTag_True() {
 	ctx := context.Background()
 	art := lib.ArtifactInfo{Repository: "library/hello-world", Tag: "latest"}

--- a/src/controller/proxy/manifestcache.go
+++ b/src/controller/proxy/manifestcache.go
@@ -126,25 +126,39 @@ func (m *ManifestListCache) updateManifestList(ctx context.Context, repo string,
 }
 
 func (m *ManifestListCache) push(ctx context.Context, repo, reference string, man distribution.Manifest) error {
-	// For manifest list, it might include some different manifest
-	// it will wait and check for 30 mins, if all depend manifests are ready then push it
-	// if time exceed, then push a updated manifest list which contains existing manifest
-	var newMan distribution.Manifest
-	var err error
+	// A manifest list references child manifests for several platforms, but a
+	// client usually pulls only one of them. We materialize the list locally as
+	// soon as any referenced child is present and re-push it whenever more
+	// arrive, keeping at most maxManifestListWait rounds to let the remaining
+	// children land.
+	pushedRefs := -1
 	for range maxManifestListWait {
-		log.Debugf("waiting for the manifest ready, repo %v, tag:%v", repo, reference)
-		time.Sleep(sleepIntervalSec * time.Second)
-		newMan, err = m.updateManifestList(ctx, repo, man)
+		newMan, err := m.updateManifestList(ctx, repo, man)
 		if err != nil {
 			return err
+		}
+		if refs := len(newMan.References()); refs > 0 && refs > pushedRefs {
+			if err := m.pushManifestList(ctx, repo, reference, newMan); err != nil {
+				return err
+			}
+			pushedRefs = refs
 		}
 		if len(newMan.References()) == len(man.References()) {
 			break
 		}
+		log.Debugf("waiting for more child manifests to be ready, repo %v, ref:%v", repo, reference)
+		time.Sleep(sleepInterval)
 	}
-	if len(newMan.References()) == 0 {
+	if pushedRefs <= 0 {
 		return libErrors.New("manifest list doesn't contain any pushed manifest")
 	}
+	return nil
+}
+
+// pushManifestList writes the (trimmed) manifest list to the local registry
+// under reference, updating the cached trimmed digest and the artifact pull
+// time. It is a no-op when the reference already resolves to the same digest.
+func (m *ManifestListCache) pushManifestList(ctx context.Context, repo, reference string, newMan distribution.Manifest) error {
 	_, pl, err := newMan.Payload()
 	if err != nil {
 		log.Errorf("failed to get payload, error %v", err)
@@ -166,8 +180,7 @@ func (m *ManifestListCache) push(ctx context.Context, repo, reference string, ma
 	if strings.HasPrefix(reference, "sha256:") {
 		reference = string(newDig)
 	}
-	err = m.local.PushManifest(repo, reference, newMan)
-	if err != nil {
+	if err := m.local.PushManifest(repo, reference, newMan); err != nil {
 		log.Errorf("failed to push manifest list, error: %v", err)
 		return err
 	}
@@ -190,7 +203,7 @@ type ManifestCache struct {
 func (m *ManifestCache) CacheContent(ctx context.Context, remoteRepo string, man distribution.Manifest, art lib.ArtifactInfo, r RemoteInterface, _ string) {
 	var waitBlobs []distribution.Descriptor
 	for n := range maxManifestWait {
-		time.Sleep(sleepIntervalSec * time.Second)
+		time.Sleep(sleepInterval)
 		waitBlobs = m.local.CheckDependencies(ctx, art.Repository, man)
 		if len(waitBlobs) == 0 {
 			break

--- a/src/controller/proxy/manifestcache_test.go
+++ b/src/controller/proxy/manifestcache_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/docker/distribution"
 	"github.com/docker/distribution/manifest"
@@ -55,18 +56,23 @@ const ociManifest = `{
 
 type CacheTestSuite struct {
 	suite.Suite
-	mCache     *ManifestCache
-	mListCache *ManifestListCache
-	local      localInterfaceMock
+	mCache        *ManifestCache
+	mListCache    *ManifestListCache
+	local         localInterfaceMock
+	origSleepIval time.Duration
 }
 
 func (suite *CacheTestSuite) SetupSuite() {
 	suite.local = localInterfaceMock{}
 	suite.mListCache = &ManifestListCache{local: &suite.local}
 	suite.mCache = &ManifestCache{local: &suite.local}
+	// Skip the inter-round delay so the wait loops don't stretch tests to minutes.
+	suite.origSleepIval = sleepInterval
+	sleepInterval = 0
 }
 
 func (suite *CacheTestSuite) TearDownSuite() {
+	sleepInterval = suite.origSleepIval
 }
 func (suite *CacheTestSuite) TestUpdateManifestList() {
 	ctx := context.Background()
@@ -174,6 +180,45 @@ func (suite *CacheTestSuite) TestPushManifestList() {
 
 	err = suite.mListCache.push(ctx, "library/hello-world", string(originDigest), manList)
 	suite.Require().Nil(err)
+}
+
+func (suite *CacheTestSuite) TestPushMaterializesTagWithPartialManifestList() {
+	// A single-platform pull of a multi-arch image: only one child manifest ever
+	// becomes present locally. push() must still materialize the tag (exactly
+	// once) rather than leaving it unresolvable until the full wait elapses, so
+	// the cached image stays pullable if the upstream later becomes unavailable.
+	ctx := context.Background()
+	amdDig := "sha256:1a9ec845ee94c202b2d5da74a24f0ed2058318bfa9879fa541efaecba272e86b"
+	armDig := "sha256:92c7f9c92844bbbb5d0a101b22f7c2a7949e40f8ea90c8b3bc396879d95e899a"
+	manList := &manifestlist.DeserializedManifestList{
+		ManifestList: manifestlist.ManifestList{
+			Versioned: manifest.Versioned{SchemaVersion: 2, MediaType: manifestlist.MediaTypeManifestList},
+			Manifests: []manifestlist.ManifestDescriptor{
+				{
+					Descriptor: distribution.Descriptor{Digest: digest.Digest(amdDig), Size: 3253, MediaType: schema2.MediaTypeManifest},
+					Platform:   manifestlist.PlatformSpec{Architecture: "amd64", OS: "linux"},
+				}, {
+					Descriptor: distribution.Descriptor{Digest: digest.Digest(armDig), Size: 3253, MediaType: schema2.MediaTypeManifest},
+					Platform:   manifestlist.PlatformSpec{Architecture: "arm64", OS: "linux"},
+				},
+			},
+		},
+	}
+	repo := "library/hello-world"
+
+	// A fresh mock so the shared suite mock's handlers don't interfere.
+	local := &localInterfaceMock{}
+	mListCache := &ManifestListCache{local: local}
+	// only the amd64 child is ever cached locally; arm64 never arrives
+	local.On("GetManifest", ctx, lib.ArtifactInfo{Repository: repo, Digest: amdDig}).Return(&artifact.Artifact{}, nil)
+	local.On("GetManifest", ctx, mock.Anything).Return(nil, nil)
+	local.On("PushManifest", repo, "3.9.0", mock.Anything).Return(nil)
+	local.On("UpdatePullTime", ctx, mock.Anything).Return(nil)
+
+	err := mListCache.push(ctx, repo, "3.9.0", manList)
+	suite.Require().NoError(err)
+	local.AssertCalled(suite.T(), "PushManifest", repo, "3.9.0", mock.Anything)
+	local.AssertNumberOfCalls(suite.T(), "PushManifest", 1)
 }
 
 func (suite *CacheTestSuite) TestManifestCache_CacheContent() {


### PR DESCRIPTION
  When a proxy-cache project's upstream registry can't be reached, pulls of
  already-cached images fail instead of being served from local cache.
  
  This PR addresses this issue:

-  UseLocalManifest serves the cached manifest on any failure of the upstream
    existence check (network, timeout, rate limit, auth), not just rate limits,
    so a cached image stays pullable regardless of why upstream is unreachable.
- ManifestListCache.push materializes the trimmed manifest list as soon as the 
  first child manifest is present locally, instead of after all platforms
    arrive or a multi-minute timeout, so the tag resolves in seconds and a
    recently cached multi-arch image is servable during an outage.

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).

### Tests

```sh
cd src && go test ./controller/proxy/...
```
are 🟢 

---

Co-Authored-By: Claude