### PR TITLE
fix: convert setup_timestamp, status_revision, and revision columns to bigint to avoid Y2K38 overflow (#23711)

### DIFF
--- a/make/migrations/postgresql/0181_2.15.3_schema.up.sql
+++ b/make/migrations/postgresql/0181_2.15.3_schema.up.sql
@@ -1,0 +1,6 @@
+/*
+Convert setup_timestamp in p2p_preheat_instance, status_revision in task, and revision in schedule to bigint to avoid y2k38 overflow, issue #23711.
+*/
+ALTER TABLE p2p_preheat_instance ALTER COLUMN setup_timestamp TYPE bigint;
+ALTER TABLE task ALTER COLUMN status_revision TYPE bigint;
+ALTER TABLE schedule ALTER COLUMN revision TYPE bigint;


### PR DESCRIPTION
fixes #23711

Alters the column types in p2p_preheat_instance, task, and schedule tables to bigint to prevent Y2K38 integer overflow issues.

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [ ] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [ ] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
