### PR TITLE
(cherry-pick) fix: convert setup_timestamp, status_revision, and revision columns to bigint to avoid Y2K38 overflow (#23711)

### DIFF
--- a/make/migrations/postgresql/0181_2.15.3_schema.up.sql
+++ b/make/migrations/postgresql/0181_2.15.3_schema.up.sql
@@ -1,0 +1,6 @@
+/*
+Convert setup_timestamp in p2p_preheat_instance, status_revision in task, and revision in schedule to bigint to avoid y2k38 overflow, issue #23711.
+*/
+ALTER TABLE p2p_preheat_instance ALTER COLUMN setup_timestamp TYPE bigint;
+ALTER TABLE task ALTER COLUMN status_revision TYPE bigint;
+ALTER TABLE schedule ALTER COLUMN revision TYPE bigint;


### PR DESCRIPTION
## Summary
- Alters the column types in `p2p_preheat_instance`, `task`, and `schedule` tables to `bigint` to prevent Y2K38 integer overflow issues.
- Cherry-picked from commit 77644e721a5934cb370408565e63f449a9a46cf8.


