### PR TITLE
test: add api and ui integration tests for proxy cache repository filter

### DIFF
--- a/tests/apitests/python/test_proxy_cache.py
+++ b/tests/apitests/python/test_proxy_cache.py
@@ -57,7 +57,7 @@ class TestProxyCache(unittest.TestCase):
             2. Delete user(UA).
         """
         subprocess.run(["docker", "image", "prune", "-a", "-f"], check=False)
-        subprocess.run(["ctr", "image", "prune", "--all"], check=False)
+        subprocess.run(["ctr", "images", "prune", "--all"], check=False)
 
         user_id, user_name = self.user.create_user(user_password = self.user_password, **ADMIN_CLIENT)
         USER_CLIENT=dict(endpoint = self.url, username = user_name, password = self.user_password)
@@ -156,18 +156,171 @@ class TestProxyCache(unittest.TestCase):
         print("Index's reference by ctr CLI:", ret_index_by_c.references)
         self.assertTrue(len(ret_index_by_c.references) == 1)
 
+    def do_validate_proxy_cache_filter(self, registry_type="harbor"):
+        """
+        Test case:
+            Proxy Cache Repository Filter
+        Test steps:
+            1. Create a registry endpoint;
+            2. Verify API pattern validation (400 Bad Request for
+               invalid regex when kind='regex');
+            3. Create a Proxy Cache Project with doublestar filter pattern;
+            4. Pull matching image -> Should succeed and be cached;
+            5. Pull non-matching image -> Should fail (filtered before proxy);
+            6. Update project metadata to regex filter pattern;
+            7. Pull image matching regex -> Should succeed;
+            8. Pull image not matching regex -> Should fail.
+        """
+        subprocess.run(["docker", "image", "prune", "-a", "-f"], check=False)
+        subprocess.run(["ctr", "images", "prune", "--all"], check=False)
+
+        user_id, user_name = self.user.create_user(
+            user_password=self.user_password, **ADMIN_CLIENT
+        )
+        USER_CLIENT = dict(
+            endpoint=self.url,
+            username=user_name,
+            password=self.user_password
+        )
+
+        if registry_type == "docker-hub":
+            user_namespace = DOCKER_USER
+            access_key = DOCKER_USER
+            access_secret = DOCKER_PWD
+            registry = "https://hub.docker.com"
+        else:
+            user_namespace = "nightly"
+            registry = "https://registry.goharbor.io"
+            access_key = ""
+            access_secret = ""
+
+        registry_payload = {
+            "url": registry,
+            "name": _random_name(registry_type + "_filter"),
+            "registry_type": registry_type,
+            "access_key": access_key,
+            "access_secret": access_secret,
+            "insecure": True,
+        }
+        registry_id, _ = self.registry.create_registry(
+            registry_payload["url"],
+            name=registry_payload["name"],
+            registry_type=registry_payload["registry_type"],
+            access_key=registry_payload["access_key"],
+            access_secret=registry_payload["access_secret"],
+            insecure=registry_payload["insecure"],
+            **ADMIN_CLIENT
+        )
+
+        # 1. Test pattern validation API error (400 Bad Request)
+        invalid_metadata = {
+            "public": "false",
+            "proxy_cache_filter_pattern": "nightly/(*",
+            "proxy_cache_filter_kind": "regex",
+        }
+        self.project.create_project(
+            registry_id=registry_id,
+            metadata=invalid_metadata,
+            expect_status_code=400,
+            **ADMIN_CLIENT
+        )
+
+        # 2. Create Proxy Cache Project with doublestar filter pattern
+        allowed_image = "for_proxy"
+        blocked_image = "redis"
+        doublestar_pattern = user_namespace + "/" + allowed_image
+        valid_metadata = {
+            "public": "false",
+            "proxy_cache_filter_pattern": doublestar_pattern,
+            "proxy_cache_filter_kind": "doublestar",
+        }
+        project_id, project_name = self.project.create_project(
+            registry_id=registry_id,
+            metadata=valid_metadata,
+            **ADMIN_CLIENT
+        )
+        self.project.add_project_members(
+            project_id, user_id=user_id, **ADMIN_CLIENT
+        )
+
+        # 3. Pull matching image -> Should succeed
+        pull_harbor_image(
+            harbor_server,
+            USER_CLIENT["username"],
+            USER_CLIENT["password"],
+            project_name + "/" + user_namespace + "/" + allowed_image,
+            "1.0"
+        )
+        self.artifact.waiting_for_reference_exist(
+            project_name,
+            urllib.parse.quote(user_namespace + "/" + allowed_image, 'utf-8'),
+            "1.0",
+            **USER_CLIENT
+        )
+
+        # 4. Pull non-matching image -> Should fail (404 / manifest unknown)
+        pull_harbor_image(
+            harbor_server,
+            USER_CLIENT["username"],
+            USER_CLIENT["password"],
+            project_name + "/" + user_namespace + "/" + blocked_image,
+            "latest",
+            expected_error_message="repository filter"
+        )
+
+        # 5. Update project metadata to regex filter pattern
+        regex_pattern = r"^" + user_namespace + r"/(for_proxy|redis)$"
+        updated_metadata = {
+            "proxy_cache_filter_pattern": regex_pattern,
+            "proxy_cache_filter_kind": "regex",
+        }
+        self.project.update_project(
+            project_id, metadata=updated_metadata, **ADMIN_CLIENT
+        )
+
+        # 6. Pull newly allowed image -> Should succeed now
+        pull_harbor_image(
+            harbor_server,
+            USER_CLIENT["username"],
+            USER_CLIENT["password"],
+            project_name + "/" + user_namespace + "/" + blocked_image,
+            "latest"
+        )
+        self.artifact.waiting_for_reference_exist(
+            project_name,
+            urllib.parse.quote(
+                user_namespace + "/" + blocked_image, 'utf-8'
+            ),
+            "latest",
+            **USER_CLIENT
+        )
+
+        # 7. Pull image not matching regex -> Should fail
+        pull_harbor_image(
+            harbor_server,
+            USER_CLIENT["username"],
+            USER_CLIENT["password"],
+            project_name + "/" + user_namespace + "/busybox",
+            "latest",
+            expected_error_message="repository filter"
+        )
+
     def test_proxy_cache(self):
         proxy_upstream_list = os.getenv("PROXY_UPSTREAM_LIST", "").lower()
         if not proxy_upstream_list or "harbor" in proxy_upstream_list:
             self.do_validate("harbor")
+            self.do_validate_proxy_cache_filter("harbor")
         if "docker-hub" in proxy_upstream_list:
             self.do_validate("docker-hub")
+            self.do_validate_proxy_cache_filter("docker-hub")
         if "jfrog" in proxy_upstream_list:
             self.do_validate("jfrog-artifactory")
 
+
 if __name__ == '__main__':
     suite = unittest.TestSuite(unittest.makeSuite(TestProxyCache))
-    result = unittest.TextTestRunner(sys.stdout, verbosity=2, failfast=True).run(suite)
+    result = unittest.TextTestRunner(
+        sys.stdout, verbosity=2, failfast=True
+    ).run(suite)
     if not result.wasSuccessful():
         raise Exception("Proxy cache test failed: {}".format(result))
-

--- a/tests/resources/Harbor-Pages/Project.robot
+++ b/tests/resources/Harbor-Pages/Project.robot
@@ -37,6 +37,33 @@ Create An New Project And Go Into Project
     Retry Double Keywords When Error  Retry Element Click  ${create_project_OK_button_xpath}  Retry Wait Until Page Not Contains Element  ${create_project_OK_button_xpath}
     Go Into Project  ${projectname}  has_image=${false}
 
+Create An New Project With Proxy Cache Filter
+    [Arguments]  ${projectname}  ${registry}  ${filter_pattern}  ${filter_kind}=doublestar
+    Navigate To Projects
+    FOR  ${n}  IN RANGE  1  8
+        ${out}  Run Keyword And Ignore Error  Retry Button Click  xpath=${create_project_button_xpath}
+        Log All  Return value is ${out[0]}
+        Exit For Loop If  '${out[0]}'=='PASS'
+    END
+    Log To Console  Project Name: ${projectname}
+    Retry Text Input  xpath=${project_name_xpath}  ${projectname}
+    Retry Element Click  ${project_proxy_cache_switcher_xpath}
+    Retry Element Click  ${project_registry_select_id}
+    Retry Element Click  xpath=//select[@id='registry']//option[contains(.,'${registry}')]
+    Retry Text Input  ${project_proxy_cache_filter_pattern_xpath}  ${filter_pattern}
+    Retry Element Click  ${project_proxy_cache_filter_kind_xpath}
+    Retry Element Click  xpath=//select[@id='repositoryFilterKind']//option[@value='${filter_kind}']
+    Retry Double Keywords When Error  Retry Element Click  ${create_project_OK_button_xpath}  Retry Wait Until Page Not Contains Element  ${create_project_OK_button_xpath}
+    Go Into Project  ${projectname}  has_image=${false}
+
+Update Project Proxy Cache Filter
+    [Arguments]  ${filter_pattern}  ${filter_kind}
+    Switch To Project Configuration
+    Retry Text Input  ${project_proxy_cache_filter_pattern_xpath}  ${filter_pattern}
+    Retry Element Click  ${project_proxy_cache_filter_kind_xpath}
+    Retry Element Click  xpath=//select[@id='repositoryFilterKind']//option[@value='${filter_kind}']
+    Retry Element Click  xpath=//button[contains(.,'SAVE')]
+
 Create An New Project With New User
     [Arguments]  ${url}  ${username}  ${email}  ${realname}  ${newPassword}  ${comment}  ${projectname}  ${public}
     Create An New User  url=${url}  username=${username}  email=${email}  realname=${realname}  newPassword=${newPassword}  comment=${comment}

--- a/tests/resources/Harbor-Pages/Project_Elements.robot
+++ b/tests/resources/Harbor-Pages/Project_Elements.robot
@@ -76,3 +76,6 @@ ${project_add_storage_quota_unit_id}    xpath=//*[@id='create_project_storage_li
 
 ${project_proxy_cache_switcher_xpath}  xpath=//form//clr-toggle-wrapper
 ${project_registry_select_id}  xpath=//*[@id='registry']
+${project_proxy_cache_filter_pattern_xpath}  xpath=//*[@id='repositoryFilter']
+${project_proxy_cache_filter_kind_xpath}  xpath=//*[@id='repositoryFilterKind']
+

--- a/tests/robot-cases/Group1-Nightly/Schedule.robot
+++ b/tests/robot-cases/Group1-Nightly/Schedule.robot
@@ -65,6 +65,27 @@ Test Case - Proxy Cache
     Cannot Push image  ${ip}  ${test_user}  ${test_pwd}  project${d}  busybox:latest  err_msg=can not push artifact to a proxy project
     Close Browser
 
+Test Case - Proxy Cache Filter
+    [Tags]  proxy_cache_filter
+    ${d}=  Get Current Date    result_format=%m%s
+    ${registry}=  Set Variable  https://registry.goharbor.io
+    ${user_namespace}=  Set Variable  nightly
+    ${allowed_image}=  Set Variable  for_proxy
+    ${allowed_tag}=  Set Variable  1.0
+    ${blocked_image}=  Set Variable  redis
+    ${blocked_tag}=  Set Variable  latest
+    Init Chrome Driver
+    Sign In Harbor  ${HARBOR_URL}  ${HARBOR_ADMIN}  ${HARBOR_PASSWORD}
+    Switch To Registries
+    Create A New Endpoint  harbor  e_filter${d}  ${registry}  ${null}  ${null}
+    Create An New Project With Proxy Cache Filter  proj_filter${d}  e_filter${d}  ${user_namespace}/${allowed_image}  doublestar
+    Pull Image  ${ip}  ${HARBOR_ADMIN}  ${HARBOR_PASSWORD}  proj_filter${d}  ${user_namespace}/${allowed_image}  tag=${allowed_tag}
+    Cannot Pull Image  ${ip}  ${HARBOR_ADMIN}  ${HARBOR_PASSWORD}  proj_filter${d}  ${user_namespace}/${blocked_image}  tag=${blocked_tag}
+    Go Into Project  proj_filter${d}
+    Update Project Proxy Cache Filter  ^${user_namespace}/(for_proxy|redis)$  regex
+    Pull Image  ${ip}  ${HARBOR_ADMIN}  ${HARBOR_PASSWORD}  proj_filter${d}  ${user_namespace}/${blocked_image}  tag=${blocked_tag}
+    Close Browser
+
 Test Case - GC Schedule Job
     [tags]  GC_schedule
     Init Chrome Driver


### PR DESCRIPTION
Thank you for contributing to Harbor!

# Comprehensive Summary of your change

Add both API and UI integration tests for proxy cache repository filter

# Issue being fixed
Fixes #(issue)

- Added `do_validate_proxy_cache_filter` in `test_proxy_cache.py` to verify API pattern validation, doublestar, and regex filtering.
- Added `Test Case - Proxy Cache Filter` in `Schedule.robot` to verify the end-to-end configuration and pull restrictions via portal.
- Ensured container image cache is properly pruned before pulling to prevent false-positive cache hits.

Testing:

- UI

Run the Robot Framework UI test suite:
```
robot -t 'Test Case - Proxy Cache Filter' \
-v 'DOCKER_USER:admin' \
-v 'DOCKER_PWD:<PASSWORD>' \
-v 'ip:<HARBOR_IP>' \
-v 'LOCAL_REGISTRY:<HARBOR_IP>' \
-v 'HARBOR_ADMIN:admin' \
-v 'HARBOR_PASSWORD:<PASSWORD>' \
-v 'network_type:private' \
-v 'http_get_ca:true' \
/drone/tests/robot-cases/Group1-Nightly/Setup.robot \
/drone/tests/robot-cases/Group1-Nightly/Schedule.robot
```
<img width="2136" height="1812" alt="image" src="https://github.com/user-attachments/assets/19939535-2f69-42ae-9d7f-9b4516aeff9c" />
<img width="3810" height="1046" alt="image" src="https://github.com/user-attachments/assets/9ba0f2be-e444-483b-b54d-40334a27e749" />


-API

Run the Python API test suite on a clean Harbor deployment:
```bash
SWAGGER_CLIENT_PATH=/drone/harborclient \
HARBOR_HOST=<HARBOR_IP> \
DOCKER_USER=admin \
DOCKER_PWD=<PASSWORD> \
PYTHONPATH=/drone/tests/apitests/python \
PROXY_UPSTREAM_LIST=harbor \
python ./tests/apitests/python/test_proxy_cache.py TestProxyCache.do_validate_proxy_cache_filter
```
```
...
send: b'GET /api/v2.0/projects/project-1786810006329/repositories/nightly%252Fredis/artifacts/latest HTTP/1.1\r\nHost: 10.158.92.38\r\nAccept-Encoding: identity\r\nAccept: application/json\r\nUser-Agent: OpenAPI-Generator/1.0.0/python\r\nAuthorization: Basic dXNlci0xNzg2ODEwMDA0NDg0OkFhMTIzNDU2\r\nContent-Type: application/json\r\n\r\n'
reply: 'HTTP/1.1 200 OK\r\n'
header: Server: nginx
header: Date: Sat, 15 Aug 2026 16:07:23 GMT
header: Content-Type: application/json
header: Content-Length: 1929
header: Connection: keep-alive
header: Set-Cookie: sid=41957607d7d2d787dd81c17ff8e5f077; Path=/; Secure; HttpOnly
header: X-Request-Id: cb80202e-5713-40ed-85b3-6eefb59a3795
header: Strict-Transport-Security: max-age=31536000; includeSubdomains; preload
header: X-Frame-Options: DENY
header: Content-Security-Policy: frame-ancestors 'none'
Returned artifact by get reference info: {'accessories': None,
 'addition_links': {'build_history': {'absolute': False,
                                      'href': '/api/v2.0/projects/project-1786810006329/repositories/nightly%252Fredis/artifacts/sha256:ff14c49d3880629b4b6f676a42c926e06135105ec4443678732a288f522b842d/additions/build_history'},
                    'sboms': {'absolute': False,
                              'href': '/api/v2.0/projects/project-1786810006329/repositories/nightly%252Fredis/artifacts//additions/sbom'},
                    'vulnerabilities': {'absolute': False,
                                        'href': '/api/v2.0/projects/project-1786810006329/repositories/nightly%252Fredis/artifacts/sha256:ff14c49d3880629b4b6f676a42c926e06135105ec4443678732a288f522b842d/additions/vulnerabilities'}},
 'annotations': None,
 'artifact_type': 'application/vnd.docker.container.image.v1+json',
 'digest': 'sha256:ff14c49d3880629b4b6f676a42c926e06135105ec4443678732a288f522b842d',
 'extra_attrs': {'architecture': 'amd64',
                 'author': '',
                 'config': {'Cmd': ['redis-server'],
                            'Entrypoint': ['docker-entrypoint.sh'],
                            'Env': ['PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
                                    'GOSU_VERSION=1.14',
                                    'REDIS_VERSION=7.0.7',
                                    'REDIS_DOWNLOAD_URL=http://download.redis.io/releases/redis-7.0.7.tar.gz',
                                    'REDIS_DOWNLOAD_SHA=8d327d7e887d1bb308fc37aaf717a0bf79f58129e3739069aaeeae88955ac586'],
                            'ExposedPorts': {'6379/tcp': {}},
                            'Volumes': {'/data': {}},
                            'WorkingDir': '/data'},
                 'created': '2022-12-21T12:41:48.980034921Z',
                 'os': 'linux'},
 'icon': 'sha256:0048162a053eef4d4ce3fe7518615bef084403614f8bca43b40ae2e762e11e06',
 'id': 85,
 'labels': None,
 'manifest_media_type': 'application/vnd.docker.distribution.manifest.v2+json',
 'media_type': 'application/vnd.docker.container.image.v1+json',
 'project_id': 36,
 'pull_time': datetime.datetime(2026, 8, 15, 16, 6, 35, 534000, tzinfo=tzlocal()),
 'push_time': datetime.datetime(2026, 8, 15, 16, 6, 35, 478000, tzinfo=tzlocal()),
 'references': None,
 'repository_id': 59,
 'repository_name': 'project-1786810006329/nightly/redis',
 'sbom_overview': None,
 'scan_overview': None,
 'size': 42393564,
 'tags': [{'artifact_id': 85,
           'id': 62,
           'immutable': False,
           'name': 'latest',
           'pull_time': datetime.datetime(2026, 8, 15, 16, 6, 44, 213000, tzinfo=tzlocal()),
           'push_time': datetime.datetime(2026, 8, 15, 16, 6, 44, 208000, tzinfo=tzlocal()),
           'repository_id': 59}],
 'type': 'IMAGE'}
Docker image login did not catch exception
Docker image pull catch exception: 500 Server Error for http+docker://localhost/v1.52/images/create?tag=latest&fromImage=10.158.92.38%2Fproject-1786810006329%2Fnightly%2Fbusybox: Internal Server Error ("unknown: resource not found: repository "nightly/busybox" does not match project repository filter")
Docker image pull got expected error message:repository filter
Case completed
ok

----------------------------------------------------------------------
Ran 1 test in 1256.147s

OK

---
exit_code: 0
elapsed_ms: 1275196
ended_at: 2026-08-15T16:09:11.993Z
---
```

Please indicate you've done the following:
- [ ] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [ ] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
