### PR TITLE
feat: Add SBOM generation steps and scripts

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -64,6 +64,9 @@ jobs:
           echo "MD5SUM_PATH=$assets_path/md5sum" >> $GITHUB_ENV
       - name: Install Cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+      - name: Install Syft
+        id: syft
+        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
       - name: Sign Release Artifacts
         run: |
           cur=${{ env.CUR_TAG }}
@@ -90,6 +93,7 @@ jobs:
           set -euo pipefail
           base=${{ env.BASE_TAG }}
           cur=${{ env.CUR_TAG }}
+          sboms_path="$GITHUB_WORKSPACE/sboms"
           : > "$GITHUB_WORKSPACE/_images_all.txt"
 
           for arch in amd64 arm64; do
@@ -99,8 +103,11 @@ jobs:
             images="$(docker images --format "{{.Repository}}" --filter=reference="goharbor/*:${base}" | xargs)"
             echo "$images" | tr ' ' '\n' >> "$GITHUB_WORKSPACE/_images_all.txt"
             source tools/release/release_utils.sh
+            generateImageSBOMs "$cur" "$base" "$sboms_path" "${{ steps.syft.outputs.cmd }}" $images
             publishImages "$cur" "$base" "${{ secrets.DOCKER_HUB_USERNAME }}" "${{ secrets.DOCKER_HUB_PASSWORD }}" $images
+            attestImageSBOMs "$cur" "" "${{ secrets.DOCKER_HUB_USERNAME }}" "${{ secrets.DOCKER_HUB_PASSWORD }}" "$sboms_path" $images
             publishPackages "$cur" "$base" "${{ github.actor }}" "${{ secrets.GITHUB_TOKEN }}" $images
+            attestImageSBOMs "$cur" "ghcr.io" "${{ github.actor }}" "${{ secrets.GITHUB_TOKEN }}" "$sboms_path" $images
             rm -rf harbor
           done
       - name: Create multi-arch manifests

--- a/tools/release/release_utils.sh
+++ b/tools/release/release_utils.sh
@@ -48,6 +48,60 @@ function generateReleaseNotes {
     echo -e $release > $releaseNotesPath
 }
 
+function generateImageSBOMs {
+    local curTag=$1
+    local baseTag=$2
+    local sbomsPath=$3
+    local syft=$4
+    local images=("${@:5}")
+    local arch=${ARCH:?ARCH must be set before generating image SBOMs}
+    local image
+    local imageRef
+    local sbom
+
+    mkdir -p "$sbomsPath"
+    for image in "${images[@]}"
+    do
+        imageRef="$image:${curTag}-${arch}"
+        sbom="$sbomsPath/${image##*/}-${arch}.spdx.json"
+        docker tag "$image:$baseTag" "$imageRef"
+        echo "generate SBOM: $imageRef"
+        "$syft" "$imageRef" --output "spdx-json=$sbom"
+    done
+}
+
+function attestImageSBOMs {
+    local curTag=$1
+    local registry=$2
+    local registryUser=$3
+    local registryPassword=$4
+    local sbomsPath=$5
+    local images=("${@:6}")
+    local arch=${ARCH:?ARCH must be set before attesting image SBOMs}
+    local registryPrefix=""
+    local image
+    local imageRef
+    local sbom
+
+    if [ -n "$registry" ]; then
+        registryPrefix="$registry/"
+        printf '%s\n' "$registryPassword" | docker login "$registry" --username "$registryUser" --password-stdin
+    else
+        printf '%s\n' "$registryPassword" | docker login --username "$registryUser" --password-stdin
+    fi
+
+    for image in "${images[@]}"
+    do
+        imageRef="${registryPrefix}${image}:${curTag}-${arch}"
+        sbom="$sbomsPath/${image##*/}-${arch}.spdx.json"
+        echo "attest SBOM: $imageRef"
+        retry 5 cosign attest --yes \
+            --type https://spdx.dev/Document \
+            --predicate "$sbom" \
+            "$imageRef"
+    done
+}
+
 function publishImages {
     # Create curTag and push it to the goharbor namespace of dockerhub
     local curTag=$1


### PR DESCRIPTION
# Comprehensive Summary of your change

# Issue being fixed
Fixes #23484 

## Summary

- Generate architecture-specific SPDX SBOMs for Harbor container images using Anchore Syft.
- Publish images to Docker Hub and GHCR.
- Attach keyless Cosign SBOM attestations to each published architecture image.
- Preserve the existing multi-architecture release flow.

> To maintainers: This PR pushes the SBOMs to the registries and not add them to the GitHub Release assets. If needed, that can also be addressed. Need review,
---
Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "`release-note/update`, `release-note/enhancement`, `release-note/infra`" 
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
