### PR TITLE
(cherry-pick) add size limit for audit log payload

### DIFF
--- a/src/common/const.go
+++ b/src/common/const.go
@@ -254,6 +254,9 @@ const (
 	// manifests are sub-MiB in practice, so 4MiB is a generous ceiling.
 	MaxManifestBodySize = 4 << 20
 
+	// MaxAuditLogPayloadSize bounds the audit log payload size.
+	MaxAuditLogPayloadSize = 4 << 20
+
 	// Global Leeway used for token validation
 	JwtLeeway = 60 * time.Second
 

--- a/src/lib/request.go
+++ b/src/lib/request.go
@@ -43,30 +43,6 @@ func (n nopCloser) Close() error {
 	return nil
 }
 
-func copyBody(body io.ReadCloser) io.ReadCloser {
-	// check if body was already read and converted into our nopCloser
-	if nc, ok := body.(nopCloser); ok {
-		_, _ = nc.Seek(0, io.SeekStart)
-		return body
-	}
-
-	defer body.Close()
-
-	var buf bytes.Buffer
-	_, _ = io.Copy(&buf, body)
-
-	return nopCloser{bytes.NewReader(buf.Bytes())}
-}
-
-// NopCloseRequest makes r.Body re-readable so it can be consumed more than once.
-func NopCloseRequest(r *http.Request) *http.Request {
-	if r != nil && r.Body != nil {
-		r.Body = copyBody(r.Body)
-	}
-
-	return r
-}
-
 // ReadRequestBody reads and returns r.Body while enforcing an optional size
 // limit. When limit > 0 and the body is larger than limit, a
 // RequestEntityTooLargeError is returned so callers surface a 413 instead of

--- a/src/lib/request_test.go
+++ b/src/lib/request_test.go
@@ -25,37 +25,6 @@ import (
 	"github.com/goharbor/harbor/src/lib/errors"
 )
 
-type NopCloseRequestTestSuite struct {
-	suite.Suite
-}
-
-func (suite *NopCloseRequestTestSuite) TestReusableBody() {
-	r, _ := http.NewRequest(http.MethodPost, "/", strings.NewReader("body"))
-
-	body, err := io.ReadAll(r.Body)
-	suite.Nil(err)
-	suite.Equal([]byte("body"), body)
-
-	body, err = io.ReadAll(r.Body)
-	suite.Nil(err)
-	suite.Equal([]byte(""), body)
-
-	r, _ = http.NewRequest(http.MethodPost, "/", strings.NewReader("body"))
-	r = NopCloseRequest(r)
-
-	body, err = io.ReadAll(r.Body)
-	suite.Nil(err)
-	suite.Equal([]byte("body"), body)
-
-	body, err = io.ReadAll(r.Body)
-	suite.Nil(err)
-	suite.Equal([]byte("body"), body)
-}
-
-func TestNopCloseRequestTestSuite(t *testing.T) {
-	suite.Run(t, &NopCloseRequestTestSuite{})
-}
-
 type ReadRequestBodyTestSuite struct {
 	suite.Suite
 }

--- a/src/server/middleware/log/log.go
+++ b/src/server/middleware/log/log.go
@@ -15,12 +15,13 @@
 package log // nolint:revive
 
 import (
-	"io"
 	"net/http"
 
+	"github.com/goharbor/harbor/src/common"
 	"github.com/goharbor/harbor/src/common/security"
 	"github.com/goharbor/harbor/src/controller/event/metadata/commonevent"
 	"github.com/goharbor/harbor/src/lib"
+	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/lib/log"
 	tracelib "github.com/goharbor/harbor/src/lib/trace"
 	"github.com/goharbor/harbor/src/pkg/notification"
@@ -52,9 +53,12 @@ func Middleware() func(http.Handler) http.Handler {
 			RequestURL:    r.URL.String(),
 		}
 		if matched, resName := e.PreCheckMetadata(); matched {
-			lib.NopCloseRequest(r)
-			body, err := io.ReadAll(r.Body)
+			body, err := lib.ReadRequestBody(r, common.MaxAuditLogPayloadSize)
 			if err != nil {
+				if errors.IsErr(err, errors.RequestEntityTooLargeCode) {
+					http.Error(w, "request body too large", http.StatusRequestEntityTooLarge)
+					return
+				}
 				http.Error(w, "failed to read request body", http.StatusInternalServerError)
 				return
 			}

--- a/src/server/middleware/log/log_test.go
+++ b/src/server/middleware/log/log_test.go
@@ -23,10 +23,12 @@ import (
 	"regexp"
 	"testing"
 
+	_ "github.com/goharbor/harbor/src/pkg/auditext/event/login"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"go.opentelemetry.io/otel/propagation"
 
+	"github.com/goharbor/harbor/src/common"
 	"github.com/goharbor/harbor/src/lib/log"
 	tracelib "github.com/goharbor/harbor/src/lib/trace"
 )
@@ -43,7 +45,7 @@ func (s *MiddlewareTestSuite) TestTableMiddleware() {
 			w.WriteHeader(http.StatusOK)
 		})
 	}
-	loc := "/server/middleware/log/log_test.go:41"
+	loc := "/server/middleware/log/log_test.go:43"
 	locPrefix := regexp.MustCompile(fmt.Sprintf(`\[([^\s]*)%s\]`, loc))
 
 	type args struct {
@@ -173,6 +175,21 @@ func (s *MiddlewareTestSuite) TestTableMiddleware() {
 			s.Equal(tt.want, line, tt.name)
 		})
 	}
+}
+
+func (s *MiddlewareTestSuite) TestRequestEntityTooLarge() {
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	largeBody := make([]byte, common.MaxAuditLogPayloadSize+1)
+	req := httptest.NewRequest("POST", "/c/login", bytes.NewReader(largeBody))
+	rr := httptest.NewRecorder()
+
+	Middleware()(next).ServeHTTP(rr, req)
+
+	s.Equal(http.StatusRequestEntityTooLarge, rr.Code)
+	s.Equal("request body too large\n", rr.Body.String())
 }
 
 func TestMiddlewareTestSuite(t *testing.T) {


### PR DESCRIPTION
  Remove unused function copyBody and NopCloseRequest


(cherry picked from commit a3cf76a087c0ab0a2cf4a923c5c431e0ddaa747d)

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [ ] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [ ] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
