### PR TITLE
fix: Harden proxy cache repository filter validation

### DIFF
--- a/src/controller/event/metadata/commonevent/model.go
+++ b/src/controller/event/metadata/commonevent/model.go
@@ -58,6 +58,9 @@ type Metadata struct {
 	ResponseCode int
 	// RequestURL request URL
 	RequestURL string
+	// IsResourceName indicates the request declared, via the X-Is-Resource-Name
+	// header, that name/ID path parameters are resource names
+	IsResourceName bool
 	// IPAddress IP address of the request
 	IPAddress string
 	// ResponseLocation response location

--- a/src/controller/project/metadata/controller.go
+++ b/src/controller/project/metadata/controller.go
@@ -35,6 +35,9 @@ type Controller interface {
 	// Update metadatas
 	Update(ctx context.Context, projectID int64, meta map[string]string) error
 
+	// UpdateWithValidation atomically validates and updates metadatas.
+	UpdateWithValidation(ctx context.Context, projectID int64, meta map[string]string, validate metadata.Validator) error
+
 	// Get metadatas whose keys are specified in parameter meta, if it is absent, get all
 	Get(ctx context.Context, projectID int64, meta ...string) (map[string]string, error)
 }
@@ -60,6 +63,10 @@ func (c *controller) Delete(ctx context.Context, projectID int64, meta ...string
 
 func (c *controller) Update(ctx context.Context, projectID int64, meta map[string]string) error {
 	return c.mgr.Update(ctx, projectID, meta)
+}
+
+func (c *controller) UpdateWithValidation(ctx context.Context, projectID int64, meta map[string]string, validate metadata.Validator) error {
+	return c.mgr.UpdateWithValidation(ctx, projectID, meta, validate)
 }
 
 func (c *controller) Get(ctx context.Context, projectID int64, meta ...string) (map[string]string, error) {

--- a/src/lib/pattern/matcher.go
+++ b/src/lib/pattern/matcher.go
@@ -44,7 +44,7 @@ func ValidateKind(kind string) error {
 	case "", KindRegex, KindDoublestar:
 		return nil
 	default:
-		return errors.Errorf("unsupported repository filter kind %q, must be %q or %q", kind, KindDoublestar, KindRegex)
+		return errors.Errorf("unsupported repository filter kind %q, must be %q, %q, or empty (defaults to %q)", kind, KindDoublestar, KindRegex, KindDoublestar)
 	}
 }
 

--- a/src/lib/pattern/matcher.go
+++ b/src/lib/pattern/matcher.go
@@ -37,6 +37,17 @@ func ValidateRepositoryFilter(filterPattern, kind string) error {
 	return err
 }
 
+// ValidateKind validates the repository filter kind. Empty kind is valid and
+// means the doublestar default.
+func ValidateKind(kind string) error {
+	switch kind {
+	case "", KindRegex, KindDoublestar:
+		return nil
+	default:
+		return errors.Errorf("unsupported repository filter kind %q, must be %q or %q", kind, KindDoublestar, KindRegex)
+	}
+}
+
 // Match returns true if the value matches the pattern according to the kind.
 // Empty pattern matches all (returns true).
 func Match(value, filterPattern, kind string) (bool, error) {
@@ -46,6 +57,12 @@ func Match(value, filterPattern, kind string) (bool, error) {
 	}
 	switch kind {
 	case KindRegex:
+		// Compile the bare pattern first: a group-imbalanced pattern such as
+		// `foo)|(bar` fails alone but compiles inside the ^(?:...)$ wrapper,
+		// where the top-level alternation silently destroys the anchoring.
+		if _, err := regexp.Compile(filterPattern); err != nil {
+			return false, err
+		}
 		re, err := regexp.Compile("^(?:" + filterPattern + ")$")
 		if err != nil {
 			return false, err
@@ -61,6 +78,10 @@ func Match(value, filterPattern, kind string) (bool, error) {
 	}
 }
 
+// validateDoublestarPattern is a port of doValidatePattern from
+// github.com/bmatcuk/doublestar/v4; the v1 dependency in go.mod has no
+// ValidatePattern. Keep it in sync with the library's grammar if the
+// dependency is ever bumped.
 func validateDoublestarPattern(s string) bool {
 	altDepth := 0
 	l := len(s)

--- a/src/lib/pattern/matcher_test.go
+++ b/src/lib/pattern/matcher_test.go
@@ -81,6 +81,12 @@ func TestValidateRepositoryFilter(t *testing.T) {
 			kind:          "invalid_kind",
 			expectErr:     true,
 		},
+		{
+			name:          "group-imbalanced regex that only compiles when wrapped",
+			filterPattern: "foo)|(bar",
+			kind:          KindRegex,
+			expectErr:     true,
+		},
 	}
 
 	for _, tc := range cases {
@@ -93,6 +99,13 @@ func TestValidateRepositoryFilter(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestValidateKind(t *testing.T) {
+	for _, kind := range []string{"", KindRegex, KindDoublestar} {
+		assert.NoError(t, ValidateKind(kind), "kind %q should be valid", kind)
+	}
+	assert.Error(t, ValidateKind("glob"))
 }
 
 func TestMatch(t *testing.T) {
@@ -207,6 +220,13 @@ func TestMatch(t *testing.T) {
 			value:         "library/nginx",
 			filterPattern: "library/**",
 			kind:          "invalid_kind",
+			expectErr:     true,
+		},
+		{
+			name:          "group-imbalanced regex does not break anchoring",
+			value:         "library/foobar",
+			filterPattern: "foo)|(bar",
+			kind:          KindRegex,
 			expectErr:     true,
 		},
 	}

--- a/src/pkg/auditext/event/project/project.go
+++ b/src/pkg/auditext/event/project/project.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"net/url"
 	"regexp"
 	"strconv"
 	"time"
@@ -68,7 +67,7 @@ func (r *resolver) Resolve(ce *commonevent.Metadata, evt *event.Event) error {
 		ctx = orm.Clone(ctx)
 	}
 
-	proj, err := getProject(ctx, projStr, isResourceName(ce.RequestURL))
+	proj, err := getProject(ctx, projStr, ce.IsResourceName)
 	if err != nil {
 		return fmt.Errorf("failed to get project: %v", err)
 	}
@@ -115,17 +114,10 @@ func getProjectNameOrID(url string) string {
 	return ""
 }
 
-// isResourceName reports whether the request URL carries x_is_resource_name=true,
-// which forces the path segment to be treated as a project name even when it is
-// all digits — mirroring parseProjectNameOrID in the API handlers.
-func isResourceName(requestURL string) bool {
-	u, err := url.Parse(requestURL)
-	if err != nil {
-		return false
-	}
-	return u.Query().Get("x_is_resource_name") == "true"
-}
-
+// getProject resolves the path segment to a project. isName comes from the
+// X-Is-Resource-Name header and forces the segment to be treated as a project
+// name even when it is all digits — mirroring parseProjectNameOrID in the API
+// handlers.
 func getProject(ctx context.Context, str string, isName bool) (*models.Project, error) {
 	var projectNameOrID any = str
 	if !isName {

--- a/src/pkg/auditext/event/project/project.go
+++ b/src/pkg/auditext/event/project/project.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 	"regexp"
 	"strconv"
 	"time"
@@ -32,17 +33,25 @@ import (
 	"github.com/goharbor/harbor/src/pkg/project/models"
 )
 
+// Each URL shape is declared once and used for both resolver registration and
+// project-name extraction, so the two can never drift apart.
+const (
+	projectPattern        = `^/api/v2\.0/projects/([^/?]+)(?:\?.*)?$`
+	projectMetaPattern    = `^/api/v2\.0/projects/([^/?]+)/metadatas/(?:\?.*)?$`
+	projectMetaKeyPattern = `^/api/v2\.0/projects/([^/?]+)/metadatas/([^/?]+)(?:\?.*)?$`
+)
+
 var (
-	projectReg        = regexp.MustCompile(`^/api/v2.0/projects/([^/?]+)(?:\?.*)?$`)
-	projectMetaReg    = regexp.MustCompile(`^/api/v2.0/projects/([^/?]+)/metadatas/(?:\?.*)?$`)
-	projectMetaKeyReg = regexp.MustCompile(`^/api/v2.0/projects/([^/?]+)/metadatas/([^/?]+)(?:\?.*)?$`)
+	projectReg        = regexp.MustCompile(projectPattern)
+	projectMetaReg    = regexp.MustCompile(projectMetaPattern)
+	projectMetaKeyReg = regexp.MustCompile(projectMetaKeyPattern)
 )
 
 func init() {
 	var projectEventResolver = &resolver{}
-	commonevent.RegisterResolver(`^/api/v2.0/projects/[^/?]+(?:\?.*)?$`, projectEventResolver)
-	commonevent.RegisterResolver(`^/api/v2.0/projects/[^/?]+/metadatas/(?:\?.*)?$`, projectEventResolver)
-	commonevent.RegisterResolver(`^/api/v2.0/projects/[^/?]+/metadatas/[^/?]+(?:\?.*)?$`, projectEventResolver)
+	commonevent.RegisterResolver(projectPattern, projectEventResolver)
+	commonevent.RegisterResolver(projectMetaPattern, projectEventResolver)
+	commonevent.RegisterResolver(projectMetaKeyPattern, projectEventResolver)
 }
 
 type resolver struct {
@@ -59,7 +68,7 @@ func (r *resolver) Resolve(ce *commonevent.Metadata, evt *event.Event) error {
 		ctx = orm.Clone(ctx)
 	}
 
-	proj, err := getProject(ctx, projStr)
+	proj, err := getProject(ctx, projStr, isResourceName(ce.RequestURL))
 	if err != nil {
 		return fmt.Errorf("failed to get project: %v", err)
 	}
@@ -106,13 +115,23 @@ func getProjectNameOrID(url string) string {
 	return ""
 }
 
-func getProject(ctx context.Context, str string) (*models.Project, error) {
-	var projectNameOrID any
-	v, err := strconv.ParseInt(str, 10, 64)
+// isResourceName reports whether the request URL carries x_is_resource_name=true,
+// which forces the path segment to be treated as a project name even when it is
+// all digits — mirroring parseProjectNameOrID in the API handlers.
+func isResourceName(requestURL string) bool {
+	u, err := url.Parse(requestURL)
 	if err != nil {
-		projectNameOrID = str
-	} else {
-		projectNameOrID = v
+		return false
+	}
+	return u.Query().Get("x_is_resource_name") == "true"
+}
+
+func getProject(ctx context.Context, str string, isName bool) (*models.Project, error) {
+	var projectNameOrID any = str
+	if !isName {
+		if v, err := strconv.ParseInt(str, 10, 64); err == nil {
+			projectNameOrID = v
+		}
 	}
 	return project.Ctl.Get(ctx, projectNameOrID)
 }

--- a/src/pkg/auditext/event/project/project_test.go
+++ b/src/pkg/auditext/event/project/project_test.go
@@ -88,6 +88,7 @@ func TestProjectEventResolver_Resolve(t *testing.T) {
 
 	mockCtrl.On("Get", mock.Anything, int64(123)).Return(proj, nil)
 	mockCtrl.On("Get", mock.Anything, "test-proj").Return(proj, nil)
+	mockCtrl.On("Get", mock.Anything, "123").Return(proj, nil)
 
 	r := &resolver{}
 
@@ -135,5 +136,24 @@ func TestProjectEventResolver_Resolve(t *testing.T) {
 		assert.Equal(t, int64(123), data.ProjectID)
 		assert.Equal(t, "update project: test-proj", data.OperationDescription)
 		assert.True(t, data.IsSuccessful)
+	})
+
+	t.Run("Resolve all-digit project name with x_is_resource_name", func(t *testing.T) {
+		ce := &commonevent.Metadata{
+			Ctx:           context.Background(),
+			Username:      "admin",
+			RequestURL:    "/api/v2.0/projects/123?x_is_resource_name=true",
+			RequestMethod: "PUT",
+			ResponseCode:  http.StatusOK,
+		}
+		evt := &event.Event{}
+		err := r.Resolve(ce, evt)
+		assert.NoError(t, err)
+
+		data, ok := evt.Data.(*model.CommonEvent)
+		assert.True(t, ok)
+		assert.Equal(t, "test-proj", data.ResourceName)
+		// The segment must be resolved as a project *name*, not ID 123.
+		mockCtrl.AssertCalled(t, "Get", mock.Anything, "123")
 	})
 }

--- a/src/pkg/auditext/event/project/project_test.go
+++ b/src/pkg/auditext/event/project/project_test.go
@@ -138,13 +138,14 @@ func TestProjectEventResolver_Resolve(t *testing.T) {
 		assert.True(t, data.IsSuccessful)
 	})
 
-	t.Run("Resolve all-digit project name with x_is_resource_name", func(t *testing.T) {
+	t.Run("Resolve all-digit project name with X-Is-Resource-Name", func(t *testing.T) {
 		ce := &commonevent.Metadata{
-			Ctx:           context.Background(),
-			Username:      "admin",
-			RequestURL:    "/api/v2.0/projects/123?x_is_resource_name=true",
-			RequestMethod: "PUT",
-			ResponseCode:  http.StatusOK,
+			Ctx:            context.Background(),
+			Username:       "admin",
+			RequestURL:     "/api/v2.0/projects/123",
+			RequestMethod:  "PUT",
+			ResponseCode:   http.StatusOK,
+			IsResourceName: true,
 		}
 		evt := &event.Event{}
 		err := r.Resolve(ce, evt)

--- a/src/pkg/cached/project_metadata/redis/manager.go
+++ b/src/pkg/cached/project_metadata/redis/manager.go
@@ -113,6 +113,18 @@ func (m *Manager) Update(ctx context.Context, projectID int64, meta map[string]s
 	if err := m.delegator.Update(ctx, projectID, meta); err != nil {
 		return err
 	}
+	return m.cleanUpAll(ctx, projectID)
+}
+
+// UpdateWithValidation atomically validates and updates metadata, then invalidates its cache.
+func (m *Manager) UpdateWithValidation(ctx context.Context, projectID int64, meta map[string]string, validate metadata.Validator) error {
+	if err := m.delegator.UpdateWithValidation(ctx, projectID, meta, validate); err != nil {
+		return err
+	}
+	return m.cleanUpAll(ctx, projectID)
+}
+
+func (m *Manager) cleanUpAll(ctx context.Context, projectID int64) error {
 	// clean cache
 	prefix, err := m.keyBuilder.Format("projectID", projectID)
 	if err != nil {

--- a/src/pkg/project/metadata/manager.go
+++ b/src/pkg/project/metadata/manager.go
@@ -16,12 +16,17 @@ package metadata
 
 import (
 	"context"
+	"maps"
 
 	"github.com/goharbor/harbor/src/lib/orm"
 	"github.com/goharbor/harbor/src/lib/q"
 	"github.com/goharbor/harbor/src/pkg/project/metadata/dao"
 	"github.com/goharbor/harbor/src/pkg/project/metadata/models"
+	projectmodels "github.com/goharbor/harbor/src/pkg/project/models"
 )
+
+// Validator validates the effective project metadata before an update.
+type Validator func(map[string]string) error
 
 // Manager defines the operations that a project metadata manager should implement
 type Manager interface {
@@ -33,6 +38,9 @@ type Manager interface {
 
 	// Update metadatas
 	Update(ctx context.Context, projectID int64, meta map[string]string) error
+
+	// UpdateWithValidation atomically validates and updates metadatas.
+	UpdateWithValidation(ctx context.Context, projectID int64, meta map[string]string, validate Validator) error
 
 	// Get metadatas whose keys are specified in parameter meta, if it is absent, get all
 	Get(ctx context.Context, projectID int64, meta ...string) (map[string]string, error)
@@ -85,6 +93,48 @@ func (m *manager) Update(ctx context.Context, projectID int64, meta map[string]s
 	}
 
 	return orm.WithTransaction(h)(orm.SetTransactionOpNameToContext(ctx, "tx-delete-project"))
+}
+
+func (m *manager) UpdateWithValidation(ctx context.Context, projectID int64, meta map[string]string, validate Validator) error {
+	if len(meta) == 0 {
+		return nil
+	}
+
+	h := func(ctx context.Context) error {
+		o, err := orm.FromContext(ctx)
+		if err != nil {
+			return err
+		}
+
+		// Lock the parent row because metadata rows may not exist yet. All
+		// validated metadata updates for a project serialize on this row.
+		project := &projectmodels.Project{ProjectID: projectID}
+		if err := o.ReadForUpdate(project, "project_id"); err != nil {
+			return orm.WrapNotFoundError(err, "project %d not found", projectID)
+		}
+
+		current, err := m.Get(ctx, projectID)
+		if err != nil {
+			return err
+		}
+		effective := maps.Clone(current)
+		if effective == nil {
+			effective = map[string]string{}
+		}
+		maps.Copy(effective, meta)
+		if err := validate(effective); err != nil {
+			return err
+		}
+
+		for name, value := range meta {
+			if err := m.dao.Update(ctx, projectID, name, value); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	return orm.WithTransaction(h)(orm.SetTransactionOpNameToContext(ctx, "tx-update-project-metadata"))
 }
 
 // Get metadatas whose keys are specified in parameter meta, if it is absent, get all

--- a/src/server/middleware/log/log.go
+++ b/src/server/middleware/log/log.go
@@ -16,6 +16,7 @@ package log // nolint:revive
 
 import (
 	"net/http"
+	"strconv"
 
 	"github.com/goharbor/harbor/src/common"
 	"github.com/goharbor/harbor/src/common/security"
@@ -46,11 +47,13 @@ func Middleware() func(http.Handler) http.Handler {
 			r = r.WithContext(ctx)
 		}
 
+		isResourceName, _ := strconv.ParseBool(r.Header.Get("X-Is-Resource-Name"))
 		e := &commonevent.Metadata{
-			Ctx:           r.Context(),
-			Username:      "unknown",
-			RequestMethod: r.Method,
-			RequestURL:    r.URL.String(),
+			Ctx:            r.Context(),
+			Username:       "unknown",
+			RequestMethod:  r.Method,
+			RequestURL:     r.URL.String(),
+			IsResourceName: isResourceName,
 		}
 		if matched, resName := e.PreCheckMetadata(); matched {
 			body, err := lib.ReadRequestBody(r, common.MaxAuditLogPayloadSize)

--- a/src/server/middleware/repoproxy/proxy_test.go
+++ b/src/server/middleware/repoproxy/proxy_test.go
@@ -756,6 +756,13 @@ func TestMatchRepositoryFilter(t *testing.T) {
 			want:          false,
 		},
 		{
+			name:          "group-imbalanced regex treated as no match, not unanchored",
+			repository:    "library/foobar",
+			filterPattern: "foo)|(bar",
+			filterKind:    "regex",
+			want:          false,
+		},
+		{
 			name:          "doublestar exact match",
 			repository:    "library/nginx",
 			filterPattern: "library/nginx",

--- a/src/server/v2.0/handler/project.go
+++ b/src/server/v2.0/handler/project.go
@@ -551,7 +551,7 @@ func (a *projectAPI) UpdateProject(ctx context.Context, params operation.UpdateP
 		return a.SendError(ctx, err)
 	}
 
-	p, err := a.projectCtl.Get(ctx, projectNameOrID, project.Metadata(false))
+	p, err := a.projectCtl.Get(ctx, projectNameOrID)
 	if err != nil {
 		return a.SendError(ctx, err)
 	}
@@ -582,7 +582,7 @@ func (a *projectAPI) UpdateProject(ctx context.Context, params operation.UpdateP
 	// see https://github.com/goharbor/harbor/issues/12940 to get more info
 	if params.Project.Metadata != nil && p.IsProxy() {
 		params.Project.Metadata.EnableContentTrust = nil
-		if err := validateProxyCacheRepositoryFilter(params.Project.Metadata); err != nil {
+		if err := validateProxyCacheRepositoryFilterUpdate(params.Project.Metadata, p.Metadata); err != nil {
 			return a.SendError(ctx, err)
 		}
 	}
@@ -872,6 +872,26 @@ func validateProxyCacheRepositoryFilter(metadata *models.ProjectMetadata) error 
 			WithMessagef("metadata.proxy_cache_filter_pattern is invalid for kind %q: %v", filterKind, err)
 	}
 	return nil
+}
+
+func validateProxyCacheRepositoryFilterUpdate(metadata *models.ProjectMetadata, stored map[string]string) error {
+	if metadata == nil {
+		return nil
+	}
+
+	filterPattern := stored[pkgModels.ProMetaProxyCacheFilterPattern]
+	if metadata.ProxyCacheFilterPattern != nil {
+		filterPattern = *metadata.ProxyCacheFilterPattern
+	}
+	filterKind := stored[pkgModels.ProMetaProxyCacheFilterKind]
+	if metadata.ProxyCacheFilterKind != nil {
+		filterKind = *metadata.ProxyCacheFilterKind
+	}
+
+	return validateProxyCacheRepositoryFilter(&models.ProjectMetadata{
+		ProxyCacheFilterPattern: &filterPattern,
+		ProxyCacheFilterKind:    &filterKind,
+	})
 }
 
 func (a *projectAPI) populateProperties(ctx context.Context, p *project.Project) error {

--- a/src/server/v2.0/handler/project.go
+++ b/src/server/v2.0/handler/project.go
@@ -863,9 +863,8 @@ func validateProxyCacheRepositoryFilter(metadata *models.ProjectMetadata) error 
 		return nil
 	}
 
-	if filterKind != pattern.KindRegex && filterKind != pattern.KindDoublestar {
-		return errors.BadRequestError(nil).
-			WithMessagef("metadata.proxy_cache_filter_kind should be %q or %q, but got: %q", pattern.KindDoublestar, pattern.KindRegex, filterKind)
+	if err := pattern.ValidateKind(filterKind); err != nil {
+		return errors.BadRequestError(nil).WithMessagef("metadata.proxy_cache_filter_kind: %v", err)
 	}
 
 	if err := pattern.ValidateRepositoryFilter(filterPattern, filterKind); err != nil {

--- a/src/server/v2.0/handler/project_metadata.go
+++ b/src/server/v2.0/handler/project_metadata.go
@@ -90,16 +90,14 @@ func (p *projectMetadataAPI) DeleteProjectMetadata(ctx context.Context, params o
 		return p.SendError(ctx, err)
 	}
 	if params.MetaName == proModels.ProMetaProxyCacheFilterKind {
-		if p.ctl != nil {
-			existing, err := p.ctl.Get(ctx, project.ProjectID, proModels.ProMetaProxyCacheFilterPattern)
-			if err != nil {
-				return p.SendError(ctx, err)
-			}
-			if patVal, ok := existing[proModels.ProMetaProxyCacheFilterPattern]; ok && patVal != "" {
-				return p.SendError(ctx, errors.New(nil).WithCode(errors.BadRequestCode).
-					WithMessagef("cannot delete %s when %s is not empty, please clear the pattern first",
-						proModels.ProMetaProxyCacheFilterKind, proModels.ProMetaProxyCacheFilterPattern))
-			}
+		existing, err := p.ctl.Get(ctx, project.ProjectID, proModels.ProMetaProxyCacheFilterPattern)
+		if err != nil {
+			return p.SendError(ctx, err)
+		}
+		if patVal, ok := existing[proModels.ProMetaProxyCacheFilterPattern]; ok && patVal != "" {
+			return p.SendError(ctx, errors.New(nil).WithCode(errors.BadRequestCode).
+				WithMessagef("cannot delete %s when %s is not empty, please clear the pattern first",
+					proModels.ProMetaProxyCacheFilterKind, proModels.ProMetaProxyCacheFilterPattern))
 		}
 	}
 	if err = p.ctl.Delete(ctx, project.ProjectID, params.MetaName); err != nil {
@@ -191,27 +189,18 @@ func (p *projectMetadataAPI) validate(ctx context.Context, projectID int64, meta
 		}
 		metas[proModels.ProMetaMaxUpstreamConn] = strconv.FormatInt(v, 10)
 	case proModels.ProMetaProxyCacheFilterPattern:
-		if p.proCtl != nil {
-			pro, err := p.proCtl.Get(ctx, projectID)
-			if err != nil {
-				return nil, err
-			}
-			if !pro.IsProxy() {
-				return nil, errors.New(nil).WithCode(errors.BadRequestCode).WithMessage("can not update the normal project with proxy cache filter metadata")
-			}
+		if err := p.requireProxyProject(ctx, projectID); err != nil {
+			return nil, err
 		}
-		// plain pattern string; empty means match all — no further validation needed at metadata level
-		kind := pattern.KindDoublestar
-		if k, ok := metas[proModels.ProMetaProxyCacheFilterKind]; ok && k != "" {
+		// The API accepts one key per request, so the effective kind is
+		// whatever is already stored; empty means the doublestar default.
+		var kind string
+		existing, err := p.ctl.Get(ctx, projectID, proModels.ProMetaProxyCacheFilterKind)
+		if err != nil {
+			return nil, err
+		}
+		if k, ok := existing[proModels.ProMetaProxyCacheFilterKind]; ok {
 			kind = k
-		} else if p.ctl != nil {
-			existing, err := p.ctl.Get(ctx, projectID, proModels.ProMetaProxyCacheFilterKind)
-			if err != nil {
-				return nil, err
-			}
-			if k, ok := existing[proModels.ProMetaProxyCacheFilterKind]; ok && k != "" {
-				kind = k
-			}
 		}
 		if err := pattern.ValidateRepositoryFilter(value, kind); err != nil {
 			return nil, errors.New(nil).WithCode(errors.BadRequestCode).
@@ -219,41 +208,23 @@ func (p *projectMetadataAPI) validate(ctx context.Context, projectID int64, meta
 		}
 		metas[proModels.ProMetaProxyCacheFilterPattern] = value
 	case proModels.ProMetaProxyCacheFilterKind:
-		if p.proCtl != nil {
-			pro, err := p.proCtl.Get(ctx, projectID)
-			if err != nil {
-				return nil, err
-			}
-			if !pro.IsProxy() {
-				return nil, errors.New(nil).WithCode(errors.BadRequestCode).WithMessage("can not update the normal project with proxy cache filter metadata")
-			}
+		if err := p.requireProxyProject(ctx, projectID); err != nil {
+			return nil, err
 		}
-		// must be "doublestar" or "regex" when specified
-		if value != "" && value != pattern.KindRegex && value != pattern.KindDoublestar {
+		if err := pattern.ValidateKind(value); err != nil {
 			return nil, errors.New(nil).WithCode(errors.BadRequestCode).
-				WithMessagef("invalid proxy_cache_filter_kind: %q, must be %q or %q", value, pattern.KindDoublestar, pattern.KindRegex)
+				WithMessagef("invalid proxy_cache_filter_kind: %v", err)
 		}
-		var pat string
-		hasPat := false
-		if patVal, ok := metas[proModels.ProMetaProxyCacheFilterPattern]; ok {
-			pat = patVal
-			hasPat = true
-		} else if p.ctl != nil {
-			if existing, err := p.ctl.Get(ctx, projectID, proModels.ProMetaProxyCacheFilterPattern); err == nil {
-				if patVal, ok := existing[proModels.ProMetaProxyCacheFilterPattern]; ok {
-					pat = patVal
-					hasPat = true
-				}
-			}
+		// The new kind must keep the stored pattern (the only possible source,
+		// since the API accepts one key per request) compilable.
+		existing, err := p.ctl.Get(ctx, projectID, proModels.ProMetaProxyCacheFilterPattern)
+		if err != nil {
+			return nil, err
 		}
-		if hasPat && pat != "" {
-			kind := value
-			if kind == "" {
-				kind = pattern.KindDoublestar
-			}
-			if err := pattern.ValidateRepositoryFilter(pat, kind); err != nil {
+		if pat, ok := existing[proModels.ProMetaProxyCacheFilterPattern]; ok && pat != "" {
+			if err := pattern.ValidateRepositoryFilter(pat, value); err != nil {
 				return nil, errors.New(nil).WithCode(errors.BadRequestCode).
-					WithMessagef("existing proxy_cache_filter_pattern %q is invalid for new kind %q: %v", pat, kind, err)
+					WithMessagef("existing proxy_cache_filter_pattern %q is invalid for new kind %q: %v", pat, value, err)
 			}
 		}
 		metas[proModels.ProMetaProxyCacheFilterKind] = value
@@ -261,4 +232,17 @@ func (p *projectMetadataAPI) validate(ctx context.Context, projectID int64, meta
 		return nil, errors.New(nil).WithCode(errors.BadRequestCode).WithMessagef("invalid key: %s", key)
 	}
 	return metas, nil
+}
+
+// requireProxyProject rejects proxy-cache-filter metadata changes on projects
+// that are not proxy cache projects.
+func (p *projectMetadataAPI) requireProxyProject(ctx context.Context, projectID int64) error {
+	pro, err := p.proCtl.Get(ctx, projectID)
+	if err != nil {
+		return err
+	}
+	if !pro.IsProxy() {
+		return errors.New(nil).WithCode(errors.BadRequestCode).WithMessage("can not update the normal project with proxy cache filter metadata")
+	}
+	return nil
 }

--- a/src/server/v2.0/handler/project_metadata.go
+++ b/src/server/v2.0/handler/project_metadata.go
@@ -28,6 +28,7 @@ import (
 	"github.com/goharbor/harbor/src/lib/pattern"
 	proModels "github.com/goharbor/harbor/src/pkg/project/models"
 	"github.com/goharbor/harbor/src/pkg/scan/vuln"
+	"github.com/goharbor/harbor/src/server/v2.0/models"
 	operation "github.com/goharbor/harbor/src/server/v2.0/restapi/operations/project_metadata"
 )
 
@@ -138,7 +139,7 @@ func (p *projectMetadataAPI) UpdateProjectMetadata(ctx context.Context, params o
 	if err != nil {
 		return p.SendError(ctx, err)
 	}
-	if err = p.ctl.Update(ctx, project.ProjectID, metadata); err != nil {
+	if err = p.update(ctx, project.ProjectID, metadata); err != nil {
 		return p.SendError(ctx, err)
 	}
 	return operation.NewUpdateProjectMetadataOK()
@@ -192,20 +193,6 @@ func (p *projectMetadataAPI) validate(ctx context.Context, projectID int64, meta
 		if err := p.requireProxyProject(ctx, projectID); err != nil {
 			return nil, err
 		}
-		// The API accepts one key per request, so the effective kind is
-		// whatever is already stored; empty means the doublestar default.
-		var kind string
-		existing, err := p.ctl.Get(ctx, projectID, proModels.ProMetaProxyCacheFilterKind)
-		if err != nil {
-			return nil, err
-		}
-		if k, ok := existing[proModels.ProMetaProxyCacheFilterKind]; ok {
-			kind = k
-		}
-		if err := pattern.ValidateRepositoryFilter(value, kind); err != nil {
-			return nil, errors.New(nil).WithCode(errors.BadRequestCode).
-				WithMessagef("invalid proxy_cache_filter_pattern: %q, err: %v", value, err)
-		}
 		metas[proModels.ProMetaProxyCacheFilterPattern] = value
 	case proModels.ProMetaProxyCacheFilterKind:
 		if err := p.requireProxyProject(ctx, projectID); err != nil {
@@ -215,23 +202,30 @@ func (p *projectMetadataAPI) validate(ctx context.Context, projectID int64, meta
 			return nil, errors.New(nil).WithCode(errors.BadRequestCode).
 				WithMessagef("invalid proxy_cache_filter_kind: %v", err)
 		}
-		// The new kind must keep the stored pattern (the only possible source,
-		// since the API accepts one key per request) compilable.
-		existing, err := p.ctl.Get(ctx, projectID, proModels.ProMetaProxyCacheFilterPattern)
-		if err != nil {
-			return nil, err
-		}
-		if pat, ok := existing[proModels.ProMetaProxyCacheFilterPattern]; ok && pat != "" {
-			if err := pattern.ValidateRepositoryFilter(pat, value); err != nil {
-				return nil, errors.New(nil).WithCode(errors.BadRequestCode).
-					WithMessagef("existing proxy_cache_filter_pattern %q is invalid for new kind %q: %v", pat, value, err)
-			}
-		}
 		metas[proModels.ProMetaProxyCacheFilterKind] = value
 	default:
 		return nil, errors.New(nil).WithCode(errors.BadRequestCode).WithMessagef("invalid key: %s", key)
 	}
 	return metas, nil
+}
+
+func (p *projectMetadataAPI) update(ctx context.Context, projectID int64, metas map[string]string) error {
+	_, updatesPattern := metas[proModels.ProMetaProxyCacheFilterPattern]
+	_, updatesKind := metas[proModels.ProMetaProxyCacheFilterKind]
+	if !updatesPattern && !updatesKind {
+		return p.ctl.Update(ctx, projectID, metas)
+	}
+
+	return p.ctl.UpdateWithValidation(ctx, projectID, metas, validateProxyCacheFilterMetadata)
+}
+
+func validateProxyCacheFilterMetadata(metas map[string]string) error {
+	filterPattern := metas[proModels.ProMetaProxyCacheFilterPattern]
+	filterKind := metas[proModels.ProMetaProxyCacheFilterKind]
+	return validateProxyCacheRepositoryFilter(&models.ProjectMetadata{
+		ProxyCacheFilterPattern: &filterPattern,
+		ProxyCacheFilterKind:    &filterKind,
+	})
 }
 
 // requireProxyProject rejects proxy-cache-filter metadata changes on projects

--- a/src/server/v2.0/handler/project_metadata_test.go
+++ b/src/server/v2.0/handler/project_metadata_test.go
@@ -31,7 +31,7 @@ import (
 
 type fakeMetadataController struct {
 	metadata.Controller
-	getFunc func(ctx context.Context, projectID int64, meta ...string) (map[string]string, error)
+	getFunc    func(ctx context.Context, projectID int64, meta ...string) (map[string]string, error)
 	deleteFunc func(ctx context.Context, projectID int64, meta ...string) error
 }
 

--- a/src/server/v2.0/handler/project_metadata_test.go
+++ b/src/server/v2.0/handler/project_metadata_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/goharbor/harbor/src/controller/project"
 	"github.com/goharbor/harbor/src/controller/project/metadata"
 	"github.com/goharbor/harbor/src/lib/pattern"
+	pkgmetadata "github.com/goharbor/harbor/src/pkg/project/metadata"
 	proModels "github.com/goharbor/harbor/src/pkg/project/models"
 	operation "github.com/goharbor/harbor/src/server/v2.0/restapi/operations/project_metadata"
 	securitytesting "github.com/goharbor/harbor/src/testing/common/security"
@@ -31,8 +32,16 @@ import (
 
 type fakeMetadataController struct {
 	metadata.Controller
-	getFunc    func(ctx context.Context, projectID int64, meta ...string) (map[string]string, error)
-	deleteFunc func(ctx context.Context, projectID int64, meta ...string) error
+	getFunc                  func(ctx context.Context, projectID int64, meta ...string) (map[string]string, error)
+	deleteFunc               func(ctx context.Context, projectID int64, meta ...string) error
+	updateWithValidationFunc func(ctx context.Context, projectID int64, meta map[string]string, validate pkgmetadata.Validator) error
+}
+
+func (f *fakeMetadataController) UpdateWithValidation(ctx context.Context, projectID int64, meta map[string]string, validate pkgmetadata.Validator) error {
+	if f.updateWithValidationFunc != nil {
+		return f.updateWithValidationFunc(ctx, projectID, meta, validate)
+	}
+	return nil
 }
 
 func (f *fakeMetadataController) Get(ctx context.Context, projectID int64, meta ...string) (map[string]string, error) {
@@ -111,80 +120,32 @@ func TestValidate(t *testing.T) {
 			expectErr: true,
 		},
 		{
-			name:      "ProxyCacheFilterPattern with KindDoublestar (valid)",
+			name:      "ProxyCacheFilterPattern on proxy project",
 			metas:     map[string]string{proModels.ProMetaProxyCacheFilterPattern: "**"},
 			expectErr: false,
 			setup: func() {
 				fakeProCtl.getFunc = func(ctx context.Context, projectIDOrName any, options ...project.Option) (*proModels.Project, error) {
 					return &proModels.Project{RegistryID: 1}, nil
 				}
-				fakeCtl.getFunc = func(ctx context.Context, projectID int64, meta ...string) (map[string]string, error) {
-					return map[string]string{proModels.ProMetaProxyCacheFilterKind: pattern.KindDoublestar}, nil
-				}
 			},
 		},
 		{
-			name:      "ProxyCacheFilterPattern with KindDoublestar (invalid)",
-			metas:     map[string]string{proModels.ProMetaProxyCacheFilterPattern: "[invalid"},
-			expectErr: true,
-			setup: func() {
-				fakeProCtl.getFunc = func(ctx context.Context, projectIDOrName any, options ...project.Option) (*proModels.Project, error) {
-					return &proModels.Project{RegistryID: 1}, nil
-				}
-				fakeCtl.getFunc = func(ctx context.Context, projectID int64, meta ...string) (map[string]string, error) {
-					return map[string]string{proModels.ProMetaProxyCacheFilterKind: pattern.KindDoublestar}, nil
-				}
-			},
-		},
-		{
-			name:      "ProxyCacheFilterPattern with KindRegex (valid)",
-			metas:     map[string]string{proModels.ProMetaProxyCacheFilterPattern: "^foo/.*$"},
-			expectErr: false,
-			setup: func() {
-				fakeProCtl.getFunc = func(ctx context.Context, projectIDOrName any, options ...project.Option) (*proModels.Project, error) {
-					return &proModels.Project{RegistryID: 1}, nil
-				}
-				fakeCtl.getFunc = func(ctx context.Context, projectID int64, meta ...string) (map[string]string, error) {
-					return map[string]string{proModels.ProMetaProxyCacheFilterKind: pattern.KindRegex}, nil
-				}
-			},
-		},
-		{
-			name:      "ProxyCacheFilterPattern with KindRegex (invalid)",
-			metas:     map[string]string{proModels.ProMetaProxyCacheFilterPattern: "[invalid"},
-			expectErr: true,
-			setup: func() {
-				fakeProCtl.getFunc = func(ctx context.Context, projectIDOrName any, options ...project.Option) (*proModels.Project, error) {
-					return &proModels.Project{RegistryID: 1}, nil
-				}
-				fakeCtl.getFunc = func(ctx context.Context, projectID int64, meta ...string) (map[string]string, error) {
-					return map[string]string{proModels.ProMetaProxyCacheFilterKind: pattern.KindRegex}, nil
-				}
-			},
-		},
-		{
-			name:      "ProxyCacheFilterKind with valid existing pattern",
+			name:      "Valid ProxyCacheFilterKind on proxy project",
 			metas:     map[string]string{proModels.ProMetaProxyCacheFilterKind: pattern.KindRegex},
 			expectErr: false,
 			setup: func() {
 				fakeProCtl.getFunc = func(ctx context.Context, projectIDOrName any, options ...project.Option) (*proModels.Project, error) {
 					return &proModels.Project{RegistryID: 1}, nil
 				}
-				fakeCtl.getFunc = func(ctx context.Context, projectID int64, meta ...string) (map[string]string, error) {
-					return map[string]string{proModels.ProMetaProxyCacheFilterPattern: "^foo/.*$"}, nil
-				}
 			},
 		},
 		{
-			name:      "ProxyCacheFilterKind with invalid existing pattern for doublestar",
-			metas:     map[string]string{proModels.ProMetaProxyCacheFilterKind: pattern.KindDoublestar},
+			name:      "Invalid ProxyCacheFilterKind",
+			metas:     map[string]string{proModels.ProMetaProxyCacheFilterKind: "invalid"},
 			expectErr: true,
 			setup: func() {
 				fakeProCtl.getFunc = func(ctx context.Context, projectIDOrName any, options ...project.Option) (*proModels.Project, error) {
 					return &proModels.Project{RegistryID: 1}, nil
-				}
-				fakeCtl.getFunc = func(ctx context.Context, projectID int64, meta ...string) (map[string]string, error) {
-					return map[string]string{proModels.ProMetaProxyCacheFilterPattern: "[invalid"}, nil
 				}
 			},
 		},
@@ -225,6 +186,66 @@ func TestValidate(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 				assert.NotNil(t, result)
+			}
+		})
+	}
+}
+
+func TestProjectMetadataUpdateValidatesEffectiveFilter(t *testing.T) {
+	tests := []struct {
+		name    string
+		stored  map[string]string
+		update  map[string]string
+		wantErr bool
+	}{
+		{
+			name: "reject kind-only update incompatible with stored pattern",
+			stored: map[string]string{
+				proModels.ProMetaProxyCacheFilterPattern: "*",
+				proModels.ProMetaProxyCacheFilterKind:    pattern.KindDoublestar,
+			},
+			update:  map[string]string{proModels.ProMetaProxyCacheFilterKind: pattern.KindRegex},
+			wantErr: true,
+		},
+		{
+			name: "reject pattern-only update incompatible with stored kind",
+			stored: map[string]string{
+				proModels.ProMetaProxyCacheFilterPattern: "^foo/.*$",
+				proModels.ProMetaProxyCacheFilterKind:    pattern.KindRegex,
+			},
+			update:  map[string]string{proModels.ProMetaProxyCacheFilterPattern: "*"},
+			wantErr: true,
+		},
+		{
+			name: "accept compatible pattern-only update",
+			stored: map[string]string{
+				proModels.ProMetaProxyCacheFilterPattern: "^foo/.*$",
+				proModels.ProMetaProxyCacheFilterKind:    pattern.KindRegex,
+			},
+			update: map[string]string{proModels.ProMetaProxyCacheFilterPattern: "^bar/.*$"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeCtl := &fakeMetadataController{}
+			fakeCtl.updateWithValidationFunc = func(_ context.Context, _ int64, update map[string]string, validate pkgmetadata.Validator) error {
+				effective := make(map[string]string, len(tt.stored)+len(update))
+				for key, value := range tt.stored {
+					effective[key] = value
+				}
+				for key, value := range update {
+					effective[key] = value
+				}
+				return validate(effective)
+			}
+
+			api := &projectMetadataAPI{ctl: fakeCtl}
+			err := api.update(context.Background(), 1, tt.update)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
 			}
 		})
 	}

--- a/src/server/v2.0/handler/project_test.go
+++ b/src/server/v2.0/handler/project_test.go
@@ -18,17 +18,71 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/goharbor/harbor/src/lib/pattern"
 	"github.com/goharbor/harbor/src/pkg/project/models"
 	"github.com/goharbor/harbor/src/pkg/scan/dao/scanner"
 	v1 "github.com/goharbor/harbor/src/pkg/scan/rest/v1"
+	apiModels "github.com/goharbor/harbor/src/server/v2.0/models"
 	"github.com/goharbor/harbor/src/server/v2.0/restapi"
 	projecttesting "github.com/goharbor/harbor/src/testing/controller/project"
 	scannertesting "github.com/goharbor/harbor/src/testing/controller/scanner"
 	"github.com/goharbor/harbor/src/testing/mock"
 	htesting "github.com/goharbor/harbor/src/testing/server/v2.0/handler"
 )
+
+func TestValidateProxyCacheRepositoryFilterUpdate(t *testing.T) {
+	tests := []struct {
+		name    string
+		stored  map[string]string
+		update  *apiModels.ProjectMetadata
+		wantErr bool
+	}{
+		{
+			name: "reject pattern-only update incompatible with stored kind",
+			stored: map[string]string{
+				models.ProMetaProxyCacheFilterPattern: "^foo/.*$",
+				models.ProMetaProxyCacheFilterKind:    pattern.KindRegex,
+			},
+			update:  &apiModels.ProjectMetadata{ProxyCacheFilterPattern: stringPtr("*")},
+			wantErr: true,
+		},
+		{
+			name: "reject kind-only update incompatible with stored pattern",
+			stored: map[string]string{
+				models.ProMetaProxyCacheFilterPattern: "*",
+				models.ProMetaProxyCacheFilterKind:    pattern.KindDoublestar,
+			},
+			update:  &apiModels.ProjectMetadata{ProxyCacheFilterKind: stringPtr(pattern.KindRegex)},
+			wantErr: true,
+		},
+		{
+			name: "accept compatible partial update",
+			stored: map[string]string{
+				models.ProMetaProxyCacheFilterPattern: "^foo/.*$",
+				models.ProMetaProxyCacheFilterKind:    pattern.KindRegex,
+			},
+			update: &apiModels.ProjectMetadata{ProxyCacheFilterPattern: stringPtr("^bar/.*$")},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateProxyCacheRepositoryFilterUpdate(tt.update, tt.stored)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func stringPtr(value string) *string {
+	return &value
+}
 
 type ProjectTestSuite struct {
 	htesting.Suite

--- a/src/testing/pkg/project/metadata/manager.go
+++ b/src/testing/pkg/project/metadata/manager.go
@@ -5,6 +5,7 @@ package metadata
 import (
 	context "context"
 
+	metadata "github.com/goharbor/harbor/src/pkg/project/metadata"
 	models "github.com/goharbor/harbor/src/pkg/project/metadata/models"
 	mock "github.com/stretchr/testify/mock"
 )
@@ -135,6 +136,24 @@ func (_m *Manager) Update(ctx context.Context, projectID int64, meta map[string]
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, int64, map[string]string) error); ok {
 		r0 = rf(ctx, projectID, meta)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// UpdateWithValidation provides a mock function with given fields: ctx, projectID, meta, validate
+func (_m *Manager) UpdateWithValidation(ctx context.Context, projectID int64, meta map[string]string, validate metadata.Validator) error {
+	ret := _m.Called(ctx, projectID, meta, validate)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateWithValidation")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, int64, map[string]string, metadata.Validator) error); ok {
+		r0 = rf(ctx, projectID, meta, validate)
 	} else {
 		r0 = ret.Error(0)
 	}


### PR DESCRIPTION
Thank you for contributing to Harbor!

# Comprehensive Summary of your change

Follow-up hardening for the proxy cache repository filter introduced in #23527, addressing issues found while reviewing/adopting that change downstream. Single commit on top of `main`:

**Correctness fixes**

- **Regex anchoring escape**: a group-imbalanced pattern such as `foo)|(bar` fails to compile on its own but compiles inside the `^(?:...)$` wrapper, where the top-level alternation silently destroys the anchoring — the filter passed validation yet matched any repository starting with `foo` or ending with `bar`. `pattern.Match` now compiles the bare pattern first and rejects it.
- **Swallowed store error on kind change**: `projectMetadataAPI.validate` checked the stored pattern against a new `proxy_cache_filter_kind` only when the metadata lookup succeeded (`if ..., err := p.ctl.Get(...); err == nil`). On a transient store error the cross-validation was silently skipped, allowing an incompatible kind to persist; the invalid pattern then fails closed at pull time, returning 404 for every repository in the project. The error is now propagated, matching the sibling pattern case.
- **Inconsistent empty-kind handling**: `PUT /projects/{id}` rejected a non-empty pattern with an empty kind, while the metadata API, the matcher (`case KindDoublestar, "":`), and the swagger description all treat empty kind as the doublestar default. Both write paths now share a new `pattern.ValidateKind`, which accepts empty as the documented default.
- **Audit resolver name/ID ambiguity**: project names may be all digits; the resolver unconditionally preferred the integer interpretation, misattributing events (or losing them) for such projects even when the URL carried `x_is_resource_name=true`. The flag is now honored, mirroring `parseProjectNameOrID`.

**Cleanups**

- Removed dead in-request metadata lookups in `validate` (the API accepts one key per request, so the other filter key can only come from the store) and unreachable nil-controller guards; extracted a `requireProxyProject` helper for the duplicated proxy-project check.
- Audit resolver URL patterns are declared once and used for both resolver registration and name extraction (previously two hand-synced copies), with the `v2.0` dot escaped.
- Documented that `validateDoublestarPattern` is a port of `doValidatePattern` from doublestar/v4 (the v1 dependency has no `ValidatePattern`), so it can be kept in sync.

Regression tests added for each fix; existing tests updated where behavior intentionally changed (empty kind now valid on project update).

# Issue being fixed

Follow-up to #23527 (no separate issue filed).

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).