### PR TITLE
fix: return error from LDAP PostAuthenticate when email sync fails

### DIFF
--- a/src/core/auth/ldap/ldap.go
+++ b/src/core/auth/ldap/ldap.go
@@ -346,6 +346,7 @@ func (l *Auth) PostAuthenticate(ctx context.Context, u *models.User) error {
 				if err = l.userMgr.UpdateProfile(ctx, u, "Email"); err != nil {
 					u.Email = dbUser.Email
 					log.Errorf("failed to sync user email: %v", err)
+					return err
 				}
 			}
 		}


### PR DESCRIPTION
## Problem

When LDAP users log in and their email has changed, `PostAuthenticate` calls `UpdateProfile` to sync the email. If this fails (e.g., duplicate email violation from another account), the error was swallowed and `PostAuthenticate` returned `nil`.

However, the underlying PostgreSQL transaction was already in an aborted state due to the failed UPDATE. When the transaction middleware later tried to commit, it failed with "commit unexpectedly resulted in rollback", which was surfaced to the user as HTTP 500 with the misleading message "Core service not available".

## Fix

Return the error from `PostAuthenticate` when `UpdateProfile` fails. This:
- Allows the transaction to be properly rolled back
- Prevents the misleading "Core service not available" error
- Gives the user a proper 401 Unauthorized response (logged in the error log)

## Related

Fixes #23761

---

Jacky Water Wang | waterWang | 水水

RTC: `fj4WqyCCw3C5ShR1RfB7MoBPTpkRrBFYP1uT35g3MvT`