### PR TITLE
[Backport] test(api): enhance stability of test_copy_disability in tag immutability

### DIFF
--- a/tests/apitests/python/test_tag_immutability.py
+++ b/tests/apitests/python/test_tag_immutability.py
@@ -216,7 +216,26 @@ class TestTagImmutability(unittest.TestCase):
         #5. Can not copy artifact from project A to project B with the same repository name.
         artifact_a_src = self.artifact.get_reference_info(project_name_src, image_a["name"], image_a["tag2"], **self.USER_CLIENT)
         print("[test_copy_disability] - artifact_a_src:{}".format(artifact_a_src))
-        self.artifact.copy_artifact(project_name, image_a["name"], project_name_src+"/"+ image_a["name"] + "@" + artifact_a_src.digest, expect_status_code=412, expect_response_body = "configured as immutable, cannot be updated", **self.USER_CLIENT)
+        import time
+        time.sleep(5)
+        last_exception = None
+        for i in range(5):
+            try:
+                self.artifact.copy_artifact(
+                    project_name,
+                    image_a["name"],
+                    project_name_src + "/" + image_a["name"] + "@" + artifact_a_src.digest,
+                    expect_status_code=412,
+                    expect_response_body="configured as immutable, cannot be updated",
+                    **self.USER_CLIENT
+                )
+                break
+            except Exception as e:
+                last_exception = e
+                print("[test_copy_disability] - copy_artifact failed (round {}): {}".format(i + 1, e))
+                time.sleep(5)
+        else:
+            raise last_exception
 
     #def test_replication_disability(self):
     #    pass


### PR DESCRIPTION
Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

This is a backport of #23774 to release-2.15.0 branch to fix test case flakiness.

Please indicate you've done the following:
- [ ] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [ ] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
