### PR TITLE
test: eliminate arbitrary sleep delays in artifact DAO and gtask pool tests

### DIFF
--- a/src/lib/gtask/pool_test.go
+++ b/src/lib/gtask/pool_test.go
@@ -67,8 +67,10 @@ func TestStartAndStop(t *testing.T) {
 		ctx1 := t.Context()
 		pool.Start(ctx1)
 
-		// Let it run for a bit
-		time.Sleep(300 * time.Millisecond)
+		// Wait for tasks to run
+		assert.Eventually(t, func() bool {
+			return len(ch1) == 1 && len(ch2) > 2
+		}, 1*time.Second, 10*time.Millisecond)
 		// ch1 should only have one element as it's a one time job
 		assert.Equal(t, 1, len(ch1))
 		// ch2 should have elements over 2 as sleep 300ms and interval is 100ms
@@ -93,8 +95,10 @@ func TestStartAndStop(t *testing.T) {
 		ctx1, cancel1 := context.WithTimeout(context.Background(), 50*time.Millisecond)
 		defer cancel1()
 		pool.Start(ctx1)
-		// Let it run for a bit
-		time.Sleep(200 * time.Millisecond)
+		// Wait for task to run
+		assert.Eventually(t, func() bool {
+			return len(ch1) == 1
+		}, 1*time.Second, 10*time.Millisecond)
 		assert.Equal(t, 1, len(ch1))
 		pool.Stop()
 		close(ch1)

--- a/src/pkg/artifact/dao/dao_test.go
+++ b/src/pkg/artifact/dao/dao_test.go
@@ -489,9 +489,7 @@ func (d *daoTestSuite) TestListWithLatest() {
 	id, err := d.dao.Create(d.ctx, art)
 	d.Require().Nil(err)
 
-	time.Sleep(1 * time.Second)
-	now = time.Now()
-
+	now1 := now.Add(1 * time.Second)
 	art2 := &Artifact{
 		Type:              "IMAGE",
 		MediaType:         v1.MediaTypeImageConfig,
@@ -500,16 +498,14 @@ func (d *daoTestSuite) TestListWithLatest() {
 		RepositoryID:      1235,
 		RepositoryName:    "library2/hello-world2",
 		Digest:            "digest",
-		PushTime:          now,
-		PullTime:          now,
+		PushTime:          now1,
+		PullTime:          now1,
 		Annotations:       `{"anno1":"value1"}`,
 	}
 	id1, err := d.dao.Create(d.ctx, art2)
 	d.Require().Nil(err)
 
-	time.Sleep(1 * time.Second)
-	now = time.Now()
-
+	now2 := now.Add(2 * time.Second)
 	art3 := &Artifact{
 		Type:              "IMAGE",
 		MediaType:         v1.MediaTypeImageConfig,
@@ -518,8 +514,8 @@ func (d *daoTestSuite) TestListWithLatest() {
 		RepositoryID:      1235,
 		RepositoryName:    "library2/hello-world2",
 		Digest:            "digest2",
-		PushTime:          now,
-		PullTime:          now,
+		PushTime:          now2,
+		PullTime:          now2,
 		Annotations:       `{"anno1":"value1"}`,
 	}
 	id2, err := d.dao.Create(d.ctx, art3)


### PR DESCRIPTION
### What this PR does / why we need it
This PR removes unnecessary `time.Sleep()` delays from unit tests in `src/pkg/artifact/dao/dao_test.go` and `src/lib/gtask/pool_test.go`:

1. **`src/pkg/artifact/dao/dao_test.go`**: Replaces two `time.Sleep(1 * time.Second)` calls in `TestListWithLatest` with explicit timestamp offsets (`now.Add(1 * time.Second)` and `now.Add(2 * time.Second)`). This eliminates 2 seconds of hardcoded sleep delay, making database test execution instantaneous and 100% deterministic.
2. **`src/lib/gtask/pool_test.go`**: Replaces `time.Sleep(300 * time.Millisecond)` and `time.Sleep(200 * time.Millisecond)` with `assert.Eventually` polling so tests complete immediately once task conditions are met.

Total test acceleration: **~2.5 seconds** saved per CI test execution while preventing race conditions and test flakiness.

### Special notes for your reviewer
- All affected unit test suites pass locally.
- Minimal and focused change with zero impact on production code.

### Checklist
- [x] Title follows conventional commits convention
- [x] Code change is minimal and focused
- [x] Unit tests pass locally