### PR TITLE
(cherry-pick): query robot account to validate proxy session and fix UT

### DIFF
--- a/src/server/middleware/repoproxy/proxy.go
+++ b/src/server/middleware/repoproxy/proxy.go
@@ -25,16 +25,17 @@ import (
 
 	"github.com/goharbor/harbor/src/common/security"
 	"github.com/goharbor/harbor/src/common/security/proxycachesecret"
-	robotSc "github.com/goharbor/harbor/src/common/security/robot"
 	"github.com/goharbor/harbor/src/controller/project"
 	"github.com/goharbor/harbor/src/controller/proxy"
 	"github.com/goharbor/harbor/src/controller/registry"
+	robotCtl "github.com/goharbor/harbor/src/controller/robot"
 	"github.com/goharbor/harbor/src/lib"
 	"github.com/goharbor/harbor/src/lib/config"
 	"github.com/goharbor/harbor/src/lib/errors"
 	httpLib "github.com/goharbor/harbor/src/lib/http"
 	"github.com/goharbor/harbor/src/lib/log"
 	"github.com/goharbor/harbor/src/lib/orm"
+	"github.com/goharbor/harbor/src/lib/q"
 	"github.com/goharbor/harbor/src/lib/redis"
 	proModels "github.com/goharbor/harbor/src/pkg/project/models"
 	"github.com/goharbor/harbor/src/pkg/proxy/connection"
@@ -333,25 +334,38 @@ func isProxySession(ctx context.Context, projectName string) bool {
 	if username == proxycachesecret.ProxyCacheService {
 		return true
 	}
-	// Verify that security context is a robot security context.
-	rSc, ok := sc.(*robotSc.SecurityContext)
-	if !ok {
-		return false
-	}
-	r := rSc.User()
-	if r == nil {
-		return false
-	}
-	// Scanner robot accounts created by system must be invisible and have CreatorRef == 0.
-	// User-created robot accounts created via API have Visible == true and CreatorRef > 0.
-	if r.Visible || r.CreatorRef != 0 {
-		return false
-	}
-	// it should include the auto generate SBOM session, so that it could generate SBOM accessory in proxy cache project
+
 	robotPrefix := config.RobotPrefix(ctx)
 	scannerPrefix := config.ScannerRobotPrefix(ctx)
 	prefix := fmt.Sprintf("%s%s+%s", robotPrefix, projectName, scannerPrefix)
-	return strings.HasPrefix(username, prefix)
+	if !strings.HasPrefix(username, prefix) {
+		return false
+	}
+
+	// Since we cannot rely on getting robot.SecurityContext directly under proxy cache sbom generation,
+	// its security context is v2_token when pushing sbom, not robot SecurityContext
+	// we verify by fetching the robot account by username from database / controller.
+	// The robot name used to query is the username without the robot prefix.
+	robotName := strings.TrimPrefix(username, robotPrefix)
+	robots, err := robotCtl.Ctl.List(ctx, q.New(q.KeyWords{
+		"name": robotName,
+	}), nil)
+	if err != nil {
+		log.Errorf("failed to list robots for validation: %v", err)
+		return false
+	}
+	if len(robots) == 0 {
+		log.Infof("no robot found with name: %s", robotName)
+		return false
+	}
+	r := robots[0]
+	// Scanner robot accounts created by system must be invisible and have CreatorRef == 0.
+	// User-created robot accounts created via API have Visible == true and CreatorRef > 0.
+	if r.Visible || r.CreatorRef != 0 {
+		log.Warningf("current robot is not a scanner robot, visible: %v, creatorRef: %v", r.Visible, r.CreatorRef)
+		return false
+	}
+	return true
 }
 
 // DisableBlobAndManifestUploadMiddleware disable push artifact to a proxy project with a non-proxy session

--- a/src/server/middleware/repoproxy/proxy_test.go
+++ b/src/server/middleware/repoproxy/proxy_test.go
@@ -24,6 +24,8 @@ import (
 	securitySecret "github.com/goharbor/harbor/src/common/security/secret"
 	"github.com/goharbor/harbor/src/controller/robot"
 	pkgRobot "github.com/goharbor/harbor/src/pkg/robot/model"
+	robotmock "github.com/goharbor/harbor/src/testing/controller/robot"
+	testingmock "github.com/goharbor/harbor/src/testing/mock"
 )
 
 func TestIsProxySession(t *testing.T) {
@@ -100,6 +102,19 @@ func TestIsProxySession(t *testing.T) {
 
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
+			robotController := &robotmock.Controller{}
+			originalRobotController := robot.Ctl
+			robot.Ctl = robotController
+			defer func() {
+				robot.Ctl = originalRobotController
+			}()
+
+			if tt.name == `system scanner robot account` {
+				testingmock.OnAnything(robotController, "List").Return([]*robot.Robot{sysScannerRobot}, nil)
+			} else if tt.name == `user-created robot prefixed with scanner (poisoning attempt)` {
+				testingmock.OnAnything(robotController, "List").Return([]*robot.Robot{poisoningRobot}, nil)
+			}
+
 			got := isProxySession(tt.in, "library")
 			if got != tt.want {
 				t.Errorf(`(%v) = %v; want "%v"`, tt.in, got, tt.want)


### PR DESCRIPTION


- Update isProxySession to fetch robot from database/controller because security context under SBOM generation uses v2_token rather than robot security context.
- Mock robot controller in TestIsProxySession so that the validation lists the expected mock robots and the unit tests pass.

(cherry picked from commit c2c9649b0e5924e3eb8d7d2354f6239a03373f03)

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [ ] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [ ] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
