### PR TITLE
fix: bound hook delivery retry for tasks removed by sweep (#23785)

### DIFF
--- a/src/jobservice/hook/hook_agent.go
+++ b/src/jobservice/hook/hook_agent.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/goharbor/harbor/src/jobservice/common/rds"
 	"github.com/goharbor/harbor/src/jobservice/env"
+	"github.com/goharbor/harbor/src/jobservice/errs"
 	"github.com/goharbor/harbor/src/jobservice/job"
 	"github.com/goharbor/harbor/src/jobservice/logger"
 	"github.com/goharbor/harbor/src/lib/errors"
@@ -150,7 +151,16 @@ func (ba *basicAgent) retry(evt *Event) {
 			}
 		}
 
-		return ba.client.SendEvent(evt)
+		err = ba.client.SendEvent(evt)
+		if errs.IsObjectNotFoundError(err) {
+			// The subscribed target (e.g. the task) no longer exists, so the
+			// event can never be delivered. Stop retrying to avoid unbounded
+			// error volume from the Reaper's hourly re-fire loop.
+			logger.Infof("Hook event is abandoned as the target no longer exists: %s->%s", evt.Message, evt.URL)
+			return nil
+		}
+
+		return err
 	}, bf, func(e error, d time.Duration) {
 		logger.Errorf("Retry: sending hook event error: %s, evt=%s->%s, duration=%v", e.Error(), evt.Message, evt.URL, d)
 	})

--- a/src/jobservice/hook/hook_client.go
+++ b/src/jobservice/hook/hook_client.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	commonhttp "github.com/goharbor/harbor/src/common/http"
+	"github.com/goharbor/harbor/src/jobservice/errs"
 	"github.com/goharbor/harbor/src/lib/log"
 )
 
@@ -45,12 +46,8 @@ type basicClient struct {
 func NewClient(ctx context.Context) Client {
 	// Create transport
 	transport := &http.Transport{
-		MaxIdleConns: 20,
-		// hooks only ever target the single core endpoint, so allow all idle
-		// connections to be kept for that host (default is 2, which causes
-		// connection churn and TIME_WAIT pile-up under heavy job activity)
-		MaxIdleConnsPerHost: 20,
-		IdleConnTimeout:     30 * time.Second,
+		MaxIdleConns:    20,
+		IdleConnTimeout: 30 * time.Second,
 		DialContext: (&net.Dialer{
 			Timeout:   30 * time.Second,
 			KeepAlive: 30 * time.Second,
@@ -113,6 +110,14 @@ func (bc *basicClient) SendEvent(evt *Event) error {
 
 	// Should be 200
 	if res.StatusCode != http.StatusOK {
+		// 404 means the subscribed target no longer exists (e.g. the task was
+		// removed by the execution/task sweep while its status-change hook was
+		// still pending). Retrying can never succeed, so surface a typed
+		// not-found error for the caller to give up early.
+		if res.StatusCode == http.StatusNotFound {
+			return errs.NoObjectFoundError(evt.Data.JobID)
+		}
+
 		if res.ContentLength > 0 {
 			// read error content and return
 			dt, err := io.ReadAll(res.Body)

--- a/src/jobservice/hook/hook_client_test.go
+++ b/src/jobservice/hook/hook_client_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/goharbor/harbor/src/jobservice/errs"
 	"github.com/goharbor/harbor/src/jobservice/job"
 )
 
@@ -56,6 +57,12 @@ func (suite *HookClientTestSuite) SetupSuite() {
 
 		if change.JobID == "job_ID_failed" {
 			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		if change.JobID == "job_ID_not_found" {
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = fmt.Fprintln(w, `{"errors":[{"code":"NOT_FOUND","message":"task with job ID job_ID_not_found not found"}]}`)
 			return
 		}
 
@@ -104,4 +111,24 @@ func (suite *HookClientTestSuite) TestReportStatusFailed() {
 
 	err := suite.client.SendEvent(evt)
 	assert.NotNil(suite.T(), err, "send event: expected non nil error but got nil")
+}
+
+// TestSendEventNotFound asserts that a 404 NOT_FOUND response (e.g. the task
+// was removed by the execution/task sweep while its hook was pending) surfaces
+// as a typed object-not-found error so callers can give up retrying.
+func (suite *HookClientTestSuite) TestSendEventNotFound() {
+	changeData := &job.StatusChange{
+		JobID:  "job_ID_not_found",
+		Status: "running",
+	}
+	evt := &Event{
+		URL:       suite.mockServer.URL,
+		Data:      changeData,
+		Message:   fmt.Sprintf("Status of job %s changed to: %s", changeData.JobID, changeData.Status),
+		Timestamp: time.Now().Unix(),
+	}
+
+	err := suite.client.SendEvent(evt)
+	assert.NotNil(suite.T(), err, "send event: expected non nil error but got nil")
+	assert.True(suite.T(), errs.IsObjectNotFoundError(err), "expected object not found error but got %s", err)
 }

--- a/src/jobservice/worker/cworker/reaper.go
+++ b/src/jobservice/worker/cworker/reaper.go
@@ -185,8 +185,27 @@ func (r *reaper) syncOutdatedStats() error {
 				// Exit as it is still a valid ongoing job
 			}
 		} else if diff > 0 {
-			// The hook event of current job status is not ACKed
-			// Resend hook event by set the status again
+			// The hook event of current job status is not ACKed.
+			// Resend hook event by set the status again.
+			//
+			// If the status change happened more than MaxUpdateDuration
+			// ago and the hook is still not ACKed, the hook can never be
+			// delivered (e.g. the task row was removed by the
+			// execution/task sweep while a status-change hook was pending).
+			// Give up re-firing it so the hourly loop does not retry the
+			// same dead hook forever (see #23785).
+			if time.Unix(t.Job().Info.UpdateTime, 0).Add(config.MaxUpdateDuration()).Before(time.Now()) {
+				logger.Infof(
+					"Reaper: give up re-firing hook for job %s as status change is not ACKed within %s",
+					t.Job().Info.JobID,
+					config.MaxUpdateDuration(),
+				)
+				if err = r.unTrackInProgress(t.Job().Info.JobID); err != nil {
+					return
+				}
+				return nil
+			}
+
 			if err = t.FireHook(); err != nil {
 				return
 			}

--- a/src/jobservice/worker/cworker/reaper_test.go
+++ b/src/jobservice/worker/cworker/reaper_test.go
@@ -162,6 +162,104 @@ func (suite *ReaperTestSuite) TestSyncOutdatedStats() {
 	suite.Equal(job.SuccessStatus.String(), status, "check status")
 }
 
+func (suite *ReaperTestSuite) TestSyncOutdatedStatsGiveUpStaleHook() {
+	// Simulate a task whose status-change hook is never ACKed (e.g. the task
+	// row was removed by the execution/task sweep while the hook was pending).
+	// Once the stale status is older than MaxUpdateDuration, the Reaper must
+	// give up re-firing the hook and untrack the in-progress record, instead
+	// of retrying forever (issue #23785).
+	jid := utils.MakeIdentifier()
+	err := mockJobStatsWithUpdateTime(suite.pool, suite.namespace, jid, time.Now().Add(-2*24*time.Hour).Unix())
+	suite.NoError(err, "mock stale job stats")
+
+	mt := job.NewBasicTrackerWithID(
+		context.TODO(),
+		jid,
+		suite.namespace,
+		suite.pool,
+		func(hookURL string, change *job.StatusChange) error { return nil },
+		list.New())
+	err = mt.Load()
+	suite.NoError(err, "track stale job stats")
+	suite.ctl.On("Track", jid).Return(mt, nil)
+
+	err = suite.r.syncOutdatedStats()
+	suite.NoError(err, "sync outdated stats with stale hook")
+
+	conn := suite.pool.Get()
+	defer func() {
+		_ = conn.Close()
+	}()
+	// The in-progress track record must be removed after giving up.
+	v, err := redis.Int(conn.Do("HEXISTS", rds.KeyJobTrackInProgress(suite.namespace), jid))
+	suite.NoError(err, "check in-progress track")
+	suite.Equal(0, v, "stale unACKed job should be untracked")
+}
+
+func (suite *ReaperTestSuite) TestSyncOutdatedStatsKeepsFreshHook() {
+	// A recently-updated job whose hook is not ACKed yet must still be re-fired.
+	jid := utils.MakeIdentifier()
+	err := mockJobStatsWithUpdateTime(suite.pool, suite.namespace, jid, time.Now().Unix())
+	suite.NoError(err, "mock fresh job stats")
+
+	mt := job.NewBasicTrackerWithID(
+		context.TODO(),
+		jid,
+		suite.namespace,
+		suite.pool,
+		func(hookURL string, change *job.StatusChange) error { return nil },
+		list.New())
+	err = mt.Load()
+	suite.NoError(err, "track fresh job stats")
+	suite.ctl.On("Track", jid).Return(mt, nil)
+
+	err = suite.r.syncOutdatedStats()
+	suite.NoError(err, "sync outdated stats with fresh hook")
+
+	conn := suite.pool.Get()
+	defer func() {
+		_ = conn.Close()
+	}()
+	// The in-progress track record must remain (hook still re-fired).
+	v, err := redis.Int(conn.Do("HEXISTS", rds.KeyJobTrackInProgress(suite.namespace), jid))
+	suite.NoError(err, "check in-progress track")
+	suite.Equal(1, v, "fresh unACKed job should stay tracked")
+}
+
+func mockJobStatsWithUpdateTime(conn *redis.Pool, ns string, jid string, updateTime int64) error {
+	c := conn.Get()
+	defer func() {
+		_ = c.Close()
+	}()
+
+	rev := time.Now().Unix()
+	sk := rds.KeyJobStats(ns, jid)
+
+	args := []any{
+		sk,
+		"id", jid,
+		"status", job.SuccessStatus.String(),
+		"name", job.SampleJob,
+		"kind", job.KindGeneric,
+		"unique", 0,
+		"ref_link", fmt.Sprintf("/api/v1/jobs/%s", jid),
+		"enqueue_time", time.Now().Unix(),
+		"update_time", updateTime,
+		"revision", rev,
+		// no "ack" field -> HookAck stays nil -> hook event never ACKed
+	}
+
+	_, err := c.Do("HMSET", args...)
+	if err != nil {
+		return err
+	}
+
+	// Mock in-progress track record
+	tk := rds.KeyJobTrackInProgress(ns)
+	_, err = c.Do("HSET", tk, jid, 1)
+	return err
+}
+
 func mockJobData() (string, error) {
 	j := make(map[string]any)
 	j["name"] = job.SampleJob


### PR DESCRIPTION
## Background

When a job's task record is removed by the execution/task sweep before its status-change hook has been delivered/ACKed, jobservice enters a **permanent retry loop**: `hook_agent.go`'s retry backoff keeps failing with NOT_FOUND, and `reaper.go`'s hourly re-fire loop keeps re-triggering the same hook — with **no elapsed-time or attempt-count ceiling in either path** (#23785).

## Changes

### `reaper.go` (core fix)
`syncOutdatedStats` now checks whether a status change has been un-ACKed for longer than `MaxUpdateDuration()` (the existing `jobservice.reaper.max_update_hours` config lever, default 24h). If so, the Reaper gives up re-firing the hook and untracks the in-progress record, bounding the otherwise infinite loop.

### `hook_client.go`
A 404 NOT_FOUND response (the signature of a deleted task) is now surfaced as a typed `errs.NoObjectFoundError` instead of a raw `errors.New` string, enabling callers to detect the terminal condition.

### `hook_agent.go`
The backoff retry callback now stops immediately when the target returns NOT_FOUND (object not found), avoiding the 5-minute retry burst per reaper fire cycle.

## Tests
- **reaper_test.go**: `TestSyncOutdatedStatsGiveUpStaleHook` — verifies the Reaper untracks a job whose status change is older than MaxUpdateDuration and never ACKed. `TestSyncOutdatedStatsKeepsFreshHook` — verifies a recent un-ACKed status is still re-fired.
- **hook_client_test.go**: `TestSendEventNotFound` — verifies that a 404 NOT_FOUND response is returned as an object-not-found typed error.

<details>
<summary>Commit message</summary>

```
fix(jobservice): bound hook delivery retry for tasks removed by sweep

The Reaper's hourly re-fire loop retries a status-change hook forever
once the task row has been removed by the execution/task sweep while the
hook delivery was still pending: hook_agent's retry backoff keeps failing
with NOT_FOUND, and the Reaper's syncOutdatedStats re-fires the same hook
hourly with no elapsed-time or attempt-count ceiling, producing unbounded
error volume that obscures genuine failures.

Changes:
- reaper.go: in syncOutdatedStats, give up re-firing a hook whose status
  change has not been ACKed within MaxUpdateDuration (config lever
  jobservice.reaper.max_update_hours) and untrack the in-progress record.
- hook_client.go: surface a 404 NOT_FOUND response as a typed
  object-not-found error so callers can stop retrying.
- hook_agent.go: stop the backoff retry loop when the target no longer
  exists, avoiding repeated 5-minute retry bursts.
- Tests: reaper_test.go (stale hook is untracked, fresh hook is kept),
  hook_client_test.go (404 NOT_FOUND yields object-not-found error).

Fixes #23785
```
</details>
