### PR TITLE
fix(session): do not persist an empty session on regenerate

### DIFF
--- a/src/core/session/session.go
+++ b/src/core/session/session.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -182,29 +183,38 @@ func (rp *Provider) SessionRegenerate(ctx context.Context, oldsid, sid string) (
 	}
 	maxlifetime := time.Duration(systemSessionTimeout(ctx, rp.maxlifetime))
 	if rdb, ok := rp.c.(*redis.Cache); ok {
-		// RENAME is atomic and reports "no such key" when oldsid is already gone,
-		// so it both moves the session and detects the miss in a single round trip.
+		// RENAME is atomic and answers "no such key" when oldsid is already gone,
+		// so it moves the session and detects the miss in a single round trip.
+		// Any other failure is a transport or server error and is propagated:
+		// beego skips Set-Cookie when this returns an error, which keeps the
+		// client on its current session instead of handing it a sid we were
+		// unable to populate.
 		if err := rdb.Rename(ctx, oldsid, sid).Err(); err != nil {
-			log.Debugf("failed to rename oldsid=%s to sid=%s, error: %s", oldsid, sid, err)
+			if !isNoSuchKey(err) {
+				return nil, err
+			}
+			log.Debugf("oldsid=%s is gone, not persisting an empty session for sid=%s", oldsid, sid)
 		} else if err := rdb.Expire(ctx, sid, maxlifetime).Err(); err != nil {
 			log.Debugf("failed to set the expiration of sid=%s, error: %s", sid, err)
 		}
 	} else {
+		// Not reachable through SessionInit, which always builds a *redis.Cache,
+		// and Store.releaseSession is a no-op for any other implementation, so a
+		// session could not be persisted here anyway.
 		kv := make(map[any]any)
 		err := rp.c.Fetch(ctx, oldsid, &kv)
-		if err != nil && !errors.Is(err, cache.ErrNotFound) {
-			return nil, err
-		}
-
-		if len(kv) > 0 {
-			err = rp.c.Delete(ctx, oldsid)
-			if err != nil {
+		switch {
+		case err == nil:
+			// A session that exists but carries no values is still a session and
+			// has to be moved, so the fetch error is what decides, not len(kv).
+			if err := rp.c.Delete(ctx, oldsid); err != nil {
 				log.Debugf("failed to delete oldsid=%s, error: %s", oldsid, err)
 			}
-			err = rp.c.Save(ctx, sid, kv, maxlifetime)
-			if err != nil {
+			if err := rp.c.Save(ctx, sid, kv, maxlifetime); err != nil {
 				log.Debugf("failed to save sid=%s, error: %s", sid, err)
 			}
+		case !errors.Is(err, cache.ErrNotFound):
+			return nil, err
 		}
 	}
 
@@ -215,6 +225,13 @@ func (rp *Provider) SessionRegenerate(ctx context.Context, oldsid, sid string) (
 	// returns a usable in-memory store, and beego writes it out on SessionRelease
 	// once the caller has populated it.
 	return rp.SessionRead(ctx, sid)
+}
+
+// isNoSuchKey reports whether err is the reply Redis sends when RENAME is called
+// on a key that no longer exists. go-redis surfaces it as a plain server error,
+// so the message is the only thing to match on.
+func isNoSuchKey(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "no such key")
 }
 
 // SessionDestroy delete redis session by id

--- a/src/core/session/session.go
+++ b/src/core/session/session.go
@@ -181,23 +181,22 @@ func (rp *Provider) SessionRegenerate(ctx context.Context, oldsid, sid string) (
 		ctx = context.TODO()
 	}
 	maxlifetime := time.Duration(systemSessionTimeout(ctx, rp.maxlifetime))
-	if isExist, _ := rp.SessionExist(ctx, oldsid); !isExist {
-		err := rp.c.Save(ctx, sid, map[any]any{}, maxlifetime)
-		if err != nil {
-			log.Debugf("failed to save sid=%s, where oldsid=%s, error: %s", sid, oldsid, err)
+	if rdb, ok := rp.c.(*redis.Cache); ok {
+		// RENAME is atomic and reports "no such key" when oldsid is already gone,
+		// so it both moves the session and detects the miss in a single round trip.
+		if err := rdb.Rename(ctx, oldsid, sid).Err(); err != nil {
+			log.Debugf("failed to rename oldsid=%s to sid=%s, error: %s", oldsid, sid, err)
+		} else if err := rdb.Expire(ctx, sid, maxlifetime).Err(); err != nil {
+			log.Debugf("failed to set the expiration of sid=%s, error: %s", sid, err)
 		}
 	} else {
-		if rdb, ok := rp.c.(*redis.Cache); ok {
-			// redis has rename command
-			rdb.Rename(ctx, oldsid, sid)
-			rdb.Expire(ctx, sid, maxlifetime)
-		} else {
-			kv := make(map[any]any)
-			err := rp.c.Fetch(ctx, oldsid, &kv)
-			if err != nil && !errors.Is(err, cache.ErrNotFound) {
-				return nil, err
-			}
+		kv := make(map[any]any)
+		err := rp.c.Fetch(ctx, oldsid, &kv)
+		if err != nil && !errors.Is(err, cache.ErrNotFound) {
+			return nil, err
+		}
 
+		if len(kv) > 0 {
 			err = rp.c.Delete(ctx, oldsid)
 			if err != nil {
 				log.Debugf("failed to delete oldsid=%s, error: %s", oldsid, err)
@@ -209,6 +208,12 @@ func (rp *Provider) SessionRegenerate(ctx context.Context, oldsid, sid string) (
 		}
 	}
 
+	// Nothing is persisted when oldsid is missing. beego hands the new sid to the
+	// browser through Set-Cookie either way, so persisting an empty session here
+	// would leave the client holding a valid cookie for a session that carries no
+	// user, and every following request would be anonymous. SessionRead still
+	// returns a usable in-memory store, and beego writes it out on SessionRelease
+	// once the caller has populated it.
 	return rp.SessionRead(ctx, sid)
 }
 

--- a/src/core/session/session_test.go
+++ b/src/core/session/session_test.go
@@ -16,6 +16,8 @@ package session
 
 import (
 	"context"
+	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/beego/beego/v2/server/web/session"
@@ -97,9 +99,69 @@ func (s *sessionTestSuite) TestSessionRegenerate() {
 	s.True(s.provider.SessionExist(ctx, "session-003"))
 	s.False(s.provider.SessionExist(ctx, "session-001"))
 
-	_, err = s.provider.SessionRegenerate(ctx, "session-001", "session-004")
+	// session-001 was renamed above, so it no longer exists. Regenerating from a
+	// missing session must not leave an empty one behind under the new sid.
+	store, err = s.provider.SessionRegenerate(ctx, "session-001", "session-004")
 	s.NoError(err, "session regenerate should not error")
-	s.True(s.provider.SessionExist(ctx, "session-004"))
+	s.NotNil(store, "the caller should still get a usable store")
+
+	exist, _ := s.provider.SessionExist(ctx, "session-004")
+	s.False(exist, "an empty session should not be persisted")
+}
+
+func (s *sessionTestSuite) TestSessionRegenerateConcurrent() {
+	ctx := context.Background()
+	const workers = 20
+
+	store, err := s.provider.SessionRead(ctx, "session-concurrent")
+	s.NoError(err, "session read should not error")
+	s.NoError(store.Set(ctx, "user", "alice"))
+	store.SessionRelease(ctx, nil)
+
+	sids := make([]string, workers)
+	for i := range sids {
+		sids[i] = fmt.Sprintf("session-concurrent-%d", i)
+	}
+
+	defer func() {
+		s.NoError(s.provider.SessionDestroy(ctx, "session-concurrent"))
+		for _, sid := range sids {
+			s.NoError(s.provider.SessionDestroy(ctx, sid))
+		}
+	}()
+
+	// Every worker regenerates the same session, which is what the UI does when
+	// several requests are in flight at once.
+	errs := make([]error, workers)
+	var wg sync.WaitGroup
+	for i, sid := range sids {
+		wg.Add(1)
+		go func(i int, sid string) {
+			defer wg.Done()
+			_, errs[i] = s.provider.SessionRegenerate(ctx, "session-concurrent", sid)
+		}(i, sid)
+	}
+	wg.Wait()
+
+	for _, err := range errs {
+		s.NoError(err, "session regenerate should not error")
+	}
+
+	// Only one worker can win the rename. The others must not persist anything:
+	// whoever receives one of those sids in a cookie would otherwise be logged out.
+	persisted := 0
+	for _, sid := range sids {
+		exist, _ := s.provider.SessionExist(ctx, sid)
+		if !exist {
+			continue
+		}
+		persisted++
+
+		regenerated, err := s.provider.SessionRead(ctx, sid)
+		s.NoError(err, "session read should not error")
+		s.Equal("alice", regenerated.Get(ctx, "user"), "the regenerated session should keep its data")
+	}
+	s.Equal(1, persisted, "exactly one regenerated session should be persisted")
 }
 
 func (s *sessionTestSuite) TestSessionDestroy() {

--- a/src/core/session/session_test.go
+++ b/src/core/session/session_test.go
@@ -19,10 +19,13 @@ import (
 	"fmt"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/beego/beego/v2/server/web/session"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/goharbor/harbor/src/lib/cache"
+	"github.com/goharbor/harbor/src/lib/cache/redis"
 	"github.com/goharbor/harbor/src/lib/config"
 	_ "github.com/goharbor/harbor/src/pkg/config/db"
 	_ "github.com/goharbor/harbor/src/pkg/config/inmemory"
@@ -162,6 +165,22 @@ func (s *sessionTestSuite) TestSessionRegenerateConcurrent() {
 		s.Equal("alice", regenerated.Get(ctx, "user"), "the regenerated session should keep its data")
 	}
 	s.Equal(1, persisted, "exactly one regenerated session should be persisted")
+}
+
+func (s *sessionTestSuite) TestSessionRegenerateTransportError() {
+	ctx := context.Background()
+
+	// Nothing is listening on this port, so every command fails at the transport
+	// level. That must not be reported as a missing session: beego only skips
+	// Set-Cookie when regenerate returns an error, and handing the client a sid
+	// we could not populate is what logs the user out.
+	c, err := redis.New(cache.Options{Address: "redis://127.0.0.1:16379/0", Codec: codec})
+	s.NoError(err, "cache should be created")
+
+	provider := &Provider{c: c, maxlifetime: int64(time.Hour)}
+	store, err := provider.SessionRegenerate(ctx, "session-001", "session-006")
+	s.Error(err, "a transport failure should be propagated")
+	s.Nil(store, "no store should be returned when the backend is unreachable")
 }
 
 func (s *sessionTestSuite) TestSessionDestroy() {


### PR DESCRIPTION
Fixes #23290.

`SessionRegenerate` persists an empty session whenever it thinks `oldsid` is gone:

```go
if isExist, _ := rp.SessionExist(ctx, oldsid); !isExist {
	err := rp.c.Save(ctx, sid, map[any]any{}, maxlifetime)
}
```

beego sends the new sid to the browser through `Set-Cookie` regardless of what this function does (`session.go:322` in beego v2.3.10), so the client is left holding a valid cookie for a session with no `user` in it. Every request after that resolves to an anonymous security context, returns 401, and the UI bounces to the login page. On our registry, Redis DB0 accumulated 54 of those empty 23-byte sessions against 2 real ones.

There are two ways into that branch and only one of them is a race.

`SessionExist` cannot report failure. It wraps `Cache.Contains`, which returns `false` on any transport error, then hardcodes a nil error on top of it, and the caller discards the error anyway. A timeout, an exhausted pool or a reconnect during that single `EXISTS` is therefore indistinguishable from a missing session, and the code answers by wiping the user's session out. No concurrency needed.

The check isn't atomic either. `SessionExist` and `Rename` are two round trips, so a concurrent request can rename `oldsid` in between. `RENAME` then fails with `no such key` and nothing looks at the error, because `Rename` and `Expire` here are the promoted `*redis.Client` methods and their `Cmd` results get dropped.

This change lets RENAME decide on its own. It's atomic and it already reports `no such key`, so it moves the session and detects the miss in a single round trip, and nothing is written when the miss happens. The non-redis branch gets the same treatment through `len(kv) > 0`.

Dropping that write is safe because regenerate never had to persist anything. Its only caller is `BaseController.PopulateUserSession` (`src/core/api/base.go:162`), which sets the user right afterwards, and beego persists the store at the end of the request through the `defer ctx.Input.CruSession.SessionRelease(...)` in its `router.go`. That path uses `Set`, not `SetXX`, so it writes whether or not the key already exists. `SessionReleaseIfPresent` is part of the beego Store interface, but beego never calls it in the HTTP flow.

## Tests

`TestSessionRegenerate` asserted the old behaviour, that regenerating from a missing session creates the new key, so I inverted that assertion. `TestSessionRegenerateConcurrent` is new: 20 goroutines regenerate the same session, and it checks that exactly one survives and still carries its data.

Against `main` both fail:

```
--- FAIL: TestSession/TestSessionRegenerate
    an empty session should not be persisted
--- FAIL: TestSession/TestSessionRegenerateConcurrent
    expected: 1
    actual  : 20
    exactly one regenerated session should be persisted
```

Twenty concurrent regenerations, twenty persisted sessions, nineteen of them empty. With this change, one. The package passes with `-race`.

I can run this on the instance where we hit the bug if that helps.
