### PR TITLE
perf(blob): skip redundant Touch of healthy blobs on HEAD/PUT probes

### DIFF
--- a/src/server/middleware/blob/head_blob.go
+++ b/src/server/middleware/blob/head_blob.go
@@ -55,7 +55,13 @@ func handleHead(req *http.Request) error {
 	}
 
 	switch bb.Status {
-	case blob_models.StatusNone, blob_models.StatusDelete:
+	case blob_models.StatusNone:
+		if err := touchIfDue(req, bb); err != nil {
+			return err
+		}
+	case blob_models.StatusDelete:
+		// Rescue the blob from GC candidacy: this status transition must
+		// always be written.
 		if err := blob.Ctl.Touch(req.Context(), bb); err != nil {
 			log.Errorf("failed to update blob: %s status to StatusNone, error:%v", blobInfo.Digest, err)
 			return errors.Wrapf(err, "the request id is: %s", req.Header.Get(requestid.HeaderXRequestID))

--- a/src/server/middleware/blob/util.go
+++ b/src/server/middleware/blob/util.go
@@ -40,7 +40,13 @@ func probeBlob(r *http.Request, digest string) error {
 	}
 
 	switch bb.Status {
-	case models.StatusNone, models.StatusDelete, models.StatusDeleteFailed:
+	case models.StatusNone:
+		if err := touchIfDue(r, bb); err != nil {
+			return err
+		}
+	case models.StatusDelete, models.StatusDeleteFailed:
+		// Rescue the blob from GC candidacy: this status transition must
+		// always be written.
 		if err := blobController.Touch(r.Context(), bb); err != nil {
 			logger.Errorf("failed to update blob: %s status to StatusNone, error:%v", bb.Digest, err)
 			return errors.Wrapf(err, "the request id is: %s", r.Header.Get(requestid.HeaderXRequestID))
@@ -59,6 +65,35 @@ func probeBlob(r *http.Request, digest string) error {
 		return errors.New(nil).WithMessagef("the asking blob is in GC, mark it as non existing, request id: %s", r.Header.Get(requestid.HeaderXRequestID)).WithCode(errors.NotFoundCode)
 	default:
 		return nil
+	}
+	return nil
+}
+
+// touchIsDue reports whether a healthy (StatusNone) blob's update_time is
+// stale enough that Touch must rewrite it. For StatusNone blobs the status
+// transition is a no-op: the write exists only to refresh update_time so
+// that the GC useless-blob sweep (update_time <= now() - GC time window)
+// cannot select a blob that is still in use. If the row was written within
+// the last half window, the stored timestamp is still at least half a
+// window away from the GC boundary and rewriting it changes nothing.
+// Under concurrent pushes of images sharing base layers, this redundant
+// write is the hottest row contention on the database (every HEAD and PUT
+// of every shared layer), so it is skipped while fresh.
+func touchIsDue(bb *models.Blob) bool {
+	return time.Since(bb.UpdateTime) > time.Duration(config.GetGCTimeWindow())*time.Hour/2
+}
+
+// touchIfDue is the shared conditional-Touch path for healthy (StatusNone)
+// blobs: the blob is already healthy, Touch only refreshes update_time to
+// keep it out of GC's candidate window, so the write is skipped while the
+// timestamp is still fresh (see touchIsDue).
+func touchIfDue(r *http.Request, bb *models.Blob) error {
+	if !touchIsDue(bb) {
+		return nil
+	}
+	if err := blobController.Touch(r.Context(), bb); err != nil {
+		log.G(r.Context()).Errorf("failed to update blob: %s status to StatusNone, error:%v", bb.Digest, err)
+		return errors.Wrapf(err, "the request id is: %s", r.Header.Get(requestid.HeaderXRequestID))
 	}
 	return nil
 }

--- a/src/server/middleware/blob/util_test.go
+++ b/src/server/middleware/blob/util_test.go
@@ -1,0 +1,60 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package blob
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/goharbor/harbor/src/lib/config"
+	"github.com/goharbor/harbor/src/pkg/blob/models"
+)
+
+func TestTouchIsDue(t *testing.T) {
+	// derive the cases from the configured window (2h by default, but
+	// GC_TIME_WINDOW_HOURS may override it in the environment) so the
+	// expectations track exactly what touchIsDue reads at runtime
+	window := time.Duration(config.GetGCTimeWindow()) * time.Hour
+	if window <= 0 {
+		// GC_TIME_WINDOW_HOURS=0 disables the debounce entirely (every
+		// probe is due); the boundary cases below only exist for a
+		// positive window
+		t.Skip("GC time window is zero in this environment")
+	}
+	threshold := window / 2
+	cases := []struct {
+		name string
+		age  time.Duration
+		due  bool
+	}{
+		{"just written", 10 * time.Second, false},
+		{"well within threshold", threshold / 2, false},
+		{"just under threshold", threshold - time.Minute, false},
+		{"just over threshold", threshold + time.Minute, true},
+		// boundary: still due long before the GC window is reached,
+		// keeping at least half a window of safety margin
+		{"three quarters of the window", window * 3 / 4, true},
+		{"past the GC window", window + time.Hour, true},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			bb := &models.Blob{UpdateTime: time.Now().Add(-c.age)}
+			assert.Equal(t, c.due, touchIsDue(bb))
+		})
+	}
+}


### PR DESCRIPTION
### What this PR does

Skips the `Touch()` write for blobs that are already `StatusNone` when their `update_time` is fresher than half the GC time window. The `StatusDelete`/`StatusDeleteFailed` → `StatusNone` transitions (rescuing a blob from GC candidacy) are unchanged and always written.

### Why

Every `HEAD /v2/<name>/blobs/<digest>` and every blob/manifest PUT probe calls `Touch()` on the blob row, even when the blob is already healthy. For a `StatusNone` blob the status transition is a no-op — the write exists only to refresh `update_time` so the GC useless-blob sweep (`update_time <= now() - GC time window`) cannot select a blob that is still in use.

Under concurrent pushes of images sharing base layers, every client probes the same few blob rows and each probe rewrites them:

```
UPDATE blob SET version = version + 1, update_time = $1, status = $2 WHERE id = $3 AND version >= $4 AND status IN (...)
```

Because the `StatusNone` case uses `version >= ?`, the write always succeeds — it never conflicts, it just serializes (row lock queueing). Measured on a production Harbor (v2.15.x) during a ~1000-blob CI push burst, this statement accounted for **6.9 average active sessions** on a 2-vCPU database, concentrated on a handful of shared base-layer rows.

### Correctness, including the GC race in #23116

The GC data-loss race described in #23116 involves a blob whose `update_time` is **stale** (older than the GC window) while it is being reused. This change does not affect that case: a stale timestamp always fails the freshness check, so `Touch` still fires exactly as today — the rescue write is preserved precisely where it matters. Only writes to rows touched within the last half-window are skipped, and such rows are by construction at least half a window away from GC's selection boundary, so GC can never select a blob that received a skipped probe.

With the default 2h window: a healthy blob is re-touched at most 1 hour after its last write, leaving a full hour of margin. The freshness comparison mirrors the one the adjacent `StatusDeleting` branch already performs against `GetGCTimeWindow()`.

A boundary unit test is included (`TestTouchIsDue`), covering the just-under/just-over threshold cases and the stale case.