### PR TITLE
Bump trivy(0.74.0) and trivy adapter(0.39.0)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,8 +125,8 @@ PREPARE_VERSION_NAME=versions
 
 #versions
 REGISTRYVERSION=v2.8.3-patch-redis
-TRIVYVERSION=v0.72.0
-TRIVYADAPTERVERSION=v0.38.0
+TRIVYVERSION=v0.74.0
+TRIVYADAPTERVERSION=v0.39.0
 NODEBUILDIMAGE=node:22.22.3
 
 # version of registry for pulling the source code


### PR DESCRIPTION
Thank you for contributing to Harbor!

# Comprehensive Summary of your change
Bump trivy adapter version to 0.39.0 and trivy version to 0.74.0 in `release-2.15.0`.

# Issue being fixed

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).

Made with [Cursor](https://cursor.com)