### PR TITLE
Return 404 instead of 500 for a missing retention policy

### DIFF
--- a/src/controller/retention/controller_test.go
+++ b/src/controller/retention/controller_test.go
@@ -17,7 +17,6 @@ package retention
 import (
 	"context"
 	"os"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/mock"
@@ -26,6 +25,7 @@ import (
 	"github.com/goharbor/harbor/src/common/dao"
 	"github.com/goharbor/harbor/src/jobservice/job"
 	"github.com/goharbor/harbor/src/lib"
+	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/lib/orm"
 	"github.com/goharbor/harbor/src/lib/q"
 	"github.com/goharbor/harbor/src/pkg/retention"
@@ -192,7 +192,7 @@ func (s *ControllerTestSuite) TestPolicy() {
 
 	p1, err = c.GetRetention(ctx, id)
 	s.Require().NotNil(err)
-	s.Require().True(strings.Contains(err.Error(), "no such Retention policy"))
+	s.Require().True(errors.IsNotFoundErr(err))
 	s.Require().Nil(p1)
 }
 

--- a/src/pkg/retention/dao/retention.go
+++ b/src/pkg/retention/dao/retention.go
@@ -64,7 +64,7 @@ func GetPolicy(ctx context.Context, id int64) (*models.RetentionPolicy, error) {
 		ID: id,
 	}
 	if err := o.Read(p); err != nil {
-		return nil, err
+		return nil, orm.WrapNotFoundError(err, "retention policy %d not found", id)
 	}
 	return p, nil
 }

--- a/src/pkg/retention/dao/retention_test.go
+++ b/src/pkg/retention/dao/retention_test.go
@@ -3,13 +3,13 @@ package dao
 import (
 	"encoding/json"
 	"os"
-	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/goharbor/harbor/src/common/dao"
+	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/lib/orm"
 	"github.com/goharbor/harbor/src/lib/q"
 	"github.com/goharbor/harbor/src/pkg/retention/dao/models"
@@ -99,5 +99,5 @@ func TestPolicy(t *testing.T) {
 
 	p1, err = GetPolicy(ctx, id)
 	assert.NotNil(t, err)
-	assert.True(t, strings.Contains(err.Error(), "no row found"))
+	assert.True(t, errors.IsNotFoundErr(err))
 }

--- a/src/pkg/retention/manager.go
+++ b/src/pkg/retention/manager.go
@@ -17,10 +17,8 @@ package retention
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"time"
 
-	"github.com/beego/beego/v2/client/orm"
 	"github.com/go-openapi/strfmt"
 
 	"github.com/goharbor/harbor/src/common/utils"
@@ -87,9 +85,6 @@ func (d *DefaultManager) DeletePolicy(ctx context.Context, id int64) error {
 func (d *DefaultManager) GetPolicy(ctx context.Context, id int64) (*policy.Metadata, error) {
 	p1, err := dao.GetPolicy(ctx, id)
 	if err != nil {
-		if err == orm.ErrNoRows {
-			return nil, fmt.Errorf("no such Retention policy with id %v", id)
-		}
 		return nil, err
 	}
 	p := &policy.Metadata{}

--- a/src/pkg/retention/manager_test.go
+++ b/src/pkg/retention/manager_test.go
@@ -2,12 +2,12 @@ package retention
 
 import (
 	"os"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/goharbor/harbor/src/common/dao"
+	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/lib/orm"
 	"github.com/goharbor/harbor/src/pkg/retention/policy"
 	"github.com/goharbor/harbor/src/pkg/retention/policy/rule"
@@ -82,7 +82,7 @@ func TestPolicy(t *testing.T) {
 
 	p1, err = m.GetPolicy(ctx, id)
 	assert.NotNil(t, err)
-	assert.True(t, strings.Contains(err.Error(), "no such Retention policy"))
+	assert.True(t, errors.IsNotFoundErr(err))
 	assert.Nil(t, p1)
 }
 


### PR DESCRIPTION
`GetPolicy()` in `src/pkg/retention/dao/retention.go` returns the raw beego `orm.ErrNoRows` straight through when a retention policy id doesn't exist, instead of wrapping it with `orm.WrapNotFoundError` like the other DAOs do (project, quota, robot, blob, etc. all do this on their `Get`). Because the raw ORM error isn't recognized by the generic API error handler, it falls back to a plain `500 internal server error` instead of a 404.

Ran into this after a project got deleted and recreated - `GET /api/v2.0/retentions/{id}` for the policy that used to belong to the old project came back as a 500 instead of a 404. It also confused tooling built on top of the API (Terraform/OpenTofu's harbor provider treats a 500 here as a hard failure instead of ordinary "this is gone, recreate it" drift).

Small fix: wrap the read the same way every other DAO already does. Updated the existing DAO test's not-found check to assert `errors.IsNotFoundErr(err)` instead of matching the raw ORM error string, matching how the project DAO test checks the same thing.

Test plan:
- `go build ./pkg/retention/...` passes
- `go vet ./pkg/retention/dao/...` passes, gofmt clean
- Didn't run `TestPolicy` itself since it needs a live Postgres instance (`dao.PrepareTestForPostgresSQL()`) I don't have set up locally - happy to if someone points me at the harness, or if CI covers it