### PR TITLE
fix(helm): support external Redis with TLS and secret-based credentials

### DIFF
--- a/src/pkg/chart/testdata/harbor-schema1/templates/_helpers.tpl
+++ b/src/pkg/chart/testdata/harbor-schema1/templates/_helpers.tpl
@@ -148,7 +148,21 @@ app: "{{ template "harbor.name" . }}"
 
 {{- define "harbor.redis.scheme" -}}
   {{- with .Values.redis }}
-    {{- ternary "redis+sentinel" "redis"  (and (eq .type "external" ) (not (not .external.sentinelMasterSet))) }}
+    {{- if eq .type "external" -}}
+      {{- if not (not .external.sentinelMasterSet) -}}
+        {{- ternary "rediss+sentinel" "redis+sentinel" (.external.tlsOptions.enable) }}
+      {{- else -}}
+        {{- ternary "rediss" "redis" (.external.tlsOptions.enable) }}
+      {{- end -}}
+    {{- else -}}
+      {{ print "redis" }}
+    {{- end -}}
+  {{- end }}
+{{- end -}}
+
+{{- define "harbor.redis.enableTLS" -}}
+  {{- with .Values.redis }}
+    {{- ternary "true" "false" (and ( eq .type "external") (.external.tlsOptions.enable)) }}
   {{- end }}
 {{- end -}}
 
@@ -161,7 +175,7 @@ app: "{{ template "harbor.name" . }}"
 
 {{- define "harbor.redis.masterSet" -}}
   {{- with .Values.redis }}
-    {{- ternary .external.sentinelMasterSet "" (eq "redis+sentinel" (include "harbor.redis.scheme" $)) }}
+    {{- ternary .external.sentinelMasterSet "" (contains "+sentinel" (include "harbor.redis.scheme" $)) }}
   {{- end }}
 {{- end -}}
 
@@ -172,14 +186,48 @@ app: "{{ template "harbor.name" . }}"
 {{- end -}}
 
 
+{{- define "harbor.redis.usernamefromsecret" -}}
+  {{- $existingSecret := (lookup "v1" "Secret"  .Release.Namespace (.Values.redis.external.existingSecret)) -}}
+  {{- if and (not (empty $existingSecret)) (hasKey $existingSecret.data "REDIS_USERNAME") -}}
+    {{- printf "%s" ($existingSecret.data.REDIS_USERNAME | b64dec | trim ) }}
+  {{- end -}}
+{{- end -}}
+
 {{- define "harbor.redis.pwdfromsecret" -}}
-  {{- (lookup "v1" "Secret"  .Release.Namespace (.Values.redis.external.existingSecret)).data.REDIS_PASSWORD  | b64dec }}
+  {{- $existingSecret := (lookup "v1" "Secret"  .Release.Namespace (.Values.redis.external.existingSecret)) -}}
+  {{- if and (not (empty $existingSecret)) (hasKey $existingSecret.data "REDIS_PASSWORD") -}}
+    {{- printf "%s" ($existingSecret.data.REDIS_PASSWORD | b64dec | trim) -}}
+  {{- end -}}
+{{- end -}}
+
+{{- define "harbor.redis.usernameForRegistry" -}}
+  {{- with .Values.redis }}
+    {{- if eq .type "internal" }}
+      {{- "" -}}
+    {{- else if .external.existingSecret }}
+      {{- include "harbor.redis.usernamefromsecret" $ | trim -}}
+    {{- else }}
+      {{- .external.username | default "" -}}
+    {{- end }}
+  {{- end }}
+{{- end -}}
+
+{{- define "harbor.redis.passwordForRegistry" -}}
+  {{- with .Values.redis }}
+    {{- if eq .type "internal" }}
+      {{- "" -}}
+    {{- else if .external.existingSecret }}
+      {{- include "harbor.redis.pwdfromsecret" $ -}}
+    {{- else }}
+      {{- .external.password | default "" -}}
+    {{- end }}
+  {{- end }}
 {{- end -}}
 
 {{- define "harbor.redis.cred" -}}
   {{- with .Values.redis }}
     {{- if (and (eq .type "external" ) (.external.existingSecret)) }}
-      {{- printf ":%s@" (include "harbor.redis.pwdfromsecret" $) }}
+      {{- printf "%s:%s@" ((include "harbor.redis.usernamefromsecret" $) | urlquery) ((include "harbor.redis.pwdfromsecret" $) | urlquery) -}}
     {{- else }}
       {{- ternary (printf "%s:%s@" (.external.username | urlquery) (.external.password | urlquery)) "" (and (eq .type "external" ) (not (not .external.password))) }}
     {{- end }}
@@ -246,6 +294,25 @@ app: "{{ template "harbor.name" . }}"
   {{- with .Values.redis }}
     {{- ternary .internal.registryDatabaseIndex .external.registryDatabaseIndex (eq .type "internal") }}
   {{- end }}
+{{- end -}}
+
+{{- define "harbor.redis.tlsCABundleVolume" -}}
+- name: redis-tls-ca
+  secret:
+    secretName: {{ .Values.redis.external.tlsOptions.caSecret }}
+{{- end -}}
+
+{{- define "harbor.redis.tlsCABundleVolumeMount" -}}
+- name: redis-tls-ca
+  mountPath: /harbor_cust_cert/redis-ca.crt
+  subPath: ca.crt
+{{- end -}}
+
+{{- define "harbor.redis.tlsCABundleEnv" -}}
+{{- if and (eq .Values.redis.type "external") (.Values.redis.external.tlsOptions.enable) (.Values.redis.external.tlsOptions.caSecret) }}
+- name: REDIS_TLS_CA_FILE
+  value: /harbor_cust_cert/redis-ca.crt
+{{- end }}
 {{- end -}}
 
 {{- define "harbor.portal" -}}

--- a/src/pkg/chart/testdata/harbor-schema1/templates/core/core-dpl.yaml
+++ b/src/pkg/chart/testdata/harbor-schema1/templates/core/core-dpl.yaml
@@ -183,6 +183,9 @@ spec:
         {{- if .Values.caBundleSecretName }}
 {{ include "harbor.caBundleVolumeMount" . | indent 8 }}
         {{- end }}
+        {{- if and (eq .Values.redis.type "external") (.Values.redis.external.tlsOptions.enable) (.Values.redis.external.tlsOptions.caSecret) }}
+{{ include "harbor.redis.tlsCABundleVolumeMount" . | indent 8 }}
+        {{- end }}
 {{- if .Values.core.resources }}
         resources:
 {{ toYaml .Values.core.resources | indent 10 }}
@@ -239,6 +242,9 @@ spec:
         emptyDir: {}
       {{- if .Values.caBundleSecretName }}
 {{ include "harbor.caBundleVolume" . | indent 6 }}
+      {{- end }}
+      {{- if and (eq .Values.redis.type "external") (.Values.redis.external.tlsOptions.enable) (.Values.redis.external.tlsOptions.caSecret) }}
+{{ include "harbor.redis.tlsCABundleVolume" . | indent 6 }}
       {{- end }}
     {{- with .Values.core.nodeSelector }}
       nodeSelector:

--- a/src/pkg/chart/testdata/harbor-schema1/templates/exporter/exporter-dpl.yaml
+++ b/src/pkg/chart/testdata/harbor-schema1/templates/exporter/exporter-dpl.yaml
@@ -128,6 +128,9 @@ spec:
       {{- if .Values.caBundleSecretName }}
 {{ include "harbor.caBundleVolume" . | indent 6 }}
       {{- end }}
+      {{- if and (eq .Values.redis.type "external") (.Values.redis.external.tlsOptions.enable) (.Values.redis.external.tlsOptions.caSecret) }}
+{{ include "harbor.redis.tlsCABundleVolume" . | indent 6 }}
+      {{- end }}
     {{- with .Values.exporter.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/src/pkg/chart/testdata/harbor-schema1/templates/jobservice/jobservice-dpl.yaml
+++ b/src/pkg/chart/testdata/harbor-schema1/templates/jobservice/jobservice-dpl.yaml
@@ -146,6 +146,9 @@ spec:
         {{- if .Values.caBundleSecretName }}
 {{ include "harbor.caBundleVolumeMount" . | indent 8 }}
         {{- end }}
+        {{- if and (eq .Values.redis.type "external") (.Values.redis.external.tlsOptions.enable) (.Values.redis.external.tlsOptions.caSecret) }}
+{{ include "harbor.redis.tlsCABundleVolumeMount" . | indent 8 }}
+        {{- end }}
       volumes:
       - name: jobservice-config
         configMap:
@@ -164,6 +167,9 @@ spec:
       {{- end }}
       {{- if .Values.caBundleSecretName }}
 {{ include "harbor.caBundleVolume" . | indent 6 }}
+      {{- end }}
+      {{- if and (eq .Values.redis.type "external") (.Values.redis.external.tlsOptions.enable) (.Values.redis.external.tlsOptions.caSecret) }}
+{{ include "harbor.redis.tlsCABundleVolume" . | indent 6 }}
       {{- end }}
     {{- with .Values.jobservice.nodeSelector }}
       nodeSelector:

--- a/src/pkg/chart/testdata/harbor-schema1/templates/registry/registry-cm.yaml
+++ b/src/pkg/chart/testdata/harbor-schema1/templates/registry/registry-cm.yaml
@@ -171,12 +171,13 @@ data:
         disable: {{ $storage.disableredirect }}
     redis:
       addr: {{ template "harbor.redis.addr" . }}
-      {{- if eq "redis+sentinel" (include "harbor.redis.scheme" .) }}
+      {{- if contains "+sentinel" (include "harbor.redis.scheme" .) }}
       sentinelMasterSet: {{ template "harbor.redis.masterSet" . }}
       {{- end }}
       db: {{ template "harbor.redis.dbForRegistry" . }}
-      {{- if not (eq (include "harbor.redis.password" .) "") }}
-      password: {{ template "harbor.redis.password" . }}
+      {{- $redisPassword := include "harbor.redis.passwordForRegistry" . -}}
+      {{- if ne $redisPassword "" }}
+      password: {{ $redisPassword }}
       {{- end }}
       readtimeout: 10s
       writetimeout: 10s

--- a/src/pkg/chart/testdata/harbor-schema1/templates/registry/registry-dpl.yaml
+++ b/src/pkg/chart/testdata/harbor-schema1/templates/registry/registry-dpl.yaml
@@ -210,6 +210,9 @@ spec:
         {{- if .Values.caBundleSecretName }}
 {{ include "harbor.caBundleVolumeMount" . | indent 8 }}
         {{- end }}
+        {{- if and (eq .Values.redis.type "external") (.Values.redis.external.tlsOptions.enable) (.Values.redis.external.tlsOptions.caSecret) }}
+{{ include "harbor.redis.tlsCABundleVolumeMount" . | indent 8 }}
+        {{- end }}
       - name: registryctl
         image: {{ .Values.registry.controller.image.repository }}:{{ .Values.registry.controller.image.tag }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
@@ -358,6 +361,9 @@ spec:
         {{- if .Values.caBundleSecretName }}
 {{ include "harbor.caBundleVolumeMount" . | indent 8 }}
         {{- end }}
+        {{- if and (eq .Values.redis.type "external") (.Values.redis.external.tlsOptions.enable) (.Values.redis.external.tlsOptions.caSecret) }}
+{{ include "harbor.redis.tlsCABundleVolumeMount" . | indent 8 }}
+        {{- end }}
       volumes:
       - name: registry-htpasswd
         secret:
@@ -413,6 +419,9 @@ spec:
       {{- end }}
       {{- if .Values.caBundleSecretName }}
 {{ include "harbor.caBundleVolume" . | indent 6 }}
+      {{- end }}
+      {{- if and (eq .Values.redis.type "external") (.Values.redis.external.tlsOptions.enable) (.Values.redis.external.tlsOptions.caSecret) }}
+{{ include "harbor.redis.tlsCABundleVolume" . | indent 6 }}
       {{- end }}
     {{- with .Values.registry.nodeSelector }}
       nodeSelector:

--- a/src/pkg/chart/testdata/harbor-schema1/templates/registry/registry-secret.yaml
+++ b/src/pkg/chart/testdata/harbor-schema1/templates/registry/registry-secret.yaml
@@ -11,7 +11,7 @@ data:
   REGISTRY_HTTP_SECRET: {{ .Values.registry.secret | default (include "harbor.secretKeyHelper" (dict "key" "REGISTRY_HTTP_SECRET" "data" $existingSecret.data)) | default (randAlphaNum 16) | b64enc | quote }}
   {{- end }}
   {{- if not .Values.redis.external.existingSecret }}
-  REGISTRY_REDIS_PASSWORD: {{ include "harbor.redis.password" . | b64enc | quote }}
+  REGISTRY_REDIS_PASSWORD: {{ include "harbor.redis.passwordForRegistry" . | b64enc | quote }}
   {{- end }}
   {{- $storage := .Values.persistence.imageChartStorage }}
   {{- $type := $storage.type }}

--- a/src/pkg/chart/testdata/harbor-schema1/templates/trivy/trivy-sts.yaml
+++ b/src/pkg/chart/testdata/harbor-schema1/templates/trivy/trivy-sts.yaml
@@ -150,6 +150,9 @@ spec:
           {{- if .Values.caBundleSecretName }}
 {{ include "harbor.caBundleVolumeMount" . | indent 10 }}
           {{- end }}
+          {{- if and (eq .Values.redis.type "external") (.Values.redis.external.tlsOptions.enable) (.Values.redis.external.tlsOptions.caSecret) }}
+{{ include "harbor.redis.tlsCABundleVolumeMount" . | indent 10 }}
+          {{- end }}
           livenessProbe:
             httpGet:
               scheme: {{ include "harbor.component.scheme" . | upper }}

--- a/src/pkg/chart/testdata/harbor-schema1/values.yaml
+++ b/src/pkg/chart/testdata/harbor-schema1/values.yaml
@@ -1020,8 +1020,16 @@ redis:
     # username field can be an empty string, and it will be authenticated against the default user
     username: ""
     password: ""
-    # If using existingSecret, the key must be REDIS_PASSWORD
+    # If using existingSecret, the key must be REDIS_PASSWORD and optionally REDIS_USERNAME
     existingSecret: ""
+    # TLS configuration for external Redis connection
+    # When enabled, the scheme will be `rediss://` (or `rediss+sentinel://` for sentinel mode)
+    # mTLS for Redis connection is not supported
+    tlsOptions:
+      enable: false
+      # The secret containing the CA certificate (key: ca.crt)
+      # If not set, the system CA bundle will be used
+      caSecret: ""
   ## Additional deployment annotations
   podAnnotations: {}
   ## Additional deployment labels

--- a/src/pkg/chart/testdata/harbor-schema2/templates/_helpers.tpl
+++ b/src/pkg/chart/testdata/harbor-schema2/templates/_helpers.tpl
@@ -148,7 +148,21 @@ app: "{{ template "harbor.name" . }}"
 
 {{- define "harbor.redis.scheme" -}}
   {{- with .Values.redis }}
-    {{- ternary "redis+sentinel" "redis"  (and (eq .type "external" ) (not (not .external.sentinelMasterSet))) }}
+    {{- if eq .type "external" -}}
+      {{- if not (not .external.sentinelMasterSet) -}}
+        {{- ternary "rediss+sentinel" "redis+sentinel" (.external.tlsOptions.enable) }}
+      {{- else -}}
+        {{- ternary "rediss" "redis" (.external.tlsOptions.enable) }}
+      {{- end -}}
+    {{- else -}}
+      {{ print "redis" }}
+    {{- end -}}
+  {{- end }}
+{{- end -}}
+
+{{- define "harbor.redis.enableTLS" -}}
+  {{- with .Values.redis }}
+    {{- ternary "true" "false" (and ( eq .type "external") (.external.tlsOptions.enable)) }}
   {{- end }}
 {{- end -}}
 
@@ -161,7 +175,7 @@ app: "{{ template "harbor.name" . }}"
 
 {{- define "harbor.redis.masterSet" -}}
   {{- with .Values.redis }}
-    {{- ternary .external.sentinelMasterSet "" (eq "redis+sentinel" (include "harbor.redis.scheme" $)) }}
+    {{- ternary .external.sentinelMasterSet "" (contains "+sentinel" (include "harbor.redis.scheme" $)) }}
   {{- end }}
 {{- end -}}
 
@@ -172,14 +186,48 @@ app: "{{ template "harbor.name" . }}"
 {{- end -}}
 
 
+{{- define "harbor.redis.usernamefromsecret" -}}
+  {{- $existingSecret := (lookup "v1" "Secret"  .Release.Namespace (.Values.redis.external.existingSecret)) -}}
+  {{- if and (not (empty $existingSecret)) (hasKey $existingSecret.data "REDIS_USERNAME") -}}
+    {{- printf "%s" ($existingSecret.data.REDIS_USERNAME | b64dec | trim ) }}
+  {{- end -}}
+{{- end -}}
+
 {{- define "harbor.redis.pwdfromsecret" -}}
-  {{- (lookup "v1" "Secret"  .Release.Namespace (.Values.redis.external.existingSecret)).data.REDIS_PASSWORD  | b64dec }}
+  {{- $existingSecret := (lookup "v1" "Secret"  .Release.Namespace (.Values.redis.external.existingSecret)) -}}
+  {{- if and (not (empty $existingSecret)) (hasKey $existingSecret.data "REDIS_PASSWORD") -}}
+    {{- printf "%s" ($existingSecret.data.REDIS_PASSWORD | b64dec | trim) -}}
+  {{- end -}}
+{{- end -}}
+
+{{- define "harbor.redis.usernameForRegistry" -}}
+  {{- with .Values.redis }}
+    {{- if eq .type "internal" }}
+      {{- "" -}}
+    {{- else if .external.existingSecret }}
+      {{- include "harbor.redis.usernamefromsecret" $ | trim -}}
+    {{- else }}
+      {{- .external.username | default "" -}}
+    {{- end }}
+  {{- end }}
+{{- end -}}
+
+{{- define "harbor.redis.passwordForRegistry" -}}
+  {{- with .Values.redis }}
+    {{- if eq .type "internal" }}
+      {{- "" -}}
+    {{- else if .external.existingSecret }}
+      {{- include "harbor.redis.pwdfromsecret" $ -}}
+    {{- else }}
+      {{- .external.password | default "" -}}
+    {{- end }}
+  {{- end }}
 {{- end -}}
 
 {{- define "harbor.redis.cred" -}}
   {{- with .Values.redis }}
     {{- if (and (eq .type "external" ) (.external.existingSecret)) }}
-      {{- printf ":%s@" (include "harbor.redis.pwdfromsecret" $) }}
+      {{- printf "%s:%s@" ((include "harbor.redis.usernamefromsecret" $) | urlquery) ((include "harbor.redis.pwdfromsecret" $) | urlquery) -}}
     {{- else }}
       {{- ternary (printf "%s:%s@" (.external.username | urlquery) (.external.password | urlquery)) "" (and (eq .type "external" ) (not (not .external.password))) }}
     {{- end }}
@@ -246,6 +294,25 @@ app: "{{ template "harbor.name" . }}"
   {{- with .Values.redis }}
     {{- ternary .internal.registryDatabaseIndex .external.registryDatabaseIndex (eq .type "internal") }}
   {{- end }}
+{{- end -}}
+
+{{- define "harbor.redis.tlsCABundleVolume" -}}
+- name: redis-tls-ca
+  secret:
+    secretName: {{ .Values.redis.external.tlsOptions.caSecret }}
+{{- end -}}
+
+{{- define "harbor.redis.tlsCABundleVolumeMount" -}}
+- name: redis-tls-ca
+  mountPath: /harbor_cust_cert/redis-ca.crt
+  subPath: ca.crt
+{{- end -}}
+
+{{- define "harbor.redis.tlsCABundleEnv" -}}
+{{- if and (eq .Values.redis.type "external") (.Values.redis.external.tlsOptions.enable) (.Values.redis.external.tlsOptions.caSecret) }}
+- name: REDIS_TLS_CA_FILE
+  value: /harbor_cust_cert/redis-ca.crt
+{{- end }}
 {{- end -}}
 
 {{- define "harbor.portal" -}}

--- a/src/pkg/chart/testdata/harbor-schema2/templates/core/core-dpl.yaml
+++ b/src/pkg/chart/testdata/harbor-schema2/templates/core/core-dpl.yaml
@@ -183,6 +183,9 @@ spec:
         {{- if .Values.caBundleSecretName }}
 {{ include "harbor.caBundleVolumeMount" . | indent 8 }}
         {{- end }}
+        {{- if and (eq .Values.redis.type "external") (.Values.redis.external.tlsOptions.enable) (.Values.redis.external.tlsOptions.caSecret) }}
+{{ include "harbor.redis.tlsCABundleVolumeMount" . | indent 8 }}
+        {{- end }}
 {{- if .Values.core.resources }}
         resources:
 {{ toYaml .Values.core.resources | indent 10 }}
@@ -239,6 +242,9 @@ spec:
         emptyDir: {}
       {{- if .Values.caBundleSecretName }}
 {{ include "harbor.caBundleVolume" . | indent 6 }}
+      {{- end }}
+      {{- if and (eq .Values.redis.type "external") (.Values.redis.external.tlsOptions.enable) (.Values.redis.external.tlsOptions.caSecret) }}
+{{ include "harbor.redis.tlsCABundleVolume" . | indent 6 }}
       {{- end }}
     {{- with .Values.core.nodeSelector }}
       nodeSelector:

--- a/src/pkg/chart/testdata/harbor-schema2/templates/exporter/exporter-dpl.yaml
+++ b/src/pkg/chart/testdata/harbor-schema2/templates/exporter/exporter-dpl.yaml
@@ -128,6 +128,9 @@ spec:
       {{- if .Values.caBundleSecretName }}
 {{ include "harbor.caBundleVolume" . | indent 6 }}
       {{- end }}
+      {{- if and (eq .Values.redis.type "external") (.Values.redis.external.tlsOptions.enable) (.Values.redis.external.tlsOptions.caSecret) }}
+{{ include "harbor.redis.tlsCABundleVolume" . | indent 6 }}
+      {{- end }}
     {{- with .Values.exporter.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/src/pkg/chart/testdata/harbor-schema2/templates/jobservice/jobservice-dpl.yaml
+++ b/src/pkg/chart/testdata/harbor-schema2/templates/jobservice/jobservice-dpl.yaml
@@ -146,6 +146,9 @@ spec:
         {{- if .Values.caBundleSecretName }}
 {{ include "harbor.caBundleVolumeMount" . | indent 8 }}
         {{- end }}
+        {{- if and (eq .Values.redis.type "external") (.Values.redis.external.tlsOptions.enable) (.Values.redis.external.tlsOptions.caSecret) }}
+{{ include "harbor.redis.tlsCABundleVolumeMount" . | indent 8 }}
+        {{- end }}
       volumes:
       - name: jobservice-config
         configMap:
@@ -164,6 +167,9 @@ spec:
       {{- end }}
       {{- if .Values.caBundleSecretName }}
 {{ include "harbor.caBundleVolume" . | indent 6 }}
+      {{- end }}
+      {{- if and (eq .Values.redis.type "external") (.Values.redis.external.tlsOptions.enable) (.Values.redis.external.tlsOptions.caSecret) }}
+{{ include "harbor.redis.tlsCABundleVolume" . | indent 6 }}
       {{- end }}
     {{- with .Values.jobservice.nodeSelector }}
       nodeSelector:

--- a/src/pkg/chart/testdata/harbor-schema2/templates/registry/registry-cm.yaml
+++ b/src/pkg/chart/testdata/harbor-schema2/templates/registry/registry-cm.yaml
@@ -171,12 +171,13 @@ data:
         disable: {{ $storage.disableredirect }}
     redis:
       addr: {{ template "harbor.redis.addr" . }}
-      {{- if eq "redis+sentinel" (include "harbor.redis.scheme" .) }}
+      {{- if contains "+sentinel" (include "harbor.redis.scheme" .) }}
       sentinelMasterSet: {{ template "harbor.redis.masterSet" . }}
       {{- end }}
       db: {{ template "harbor.redis.dbForRegistry" . }}
-      {{- if not (eq (include "harbor.redis.password" .) "") }}
-      password: {{ template "harbor.redis.password" . }}
+      {{- $redisPassword := include "harbor.redis.passwordForRegistry" . -}}
+      {{- if ne $redisPassword "" }}
+      password: {{ $redisPassword }}
       {{- end }}
       readtimeout: 10s
       writetimeout: 10s

--- a/src/pkg/chart/testdata/harbor-schema2/templates/registry/registry-dpl.yaml
+++ b/src/pkg/chart/testdata/harbor-schema2/templates/registry/registry-dpl.yaml
@@ -210,6 +210,9 @@ spec:
         {{- if .Values.caBundleSecretName }}
 {{ include "harbor.caBundleVolumeMount" . | indent 8 }}
         {{- end }}
+        {{- if and (eq .Values.redis.type "external") (.Values.redis.external.tlsOptions.enable) (.Values.redis.external.tlsOptions.caSecret) }}
+{{ include "harbor.redis.tlsCABundleVolumeMount" . | indent 8 }}
+        {{- end }}
       - name: registryctl
         image: {{ .Values.registry.controller.image.repository }}:{{ .Values.registry.controller.image.tag }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
@@ -358,6 +361,9 @@ spec:
         {{- if .Values.caBundleSecretName }}
 {{ include "harbor.caBundleVolumeMount" . | indent 8 }}
         {{- end }}
+        {{- if and (eq .Values.redis.type "external") (.Values.redis.external.tlsOptions.enable) (.Values.redis.external.tlsOptions.caSecret) }}
+{{ include "harbor.redis.tlsCABundleVolumeMount" . | indent 8 }}
+        {{- end }}
       volumes:
       - name: registry-htpasswd
         secret:
@@ -413,6 +419,9 @@ spec:
       {{- end }}
       {{- if .Values.caBundleSecretName }}
 {{ include "harbor.caBundleVolume" . | indent 6 }}
+      {{- end }}
+      {{- if and (eq .Values.redis.type "external") (.Values.redis.external.tlsOptions.enable) (.Values.redis.external.tlsOptions.caSecret) }}
+{{ include "harbor.redis.tlsCABundleVolume" . | indent 6 }}
       {{- end }}
     {{- with .Values.registry.nodeSelector }}
       nodeSelector:

--- a/src/pkg/chart/testdata/harbor-schema2/templates/registry/registry-secret.yaml
+++ b/src/pkg/chart/testdata/harbor-schema2/templates/registry/registry-secret.yaml
@@ -11,7 +11,7 @@ data:
   REGISTRY_HTTP_SECRET: {{ .Values.registry.secret | default (include "harbor.secretKeyHelper" (dict "key" "REGISTRY_HTTP_SECRET" "data" $existingSecret.data)) | default (randAlphaNum 16) | b64enc | quote }}
   {{- end }}
   {{- if not .Values.redis.external.existingSecret }}
-  REGISTRY_REDIS_PASSWORD: {{ include "harbor.redis.password" . | b64enc | quote }}
+  REGISTRY_REDIS_PASSWORD: {{ include "harbor.redis.passwordForRegistry" . | b64enc | quote }}
   {{- end }}
   {{- $storage := .Values.persistence.imageChartStorage }}
   {{- $type := $storage.type }}

--- a/src/pkg/chart/testdata/harbor-schema2/templates/trivy/trivy-sts.yaml
+++ b/src/pkg/chart/testdata/harbor-schema2/templates/trivy/trivy-sts.yaml
@@ -150,6 +150,9 @@ spec:
           {{- if .Values.caBundleSecretName }}
 {{ include "harbor.caBundleVolumeMount" . | indent 10 }}
           {{- end }}
+          {{- if and (eq .Values.redis.type "external") (.Values.redis.external.tlsOptions.enable) (.Values.redis.external.tlsOptions.caSecret) }}
+{{ include "harbor.redis.tlsCABundleVolumeMount" . | indent 10 }}
+          {{- end }}
           livenessProbe:
             httpGet:
               scheme: {{ include "harbor.component.scheme" . | upper }}

--- a/src/pkg/chart/testdata/harbor-schema2/values.yaml
+++ b/src/pkg/chart/testdata/harbor-schema2/values.yaml
@@ -1020,8 +1020,16 @@ redis:
     # username field can be an empty string, and it will be authenticated against the default user
     username: ""
     password: ""
-    # If using existingSecret, the key must be REDIS_PASSWORD
+    # If using existingSecret, the key must be REDIS_PASSWORD and optionally REDIS_USERNAME
     existingSecret: ""
+    # TLS configuration for external Redis connection
+    # When enabled, the scheme will be `rediss://` (or `rediss+sentinel://` for sentinel mode)
+    # mTLS for Redis connection is not supported
+    tlsOptions:
+      enable: false
+      # The secret containing the CA certificate (key: ca.crt)
+      # If not set, the system CA bundle will be used
+      caSecret: ""
   ## Additional deployment annotations
   podAnnotations: {}
   ## Additional deployment labels


### PR DESCRIPTION
Fixes 8 templating bugs that prevent using a managed external Redis (e.g. Managed Valkey) with TLS and Kubernetes Secrets:

1. harbor.redis.scheme: Add rediss:// and rediss+sentinel:// support via redis.external.tlsOptions.enable (was always redis://)

2. harbor.redis.pwdfromsecret: Nil-safe secret lookup — no longer crashes if the secret doesn't exist yet (Sealed Secrets, External Secrets, etc.)

3. harbor.redis.usernamefromsecret: New helper to pull REDIS_USERNAME from existing secret (was missing entirely)

4. harbor.redis.cred: Include username from secret, not just password (was hardcoded to :password@, dropping ACL usernames)

5. harbor.redis.masterSet: Use contains instead of eq so sentinel+TLS (rediss+sentinel) works (eq broke it)

6. harbor.redis.passwordForRegistry/usernameForRegistry: New helpers that resolve credentials from either plaintext values or existing secret, used by registry configmap and secret templates

7. registry-cm.yaml: Use passwordForRegistry so password is picked up from existing secret instead of only plaintext .external.password

8. Add tlsOptions (enable + caSecret) to values.yaml for both schema1 and schema2. Wire CA cert volume mounts into core, jobservice, registry, trivy, and exporter deployments.

With these fixes, configuring external Redis is:
  redis:
    type: external
    external:
      addr: valkey.example.com:6379
      existingSecret: harbor-redis-creds  # REDIS_USERNAME + REDIS_PASSWORD
      tlsOptions:
        enable: true
        caSecret: harbor-redis-ca       # ca.crt

No in-cluster Redis PVC required.

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [ ] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [ ] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
