### PR TITLE
fix(exporter): use consistent time units for cache expiration

### DIFF
--- a/src/pkg/exporter/cache.go
+++ b/src/pkg/exporter/cache.go
@@ -70,7 +70,10 @@ func CacheDelete(key string) {
 
 // StartCacheCleaner start a cache clean job
 func StartCacheCleaner() {
-	now := time.Now().UnixNano()
+	cleanExpired(time.Now().Unix())
+}
+
+func cleanExpired(now int64) {
 	c.Lock()
 	defer c.Unlock()
 	for k, v := range c.store {

--- a/src/pkg/exporter/cache_test.go
+++ b/src/pkg/exporter/cache_test.go
@@ -68,3 +68,28 @@ func TestCleanExpired(t *testing.T) {
 		t.Fatal("cleanExpired retained an expired cache entry")
 	}
 }
+
+func TestStartCacheCleaner(t *testing.T) {
+	CacheInit(&Opt{CacheDuration: 60})
+	CachePut("fresh", "v")
+
+	c.Lock()
+	c.store["stale"] = cachedValue{
+		Value:      "v",
+		Expiration: time.Now().Unix() - 1,
+	}
+	c.Unlock()
+
+	StartCacheCleaner()
+
+	if _, ok := CacheGet("fresh"); !ok {
+		t.Fatal("StartCacheCleaner removed a fresh entry")
+	}
+
+	c.RLock()
+	_, ok := c.store["stale"]
+	c.RUnlock()
+	if ok {
+		t.Fatal("StartCacheCleaner retained an expired entry")
+	}
+}

--- a/src/pkg/exporter/cache_test.go
+++ b/src/pkg/exporter/cache_test.go
@@ -1,6 +1,7 @@
 package exporter
 
 import (
+	"testing"
 	"time"
 
 	"github.com/stretchr/testify/suite"
@@ -35,4 +36,35 @@ func (c *CacheTestSuite) TestCacheFunction() {
 	time.Sleep(2 * time.Second)
 	_, ok = CacheGet("key2")
 	c.False(ok)
+}
+
+func TestCleanExpired(t *testing.T) {
+	CacheInit(&Opt{
+		CacheDuration: 60,
+	})
+
+	now := time.Now().Unix()
+	c.Lock()
+	c.store["valid"] = cachedValue{
+		Value:      "valid",
+		Expiration: now + 60,
+	}
+	c.store["expired"] = cachedValue{
+		Value:      "expired",
+		Expiration: now - 1,
+	}
+	c.Unlock()
+
+	cleanExpired(now)
+
+	c.RLock()
+	_, validExists := c.store["valid"]
+	_, expiredExists := c.store["expired"]
+	c.RUnlock()
+	if !validExists {
+		t.Fatal("cleanExpired removed a valid cache entry")
+	}
+	if expiredExists {
+		t.Fatal("cleanExpired retained an expired cache entry")
+	}
 }


### PR DESCRIPTION
# Comprehensive Summary of your change

Fix the Harbor exporter cache cleaner so that it compares cache expiration timestamps using the same time unit used when entries are stored.

`CachePut` stores expiration timestamps in Unix seconds, while `StartCacheCleaner` previously used Unix nanoseconds for the current time. This caused valid cache entries to be deleted during the first cleaner run.

This change:

- Uses Unix seconds in `StartCacheCleaner`.
- Extracts the expiration removal logic into `cleanExpired(now int64)`.
- Adds regression coverage for valid and expired cache entries.

# Issue being fixed

Fixes  https://github.com/goharbor/harbor/issues/23805

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [ ] Label the PR as needed.
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact; no documentation changes are required for this bug fix.