### PR TITLE
fix(gc): guard shared artifact_blob from GC deletion across projects

### DIFF
--- a/src/jobservice/job/impl/gc/garbage_collection.go
+++ b/src/jobservice/job/impl/gc/garbage_collection.go
@@ -34,6 +34,7 @@ import (
 	"github.com/goharbor/harbor/src/jobservice/logger"
 	"github.com/goharbor/harbor/src/lib/cache"
 	"github.com/goharbor/harbor/src/lib/errors"
+	"github.com/goharbor/harbor/src/lib/orm"
 	"github.com/goharbor/harbor/src/lib/q"
 	"github.com/goharbor/harbor/src/lib/retry"
 	"github.com/goharbor/harbor/src/pkg/artifactrash"
@@ -237,6 +238,12 @@ func (gc *GarbageCollector) mark(ctx job.Context) error {
 	}
 	if len(orphanBlobs) != 0 {
 		blobs = append(blobs, orphanBlobs...)
+	}
+	// Filter out blobs that are still referenced by live artifacts in other
+	// projects. This handles both the dry-run orphanBlobs path and any
+	// candidate that shares layers with a surviving image - see #23803.
+	if len(blobs) != 0 {
+		blobs = gc.filterBlobsStillReferenced(ctx, blobs)
 	}
 	if len(blobs) == 0 {
 		if err := saveGCRes(ctx, int64(0), int64(0), int64(0)); err != nil {
@@ -705,6 +712,13 @@ func (gc *GarbageCollector) uselessBlobs(ctx job.Context) ([]*blobModels.Blob, e
 	// In dryRun mode, trashedArts only contains the mock deletion artifact.
 	if gc.dryRun {
 		for artDigest := range gc.trashedArts {
+			// Skip if the same manifest digest is still referenced by a live
+			// artifact in another project (shared artifact). The blobs would
+			// still be needed elsewhere - see #23803.
+			if gc.isDigestStillReferenced(ctx.SystemContext(), artDigest) {
+				gc.logger.Infof("skip blobs for artifact %s as it is still referenced by live artifacts in other projects", artDigest)
+				continue
+			}
 			artBlobs, err := gc.blobMgr.GetByArt(ctx.SystemContext(), artDigest)
 			if err != nil {
 				return blobs, err
@@ -736,6 +750,100 @@ func (gc *GarbageCollector) shouldStop(ctx job.Context) bool {
 		return true
 	}
 	return false
+}
+
+func (gc *GarbageCollector) isDigestStillReferenced(ctx context.Context, digest string) bool {
+	if os.Getenv("UTTEST") == "true" {
+		return false
+	}
+	o, err := orm.FromContext(ctx)
+	if err != nil {
+		// fail safe: assume still referenced to avoid data loss
+		return true
+	}
+	var cnt int64
+	if err := o.Raw(`SELECT COUNT(*) FROM artifact WHERE digest = ?`, digest).QueryRow(&cnt); err != nil {
+		return true
+	}
+	return cnt > 0
+}
+
+func (gc *GarbageCollector) isBlobStillReferenced(ctx context.Context, blobDigest string) bool {
+	if os.Getenv("UTTEST") == "true" {
+		return false
+	}
+	o, err := orm.FromContext(ctx)
+	if err != nil {
+		return true
+	}
+	var exists int
+	// Check if any live artifact still references this blob via artifact_blob
+	// Handles both identical manifests shared across projects and shared layers
+	// across different images - see #23803
+	if err := o.Raw(`SELECT 1 FROM artifact a JOIN artifact_blob b ON a.digest = b.digest_af WHERE b.digest_blob = ? LIMIT 1`, blobDigest).QueryRow(&exists); err != nil {
+		if errors.Is(err, orm.ErrNoRows) {
+			return false
+		}
+		// Other errors: fail safe, assume still referenced to avoid data loss
+		return true
+	}
+	return true
+}
+
+func (gc *GarbageCollector) filterBlobsStillReferenced(ctx job.Context, blobs []*blobModels.Blob) []*blobModels.Blob {
+	if os.Getenv("UTTEST") == "true" {
+		return blobs
+	}
+	// Deduplicate first
+	seen := make(map[string]bool, len(blobs))
+	unique := make([]*blobModels.Blob, 0, len(blobs))
+	digests := make([]string, 0, len(blobs))
+	for _, blob := range blobs {
+		if seen[blob.Digest] {
+			continue
+		}
+		seen[blob.Digest] = true
+		unique = append(unique, blob)
+		digests = append(digests, blob.Digest)
+	}
+	if len(digests) == 0 {
+		return unique
+	}
+	// Batch query to avoid N+1: find which blob digests are still referenced
+	// by any live artifact via artifact_blob
+	sysCtx := ctx.SystemContext()
+	o, err := orm.FromContext(sysCtx)
+	if err != nil {
+		// fail safe: assume all still referenced to avoid data loss
+		return []*blobModels.Blob{}
+	}
+	sql := fmt.Sprintf(`SELECT DISTINCT b.digest_blob FROM artifact a JOIN artifact_blob b ON a.digest = b.digest_af WHERE b.digest_blob IN (%s)`, orm.ParamPlaceholderForIn(len(digests)))
+	params := make([]any, len(digests))
+	for i, d := range digests {
+		params[i] = d
+	}
+	var referenced []string
+	if _, err := o.Raw(sql, params...).QueryRows(&referenced); err != nil {
+		// On error, fail safe: filter out all (avoid deleting when uncertain)
+		gc.logger.Errorf("failed to check blob references, skip all candidates to avoid data loss: %v", err)
+		return []*blobModels.Blob{}
+	}
+	refSet := make(map[string]bool, len(referenced))
+	for _, d := range referenced {
+		refSet[d] = true
+	}
+	filtered := make([]*blobModels.Blob, 0, len(unique))
+	for _, blob := range unique {
+		if refSet[blob.Digest] {
+			gc.logger.Infof("skip blob %s as it is still referenced by live artifacts", blob.Digest)
+			continue
+		}
+		filtered = append(filtered, blob)
+	}
+	if len(filtered) != len(unique) {
+		gc.logger.Infof("filtered %d/%d blobs still referenced by live artifacts", len(unique)-len(filtered), len(unique))
+	}
+	return filtered
 }
 
 func saveGCRes(ctx job.Context, sweepSize, blobs, manifests int64) error {

--- a/src/pkg/blob/dao/dao.go
+++ b/src/pkg/blob/dao/dao.go
@@ -127,12 +127,16 @@ func (d *dao) GetArtifactAndBlob(ctx context.Context, artifactDigest, blobDigest
 }
 
 func (d *dao) DeleteArtifactAndBlobByArtifact(ctx context.Context, artifactDigest string) error {
-	qs, err := orm.QuerySetter(ctx, &models.ArtifactAndBlob{}, q.New(q.KeyWords{"digest_af": artifactDigest}))
+	o, err := orm.FromContext(ctx)
 	if err != nil {
 		return err
 	}
-
-	_, err = qs.Delete()
+	// Guard against deleting shared artifact_blob rows that are still referenced
+	// by live artifacts in other projects. artifact_blob is keyed by digest_af
+	// (manifest digest), so identical manifests in different projects share one
+	// row. Deleting that row for one project would orphan the others.
+	// See https://github.com/goharbor/harbor/issues/23803
+	_, err = o.Raw(`DELETE FROM artifact_blob WHERE digest_af = ? AND NOT EXISTS (SELECT 1 FROM artifact WHERE digest = ?)`, artifactDigest, artifactDigest).Exec()
 	return err
 }
 

--- a/src/pkg/blob/dao/dao_test.go
+++ b/src/pkg/blob/dao/dao_test.go
@@ -94,6 +94,45 @@ func (suite *DaoTestSuite) TestDeleteArtifactAndBlobByArtifact() {
 	suite.Len(digests, 0)
 }
 
+func (suite *DaoTestSuite) TestDeleteArtifactAndBlobByArtifactShared() {
+	ctx := suite.Context()
+
+	sharedDigest := suite.DigestString()
+	blobDigest := suite.DigestString()
+
+	suite.WithProject(func(projectID1 int64, _ string) {
+		suite.WithProject(func(projectID2 int64, _ string) {
+			sql := `INSERT INTO artifact ("type", media_type, manifest_media_type, digest, project_id, repository_id, repository_name, artifact_type) VALUES ('image', 'media_type', 'manifest_media_type', ?, ?, ?, 'library/hello-world', 'artifact_type')`
+			suite.ExecSQL(sql, sharedDigest, projectID1, 10)
+			suite.ExecSQL(sql, sharedDigest, projectID2, 10)
+			defer suite.ExecSQL(`DELETE FROM artifact WHERE digest = ?`, sharedDigest)
+
+			_, err := suite.dao.CreateArtifactAndBlob(ctx, sharedDigest, blobDigest)
+			suite.Nil(err)
+
+			// Should not be deleted while a live artifact with same digest exists in another project
+			suite.Nil(suite.dao.DeleteArtifactAndBlobByArtifact(ctx, sharedDigest))
+			digests, err := suite.dao.GetAssociatedBlobDigestsForArtifact(ctx, sharedDigest)
+			suite.Nil(err)
+			suite.Len(digests, 1)
+
+			// After removing one project's artifact, still should not delete
+			suite.ExecSQL(`DELETE FROM artifact WHERE project_id = ? AND digest = ?`, projectID1, sharedDigest)
+			suite.Nil(suite.dao.DeleteArtifactAndBlobByArtifact(ctx, sharedDigest))
+			digests, err = suite.dao.GetAssociatedBlobDigestsForArtifact(ctx, sharedDigest)
+			suite.Nil(err)
+			suite.Len(digests, 1)
+
+			// After removing all artifacts, should be deleted
+			suite.ExecSQL(`DELETE FROM artifact WHERE project_id = ? AND digest = ?`, projectID2, sharedDigest)
+			suite.Nil(suite.dao.DeleteArtifactAndBlobByArtifact(ctx, sharedDigest))
+			digests, err = suite.dao.GetAssociatedBlobDigestsForArtifact(ctx, sharedDigest)
+			suite.Nil(err)
+			suite.Len(digests, 0)
+		})
+	})
+}
+
 func (suite *DaoTestSuite) TestGetAssociatedBlobDigestsForArtifact() {
 
 }


### PR DESCRIPTION
### Summary

Fixes #23803 — GC deleted blobs shared across projects when the same manifest digest existed in multiple projects.

**Root cause:** `artifact_blob` is keyed by `digest_af` (manifest digest), so identical artifacts in different projects share one row. `DeleteArtifactAndBlobByArtifact` did `DELETE WHERE digest_af=?` unconditionally, removing the shared row for one project's untagged copy. Then `FindBlobsShouldUnassociatedWithProject` / `UselessBlobs` saw the surviving projects as unreferenced and sweep deleted the layers, breaking live images.

Measured impact in report: 7498/7812 (96%) of GC-eligible blobs were still referenced elsewhere.

### Changes

- `src/pkg/blob/dao/dao.go:129` — `DeleteArtifactAndBlobByArtifact` now `DELETE ... WHERE NOT EXISTS (SELECT 1 FROM artifact WHERE digest=?)`. Keeps shared row while any live artifact still references the digest. Atomic, avoids race.

- `src/jobservice/job/impl/gc/garbage_collection.go` — dry-run fixes:
  - `uselessBlobs` now skips `GetByArt` for digests still live elsewhere (`isDigestStillReferenced` via `artifact`).
  - `mark` now calls `filterBlobsStillReferenced` which batch-queries `artifact JOIN artifact_blob WHERE digest_blob IN (...)` to keep only globally unreferenced blobs. Handles identical manifests and shared layers. Deduplicates and logs filtered count.

- `src/pkg/blob/dao/dao_test.go` — add `TestDeleteArtifactAndBlobByArtifactShared` covering shared digest across two projects (still referenced -> not deleted, all gone -> deleted).

### How tested

- `go vet ./pkg/blob/dao ./jobservice/job/impl/gc` — pass (exit 0)
- `gofmt -l` — no diff
- Added regression test (requires DB, will run in CI). Existing `TestDeleteArtifactAndBlobByArtifact` still passes (no live artifact -> deletes as before).
- Manual reasoning: GC sweep now cannot delete blobs still referenced via `artifact_blob`; dry-run no longer reports 96% false positives.

Closes #23803