### PR TITLE
fix(proxy): resolve tags asynchronously for proxy-cache audit logs

### DIFF
--- a/src/controller/event/handler/auditlog/auditlog.go
+++ b/src/controller/event/handler/auditlog/auditlog.go
@@ -17,13 +17,17 @@ package auditlog
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/goharbor/harbor/src/controller/event"
 	evtModel "github.com/goharbor/harbor/src/controller/event/model"
+	"github.com/goharbor/harbor/src/jobservice/job"
+	atrJob "github.com/goharbor/harbor/src/jobservice/job/impl/audittagresolution"
 	"github.com/goharbor/harbor/src/lib/config"
 	"github.com/goharbor/harbor/src/lib/log"
 	"github.com/goharbor/harbor/src/pkg/auditext"
 	am "github.com/goharbor/harbor/src/pkg/auditext/model"
+	"github.com/goharbor/harbor/src/pkg/task"
 )
 
 // Handler - audit log handler
@@ -43,6 +47,7 @@ func (h *Handler) Name() string {
 // Handle ...
 func (h *Handler) Handle(ctx context.Context, value any) error {
 	var addAuditLog bool
+	var isPull bool
 	switch v := value.(type) {
 	case *event.PushArtifactEvent, *event.DeleteArtifactEvent,
 		*event.DeleteRepositoryEvent, *event.CreateProjectEvent, *event.DeleteProjectEvent,
@@ -51,6 +56,7 @@ func (h *Handler) Handle(ctx context.Context, value any) error {
 		addAuditLog = true
 	case *event.PullArtifactEvent:
 		addAuditLog = !config.PullAuditLogDisable(ctx)
+		isPull = true
 	default:
 		log.Errorf("Can not handler this event type! %#v", v)
 	}
@@ -63,13 +69,49 @@ func (h *Handler) Handle(ctx context.Context, value any) error {
 			return err
 		}
 		if auditLog != nil && config.AuditLogEventEnabled(ctx, fmt.Sprintf("%v_%v", auditLog.Operation, auditLog.ResourceType)) {
-			_, err := auditext.Mgr.Create(ctx, auditLog)
+			id, err := auditext.Mgr.Create(ctx, auditLog)
 			if err != nil {
 				log.Infof("add audit log err: %v", err)
+			}
+			// For digest-only pull entries, enqueue a background job to resolve tags.
+			// The resource field uses "@" for digest references and ":" for tag references.
+			if isPull && id > 0 && strings.Contains(auditLog.Resource, "@") {
+				h.enqueueTagResolution(ctx, id, auditLog)
 			}
 		}
 	}
 	return nil
+}
+
+func (h *Handler) enqueueTagResolution(ctx context.Context, auditLogID int64, auditLog *am.AuditLogExt) {
+	// Extract repository and digest from resource "repo@sha256:abc..."
+	parts := strings.SplitN(auditLog.Resource, "@", 2)
+	if len(parts) != 2 {
+		return
+	}
+	repo, digest := parts[0], parts[1]
+
+	params := map[string]any{
+		atrJob.ParamAuditLogID: auditLogID,
+		atrJob.ParamRepository: repo,
+		atrJob.ParamDigest:     digest,
+	}
+
+	execID, err := task.ExecMgr.Create(ctx, job.AuditTagResolutionVendorType, -1, task.ExecutionTriggerEvent, params)
+	if err != nil {
+		log.Errorf("failed to create audit tag resolution execution: %v", err)
+		return
+	}
+	_, err = task.Mgr.Create(ctx, execID, &task.Job{
+		Name: job.AuditTagResolutionVendorType,
+		Metadata: &job.Metadata{
+			JobKind: job.KindGeneric,
+		},
+		Parameters: params,
+	})
+	if err != nil {
+		log.Errorf("failed to create audit tag resolution task: %v", err)
+	}
 }
 
 // IsStateful ...

--- a/src/jobservice/job/impl/audittagresolution/job.go
+++ b/src/jobservice/job/impl/audittagresolution/job.go
@@ -1,0 +1,137 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package audittagresolution
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/goharbor/harbor/src/jobservice/job"
+	"github.com/goharbor/harbor/src/lib/errors"
+	"github.com/goharbor/harbor/src/lib/q"
+	"github.com/goharbor/harbor/src/pkg/artifact"
+	"github.com/goharbor/harbor/src/pkg/auditext"
+	"github.com/goharbor/harbor/src/pkg/tag"
+)
+
+const (
+	ParamAuditLogID = "audit_log_id"
+	ParamRepository = "repository"
+	ParamDigest     = "digest"
+)
+
+// Job resolves tags for audit log entries that were recorded with a digest
+// instead of a tag (e.g. proxy cache pulls where the GET uses the digest).
+type Job struct {
+	auditMgr    auditext.Manager
+	artifactMgr artifact.Manager
+	tagMgr      tag.Manager
+}
+
+func (j *Job) MaxFails() uint {
+	return 3
+}
+
+func (j *Job) MaxCurrency() uint {
+	return 5
+}
+
+func (j *Job) ShouldRetry() bool {
+	return true
+}
+
+func (j *Job) Validate(params job.Parameters) error {
+	if params == nil {
+		return errors.New("missing job parameters")
+	}
+	for _, key := range []string{ParamAuditLogID, ParamRepository, ParamDigest} {
+		if _, ok := params[key]; !ok {
+			return fmt.Errorf("missing required parameter %q", key)
+		}
+	}
+	return nil
+}
+
+func (j *Job) init() {
+	if j.auditMgr == nil {
+		j.auditMgr = auditext.Mgr
+	}
+	if j.artifactMgr == nil {
+		j.artifactMgr = artifact.NewManager()
+	}
+	if j.tagMgr == nil {
+		j.tagMgr = tag.NewManager()
+	}
+}
+
+func (j *Job) Run(ctx job.Context, params job.Parameters) error {
+	j.init()
+	logger := ctx.GetLogger()
+	sysCtx := ctx.SystemContext()
+
+	auditLogID, ok := params[ParamAuditLogID].(float64)
+	if !ok {
+		return fmt.Errorf("invalid type for %s", ParamAuditLogID)
+	}
+	repo, ok := params[ParamRepository].(string)
+	if !ok {
+		return fmt.Errorf("invalid type for %s", ParamRepository)
+	}
+	digest, ok := params[ParamDigest].(string)
+	if !ok {
+		return fmt.Errorf("invalid type for %s", ParamDigest)
+	}
+
+	art, err := j.artifactMgr.GetByDigest(sysCtx, repo, digest)
+	if err != nil {
+		if errors.IsNotFoundErr(err) {
+			logger.Infof("artifact %s@%s not found, skipping tag resolution", repo, digest)
+			return nil
+		}
+		return err
+	}
+
+	tags, err := j.tagMgr.List(sysCtx, q.New(q.KeyWords{"ArtifactID": art.ID}))
+	if err != nil {
+		return err
+	}
+	if len(tags) == 0 {
+		return nil
+	}
+
+	names := make([]string, 0, len(tags))
+	for _, t := range tags {
+		names = append(names, t.Name)
+	}
+
+	entry, err := j.auditMgr.Get(sysCtx, int64(auditLogID))
+	if err != nil {
+		return err
+	}
+
+	resolvedNote := fmt.Sprintf("resolved tags: %s", strings.Join(names, ", "))
+	if entry.OperationDescription != "" {
+		entry.OperationDescription += "; " + resolvedNote
+	} else {
+		entry.OperationDescription = resolvedNote
+	}
+
+	if err := j.auditMgr.Update(sysCtx, entry, "OperationDescription"); err != nil {
+		return err
+	}
+
+	logger.Infof("resolved tags for audit log %d: %s", int64(auditLogID), strings.Join(names, ", "))
+	return nil
+}

--- a/src/jobservice/job/impl/audittagresolution/job_test.go
+++ b/src/jobservice/job/impl/audittagresolution/job_test.go
@@ -1,0 +1,151 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package audittagresolution
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/goharbor/harbor/src/jobservice/job"
+	"github.com/goharbor/harbor/src/lib/errors"
+	"github.com/goharbor/harbor/src/lib/q"
+	artpkg "github.com/goharbor/harbor/src/pkg/artifact"
+	am "github.com/goharbor/harbor/src/pkg/auditext/model"
+	tagmodel "github.com/goharbor/harbor/src/pkg/tag/model/tag"
+	mockjobservice "github.com/goharbor/harbor/src/testing/jobservice"
+	mockAuditExt "github.com/goharbor/harbor/src/testing/pkg/auditext"
+	mockArt "github.com/goharbor/harbor/src/testing/pkg/artifact"
+	mockTag "github.com/goharbor/harbor/src/testing/pkg/tag"
+)
+
+func TestValidateParams(t *testing.T) {
+	j := &Job{}
+	assert.Error(t, j.Validate(nil))
+	assert.Error(t, j.Validate(job.Parameters{}))
+	assert.Error(t, j.Validate(job.Parameters{ParamAuditLogID: float64(1)}))
+	assert.NoError(t, j.Validate(job.Parameters{
+		ParamAuditLogID: float64(1),
+		ParamRepository: "library/nginx",
+		ParamDigest:     "sha256:abc",
+	}))
+}
+
+func TestShouldRetry(t *testing.T) {
+	j := &Job{}
+	assert.True(t, j.ShouldRetry())
+}
+
+func TestRunResolvesTag(t *testing.T) {
+	auditMgr := mockAuditExt.NewManager(t)
+	artifactMgr := mockArt.NewManager(t)
+	tagMgr := mockTag.NewManager(t)
+
+	j := &Job{
+		auditMgr:    auditMgr,
+		artifactMgr: artifactMgr,
+		tagMgr:      tagMgr,
+	}
+
+	ctx := &mockjobservice.MockJobContext{}
+	ctx.On("GetLogger").Return(&mockjobservice.MockJobLogger{})
+
+	params := job.Parameters{
+		ParamAuditLogID: float64(42),
+		ParamRepository: "library/nginx",
+		ParamDigest:     "sha256:abc",
+	}
+
+	art := &artpkg.Artifact{}
+	art.ID = 10
+	artifactMgr.On("GetByDigest", context.TODO(), "library/nginx", "sha256:abc").Return(art, nil)
+
+	tagMgr.On("List", context.TODO(), mock.MatchedBy(func(query *q.Query) bool {
+		return query.Keywords["ArtifactID"] == int64(10)
+	})).Return([]*tagmodel.Tag{
+		{Name: "8.1.0"},
+		{Name: "latest"},
+	}, nil)
+
+	entry := &am.AuditLogExt{
+		ID:                   42,
+		OperationDescription: "pull artifact: library/nginx@sha256:abc",
+	}
+	auditMgr.On("Get", context.TODO(), int64(42)).Return(entry, nil)
+	auditMgr.On("Update", context.TODO(), mock.MatchedBy(func(a *am.AuditLogExt) bool {
+		return a.OperationDescription == "pull artifact: library/nginx@sha256:abc; resolved tags: 8.1.0, latest"
+	}), "OperationDescription").Return(nil)
+
+	err := j.Run(ctx, params)
+	assert.NoError(t, err)
+}
+
+func TestRunNoTags(t *testing.T) {
+	auditMgr := mockAuditExt.NewManager(t)
+	artifactMgr := mockArt.NewManager(t)
+	tagMgr := mockTag.NewManager(t)
+
+	j := &Job{
+		auditMgr:    auditMgr,
+		artifactMgr: artifactMgr,
+		tagMgr:      tagMgr,
+	}
+
+	ctx := &mockjobservice.MockJobContext{}
+	ctx.On("GetLogger").Return(&mockjobservice.MockJobLogger{})
+
+	params := job.Parameters{
+		ParamAuditLogID: float64(42),
+		ParamRepository: "library/nginx",
+		ParamDigest:     "sha256:abc",
+	}
+
+	art := &artpkg.Artifact{}
+	art.ID = 10
+	artifactMgr.On("GetByDigest", context.TODO(), "library/nginx", "sha256:abc").Return(art, nil)
+	tagMgr.On("List", context.TODO(), mock.Anything).Return([]*tagmodel.Tag{}, nil)
+
+	err := j.Run(ctx, params)
+	assert.NoError(t, err)
+}
+
+func TestRunArtifactNotFound(t *testing.T) {
+	auditMgr := mockAuditExt.NewManager(t)
+	artifactMgr := mockArt.NewManager(t)
+	tagMgr := mockTag.NewManager(t)
+
+	j := &Job{
+		auditMgr:    auditMgr,
+		artifactMgr: artifactMgr,
+		tagMgr:      tagMgr,
+	}
+
+	ctx := &mockjobservice.MockJobContext{}
+	ctx.On("GetLogger").Return(&mockjobservice.MockJobLogger{})
+
+	params := job.Parameters{
+		ParamAuditLogID: float64(42),
+		ParamRepository: "library/nginx",
+		ParamDigest:     "sha256:abc",
+	}
+
+	artifactMgr.On("GetByDigest", context.TODO(), "library/nginx", "sha256:abc").
+		Return(nil, errors.NotFoundError(nil).WithMessage("not found"))
+
+	err := j.Run(ctx, params)
+	assert.NoError(t, err)
+}

--- a/src/jobservice/job/known_jobs.go
+++ b/src/jobservice/job/known_jobs.go
@@ -50,6 +50,8 @@ const (
 	ScanAllVendorType = "SCAN_ALL"
 	// AuditLogsGDPRCompliantVendorType : the name of the job which makes audit logs table GDPR-compliant
 	AuditLogsGDPRCompliantVendorType = "AUDIT_LOGS_GDPR_COMPLIANT"
+	// AuditTagResolutionVendorType : the name of the job which resolves tags for digest-only audit log entries
+	AuditTagResolutionVendorType = "AUDIT_TAG_RESOLUTION"
 )
 
 var (
@@ -68,6 +70,7 @@ var (
 		SystemArtifactCleanupVendorType: lib.GetEnvInt64("SYSTEM_ARTIFACT_CLEANUP_EXECUTION_RETENTION_COUNT", 50),
 		P2PPreheatVendorType:            lib.GetEnvInt64("P2P_PREHEAT_EXECUTION_RETENTION_COUNT", 50),
 		RetentionVendorType:             lib.GetEnvInt64("RETENTION_EXECUTION_RETENTION_COUNT", 50),
+		AuditTagResolutionVendorType:    lib.GetEnvInt64("AUDIT_TAG_RESOLUTION_EXECUTION_RETENTION_COUNT", 50),
 	}
 )
 

--- a/src/jobservice/runtime/bootstrap.go
+++ b/src/jobservice/runtime/bootstrap.go
@@ -24,6 +24,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/goharbor/harbor/src/jobservice/job/impl/audittagresolution"
 	"github.com/goharbor/harbor/src/jobservice/job/impl/gdpr"
 
 	"github.com/gomodule/redigo/redis"
@@ -335,6 +336,7 @@ func (bs *Bootstrap) loadAndRunRedisWorkerPool(
 			job.SystemArtifactCleanupVendorType:  (*systemartifact.Cleanup)(nil),
 			job.ExecSweepVendorType:              (*task.SweepJob)(nil),
 			job.AuditLogsGDPRCompliantVendorType: (*gdpr.AuditLogsDataMasking)(nil),
+			job.AuditTagResolutionVendorType:     (*audittagresolution.Job)(nil),
 		}); err != nil {
 		// exit
 		return nil, err

--- a/src/pkg/auditext/dao/dao.go
+++ b/src/pkg/auditext/dao/dao.go
@@ -44,6 +44,8 @@ type DAO interface {
 	Purge(ctx context.Context, retentionHour int, includeOperations []string, dryRun bool) (int64, error)
 	// UpdateUsername replaces username in matched records
 	UpdateUsername(ctx context.Context, username string, usernameReplace string) error
+	// Update updates the audit log ext. Only the properties specified by "props" will be updated if set
+	Update(ctx context.Context, audit *model.AuditLogExt, props ...string) error
 }
 
 // New returns an instance of the default DAO
@@ -136,6 +138,16 @@ func (d *dao) Delete(ctx context.Context, id int64) error {
 		return errors.NotFoundError(nil).WithMessagef("access %d not found", id)
 	}
 	return nil
+}
+
+// Update updates the audit log ext record
+func (d *dao) Update(ctx context.Context, audit *model.AuditLogExt, props ...string) error {
+	o, err := orm.FromContext(ctx)
+	if err != nil {
+		return err
+	}
+	_, err = o.Update(audit, props...)
+	return err
 }
 
 // Purge delete expired audit log ext

--- a/src/pkg/auditext/manager.go
+++ b/src/pkg/auditext/manager.go
@@ -43,6 +43,8 @@ type Manager interface {
 	Purge(ctx context.Context, retentionHour int, includeOperations []string, dryRun bool) (int64, error)
 	// UpdateUsername Replace all log records username with its hash
 	UpdateUsername(ctx context.Context, username string, replaceWith string) error
+	// Update the audit log. Only the properties specified by "props" will be updated if set
+	Update(ctx context.Context, audit *model.AuditLogExt, props ...string) error
 }
 
 // New returns a default implementation of Manager
@@ -99,4 +101,8 @@ func (m *manager) Purge(ctx context.Context, retentionHour int, includeOperation
 // Delete ...
 func (m *manager) Delete(ctx context.Context, id int64) error {
 	return m.dao.Delete(ctx, id)
+}
+
+func (m *manager) Update(ctx context.Context, audit *model.AuditLogExt, props ...string) error {
+	return m.dao.Update(ctx, audit, props...)
 }

--- a/src/testing/pkg/auditext/dao/dao.go
+++ b/src/testing/pkg/auditext/dao/dao.go
@@ -177,6 +177,31 @@ func (_m *DAO) Purge(ctx context.Context, retentionHour int, includeOperations [
 	return r0, r1
 }
 
+// Update provides a mock function with given fields: ctx, audit, props
+func (_m *DAO) Update(ctx context.Context, audit *model.AuditLogExt, props ...string) error {
+	_va := make([]interface{}, len(props))
+	for _i := range props {
+		_va[_i] = props[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, audit)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Update")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, *model.AuditLogExt, ...string) error); ok {
+		r0 = rf(ctx, audit, props...)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // UpdateUsername provides a mock function with given fields: ctx, username, usernameReplace
 func (_m *DAO) UpdateUsername(ctx context.Context, username string, usernameReplace string) error {
 	ret := _m.Called(ctx, username, usernameReplace)

--- a/src/testing/pkg/auditext/manager.go
+++ b/src/testing/pkg/auditext/manager.go
@@ -177,6 +177,31 @@ func (_m *Manager) Purge(ctx context.Context, retentionHour int, includeOperatio
 	return r0, r1
 }
 
+// Update provides a mock function with given fields: ctx, audit, props
+func (_m *Manager) Update(ctx context.Context, audit *model.AuditLogExt, props ...string) error {
+	_va := make([]interface{}, len(props))
+	for _i := range props {
+		_va[_i] = props[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, audit)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Update")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, *model.AuditLogExt, ...string) error); ok {
+		r0 = rf(ctx, audit, props...)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // UpdateUsername provides a mock function with given fields: ctx, username, replaceWith
 func (_m *Manager) UpdateUsername(ctx context.Context, username string, replaceWith string) error {
 	ret := _m.Called(ctx, username, replaceWith)


### PR DESCRIPTION
# Description

When an image is pulled by tag through a Proxy Cache project, Docker resolves it in two separate HTTP requests: a HEAD (which knows the tag) followed by a GET (which uses the resolved digest, not the tag). The audit log event fires during the GET, so it records the digest instead of the tag, making pull auditing impossible for proxy cache projects.

This PR adds an async background job that resolves the tag after the fact, without touching the pull path itself. After a digest-only pull audit log entry is created, the job is enqueued. It looks up the artifact by digest, reads whatever tag(s) currently point at it, and appends a `resolved tags: <tags>` note to the entry's description. If multiple tags currently resolve to the same digest, all of them are listed. If no tag is found (a legitimate direct-digest pull), the job does nothing.

The pull/push critical path (`proxyManifestHead`, `ProxyManifest`, `SendPullEvent`) is unmodified. No caching is introduced.

Fixes #23783 ( following the approach discussed with @Vad1mo on the issue.
Fully decoupled, async, triggered after the audit log write, with resolved tags appended to the entry rather than mutating the original logged identifier.)

Note on format:
Harbor's audit log model (AuditLogExt) doesn't have a dedicated comments field, so the resolved tags note is appended to OperationDescription instead it already holds descriptive pull text (e.g. pull artifact: repo@sha256:...), and this keeps the addition visible in the same place. Open to a different field if you'd prefer.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Unit test: tag resolves correctly and is appended to the audit log entry
- [x] Unit test: multiple tags on the same digest are all listed, comma-separated
- [x] Unit test: no tags found for the digest → job exits without modifying the entry
- [x] Unit test: artifact not found for the digest → job exits without error

**Test Configuration**:
* Harbor version: v2.15.2
* Reproduced manually with a Proxy Cache project against Docker Hub, pulling by tag via Docker CLI, and confirming the audit log entry is updated with the resolved tag shortly after the pull

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules