### PR TITLE
fix: make hostname comparisons case-insensitive

### DIFF
--- a/src/pkg/reg/adapter/awsecr/auth.go
+++ b/src/pkg/reg/adapter/awsecr/auth.go
@@ -59,7 +59,7 @@ const DefaultCacheExpiredTime = time.Hour * 1
 
 func (a *awsAuthCredential) Modify(req *http.Request) error {
 	// url maybe redirect to s3
-	if !strings.Contains(req.URL.Host, ".ecr.") {
+	if !strings.Contains(strings.ToLower(req.URL.Host), ".ecr.") {
 		return nil
 	}
 	if !a.isTokenValid() {

--- a/src/pkg/reg/adapter/harbor/base/adapter.go
+++ b/src/pkg/reg/adapter/harbor/base/adapter.go
@@ -17,6 +17,7 @@ package base
 import (
 	"fmt"
 	"net/http"
+	neturl "net/url"
 	"os"
 	"strconv"
 	"strings"
@@ -317,8 +318,23 @@ type Project struct {
 	RegistryID int64          `json:"registry_id"`
 }
 
-func isLocalHarbor(url string) bool {
-	return url == os.Getenv("CORE_URL")
+func isLocalHarbor(rawURL string) bool {
+	coreURL := os.Getenv("CORE_URL")
+	if rawURL == coreURL {
+		return true
+	}
+	u, err := neturl.Parse(rawURL)
+	if err != nil {
+		return false
+	}
+	c, err := neturl.Parse(coreURL)
+	if err != nil {
+		return false
+	}
+	// the host portion of a URL (DNS name) is case-insensitive, unlike the path
+	u.Host = strings.ToLower(u.Host)
+	c.Host = strings.ToLower(c.Host)
+	return u.String() == c.String()
 }
 
 // check whether the current process is running inside core

--- a/src/pkg/reg/adapter/harbor/base/adapter_test.go
+++ b/src/pkg/reg/adapter/harbor/base/adapter_test.go
@@ -315,3 +315,96 @@ func TestListProjects(t *testing.T) {
 	require.Equal(t, "p1", projects[0].Name)
 	require.Equal(t, "p2", projects[1].Name)
 }
+
+func TestIsLocalHarbor(t *testing.T) {
+	tests := []struct {
+		name     string
+		coreURL  string
+		rawURL   string
+		expected bool
+	}{
+		{
+			name:     "Identical URLs",
+			coreURL:  "http://core:8080",
+			rawURL:   "http://core:8080",
+			expected: true,
+		},
+		{
+			name:     "Case insensitive host",
+			coreURL:  "http://core:8080",
+			rawURL:   "http://CORE:8080",
+			expected: true,
+		},
+		{
+			name:     "Case sensitive path",
+			coreURL:  "http://core:8080/api",
+			rawURL:   "http://core:8080/API",
+			expected: false,
+		},
+		{
+			name:     "Different URLs",
+			coreURL:  "http://core:8080",
+			rawURL:   "http://other:8080",
+			expected: false,
+		},
+		{
+			name:     "Invalid raw URL",
+			coreURL:  "http://core:8080",
+			rawURL:   "http://\x7finvalid-url",
+			expected: false,
+		},
+		{
+			name:     "Invalid core URL",
+			coreURL:  "http://\x7finvalid-url",
+			rawURL:   "http://core:8080",
+			expected: false,
+		},
+		{
+			name:     "Empty core URL",
+			coreURL:  "",
+			rawURL:   "http://core:8080",
+			expected: false,
+		},
+		{
+			name:     "Empty raw URL",
+			coreURL:  "http://core:8080",
+			rawURL:   "",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("CORE_URL", tt.coreURL)
+			actual := isLocalHarbor(tt.rawURL)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
+func TestIsInCore(t *testing.T) {
+	tests := []struct {
+		name        string
+		extEndpoint string
+		expected    bool
+	}{
+		{
+			name:        "In Core with endpoint",
+			extEndpoint: "http://core:8080",
+			expected:    true,
+		},
+		{
+			name:        "Not in Core with empty endpoint",
+			extEndpoint: "",
+			expected:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("EXT_ENDPOINT", tt.extEndpoint)
+			actual := isInCore()
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}

--- a/src/pkg/registry/auth/authorizer.go
+++ b/src/pkg/registry/auth/authorizer.go
@@ -145,7 +145,7 @@ func (a *authorizer) isTarget(req *http.Request) bool {
 	if index == -1 {
 		return false
 	}
-	if req.URL.Host != a.url.Host || req.URL.Scheme != a.url.Scheme ||
+	if !strings.EqualFold(req.URL.Host, a.url.Host) || req.URL.Scheme != a.url.Scheme ||
 		req.URL.Path[:index+4] != a.url.Path {
 		return false
 	}

--- a/src/server/middleware/v2auth/auth.go
+++ b/src/server/middleware/v2auth/auth.go
@@ -156,7 +156,7 @@ func match(ctx context.Context, reqHost, rawURL string) bool {
 	if cfgURL.Scheme == "https" && strings.HasSuffix(reqHost, ":443") {
 		reqHost = strings.TrimSuffix(reqHost, ":443")
 	}
-	return reqHost == cfgURL.Host
+	return strings.EqualFold(reqHost, cfgURL.Host)
 }
 
 var (


### PR DESCRIPTION
    - Support case-insensitive host comparisons in registry auth, adapter, and v2auth middleware.
    - Parse and downcase the host part of URLs when verifying local Harbor instances.
    - Add comprehensive unit tests for isLocalHarbor

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [ ] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [ ] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
