### PR TITLE
fix: correct typos in comments and two log/error messages

### DIFF
--- a/src/common/utils/uaa/client.go
+++ b/src/common/utils/uaa/client.go
@@ -62,7 +62,7 @@ type ClientConfig struct {
 	ClientSecret  string
 	Endpoint      string
 	SkipTLSVerify bool
-	// Absolut path for CA root used to communicate with UAA, only effective when skipTLSVerify set to false.
+	// Absolute path for CA root used to communicate with UAA, only effective when skipTLSVerify set to false.
 	CARootPath string
 }
 

--- a/src/controller/blob/controller.go
+++ b/src/controller/blob/controller.go
@@ -58,7 +58,7 @@ type Controller interface {
 
 	// Exist check blob exist by digest,
 	// it check the blob associated with the artifact when `IsAssociatedWithArtifact` option provided,
-	// and also check the blob associated with the project when `IsAssociatedWithProject` option provied.
+	// and also check the blob associated with the project when `IsAssociatedWithProject` option provided.
 	Exist(ctx context.Context, digest string, options ...Option) (bool, error)
 
 	// FindMissingAssociationsForProjectByArtifact returns blobs which are associated with artifact but not associated with project
@@ -66,7 +66,7 @@ type Controller interface {
 
 	// Get get the blob by digest,
 	// it check the blob associated with the artifact when `IsAssociatedWithArtifact` option provided,
-	// and also check the blob associated with the project when `IsAssociatedWithProject` option provied.
+	// and also check the blob associated with the project when `IsAssociatedWithProject` option provided.
 	Get(ctx context.Context, digest string, options ...Option) (*blob.Blob, error)
 
 	// List list blobs

--- a/src/controller/replication/transfer/transfer.go
+++ b/src/controller/replication/transfer/transfer.go
@@ -39,9 +39,9 @@ type Transfer interface {
 
 // Logger defines an interface for logging
 type Logger interface {
-	// For debuging
+	// For debugging
 	Debug(v ...any)
-	// For debuging with format
+	// For debugging with format
 	Debugf(format string, v ...any)
 	// For logging info
 	Info(v ...any)

--- a/src/core/auth/ldap/ldap.go
+++ b/src/core/auth/ldap/ldap.go
@@ -127,7 +127,7 @@ func (l *Auth) attachLDAPGroup(ctx context.Context, ldapUsers []model.User, u *m
 		l.attachGroupParallel(ctx, ldapUsers, u)
 		return
 	}
-	// Attach LDAP group sequencially
+	// Attach LDAP group sequentially
 	for _, dn := range ldapUsers[0].GroupDNList {
 		if lgroup, exist := verifyGroupInLDAP(dn, sess); exist {
 			userGroups = append(userGroups, ugModel.UserGroup{GroupName: lgroup.Name, LdapGroupDN: dn, GroupType: common.LDAPGroupType})
@@ -292,7 +292,7 @@ func (l *Auth) SearchGroup(ctx context.Context, groupKey string) (*ugModel.UserG
 	}
 
 	if len(userGroupList) == 0 {
-		return nil, errors.NotFoundError(nil).WithMessagef("failed to searh ldap group with groupDN:%v", groupKey)
+		return nil, errors.NotFoundError(nil).WithMessagef("failed to search ldap group with groupDN:%v", groupKey)
 	}
 	userGroup := ugModel.UserGroup{
 		GroupName:   userGroupList[0].Name,

--- a/src/core/main.go
+++ b/src/core/main.go
@@ -400,7 +400,7 @@ func initSkipAuditDBbyEnv(ctx context.Context) error {
 			return err
 		}
 	} else {
-		log.Debugf("key SkipAuditLogDatabase aleady exist in the db with value %v", val)
+		log.Debugf("key SkipAuditLogDatabase already exist in the db with value %v", val)
 	}
 	return nil
 }

--- a/src/core/service/token/creator.go
+++ b/src/core/service/token/creator.go
@@ -146,7 +146,7 @@ type repositoryFilter struct {
 
 func (rep repositoryFilter) filter(ctx context.Context, ctl project.Controller,
 	a *token.ResourceActions) error {
-	// clear action list to assign to new acess element after perm check.
+	// clear action list to assign to new access element after perm check.
 	img, err := rep.parser.parse(a.Name)
 	if err != nil {
 		return err

--- a/src/jobservice/common/utils/utils.go
+++ b/src/jobservice/common/utils/utils.go
@@ -48,7 +48,7 @@ func MakeIdentifier() string {
 	return fmt.Sprintf("%x", b)
 }
 
-// IsEmptyStr check if the specified str is empty (len ==0) after triming prefix and suffix spaces.
+// IsEmptyStr check if the specified str is empty (len ==0) after trimming prefix and suffix spaces.
 func IsEmptyStr(str string) bool {
 	return len(strings.TrimSpace(str)) == 0
 }


### PR DESCRIPTION
Small spelling fixes I ran into while reading through the blob controller and jobservice code:

- comments: `Absolut`, `provied`, `debuging`, `sequencially`, `acess`, `triming`
- one error message in `core/auth/ldap`: `failed to searh ldap group` -> `search`
- one debug log in `core/main.go`: `aleady` -> `already`

No functional change.