### PR TITLE
Remove hardcoded credentials placeholders and prevent log credential/secret in debug log

### DIFF
--- a/src/common/security/secret/context.go
+++ b/src/common/security/secret/context.go
@@ -49,7 +49,7 @@ func (s *SecurityContext) IsAuthenticated() bool {
 	}
 	valid := s.store.IsValid(s.secret)
 	if !valid {
-		log.Debugf("invalid secret: %s", s.secret)
+		log.Debug("invalid secret")
 	}
 
 	return valid

--- a/src/common/utils/utils.go
+++ b/src/common/utils/utils.go
@@ -66,19 +66,33 @@ func ParseRepository(repository string) (project, rest string) {
 	return
 }
 
-// GenerateRandomStringWithLen generates a random string with length
-func GenerateRandomStringWithLen(length int) string {
+// GenerateRandomStringWithLenAndError generates a random string with length or returns an error if entropy cannot be read
+func GenerateRandomStringWithLenAndError(length int) (string, error) {
 	const chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 	l := len(chars)
 	result := make([]byte, length)
 	_, err := rand.Read(result)
 	if err != nil {
-		log.Warningf("Error reading random bytes: %v", err)
+		return "", fmt.Errorf("failed to read random bytes: %w", err)
 	}
 	for i := range length {
 		result[i] = chars[int(result[i])%l]
 	}
-	return string(result)
+	return string(result), nil
+}
+
+// GenerateRandomStringOrError generates a random string with 32 byte length or returns an error if entropy cannot be read
+func GenerateRandomStringOrError() (string, error) {
+	return GenerateRandomStringWithLenAndError(32)
+}
+
+// GenerateRandomStringWithLen generates a random string with length
+func GenerateRandomStringWithLen(length int) string {
+	str, err := GenerateRandomStringWithLenAndError(length)
+	if err != nil {
+		log.Warningf("Error reading random bytes: %v", err)
+	}
+	return str
 }
 
 // GenerateRandomString generate a random string with 32 byte length

--- a/src/common/utils/utils_test.go
+++ b/src/common/utils/utils_test.go
@@ -155,11 +155,26 @@ func TestGenerateRandomString(t *testing.T) {
 	}
 }
 
+func TestGenerateRandomStringOrError(t *testing.T) {
+	str, err := GenerateRandomStringOrError()
+	assert.Nil(t, err)
+	assert.Equal(t, 32, len(str))
+	str2, err := GenerateRandomStringOrError()
+	assert.Nil(t, err)
+	assert.NotEqual(t, str, str2)
+}
+
 func TestGenerateRandomStringWithLen(t *testing.T) {
 	str := GenerateRandomStringWithLen(16)
 	if len(str) != 16 {
 		t.Errorf("Failed to generate ramdom string with fixed length.")
 	}
+}
+
+func TestGenerateRandomStringWithLenAndError(t *testing.T) {
+	str, err := GenerateRandomStringWithLenAndError(16)
+	assert.Nil(t, err)
+	assert.Equal(t, 16, len(str))
 }
 
 func TestTestTCPConn(t *testing.T) {

--- a/src/core/auth/authproxy/auth.go
+++ b/src/core/auth/authproxy/auth.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/goharbor/harbor/src/common"
 	"github.com/goharbor/harbor/src/common/models"
+	"github.com/goharbor/harbor/src/common/utils"
 	"github.com/goharbor/harbor/src/controller/usergroup"
 	"github.com/goharbor/harbor/src/core/auth"
 	"github.com/goharbor/harbor/src/jobservice/logger"
@@ -209,7 +210,11 @@ func (a *Auth) fillInModel(u *models.User) error {
 		return fmt.Errorf("username cannot be empty")
 	}
 	u.Realname = u.Username
-	u.Password = "1234567ab"
+	pwd, err := utils.GenerateRandomStringOrError()
+	if err != nil {
+		return fmt.Errorf("failed to generate random password: %w", err)
+	}
+	u.Password = pwd
 	u.Comment = userEntryComment
 	if strings.Contains(u.Username, "@") {
 		u.Email = u.Username

--- a/src/core/auth/ldap/ldap.go
+++ b/src/core/auth/ldap/ldap.go
@@ -230,8 +230,12 @@ func (l *Auth) OnBoardUser(ctx context.Context, u *models.User) error {
 			u.Email = u.Username
 		}
 	}
-	u.Password = "12345678AbC" // Password is not kept in local db
-	u.Comment = "from LDAP."   // Source is from LDAP
+	pwd, err := utils.GenerateRandomStringOrError()
+	if err != nil {
+		return fmt.Errorf("failed to generate random password: %w", err)
+	}
+	u.Password = pwd         // Password is not kept in local db
+	u.Comment = "from LDAP." // Source is from LDAP
 
 	return l.userMgr.Onboard(ctx, u)
 }

--- a/src/core/auth/uaa/uaa.go
+++ b/src/core/auth/uaa/uaa.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/goharbor/harbor/src/common"
 	"github.com/goharbor/harbor/src/common/models"
+	"github.com/goharbor/harbor/src/common/utils"
 	"github.com/goharbor/harbor/src/common/utils/uaa"
 	"github.com/goharbor/harbor/src/core/auth"
 	"github.com/goharbor/harbor/src/lib/config"
@@ -69,7 +70,11 @@ func (u *Auth) OnBoardUser(ctx context.Context, user *models.User) error {
 		return fmt.Errorf("the Username is empty")
 	}
 	if len(user.Password) == 0 {
-		user.Password = "1234567ab"
+		pwd, err := utils.GenerateRandomStringOrError()
+		if err != nil {
+			return fmt.Errorf("failed to generate random password: %w", err)
+		}
+		user.Password = pwd
 	}
 	fillEmailRealName(user)
 	user.Comment = "From UAA"

--- a/src/lib/trace/config.go
+++ b/src/lib/trace/config.go
@@ -38,7 +38,7 @@ type OtelConfig struct {
 	Timeout     int    `mapstructure:"otel_trace_timeout"`
 }
 
-func (c *OtelConfig) String() string {
+func (c OtelConfig) String() string {
 	return fmt.Sprintf("endpoint: %s, url_path: %s, compression: %t, insecure: %t, timeout: %d",
 		c.Endpoint, c.URLPath, c.Compression, c.Insecure, c.Timeout)
 }
@@ -52,9 +52,13 @@ type JaegerConfig struct {
 	AgentPort string `mapstructure:"jaeger_agent_port"`
 }
 
-func (c *JaegerConfig) String() string {
+func (c JaegerConfig) String() string {
+	password := c.Password
+	if len(password) > 0 {
+		password = "******"
+	}
 	return fmt.Sprintf("endpoint: %s, username: %s, password: %s, agent_host: %s, agent_port: %s",
-		c.Endpoint, c.Username, c.Password, c.AgentHost, c.AgentPort)
+		c.Endpoint, c.Username, password, c.AgentHost, c.AgentPort)
 }
 
 // Config is the configuration for trace
@@ -68,7 +72,7 @@ type Config struct {
 	Attributes  map[string]string
 }
 
-func (c *Config) String() string {
+func (c Config) String() string {
 	return fmt.Sprintf("{Enabled: %v, ServiceName: %v,  SampleRate: %v, Namespace: %v, ServiceName: %v, Jaeger: %v, Otel: %v}", c.Enabled, c.ServiceName, c.SampleRate, c.Namespace, c.ServiceName, c.Jaeger, c.Otel)
 }
 

--- a/src/lib/trace/config_test.go
+++ b/src/lib/trace/config_test.go
@@ -1,0 +1,94 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trace
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestJaegerConfigString(t *testing.T) {
+	// Value receiver with password
+	cfgVal := JaegerConfig{
+		Endpoint:  "http://jaeger:14268",
+		Username:  "admin",
+		Password:  "secret_password_123",
+		AgentHost: "localhost",
+		AgentPort: "6831",
+	}
+	assert.NotContains(t, cfgVal.String(), "secret_password_123")
+	assert.Contains(t, cfgVal.String(), "password: ******")
+
+	// Pointer receiver with password
+	cfgPtr := &JaegerConfig{
+		Endpoint:  "http://jaeger:14268",
+		Username:  "admin",
+		Password:  "secret_password_123",
+		AgentHost: "localhost",
+		AgentPort: "6831",
+	}
+	assert.NotContains(t, cfgPtr.String(), "secret_password_123")
+	assert.Contains(t, cfgPtr.String(), "password: ******")
+
+	// Empty password
+	cfgEmpty := JaegerConfig{
+		Endpoint:  "http://jaeger:14268",
+		Username:  "admin",
+		Password:  "",
+		AgentHost: "localhost",
+		AgentPort: "6831",
+	}
+	assert.Contains(t, cfgEmpty.String(), "password: ,")
+}
+
+func TestConfigStringMasksJaegerPassword(t *testing.T) {
+	c := Config{
+		Enabled:     true,
+		ServiceName: "harbor-core",
+		Jaeger: JaegerConfig{
+			Endpoint:  "http://jaeger:14268",
+			Username:  "admin",
+			Password:  "my_super_secret_password",
+			AgentHost: "localhost",
+			AgentPort: "6831",
+		},
+		Otel: OtelConfig{
+			Endpoint: "http://otel:4317",
+		},
+	}
+
+	// Direct String() call on value
+	strVal := c.String()
+	assert.NotContains(t, strVal, "my_super_secret_password")
+	assert.Contains(t, strVal, "password: ******")
+
+	// Direct String() call on pointer
+	strPtr := (&c).String()
+	assert.NotContains(t, strPtr, "my_super_secret_password")
+	assert.Contains(t, strPtr, "password: ******")
+
+	// Formatted via %v on value
+	formattedVal := fmt.Sprintf("%v", c)
+	assert.False(t, strings.Contains(formattedVal, "my_super_secret_password"), "fmt.Sprintf(%%v, c) exposed password: %s", formattedVal)
+	assert.Contains(t, formattedVal, "password: ******")
+
+	// Formatted via %v on pointer
+	formattedPtr := fmt.Sprintf("%v", &c)
+	assert.False(t, strings.Contains(formattedPtr, "my_super_secret_password"), "fmt.Sprintf(%%v, &c) exposed password: %s", formattedPtr)
+	assert.Contains(t, formattedPtr, "password: ******")
+}

--- a/src/pkg/oidc/helper.go
+++ b/src/pkg/oidc/helper.go
@@ -225,7 +225,6 @@ func VerifyToken(ctx context.Context, rawIDToken string) (*gooidc.IDToken, error
 }
 
 func verifyTokenWithConfig(ctx context.Context, rawIDToken string, conf *gooidc.Config) (*gooidc.IDToken, error) {
-	log.Debugf("Raw ID token for verification: %s", rawIDToken)
 	p, err := provider.get(ctx)
 	if err != nil {
 		return nil, err

--- a/src/pkg/proxy/secret/manager.go
+++ b/src/pkg/proxy/secret/manager.go
@@ -132,7 +132,7 @@ func (man *mgr) gc() {
 	man.m.Range(func(k, v any) bool {
 		repoV, ok := v.(targetRepository)
 		if ok && repoV.expiresAt.Before(time.Now()) {
-			log.Debugf("Removed expire secret: %s, repo: %s", k, repoV.name)
+			log.Debugf("Removed expired secret for repo: %s", repoV.name)
 			man.delete(k.(string))
 		}
 		return true

--- a/src/pkg/reg/adapter/tencentcr/auth.go
+++ b/src/pkg/reg/adapter/tencentcr/auth.go
@@ -39,7 +39,7 @@ func (q *qcloudAuthCredential) Modify(r *http.Request) (err error) {
 		}
 	}
 	r.SetBasicAuth(q.cacheTokener.username, q.cacheTokener.token)
-	log.Debugf("[qcloudAuthCredential.Modify]Host: %v, header: %#v", r.Host, r.Header)
+	log.Debugf("[qcloudAuthCredential.Modify]Host: %v", r.Host)
 	return
 }
 
@@ -89,7 +89,7 @@ func (q *qcloudAuthCredential) getTempInstanceToken() (err error) {
 
 	q.cacheTokener = &temporaryTokener{*resp.Response.Username, *resp.Response.Token}
 	q.cacheTokenExpiredAt = time.Unix(*resp.Response.ExpTime/1e3, *resp.Response.ExpTime%1e3)
-	log.Debugf("[qcloudAuthCredential.getTempInstanceToken]Update temp token=%#v, cacheTokenExpiredAt=%s, unix=%v", q.cacheTokener,
+	log.Debugf("[qcloudAuthCredential.getTempInstanceToken]Update temp token for user=%s, cacheTokenExpiredAt=%s, unix=%v", q.cacheTokener.username,
 		q.cacheTokenExpiredAt.UTC().String(), *resp.Response.ExpTime)
 
 	return

--- a/src/pkg/token/token.go
+++ b/src/pkg/token/token.go
@@ -82,7 +82,7 @@ func Parse(opt *Options, rawToken string, claims jwt.Claims) (*Token, error) {
 	}
 
 	if !token.Valid {
-		log.Errorf("invalid jwt token, %v", token)
+		log.Errorf("invalid jwt token")
 		return nil, errors.New("invalid jwt token")
 	}
 	return &Token{

--- a/src/server/middleware/csrf/csrf.go
+++ b/src/server/middleware/csrf/csrf.go
@@ -70,7 +70,7 @@ func Middleware() func(handler http.Handler) http.Handler {
 		if len(key) == 0 {
 			key = utils.GenerateRandomString()
 		} else if len(key) != 32 {
-			log.Errorf("Invalid CSRF key length from the environment: %s. Please ensure the key length is 32 characters.", key)
+			log.Errorf("Invalid CSRF key length from the environment (%d characters). Please ensure the key length is 32 characters.", len(key))
 			protect = func(_ http.Handler) http.Handler {
 				return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 					lib_http.SendError(w, errors.New("invalid CSRF key length from the environment. Please ensure the key length is 32 characters"))


### PR DESCRIPTION
Fixes #23834 

## Identified Issues & Changes

### 1. Hardcoded User Passwords in Auth Providers
- **Locations**:
  - `src/core/auth/authproxy/auth.go`
  - `src/core/auth/ldap/ldap.go`
  - `src/core/auth/uaa/uaa.go`
- **Issue**: Static default passwords (e.g. `"1234567ab"`, `"12345678AbC"`) were assigned when onboarding external users into the local database.
- **Fix**: Replaced static passwords with securely generated random strings via `utils.GenerateRandomString()`.

### 2. Clear-Text Secrets and Sensitive Logging
- **`src/common/security/secret/context.go`**:
  - Removed clear-text `s.secret` from debug logs on secret validation failure.
- **`src/lib/trace/config.go`**:
  - Masked Jaeger password (`******`) in `JaegerConfig.String()` representation.
- **`src/pkg/oidc/helper.go`**:
  - Removed debug log that dumped raw OIDC ID tokens before verification.
- **`src/pkg/proxy/secret/manager.go`**:
  - Stopped logging expired secret keys during GC cleanup.
- **`src/pkg/reg/adapter/tencentcr/auth.go`**:
  - Removed request headers (which include Basic Auth tokens) and raw temporary instance tokens from debug logs.
- **`src/pkg/token/token.go`**:
  - Removed token object dump in error logs when JWT token validation fails.
- **`src/server/middleware/csrf/csrf.go`**:
  - Prevented logging invalid CSRF key contents from environment variables; now logs key length instead.

---

## Affected Files
- `src/common/security/secret/context.go`
- `src/core/auth/authproxy/auth.go`
- `src/core/auth/ldap/ldap.go`
- `src/core/auth/uaa/uaa.go`
- `src/lib/trace/config.go`
- `src/pkg/oidc/helper.go`
- `src/pkg/proxy/secret/manager.go`
- `src/pkg/reg/adapter/tencentcr/auth.go`
- `src/pkg/token/token.go`
- `src/server/middleware/csrf/csrf.go`

---

## Verification & Testing
- Verified that all modified packages compile without errors.
- Verified unit tests pass for affected packages (`src/lib/trace`, `src/common/security/secret`, `src/pkg/proxy/secret`).