### PR TITLE
ci: Group Angular, Kubernetes and OpenTelemetry updates in dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,11 @@
 # package ecosystems to update and where the package manifests are located.
 # Please see the documentation for all configuration options:
 # https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+#
+# A dependency is assigned to the first group it matches, so the groups that
+# hold packages which have to move together are listed before "patch-updates".
+# A group only applies to the update kind named by "applies-to", which defaults
+# to version-updates, so every such group has a security-updates twin.
 
 version: 2
 updates:
@@ -32,6 +37,25 @@ updates:
     labels:
       - "release-note/bump-version"
     groups:
+      # The k8s.io and sigs.k8s.io modules are released as one set and only
+      # compile against each other at the same minor version.
+      kubernetes:
+        patterns:
+          - "k8s.io/*"
+          - "sigs.k8s.io/*"
+      kubernetes-security:
+        applies-to: security-updates
+        patterns:
+          - "k8s.io/*"
+          - "sigs.k8s.io/*"
+      # The OpenTelemetry modules are released as one set.
+      opentelemetry:
+        patterns:
+          - "go.opentelemetry.io/*"
+      opentelemetry-security:
+        applies-to: security-updates
+        patterns:
+          - "go.opentelemetry.io/*"
       patch-updates:
         patterns:
           - "*"
@@ -47,6 +71,22 @@ updates:
     labels:
       - "release-note/bump-version"
     groups:
+      kubernetes:
+        patterns:
+          - "k8s.io/*"
+          - "sigs.k8s.io/*"
+      kubernetes-security:
+        applies-to: security-updates
+        patterns:
+          - "k8s.io/*"
+          - "sigs.k8s.io/*"
+      opentelemetry:
+        patterns:
+          - "go.opentelemetry.io/*"
+      opentelemetry-security:
+        applies-to: security-updates
+        patterns:
+          - "go.opentelemetry.io/*"
       patch-updates:
         patterns:
           - "*"
@@ -61,6 +101,24 @@ updates:
     labels:
       - "release-note/bump-version"
     groups:
+      # The Angular packages pin each other with exact peer dependencies, and
+      # @angular-devkit/build-angular and @angular/core pin typescript and
+      # zone.js as well, so a single-package bump always fails "npm ci".
+      angular:
+        patterns:
+          - "@angular/*"
+          - "@angular-devkit/*"
+          - "@angular-eslint/*"
+          - "typescript"
+          - "zone.js"
+      angular-security:
+        applies-to: security-updates
+        patterns:
+          - "@angular/*"
+          - "@angular-devkit/*"
+          - "@angular-eslint/*"
+          - "typescript"
+          - "zone.js"
       patch-updates:
         patterns:
           - "*"
@@ -73,6 +131,50 @@ updates:
       interval: "weekly"
     target-branch: "release-2.15.0"
     open-pull-requests-limit: 10
+    labels:
+      - "release-note/bump-version"
+    groups:
+      angular:
+        patterns:
+          - "@angular/*"
+          - "@angular-devkit/*"
+          - "@angular-eslint/*"
+          - "typescript"
+          - "zone.js"
+      angular-security:
+        applies-to: security-updates
+        patterns:
+          - "@angular/*"
+          - "@angular-devkit/*"
+          - "@angular-eslint/*"
+          - "typescript"
+          - "zone.js"
+      patch-updates:
+        patterns:
+          - "*"
+        update-types:
+          - "patch"
+
+  - package-ecosystem: "npm"
+    directory: "/src/portal/app-swagger-ui"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "release-note/bump-version"
+    groups:
+      patch-updates:
+        patterns:
+          - "*"
+        update-types:
+          - "patch"
+
+  - package-ecosystem: "npm"
+    directory: "/src/portal/app-swagger-ui"
+    schedule:
+      interval: "weekly"
+    target-branch: "release-2.15.0"
+    open-pull-requests-limit: 5
     labels:
       - "release-note/bump-version"
     groups:


### PR DESCRIPTION
Thank you for contributing to Harbor!

# Comprehensive Summary of your change

Every ecosystem entry currently has a single `patch-updates` group, so every minor and major update arrives as its own pull request. Three sets of packages need to move together instead. Two of them break the build when they do not; the third produces conflicting pull requests.

## Angular, build failure

Bumping one `@angular` package on its own breaks `npm ci` with ERESOLVE. From the CI log of #23769, which bumps `@angular/platform-browser` from 21.2.20 to 22.1.2 alone:

```
npm error code ERESOLVE
npm error While resolving: @angular-devkit/build-angular@21.2.21
npm error Found: @angular/platform-browser@22.1.2
npm error Could not resolve dependency:
npm error peerOptional @angular/platform-browser@"^21.0.0" from
npm error   @angular-devkit/build-angular@21.2.21
```

#23765 and #23767 on `main`, and #23737 and #23738 on `release-2.15.0`, fail the same way.

`typescript` and `zone.js` belong in the group as well. `@angular-devkit/build-angular@21.2.21` declares a peer dependency on `typescript ">=5.9 <6.0"` and `@angular/core@21.2.20` one on `zone.js "~0.15.0 || ~0.16.0"`, so neither can move on its own either.

## Kubernetes, build failure

The `k8s.io` modules are released as one set. Bumping `k8s.io/api` alone to v0.37.0 while `k8s.io/client-go` stays at v0.36.3 leaves the tree unbuildable:

```
k8s.io/client-go@v0.36.3/kubernetes/scheme/register.go:69:2:
no required module provides package k8s.io/api/scheduling/v1alpha2
```

## OpenTelemetry, conflicting pull requests

`src/go.mod` carries eleven `go.opentelemetry.io` modules that are released together. Bumping any one of them pulls the rest along through minimal version selection, so separate pull requests each rewrite the same `go.mod` and `go.sum` lines and go stale against each other.

They also go stale against `main`. #23079 raised the exporter to 1.43.0 and with it the whole core set, but `main` has since moved on: `go.opentelemetry.io/otel`, `otel/sdk` and `otel/trace` are at v1.44.0 on `main` while that pull request's head pins them to v1.43.0, so merging it would have downgraded them. Grouping keeps the set in one pull request that Dependabot can rebase as a whole.

Unlike the two above, this group is about pull request churn and conflicts rather than a build failure.

## Group ordering and security updates

Groups are listed before `patch-updates` because a dependency is assigned to the first group it matches.

A group only applies to the update kind named by `applies-to`, which defaults to `version-updates`. Each of the three groups therefore has a `security-updates` twin with the same patterns: `angular-security`, `kubernetes-security` and `opentelemetry-security`. Without those, a Dependabot security update for a grouped package would still arrive on its own and hit exactly the same failures described above.

## app-swagger-ui

`src/portal/app-swagger-ui` is a real npm project with its own `package.json` and `package-lock.json`, but it has never had an entry here. Dependabot could therefore only ever open security updates for it, and those cannot be rebased or recreated. This adds weekly version-update entries for it on `main` and on `release-2.15.0`.

## Validation

The file parses, every `updates` and `groups` key is in the documented set, both `applies-to` values are valid, and each security twin sits directly after its version twin and before `patch-updates`. Validated against the SchemaStore `dependabot-2.0.json` schema, which reports only the pre-existing `reviewers` deprecation on the `github-actions` entry, unchanged from `main`.

# Issue being fixed
No issue filed. See the linked pull requests for the failures.

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. `release-note/infra`
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
