### PR TITLE
fix: make hostname and endpoint comparisons case-insensitive(2)

### DIFF
--- a/src/common/utils/utils.go
+++ b/src/common/utils/utils.go
@@ -54,6 +54,21 @@ func ParseEndpoint(endpoint string) (*url.URL, error) {
 	return url.ParseRequestURI(endpoint)
 }
 
+// EqualURL checks whether two URLs are equal, with case-insensitive host matching per RFC 1035.
+func EqualURL(rawURL1, rawURL2 string) bool {
+	if rawURL1 == rawURL2 {
+		return true
+	}
+	u1, err1 := url.Parse(rawURL1)
+	u2, err2 := url.Parse(rawURL2)
+	if err1 != nil || err2 != nil {
+		return false
+	}
+	u1.Host = strings.ToLower(u1.Host)
+	u2.Host = strings.ToLower(u2.Host)
+	return u1.String() == u2.String()
+}
+
 // ParseRepository splits a repository into two parts: project and rest
 func ParseRepository(repository string) (project, rest string) {
 	repository = strings.TrimLeft(repository, "/")

--- a/src/common/utils/utils_test.go
+++ b/src/common/utils/utils_test.go
@@ -51,6 +51,31 @@ func TestParseEndpoint(t *testing.T) {
 	}
 }
 
+func TestEqualURL(t *testing.T) {
+	cases := []struct {
+		url1     string
+		url2     string
+		expected bool
+	}{
+		{"http://example.com:8080/v2", "http://example.com:8080/v2", true},
+		{"http://EXAMPLE.COM:8080/v2", "http://example.com:8080/v2", true},
+		{"http://example.com:8080/V2", "http://example.com:8080/v2", false},
+		{"https://core:8080", "https://CORE:8080", true},
+		{"http://example.com", "https://example.com", false},
+		{"http://example.com:8080", "http://example.com:8081", false},
+		{"http://example.com/foo", "http://example.com/bar", false},
+		{"://invalid-url-1", "http://example.com", false},
+		{"http://example.com", "://invalid-url-2", false},
+		{"http://example.com/A%", "http://example.com/a%", false},
+	}
+
+	for _, c := range cases {
+		t.Run(c.url1+"_vs_"+c.url2, func(t *testing.T) {
+			assert.Equal(t, c.expected, EqualURL(c.url1, c.url2))
+		})
+	}
+}
+
 func TestParseRepository(t *testing.T) {
 	repository := "library/ubuntu"
 	project, rest := ParseRepository(repository)

--- a/src/controller/event/handler/webhook/artifact/replication.go
+++ b/src/controller/event/handler/webhook/artifact/replication.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/goharbor/harbor/src/common/utils"
 	"github.com/goharbor/harbor/src/controller/event"
 	"github.com/goharbor/harbor/src/controller/event/handler/util"
 	ctlModel "github.com/goharbor/harbor/src/controller/event/model"
@@ -232,7 +233,7 @@ func isLocalRegistry(registry *rpModel.Registry) bool {
 	if registry != nil {
 		return registry.Type == rpModel.RegistryTypeHarbor &&
 			registry.Name == "Local" &&
-			registry.URL == config.InternalCoreURL()
+			utils.EqualURL(registry.URL, config.InternalCoreURL())
 	}
 
 	return false

--- a/src/controller/event/handler/webhook/artifact/replication_test.go
+++ b/src/controller/event/handler/webhook/artifact/replication_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	common_dao "github.com/goharbor/harbor/src/common/dao"
+	"github.com/goharbor/harbor/src/common/utils"
 	"github.com/goharbor/harbor/src/controller/event"
 	"github.com/goharbor/harbor/src/controller/project"
 	repctl "github.com/goharbor/harbor/src/controller/replication"
@@ -138,6 +139,13 @@ func TestIsLocalRegistry(t *testing.T) {
 		URL:  config.InternalCoreURL(),
 	}
 	assert.True(t, isLocalRegistry(reg1))
+	// local registry with mixed-case host URL should return true
+	reg1MixedCase := &rpModel.Registry{
+		Type: "harbor",
+		Name: "Local",
+		URL:  "http://CORE:8080",
+	}
+	assert.True(t, utils.EqualURL(reg1MixedCase.URL, "http://core:8080"))
 	// non-local registry should return false
 	reg2 := &rpModel.Registry{
 		Type: "docker-registry",

--- a/src/pkg/audit/forward.go
+++ b/src/pkg/audit/forward.go
@@ -19,6 +19,7 @@ import (
 	"io"
 	"log/syslog"
 	"os"
+	"strings"
 
 	"github.com/goharbor/harbor/src/lib/config"
 	"github.com/goharbor/harbor/src/lib/log"
@@ -54,7 +55,7 @@ func (a *LoggerManager) Init(_ context.Context, logEndpoint string) {
 // DefaultLogger ...
 func (a *LoggerManager) DefaultLogger(ctx context.Context) *log.Logger {
 	endpoint := config.AuditLogForwardEndpoint(ctx)
-	if a.endpoint != endpoint {
+	if !strings.EqualFold(a.endpoint, endpoint) {
 		a.Init(ctx, endpoint)
 		a.initialized = true
 	}

--- a/src/pkg/oidc/helper.go
+++ b/src/pkg/oidc/helper.go
@@ -146,7 +146,7 @@ func getOauthConf(ctx context.Context) (*oauth2.Config, error) {
 	}
 	scopes := make([]string, 0)
 	for _, sc := range setting.Scope {
-		if strings.HasPrefix(p.Endpoint().AuthURL, googleEndpoint) && sc == gooidc.ScopeOfflineAccess {
+		if strings.HasPrefix(strings.ToLower(p.Endpoint().AuthURL), googleEndpoint) && sc == gooidc.ScopeOfflineAccess {
 			log.Warningf("Dropped unsupported scope: %s ", sc)
 			continue
 		}
@@ -179,7 +179,7 @@ func AuthCodeURL(ctx context.Context, state string, pkceCode pkce.Code) (string,
 	for k, v := range setting.ExtraRedirectParms {
 		options = append(options, oauth2.SetAuthURLParam(k, v))
 	}
-	if strings.HasPrefix(conf.Endpoint.AuthURL, googleEndpoint) { // make sure the refresh token will be returned
+	if strings.HasPrefix(strings.ToLower(conf.Endpoint.AuthURL), googleEndpoint) { // make sure the refresh token will be returned
 		options = append(options, oauth2.AccessTypeOffline)
 		options = append(options, oauth2.SetAuthURLParam("prompt", "consent"))
 	}

--- a/src/pkg/reg/adapter/aliacr/adapter.go
+++ b/src/pkg/reg/adapter/aliacr/adapter.go
@@ -56,7 +56,7 @@ func init() {
 
 // example:
 // https://cr.%s.aliyuncs.com
-var regACRServiceURL = regexp.MustCompile(`https://cr\.([\w\-]+)\.aliyuncs\.com`)
+var regACRServiceURL = regexp.MustCompile(`(?i)https://cr\.([\w\-]+)\.aliyuncs\.com`)
 
 func getRegistryURL(url string) (string, error) {
 	if url == "" {
@@ -66,7 +66,7 @@ func getRegistryURL(url string) (string, error) {
 	if rs == nil {
 		return url, nil
 	}
-	return fmt.Sprintf(registryEndpointTpl, rs[1]), nil
+	return fmt.Sprintf(registryEndpointTpl, strings.ToLower(rs[1])), nil
 }
 
 // example:

--- a/src/pkg/reg/adapter/aliacr/adapter_test.go
+++ b/src/pkg/reg/adapter/aliacr/adapter_test.go
@@ -102,6 +102,12 @@ func Test_getRegistryURL(t *testing.T) {
 			"https://registry.cn-hangzhou.aliyuncs.com",
 			false,
 		},
+		{
+			"change match mixed case url",
+			"https://CR.CN-Hangzhou.AliyunCS.com",
+			"https://registry.cn-hangzhou.aliyuncs.com",
+			false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/src/pkg/reg/adapter/awsecr/adapter.go
+++ b/src/pkg/reg/adapter/awsecr/adapter.go
@@ -32,7 +32,7 @@ import (
 )
 
 const (
-	ecrPattern = "https://(?:api|(\\d+)\\.dkr)\\.ecr(?:-public|-fips)?\\.([\\w\\-]+)\\.(amazonaws\\.com(\\.cn)?|sc2s\\.sgov\\.gov|c2s\\.ic\\.gov)"
+	ecrPattern = "(?i)https://(?:api|(\\d+)\\.dkr)\\.ecr(?:-public|-fips)?\\.([\\w\\-]+)\\.(amazonaws\\.com(\\.cn)?|sc2s\\.sgov\\.gov|c2s\\.ic\\.gov)"
 )
 
 var (
@@ -70,7 +70,7 @@ func parseAccountRegion(url string) (string, string, error) {
 	if rs == nil || len(rs) < 3 {
 		return "", "", errors.New("bad aws url")
 	}
-	return rs[1], rs[2], nil
+	return rs[1], strings.ToLower(rs[2]), nil
 }
 
 type factory struct {

--- a/src/pkg/reg/adapter/awsecr/adapter_test.go
+++ b/src/pkg/reg/adapter/awsecr/adapter_test.go
@@ -126,6 +126,17 @@ func TestAdapter_NewAdapter(t *testing.T) {
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, adapter)
+
+	adapter, err = newAdapter(&model.Registry{
+		Type: model.RegistryTypeAwsEcr,
+		Credential: &model.Credential{
+			AccessKey:    "xxx",
+			AccessSecret: "ppp",
+		},
+		URL: "https://123456.DKR.ECR.TEST-REGION.AMAZONAWS.COM",
+	})
+	assert.Nil(t, err)
+	assert.NotNil(t, adapter)
 }
 
 func TestParseAccountRegion(t *testing.T) {
@@ -145,6 +156,18 @@ func TestParseAccountRegion(t *testing.T) {
 			url:         "https://123456.dkr.ecr.us-west-2.amazonaws.com",
 			expectedID:  "123456",
 			expectedReg: "us-west-2",
+			expectErr:   false,
+		},
+		{
+			url:         "https://123456.DKR.ECR.US-WEST-2.AMAZONAWS.COM",
+			expectedID:  "123456",
+			expectedReg: "us-west-2",
+			expectErr:   false,
+		},
+		{
+			url:         "HTTPS://API.ECR.CN-NORTH-1.AMAZONAWS.COM.CN",
+			expectedID:  "",
+			expectedReg: "cn-north-1",
 			expectErr:   false,
 		},
 		{
@@ -383,7 +406,7 @@ func TestAwsAuthCredential_Modify(t *testing.T) {
 		"test-region", "xxx", "ppp", true, "", &server.URL)
 	require.Nil(t, err)
 	a, _ := NewAuth("xxx", svc).(*awsAuthCredential)
-	req := httptest.NewRequest(http.MethodGet, "https://1234.dkr.ecr.test-region.amazonaws.com/v2/", nil)
+	req := httptest.NewRequest(http.MethodGet, "https://1234.DKR.ECR.TEST-REGION.AMAZONAWS.COM/v2/", nil)
 	err = a.Modify(req)
 	require.Nil(t, err)
 	err = a.Modify(req)

--- a/src/pkg/reg/adapter/harbor/base/adapter.go
+++ b/src/pkg/reg/adapter/harbor/base/adapter.go
@@ -17,7 +17,6 @@ package base
 import (
 	"fmt"
 	"net/http"
-	neturl "net/url"
 	"os"
 	"strconv"
 	"strings"
@@ -25,6 +24,7 @@ import (
 	common_http "github.com/goharbor/harbor/src/common/http"
 	"github.com/goharbor/harbor/src/common/http/modifier"
 	common_http_auth "github.com/goharbor/harbor/src/common/http/modifier/auth"
+	"github.com/goharbor/harbor/src/common/utils"
 	"github.com/goharbor/harbor/src/lib/config"
 	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/lib/log"
@@ -320,21 +320,10 @@ type Project struct {
 
 func isLocalHarbor(rawURL string) bool {
 	coreURL := os.Getenv("CORE_URL")
-	if rawURL == coreURL {
-		return true
-	}
-	u, err := neturl.Parse(rawURL)
-	if err != nil {
+	if rawURL == "" || coreURL == "" {
 		return false
 	}
-	c, err := neturl.Parse(coreURL)
-	if err != nil {
-		return false
-	}
-	// the host portion of a URL (DNS name) is case-insensitive, unlike the path
-	u.Host = strings.ToLower(u.Host)
-	c.Host = strings.ToLower(c.Host)
-	return u.String() == c.String()
+	return utils.EqualURL(rawURL, coreURL)
 }
 
 // check whether the current process is running inside core

--- a/src/pkg/reg/adapter/tencentcr/adapter.go
+++ b/src/pkg/reg/adapter/tencentcr/adapter.go
@@ -95,6 +95,19 @@ type adapter struct {
 **/
 var _ adp.Adapter = &adapter{}
 
+// validateEndpoint checks if the TCR endpoint is valid and returns the lowercased host.
+func validateEndpoint(rawURL string) (string, bool) {
+	registryURL, err := url.Parse(rawURL)
+	if err != nil || registryURL == nil {
+		return "", false
+	}
+	host := strings.ToLower(registryURL.Hostname())
+	if host == "" || !strings.HasSuffix(host, ".tencentcloudcr.com") || host == ".tencentcloudcr.com" {
+		return "", false
+	}
+	return host, true
+}
+
 func newAdapter(registry *model.Registry) (a *adapter, err error) {
 	if !isSecretID(registry.Credential.AccessKey) {
 		err = errors.New("[tencent-tcr.newAdapter] Please use SecretId/SecretKey, NOT docker login Username/Password")
@@ -106,9 +119,16 @@ func newAdapter(registry *model.Registry) (a *adapter, err error) {
 	var registryURL *url.URL
 	registryURL, _ = url.Parse(registry.URL)
 
-	// only validate registryURL.Host in non-UT scenario
+	var host string
+	if registryURL != nil {
+		host = strings.ToLower(registryURL.Hostname())
+	}
+
+	// only validate registryURL in non-UT scenario
 	if os.Getenv("UTTEST") != "true" {
-		if !strings.Contains(registryURL.Host, ".tencentcloudcr.com") {
+		var ok bool
+		host, ok = validateEndpoint(registry.URL)
+		if !ok {
 			log.Errorf("[tencent-tcr.newAdapter] errInvalidTcrEndpoint=%v", err)
 			return nil, errInvalidTcrEndpoint
 		}
@@ -136,7 +156,7 @@ func newAdapter(registry *model.Registry) (a *adapter, err error) {
 	req.Filters = []*tcr.Filter{
 		{
 			Name:   common.StringPtr("RegistryName"),
-			Values: []*string{common.StringPtr(strings.ReplaceAll(registryURL.Host, ".tencentcloudcr.com", ""))},
+			Values: []*string{common.StringPtr(strings.TrimSuffix(host, ".tencentcloudcr.com"))},
 		},
 	}
 	var resp *tcr.DescribeInstancesResponse

--- a/src/pkg/reg/adapter/tencentcr/adapter_test.go
+++ b/src/pkg/reg/adapter/tencentcr/adapter_test.go
@@ -107,6 +107,32 @@ func TestAdapter_NewAdapter_Pingfailed(t *testing.T) {
 	assert.Nil(t, adapter)
 }
 
+func TestAdapter_validateEndpoint(t *testing.T) {
+	validEndpoints := []string{
+		"https://my-registry.tencentcloudcr.com",
+		"https://my-registry.TencentCloudCR.com",
+		"https://my-registry.tencentcloudcr.com:443",
+		"http://sub.my-registry.tencentcloudcr.com:8080",
+	}
+	for _, ep := range validEndpoints {
+		host, ok := validateEndpoint(ep)
+		assert.True(t, ok, "expected valid endpoint for %s", ep)
+		assert.NotEmpty(t, host)
+	}
+
+	invalidEndpoints := []string{
+		"$$$",
+		"https://registry.tencentcloudcr.com.attacker.example",
+		"https://attacker.example/.tencentcloudcr.com",
+		"https://not-tencentcloudcr.com",
+		"https://.tencentcloudcr.com",
+	}
+	for _, ep := range invalidEndpoints {
+		_, ok := validateEndpoint(ep)
+		assert.False(t, ok, "expected invalid endpoint for %s", ep)
+	}
+}
+
 func TestAdapter_NewAdapter_InvalidAKSK(t *testing.T) {
 	// Error AK/SK
 	adapter, err := newAdapter(&model.Registry{

--- a/src/pkg/reg/adapter/volcenginecr/helper.go
+++ b/src/pkg/reg/adapter/volcenginecr/helper.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"net/http"
 	"regexp"
+	"strings"
 
 	"github.com/docker/distribution/registry/client/auth/challenge"
 
@@ -28,20 +29,20 @@ import (
 )
 
 func getRegionRegistryName(url string) (string, string, error) {
-	reg := regexp.MustCompile(`https://(.*)\.cr\.volces|ivolces\.com`)
+	reg := regexp.MustCompile(`(?i)https://(.*)\.cr\.(?:volces|ivolces)\.com`)
 	rs := reg.FindStringSubmatch(url)
 	if rs == nil || len(rs) != 2 {
 		return "", "", errors.New("Invalid url")
 	}
 	registryNameRegion := rs[1]
 	for regionReg := range regionRegs {
-		reg = regexp.MustCompile(regionReg)
+		reg = regexp.MustCompile("(?i)" + regionReg)
 		res := reg.FindStringSubmatch(registryNameRegion)
 		if res == nil || len(res) != 3 {
 			log.Debug("fail to match", "reg", regionReg)
 			continue
 		}
-		return res[2], res[1], nil
+		return strings.ToLower(res[2]), res[1], nil
 	}
 
 	return "", "", errors.New("invalid region")

--- a/src/pkg/reg/adapter/volcenginecr/helper_test.go
+++ b/src/pkg/reg/adapter/volcenginecr/helper_test.go
@@ -17,6 +17,8 @@ func Test_getRegionRegistryNamer(t *testing.T) {
 		wantErr      bool
 	}{
 		{"registry beijing", "https://enterprise-cn-beijing.cr.volces.com", "cn-beijing", "enterprise", false},
+		{"registry beijing mixed case", "https://Enterprise-CN-Beijing.CR.Volces.com", "cn-beijing", "Enterprise", false},
+		{"registry ivolces", "https://enterprise-cn-beijing.cr.ivolces.com", "cn-beijing", "enterprise", false},
 		{"invalid url", "http://enterprise-cn-beijing.cr.volces.com", "", "", true},
 		{"invalid region", "https://enterprise-us-test.cr.volces.com", "", "", true},
 		{"invalid suffix", "https://enterprise-us-test.cr-test.volces.com", "", "", true},

--- a/src/pkg/scan/init.go
+++ b/src/pkg/scan/init.go
@@ -17,6 +17,7 @@ package scan
 import (
 	"context"
 
+	"github.com/goharbor/harbor/src/common/utils"
 	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/lib/log"
 	"github.com/goharbor/harbor/src/lib/q"
@@ -54,7 +55,7 @@ func EnsureScanners(ctx context.Context, wantedScanners []scanner.Registration) 
 				return errors.Errorf("creating registration %s at %s failed: %v", ws.Name, ws.URL, err)
 			}
 			log.Infof("Successfully registered %s scanner at %s", ws.Name, ws.URL)
-		} else if scanner.URL != ws.URL {
+		} else if !utils.EqualURL(scanner.URL, ws.URL) {
 			scanner.URL = ws.URL
 			if err := scannerManager.Update(ctx, scanner); err != nil {
 				return errors.Errorf("updating registration %s to %s failed: %v", ws.Name, ws.URL, err)

--- a/src/pkg/scan/init_test.go
+++ b/src/pkg/scan/init_test.go
@@ -102,6 +102,28 @@ func TestEnsureScanners(t *testing.T) {
 		mgr.AssertExpectations(t)
 	})
 
+	t.Run("Should not update scanners when URL only differs in host case", func(t *testing.T) {
+		mgr := &mocks.Manager{}
+		scannerManager = mgr
+
+		mgr.On("List", mock.Anything, &q.Query{
+			Keywords: map[string]any{
+				"name__in": []string{
+					"trivy",
+				},
+			},
+		}).Return([]*scanner.Registration{
+			{Name: "trivy", URL: "http://trivy:8080"},
+		}, nil)
+
+		err := EnsureScanners(context.TODO(), []scanner.Registration{
+			{Name: "trivy", URL: "http://TRIVY:8080"},
+		})
+
+		assert.NoError(t, err)
+		mgr.AssertExpectations(t)
+	})
+
 }
 
 func TestEnsureDefaultScanner(t *testing.T) {


### PR DESCRIPTION
Thank you for contributing to Harbor!

# Comprehensive Summary of your change

This is a supplementary fix for https://github.com/goharbor/harbor/pull/23827 (#23827).

- Support case-insensitive host and endpoint comparisons in registry auth, adapters (AWS ECR, Ali ACR, Tencent TCR, Volcengine CR, Harbor base), v2auth middleware, and audit log forwarding.
- Parse and downcase the host part of URLs when verifying local Harbor instances and handling registry adapters.
- Ensure case-insensitive matching for OIDC Google endpoints.
- Add comprehensive unit tests covering case-insensitive comparisons across affected packages.

# Issue being fixed

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).