### PR TITLE
ci: Ignore Angular and TypeScript major updates in the portal Dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -100,6 +100,19 @@ updates:
     open-pull-requests-limit: 10
     labels:
       - "release-note/bump-version"
+    # Angular majors are a migration, not a bump: the new major pins a new
+    # TypeScript major, changes the ng-swagger-gen output and needs the wrapper
+    # libraries (ngx-markdown, @clr/*) to follow. Keep the group on the current
+    # major; upgrade Angular in a dedicated PR. See #23854 and #23856.
+    ignore:
+      - dependency-name: "@angular/*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@angular-devkit/*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@angular-eslint/*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
     groups:
       # The Angular packages pin each other with exact peer dependencies, and
       # @angular-devkit/build-angular and @angular/core pin typescript and
@@ -133,6 +146,19 @@ updates:
     open-pull-requests-limit: 10
     labels:
       - "release-note/bump-version"
+    # Angular majors are a migration, not a bump: the new major pins a new
+    # TypeScript major, changes the ng-swagger-gen output and needs the wrapper
+    # libraries (ngx-markdown, @clr/*) to follow. Keep the group on the current
+    # major; upgrade Angular in a dedicated PR. See #23854 and #23856.
+    ignore:
+      - dependency-name: "@angular/*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@angular-devkit/*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@angular-eslint/*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
     groups:
       angular:
         patterns:


### PR DESCRIPTION
Follow-up to #23839.

# Comprehensive Summary of your change

The first `angular` group PRs (#23854 on `main`, #23856 on `release-2.15.0`) bump Angular 21 -> 22 together with TypeScript 5.9 -> 7.0.2. Both fail `npm ci` with ERESOLVE (`@angular-devkit/build-angular@21.2.22` peers `@angular/compiler-cli ^21`, while the group moved `compiler-cli` to 22.1.4; `compiler-cli@22` peers `typescript >=6.0 <6.1`, so 7.0.2 is invalid for either major). With the set corrected by hand (build-angular 22.1.7, TypeScript 6.0.3, ngx-markdown 22.0.2, animations and platform-browser-dynamic 22.1.4) the portal still does not build: 2459 TypeScript errors in 271 files under TS 6 plus a new `marked-katex-extension` peer from ngx-markdown 22.

An Angular major is a migration, not a dependency bump. This change tells Dependabot to skip `version-update:semver-major` for `@angular/*`, `@angular-devkit/*`, `@angular-eslint/*` and `typescript` in both `src/portal` entries, so the group keeps delivering 21.x patch and minor updates (which merge cleanly, see #23743's content and #23766) and Angular 22 is done in a dedicated PR when the wrappers support it.

Only `ignore` is added; the groups and the `app-swagger-ui` entries are unchanged. `zone.js` is left out because its major is not tied to the Angular major.

# Issue being fixed

Per-major Angular group PRs that can never merge (#23854, #23856).

Please indicate you've done the following:

- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
