### PR TITLE
fix(portal): Keep the swagger-ui loading page intact when webpack minifies HTML

### DIFF
--- a/src/portal/app-swagger-ui/index.html
+++ b/src/portal/app-swagger-ui/index.html
@@ -18,7 +18,12 @@
                 width: 108px;
                 height: 108px;
                 animation: spin 1s linear infinite;
-                background: url(data:image/svg+xml;charset=utf8,%3Csvg%20id%3D%22Layer_2%22%20data-name%3D%22Layer%202%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2072%2072%22%3E%0A%20%20%20%20%3Cdefs%3E%0A%20%20%20%20%20%20%20%20%3Cstyle%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20.cls-1%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20.cls-2%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20fill%3A%20none%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20stroke-miterlimit%3A%2010%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20stroke-width%3A%205px%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20.cls-1%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20stroke%3A%20%23000000%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20stroke-opacity%3A%200.15%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20.cls-2%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20stroke%3A%20%230072a3%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%3C%2Fstyle%3E%0A%20%20%20%20%3C%2Fdefs%3E%0A%20%20%20%20%3Ctitle%3EPreloader_72x2%3C%2Ftitle%3E%0A%20%20%20%20%3Ccircle%20class%3D%22cls-1%22%20cx%3D%2236%22%20cy%3D%2236%22%20r%3D%2233%22%2F%3E%0A%20%20%20%20%3Cpath%20class%3D%22cls-2%22%20d%3D%22M14.3%2C60.9A33%2C33%2C0%2C0%2C1%2C36%2C3%22%3E%0A%20%20%20%20%3C%2Fpath%3E%0A%3C%2Fsvg%3E%0A);
+                /* The shapes below carry presentation attributes rather than an
+                   SVG stylesheet on purpose. Webpack's HTML minifier percent-decodes
+                   this data URI, so a style element nested in the SVG would emit a
+                   closing style tag here, end this block early and spill the rest of
+                   the SVG into the page. Keep the encoded SVG free of one. */
+                background: url(data:image/svg+xml;charset=utf8,%3Csvg%20id%3D%22Layer_2%22%20data-name%3D%22Layer%202%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2072%2072%22%3E%0A%20%20%20%20%3Ctitle%3EPreloader_72x2%3C%2Ftitle%3E%0A%20%20%20%20%3Ccircle%20cx%3D%2236%22%20cy%3D%2236%22%20r%3D%2233%22%20fill%3D%22none%22%20stroke%3D%22%23000000%22%20stroke-opacity%3D%220.15%22%20stroke-miterlimit%3D%2210%22%20stroke-width%3D%225%22%2F%3E%0A%20%20%20%20%3Cpath%20d%3D%22M14.3%2C60.9A33%2C33%2C0%2C0%2C1%2C36%2C3%22%20fill%3D%22none%22%20stroke%3D%22%230072a3%22%20stroke-miterlimit%3D%2210%22%20stroke-width%3D%225%22%2F%3E%0A%3C%2Fsvg%3E%0A);
                 text-indent: 100%;
                 overflow: hidden;
                 white-space: nowrap;


### PR DESCRIPTION
Thank you for contributing to Harbor!

# Comprehensive Summary of your change

The swagger-ui loading spinner in `src/portal/app-swagger-ui/index.html` is a
percent-encoded SVG data URI inside the page's inline `<style>` block, and that
SVG carried its own nested `<style>` element holding the `.cls-1` / `.cls-2`
rules.

webpack 5.110.0 extended `optimization.minimize` to cover emitted HTML in
addition to JavaScript and CSS (webpack/webpack#21841, "Minify more HTML and CSS
shorthands"). The minifier percent-decodes the escapes it considers safe, which
turns the SVG's nested `%3C%2Fstyle%3E` into a literal closing style tag. The
browser ends the page's style block at that point, so the `.spinner` rule and
the `@keyframes spin` are dropped and the remainder of the SVG is painted as raw
text above the container. The user sees no spinner, a line of CSS source, and a
bare "Loading...".

This fix removes the nested stylesheet and styles the circle and the path with
SVG presentation attributes instead, so the decoded data URI can no longer
contain a closing style tag. No webpack configuration opt-out is needed and the
change is inert on the currently pinned webpack.

## Reproduction and measurements

Run in `src/portal/app-swagger-ui`: `npm ci` then `npm run build`, which is
exactly what `make/photon/portal/Dockerfile` does. Measurements are taken on
`dist/swagger-ui-index.html`; the body column is the length of `<body>` from
`chrome --headless --dump-dom`, where 63 characters is the expected
`<div id="swagger-ui-container" class="spinner">Loading...</div>` and nothing
else.

| index.html | webpack | dist bytes | closing style tags | `<body>` length |
| --- | --- | --- | --- | --- |
| before this PR | 5.107.2 (current pin) | 2476 | 1 | 63 |
| before this PR | 5.110.2 | 1867 | 2 | 616 |
| after this PR | 5.107.2 | 2150 | 1 | 63 |
| after this PR | 5.110.2 | 1173 | 1 | 63 |

The 616-character body on the broken build begins
`%0A%20%20%20%20%0A%20%20%20%20<title>Preloader_72x2</title>...` and ends with
the leaked `@keyframes spin` declaration.

## Affected versions

Bisected across the webpack 5.10x line: 5.107.2, 5.108.0, 5.109.0 and 5.109.2
produce a correct page. 5.110.0, 5.110.1, 5.110.2 and 5.110.3 all corrupt it.
The regression therefore starts at 5.110.0, the release that turned on HTML
minification.

## Rendering equivalence

The spinner artwork is unchanged. I extracted the emitted `url(...)` value from
the pre-change build and from the post-change build, rendered each into a
108x108 box with the animation disabled, and screenshotted both with headless
Chrome. the two renders show the same ring and arc (same colours, same non-white pixel count), and the image is the expected light
grey ring with the blue arc rather than a blank box. Full-page screenshots of
the built page under both webpack versions show the normal spinner, differing
only in animation phase.

## Applies to release-2.15.0

`src/portal/app-swagger-ui/index.html` and `webpack.prod.js` are byte-identical
on `main` and `release-2.15.0`, so this commit cherry-picks with no conflict. I
verified the cherry-pick on that branch against its own lockfile: 2150 bytes and
one closing style tag with webpack 5.107.2, and 1173 bytes, one closing style
tag and a 63-character body with 5.110.2.

## Relationship to the pending dependabot PRs

This change unblocks #23845 (webpack bump on `main`) and #23849 (the same bump on
`release-2.15.0`). Both currently ship a broken swagger-ui loading page, and
neither is safe to merge before this lands. Merging this first, then rebasing
those PRs, keeps the loading page correct across the bump.

# Issue being fixed
N/A

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
