### PR TITLE
Fix unnecessary Docker Hub authentication during proxy-cache pulls

### DIFF
--- a/src/pkg/reg/adapter/dockerhub/adapter_test.go
+++ b/src/pkg/reg/adapter/dockerhub/adapter_test.go
@@ -2,13 +2,19 @@ package dockerhub
 
 import (
 	"fmt"
+	"io"
 	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
 	"testing"
 
+	"github.com/opencontainers/go-digest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/h2non/gock.v1"
 
+	"github.com/goharbor/harbor/src/pkg/reg/adapter/native"
 	"github.com/goharbor/harbor/src/pkg/reg/model"
 )
 
@@ -87,4 +93,101 @@ func TestFetchArtifacts(t *testing.T) {
 		},
 	})
 	require.Nil(t, err)
+}
+
+func TestConcurrentAdapterCreationDoesNotAuthenticate(testingContext *testing.T) {
+	restoreNetwork := blockClientNetwork(testingContext)
+	defer restoreNetwork()
+	registry := &model.Registry{
+		URL:        baseURL,
+		Credential: &model.Credential{AccessKey: "test-user", AccessSecret: "test-secret"},
+	}
+	var workers sync.WaitGroup
+	start := make(chan struct{})
+	results := make(chan error, 32)
+	for index := 0; index < cap(results); index++ {
+		workers.Add(1)
+		go func() {
+			defer workers.Done()
+			<-start
+			_, err := newAdapter(registry)
+			results <- err
+		}()
+	}
+	close(start)
+	workers.Wait()
+	close(results)
+	for err := range results {
+		require.NoError(testingContext, err)
+	}
+}
+
+func TestNativePullDoesNotRequireDockerHubLogin(testingContext *testing.T) {
+	manifestPayload := `{"schemaVersion":2,"mediaType":"application/vnd.oci.image.index.v1+json","manifests":[]}`
+	manifestDigest := digest.FromString(manifestPayload).String()
+	var hubLogins, registryLogins atomic.Int32
+	var registryEndpoint string
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.URL.Path == "/token" {
+			username, secret, ok := request.BasicAuth()
+			if !ok || username != "test-user" || secret != "valid-secret" {
+				writer.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+			registryLogins.Add(1)
+			_, _ = io.WriteString(writer, `{"token":"registry-bearer","expires_in":300}`)
+			return
+		}
+		if request.Header.Get("Authorization") != "Bearer registry-bearer" {
+			writer.Header().Set("WWW-Authenticate", fmt.Sprintf(`Bearer realm="%s/token",service="test-registry"`, registryEndpoint))
+			writer.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		if request.URL.Path == "/v2/library/busybox/manifests/latest" {
+			writer.Header().Set("Docker-Content-Digest", manifestDigest)
+			writer.Header().Set("Content-Type", "application/vnd.oci.image.index.v1+json")
+			writer.Header().Set("Content-Length", fmt.Sprint(len(manifestPayload)))
+			if request.Method == http.MethodGet {
+				_, _ = io.WriteString(writer, manifestPayload)
+			}
+			return
+		}
+		writer.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+	registryEndpoint = server.URL
+	for _, secret := range []string{"valid-secret", "invalid-secret"} {
+		testingContext.Run(secret, func(testingContext *testing.T) {
+			registry := &model.Registry{URL: baseURL, Credential: &model.Credential{AccessKey: "test-user", AccessSecret: secret}}
+			restoreNetwork := blockClientNetwork(testingContext)
+			created, err := newAdapter(registry)
+			restoreNetwork()
+			require.NoError(testingContext, err)
+			adapter := created.(*adapter)
+			adapter.client.client.Transport = clientTestTransport(func(request *http.Request) (*http.Response, error) {
+				hubLogins.Add(1)
+				return clientTestResponse(http.StatusTooManyRequests, "{}"), nil
+			})
+			adapter.Adapter = native.NewAdapter(&model.Registry{URL: registryEndpoint, Credential: registry.Credential})
+			health, err := adapter.HealthCheck()
+			require.NoError(testingContext, err)
+			if secret == "invalid-secret" {
+				require.Equal(testingContext, model.Unhealthy, health)
+				_, _, err = adapter.PullManifest("library/busybox", "latest")
+				require.Error(testingContext, err)
+				return
+			}
+			require.Equal(testingContext, model.Healthy, health)
+			exists, descriptor, err := adapter.ManifestExist("library/busybox", "latest")
+			require.NoError(testingContext, err)
+			require.True(testingContext, exists)
+			require.Equal(testingContext, manifestDigest, descriptor.Digest.String())
+			manifest, pulledDigest, err := adapter.PullManifest("library/busybox", "latest")
+			require.NoError(testingContext, err)
+			require.NotNil(testingContext, manifest)
+			require.Equal(testingContext, manifestDigest, pulledDigest)
+		})
+	}
+	require.Zero(testingContext, hubLogins.Load())
+	require.Positive(testingContext, registryLogins.Load())
 }

--- a/src/pkg/reg/adapter/dockerhub/client.go
+++ b/src/pkg/reg/adapter/dockerhub/client.go
@@ -58,17 +58,13 @@ func NewClient(registry *model.Registry) (*Client, error) {
 		return client, nil
 	}
 
-	// Login to DockerHub to get access token. Tokens expire after 10 minutes;
-	// subsequent calls via Do() will refresh the token automatically.
+	// Keep authentication lazy. Proxy-cache pulls use the embedded native
+	// registry adapter and do not need the Docker Hub API token. Authenticating
+	// here would call /v2/auth/token for every short-lived proxy adapter.
 	client.credential = LoginCredential{
 		Identifier: registry.Credential.AccessKey,
 		Secret:     registry.Credential.AccessSecret,
 	}
-	err := client.refreshToken()
-	if err != nil {
-		return nil, fmt.Errorf("login to dockerhub error: %v", err)
-	}
-
 	return client, nil
 }
 
@@ -105,6 +101,9 @@ func (c *Client) refreshToken() error {
 	if err = json.Unmarshal(body, token); err != nil {
 		return fmt.Errorf("unmarshal token response error: %v", err)
 	}
+	if token.AccessToken == "" {
+		return fmt.Errorf("dockerhub token response contains no access_token")
+	}
 
 	c.token = token.AccessToken
 	// Tokens issued by /v2/auth/token expire after 10 minutes; refresh 1 minute
@@ -113,25 +112,31 @@ func (c *Client) refreshToken() error {
 	return nil
 }
 
-// ensureToken refreshes the bearer token when it has expired or is close to
-// expiring. It is a no-op for anonymous (unauthenticated) clients.
-func (c *Client) ensureToken() error {
-	if len(c.credential.Identifier) == 0 {
-		return nil
+// ensureToken returns a cached bearer token, refreshing it when it is expired
+// or close to expiring. It is a no-op for anonymous clients.
+func (c *Client) ensureToken() (string, error) {
+	if len(c.credential.Identifier) == 0 && len(c.credential.Secret) == 0 {
+		return "", nil
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
+
 	if time.Now().Before(c.tokenExpiry) {
-		return nil
+		return c.token, nil
 	}
-	return c.refreshToken()
+
+	if err := c.refreshToken(); err != nil {
+		return "", err
+	}
+	return c.token, nil
 }
 
 // Do performs an HTTP request to DockerHub, refreshing the bearer token when
 // needed and attaching it to the Authorization header.
 func (c *Client) Do(method, path string, body io.Reader) (*http.Response, error) {
-	if err := c.ensureToken(); err != nil {
-		return nil, fmt.Errorf("refresh dockerhub token: %v", err)
+	token, err := c.ensureToken()
+	if err != nil {
+		return nil, fmt.Errorf("refresh dockerhub token: %w", err)
 	}
 
 	url := baseURL + path
@@ -143,7 +148,21 @@ func (c *Client) Do(method, path string, body io.Reader) (*http.Response, error)
 	if body != nil || method == http.MethodPost || method == http.MethodPut {
 		req.Header.Set("Content-Type", "application/json")
 	}
-	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.token))
+	if token != "" {
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+	}
 
-	return c.client.Do(req)
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return resp, err
+	}
+	if resp.StatusCode == http.StatusUnauthorized && token != "" {
+		c.mu.Lock()
+		if c.token == token {
+			c.token = ""
+			c.tokenExpiry = time.Time{}
+		}
+		c.mu.Unlock()
+	}
+	return resp, nil
 }

--- a/src/pkg/reg/adapter/dockerhub/client_test.go
+++ b/src/pkg/reg/adapter/dockerhub/client_test.go
@@ -1,0 +1,326 @@
+package dockerhub
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	commonhttp "github.com/goharbor/harbor/src/common/http"
+	"github.com/goharbor/harbor/src/lib/config"
+	"github.com/goharbor/harbor/src/pkg/reg/model"
+)
+
+type clientTestTransport func(*http.Request) (*http.Response, error)
+
+func (transport clientTestTransport) RoundTrip(request *http.Request) (*http.Response, error) {
+	return transport(request)
+}
+
+func clientTestResponse(status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}
+
+func blockClientNetwork(testingContext *testing.T) func() {
+	testingContext.Helper()
+	transport, ok := commonhttp.GetHTTPTransport().(*http.Transport)
+	require.True(testingContext, ok)
+	originalProxy := transport.Proxy
+	transport.Proxy = func(request *http.Request) (*url.URL, error) {
+		return nil, fmt.Errorf("unexpected network request: %s", request.URL)
+	}
+	return func() { transport.Proxy = originalProxy }
+}
+
+func newTestClient(testingContext *testing.T, credential *model.Credential, transport http.RoundTripper) *Client {
+	testingContext.Helper()
+	restoreNetwork := blockClientNetwork(testingContext)
+	defer restoreNetwork()
+	client, err := NewClient(&model.Registry{URL: baseURL, Credential: credential})
+	require.NoError(testingContext, err)
+	require.Equal(testingContext, config.RegistryHTTPClientTimeout(), client.client.Timeout)
+	require.Positive(testingContext, client.client.Timeout)
+	client.client.Transport = transport
+	return client
+}
+
+func TestClientLazyAuthenticationAndRefresh(testingContext *testing.T) {
+	credential := &model.Credential{AccessKey: "test-user", AccessSecret: "test-secret"}
+	logins := 0
+	transport := clientTestTransport(func(request *http.Request) (*http.Response, error) {
+		if request.URL.Path == loginPath {
+			require.Equal(testingContext, http.MethodPost, request.Method)
+			require.Equal(testingContext, "application/json", request.Header.Get("Content-Type"))
+			var supplied LoginCredential
+			require.NoError(testingContext, json.NewDecoder(request.Body).Decode(&supplied))
+			require.Equal(testingContext, LoginCredential{Identifier: credential.AccessKey, Secret: credential.AccessSecret}, supplied)
+			logins++
+			return clientTestResponse(http.StatusOK, fmt.Sprintf(`{"access_token":"token-%d"}`, logins)), nil
+		}
+		return clientTestResponse(http.StatusOK, request.Header.Get("Authorization")), nil
+	})
+	firstClient := newTestClient(testingContext, credential, transport)
+	secondClient := newTestClient(testingContext, credential, transport)
+	require.Zero(testingContext, logins)
+
+	checkAuthorization := func(client *Client, expected string) {
+		testingContext.Helper()
+		response, err := client.Do(http.MethodGet, listNamespacePath, nil)
+		require.NoError(testingContext, err)
+		defer response.Body.Close()
+		body, err := io.ReadAll(response.Body)
+		require.NoError(testingContext, err)
+		require.Equal(testingContext, expected, string(body))
+	}
+	checkAuthorization(firstClient, "Bearer token-1")
+	checkAuthorization(firstClient, "Bearer token-1")
+	require.Equal(testingContext, 1, logins)
+	checkAuthorization(secondClient, "Bearer token-2")
+	checkAuthorization(firstClient, "Bearer token-1")
+	require.Equal(testingContext, 2, logins)
+	firstClient.mu.Lock()
+	firstClient.tokenExpiry = time.Now().Add(-time.Second)
+	firstClient.mu.Unlock()
+	checkAuthorization(firstClient, "Bearer token-3")
+	require.Equal(testingContext, 3, logins)
+}
+
+func TestClientConcurrentRefresh(testingContext *testing.T) {
+	var logins atomic.Int32
+	client := newTestClient(testingContext, &model.Credential{AccessKey: "test-user", AccessSecret: "test-secret"}, nil)
+	for round := 1; round <= 2; round++ {
+		loginStarted := make(chan struct{}, 32)
+		finishLogin := make(chan struct{})
+		client.client.Transport = clientTestTransport(func(request *http.Request) (*http.Response, error) {
+			if request.URL.Path == loginPath {
+				sequence := logins.Add(1)
+				loginStarted <- struct{}{}
+				<-finishLogin
+				return clientTestResponse(http.StatusOK, fmt.Sprintf(`{"access_token":"token-%d"}`, sequence)), nil
+			}
+			if request.Header.Get("Authorization") != fmt.Sprintf("Bearer token-%d", round) {
+				return nil, fmt.Errorf("request used the wrong token")
+			}
+			return clientTestResponse(http.StatusOK, "{}"), nil
+		})
+		client.mu.Lock()
+		client.tokenExpiry = time.Now().Add(-time.Second)
+		client.mu.Unlock()
+		var workers sync.WaitGroup
+		start := make(chan struct{})
+		results := make(chan error, 32)
+		for index := 0; index < cap(results); index++ {
+			workers.Add(1)
+			go func() {
+				defer workers.Done()
+				<-start
+				response, err := client.Do(http.MethodGet, listNamespacePath, nil)
+				if response != nil {
+					response.Body.Close()
+				}
+				results <- err
+			}()
+		}
+		close(start)
+		select {
+		case <-loginStarted:
+		case <-time.After(5 * time.Second):
+			close(finishLogin)
+			testingContext.Fatal("authentication request did not start")
+		}
+		lockAvailable := client.mu.TryLock()
+		if lockAvailable {
+			client.mu.Unlock()
+		}
+		close(finishLogin)
+		workers.Wait()
+		require.False(testingContext, lockAvailable, "the in-flight refresh must hold the client lock")
+		close(results)
+		for err := range results {
+			require.NoError(testingContext, err)
+		}
+		require.EqualValues(testingContext, round, logins.Load())
+	}
+}
+
+func TestClientAnonymousAccess(testingContext *testing.T) {
+	for _, credential := range []*model.Credential{nil, {}} {
+		requests := 0
+		client := newTestClient(testingContext, credential, clientTestTransport(func(request *http.Request) (*http.Response, error) {
+			requests++
+			require.Equal(testingContext, listNamespacePath, request.URL.Path)
+			require.Empty(testingContext, request.Header.Get("Authorization"))
+			return clientTestResponse(http.StatusOK, "{}"), nil
+		}))
+		response, err := client.Do(http.MethodGet, listNamespacePath, nil)
+		require.NoError(testingContext, err)
+		response.Body.Close()
+		require.Equal(testingContext, 1, requests)
+	}
+}
+
+func TestClientAuthenticationFailures(testingContext *testing.T) {
+	for _, testCase := range []struct {
+		name   string
+		status int
+		body   string
+	}{
+		{name: "rate limited", status: http.StatusTooManyRequests, body: `{"detail":"Rate limit exceeded"}`},
+		{name: "unauthorized", status: http.StatusUnauthorized, body: `{"detail":"Invalid credentials"}`},
+		{name: "malformed JSON", status: http.StatusOK, body: "{"},
+		{name: "missing token", status: http.StatusOK, body: "{}"},
+		{name: "empty token", status: http.StatusOK, body: `{"access_token":""}`},
+	} {
+		testingContext.Run(testCase.name, func(testingContext *testing.T) {
+			logins, apiRequests := 0, 0
+			client := newTestClient(testingContext, &model.Credential{AccessKey: "test-user", AccessSecret: "test-secret"}, clientTestTransport(func(request *http.Request) (*http.Response, error) {
+				if request.URL.Path == loginPath {
+					logins++
+					if logins == 1 {
+						return clientTestResponse(testCase.status, testCase.body), nil
+					}
+					return clientTestResponse(http.StatusOK, `{"access_token":"recovered"}`), nil
+				}
+				apiRequests++
+				require.Equal(testingContext, "Bearer recovered", request.Header.Get("Authorization"))
+				return clientTestResponse(http.StatusOK, "{}"), nil
+			}))
+			response, err := client.Do(http.MethodGet, listNamespacePath, nil)
+			require.Error(testingContext, err)
+			require.Nil(testingContext, response)
+			require.Equal(testingContext, 1, logins)
+			require.Zero(testingContext, apiRequests)
+			require.Empty(testingContext, client.token)
+			require.True(testingContext, client.tokenExpiry.IsZero())
+			response, err = client.Do(http.MethodGet, listNamespacePath, nil)
+			require.NoError(testingContext, err)
+			response.Body.Close()
+			require.Equal(testingContext, 2, logins)
+			require.Equal(testingContext, 1, apiRequests)
+		})
+	}
+}
+
+func TestClientIncompleteCredentialsAreNotAnonymous(testingContext *testing.T) {
+	for _, credential := range []*model.Credential{{AccessKey: "test-user"}, {AccessSecret: "test-secret"}} {
+		logins := 0
+		client := newTestClient(testingContext, credential, clientTestTransport(func(request *http.Request) (*http.Response, error) {
+			require.Equal(testingContext, loginPath, request.URL.Path)
+			logins++
+			return clientTestResponse(http.StatusUnauthorized, "{}"), nil
+		}))
+		response, err := client.Do(http.MethodGet, listNamespacePath, nil)
+		require.Error(testingContext, err)
+		require.Nil(testingContext, response)
+		require.Equal(testingContext, 1, logins)
+	}
+}
+
+func TestClientInvalidatesUnauthorizedWithoutReplay(testingContext *testing.T) {
+	for _, status := range []int{http.StatusUnauthorized, http.StatusForbidden} {
+		testingContext.Run(http.StatusText(status), func(testingContext *testing.T) {
+			logins, apiRequests := 0, 0
+			client := newTestClient(testingContext, &model.Credential{AccessKey: "test-user", AccessSecret: "test-secret"}, clientTestTransport(func(request *http.Request) (*http.Response, error) {
+				if request.URL.Path == loginPath {
+					logins++
+					return clientTestResponse(http.StatusOK, fmt.Sprintf(`{"access_token":"token-%d"}`, logins)), nil
+				}
+				apiRequests++
+				require.Equal(testingContext, fmt.Sprintf("Bearer token-%d", logins), request.Header.Get("Authorization"))
+				if apiRequests == 1 {
+					require.Equal(testingContext, http.MethodPost, request.Method)
+					return clientTestResponse(status, "{}"), nil
+				}
+				return clientTestResponse(http.StatusOK, "{}"), nil
+			}))
+			response, err := client.Do(http.MethodPost, createNamespacePath, strings.NewReader(`{"orgname":"test"}`))
+			require.NoError(testingContext, err)
+			require.Equal(testingContext, status, response.StatusCode)
+			response.Body.Close()
+			require.Equal(testingContext, 1, apiRequests)
+			require.Equal(testingContext, 1, logins)
+			response, err = client.Do(http.MethodGet, listNamespacePath, nil)
+			require.NoError(testingContext, err)
+			response.Body.Close()
+			require.Equal(testingContext, 2, apiRequests)
+			if status == http.StatusUnauthorized {
+				require.Equal(testingContext, 2, logins)
+			} else {
+				require.Equal(testingContext, 1, logins)
+			}
+		})
+	}
+}
+
+func TestClientLateUnauthorizedDoesNotInvalidateFreshToken(testingContext *testing.T) {
+	var logins atomic.Int32
+	started, release := make(chan struct{}), make(chan struct{})
+	var releaseOnce sync.Once
+	defer releaseOnce.Do(func() { close(release) })
+	client := newTestClient(testingContext, &model.Credential{AccessKey: "test-user", AccessSecret: "test-secret"}, clientTestTransport(func(request *http.Request) (*http.Response, error) {
+		if request.URL.Path == loginPath {
+			return clientTestResponse(http.StatusOK, fmt.Sprintf(`{"access_token":"token-%d"}`, logins.Add(1))), nil
+		}
+		if request.URL.Path == "/slow" {
+			close(started)
+			<-release
+			return clientTestResponse(http.StatusUnauthorized, "{}"), nil
+		}
+		return clientTestResponse(http.StatusOK, "{}"), nil
+	}))
+	finished := make(chan error, 1)
+	go func() {
+		response, err := client.Do(http.MethodGet, "/slow", nil)
+		if response != nil {
+			response.Body.Close()
+		}
+		finished <- err
+	}()
+	<-started
+	client.mu.Lock()
+	client.tokenExpiry = time.Now().Add(-time.Second)
+	client.mu.Unlock()
+	response, err := client.Do(http.MethodGet, listNamespacePath, nil)
+	require.NoError(testingContext, err)
+	response.Body.Close()
+	releaseOnce.Do(func() { close(release) })
+	require.NoError(testingContext, <-finished)
+	response, err = client.Do(http.MethodGet, listNamespacePath, nil)
+	require.NoError(testingContext, err)
+	response.Body.Close()
+	require.EqualValues(testingContext, 2, logins.Load())
+}
+
+func TestClientAuthenticationTimeout(testingContext *testing.T) {
+	client := newTestClient(testingContext, &model.Credential{AccessKey: "test-user", AccessSecret: "test-secret"}, clientTestTransport(func(request *http.Request) (*http.Response, error) {
+		<-request.Context().Done()
+		return nil, request.Context().Err()
+	}))
+	client.client.Timeout = 20 * time.Millisecond
+	response, err := client.Do(http.MethodGet, listNamespacePath, nil)
+	require.ErrorIs(testingContext, err, context.DeadlineExceeded)
+	require.Nil(testingContext, response)
+	client.client.Timeout = config.RegistryHTTPClientTimeout()
+	client.client.Transport = clientTestTransport(func(request *http.Request) (*http.Response, error) {
+		if request.URL.Path == loginPath {
+			return clientTestResponse(http.StatusOK, `{"access_token":"recovered"}`), nil
+		}
+		return clientTestResponse(http.StatusOK, "{}"), nil
+	})
+	response, err = client.Do(http.MethodGet, listNamespacePath, nil)
+	require.NoError(testingContext, err)
+	response.Body.Close()
+}


### PR DESCRIPTION
# Comprehensive Summary of your change

Docker Hub adapter construction eagerly authenticated against `POST /v2/auth/token`. Because proxy-cache requests create short-lived adapters, concurrent image pulls could generate unnecessary Hub API login requests, trigger rate limiting, and cause uncached images to return not-found errors when Harbor fell back to local storage.

This change makes Docker Hub API authentication lazy. Proxy-cache pulls continue to authenticate through the native registry client, without requiring a separate Docker Hub API login.

This bug was introduced in https://github.com/goharbor/harbor/pull/23096
Reference issue - https://github.com/goharbor/harbor/issues/23750

## Implementation

- Defer Hub API authentication until an API operation requires it.
- Retain per-client token caching and the existing nine-minute refresh window.
- Return the cached token while holding the client mutex to avoid concurrent
  reads racing with token refresh.
- Preserve the configured registry HTTP client timeout.
- Reject successful authentication responses that omit an access token.
- Invalidate a token rejected with HTTP 401 so the next request can refresh it,
  without automatically replaying the failed request.
- Avoid invalidating a newer token when an older in-flight request returns 401.

The process-wide cache from the original revision has been removed.
This PR does not introduce cross-client token sharing or a general
authentication retry/backoff policy.

## Regression coverage

Tests cover:

- Concurrent adapter construction without Hub API login requests.
- Authenticated native manifest access while Hub API login is unavailable.
- Rejection of invalid registry credentials.
- Lazy authentication, per-client token reuse, expiry, and concurrent refresh.
- Anonymous access and incomplete credentials.
- Authentication errors, malformed responses, and empty tokens.
- HTTP 401 invalidation without replay, including late responses for older tokens.
- Authentication timeout and subsequent recovery.

## Validation

Passed locally:

```bash
go test -race -count=1 ./pkg/reg/adapter/dockerhub ./pkg/reg/adapter/native ./pkg/registry/...
go test -race -count=20 ./pkg/reg/adapter/dockerhub
go vet ./pkg/reg/adapter/dockerhub
git diff --check
```

The constructor regression tests fail against unpatched main. The concurrent
refresh test also fails when the refresh lock is removed.

This PR targets `main`; a subsequent backport to `release-2.15.0` is intended.

# Issue being fixed

Fixes #23750

Please indicate you've done the following:

- [x] Well Written Title and Summary of the PR
- [ ] Label the PR as needed: `release-note/update`
- [x] Accepted the DCO. The commit includes a `Signed-off-by` trailer.
- [x] Made sure tests are passing locally and added regression coverage.
- [x] Considered the docs impact. No configuration or public API changes require documentation updates.