### PR TITLE
fix(config): bound the scientific-notation fallback in parseInt64 and parseInt

### DIFF
--- a/src/lib/config/metadata/type.go
+++ b/src/lib/config/metadata/type.go
@@ -257,7 +257,10 @@ func parseInt64(str string) (int64, error) {
 	}
 
 	fval, err := strconv.ParseFloat(str, 64)
-	if err == nil && fval == math.Trunc(fval) {
+	// float64(math.MaxInt64) rounds up to 2^63, so the upper bound is exclusive;
+	// float64(math.MinInt64) is exact, so the lower bound is inclusive.
+	if err == nil && fval == math.Trunc(fval) &&
+		fval >= float64(math.MinInt64) && fval < float64(math.MaxInt64) {
 		return int64(fval), nil
 	}
 
@@ -271,7 +274,8 @@ func parseInt(str string) (int, error) {
 	}
 
 	fval, err := strconv.ParseFloat(str, 32)
-	if err == nil && fval == math.Trunc(fval) {
+	if err == nil && fval == math.Trunc(fval) &&
+		fval >= float64(math.MinInt64) && fval < float64(math.MaxInt64) {
 		return int(fval), nil
 	}
 

--- a/src/lib/config/metadata/type_test.go
+++ b/src/lib/config/metadata/type_test.go
@@ -15,6 +15,7 @@
 package metadata
 
 import (
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -60,6 +61,55 @@ func TestInt64Type_get(t *testing.T) {
 	test := &Int64Type{}
 	result, _ := test.get("32")
 	assert.Equal(t, result, int64(32))
+}
+
+func TestParseInt64Bounds(t *testing.T) {
+	// The scientific-notation fallback must reject what strconv.ParseInt
+	// already rejects a few lines above it.
+	for _, str := range []string{
+		"9223372036854775808",
+		"9.223372036854775808e18",
+		"1e30",
+		"Inf",
+		"+Inf",
+		"Infinity",
+		"-Infinity",
+		"NaN",
+	} {
+		_, err := parseInt64(str)
+		assert.Error(t, err, str)
+	}
+
+	// float64(math.MinInt64) is exact, so the lower bound stays inclusive.
+	for str, want := range map[string]int64{
+		"9223372036854775807":      math.MaxInt64,
+		"-9223372036854775808":     math.MinInt64,
+		"-9.223372036854775808e18": math.MinInt64,
+		"6e1":                      60,
+	} {
+		got, err := parseInt64(str)
+		assert.NoError(t, err, str)
+		assert.Equal(t, want, got, str)
+	}
+}
+
+func TestParseIntBounds(t *testing.T) {
+	for _, str := range []string{"1e30", "Inf", "-Inf", "NaN"} {
+		_, err := parseInt(str)
+		assert.Error(t, err, str)
+	}
+
+	// Values that already worked must keep working; verifyValueLengthCfg
+	// allows ten digits, which is beyond int32.
+	for str, want := range map[string]int{
+		"60":         60,
+		"2147483647": 2147483647,
+		"1e10":       10000000000,
+	} {
+		got, err := parseInt(str)
+		assert.NoError(t, err, str)
+		assert.Equal(t, want, got, str)
+	}
 }
 
 func TestBoolType_validate(t *testing.T) {


### PR DESCRIPTION
`parseInt64` and `parseInt` (`src/lib/config/metadata/type.go:253` and `:270`) both try `strconv.ParseInt` first, which rejects anything outside the target width, and then fall back to `strconv.ParseFloat` so that scientific notation is accepted. The fallback had no range check, so a value the first attempt had just refused was converted anyway and the result wrapped.

Measured on `main`:

```
input                      result
9223372036854775808        -9223372036854775808
9.223372036854775808e18    -9223372036854775808
1e30                       -9223372036854775808
Inf / +Inf / Infinity      -9223372036854775808
NaN                        rejected (already)
```

`math.Trunc(NaN) != NaN` was already rejecting NaN, but `math.Trunc(+Inf) == +Inf`, so the infinities went through as well.

### Where it shows

`session_timeout` is an `Int64Type` and `Editable: true` (`src/lib/config/metadata/metadatalist.go:197`), so `PUT /api/v2.0/configurations` with `{"session_timeout": 1e30}` passes validation and stores the wrapped negative value. `systemSessionTimeout` (`src/core/session/session.go:237`) then reads it as

```go
if sysTimeout := config.SessionTimeout(ctx); sysTimeout > 0 {
```

and a negative reads as "not configured", so the administrator gets 200 OK and their setting is silently dropped — sessions keep the beego default.

The named X is four lines above the fallback in the same function: `strconv.ParseInt(str, 10, 64)` refuses exactly these values. Harbor does it correctly elsewhere in the same validation pass too — `src/pkg/config/manager.go:191` bounds `storage_per_project` with `strconv.ParseInt` and errors out.

### The bounds are deliberately asymmetric

`float64(math.MaxInt64)` rounds **up** to 2^63, which int64 cannot hold, so the upper bound is exclusive. `float64(math.MinInt64)` is exactly -2^63 and *is* representable, so the lower bound stays inclusive and `-9.223372036854775808e18` remains valid. Both are pinned by tests so they do not get made symmetric later.

`parseInt` keeps `strconv.ParseFloat(str, 32)` and its existing float32 rounding; this change only stops the out-of-range values. Ten-digit configuration values such as `token_expiration`, which `verifyValueLengthCfg` allows and which exceed int32, keep parsing exactly as before — there is a test row for that.

Also worth knowing, not changed here: `src/controller/config/controller.go:188` compares with `if int64(vf) > maxValue`, which is itself an unguarded narrowing, so `int64(1e30)` is not greater than `9999999999` and the ten-digit UI limit was bypassed. That path runs `ValidateCfg` first (`controller.go:132` before `:142`), so this fix covers it.

### Testing

`TestParseInt64Bounds` and `TestParseIntBounds` added to `src/lib/config/metadata/type_test.go`, covering the rejected values, `math.MaxInt64` and `math.MinInt64` as still accepted, and the ten-digit case.

- Both fail on `main` and pass here.
- Mutation-checked, all three caught: weakening the upper bound to `<=`, rejecting the exact negative bound, and dropping the bounds from `parseInt`.
- `gofmt` clean, `go vet ./lib/config/metadata/` clean, `golangci-lint run ./lib/config/metadata/...` reports 0 issues.
- `go test ./lib/config/... ./pkg/config/...` passes. Three packages (`lib/config/test`, `pkg/config/db`, `pkg/config/validate/test`) fail identically on an unmodified tree here because they need `POSTGRESQL_HOST`.

---

AI assistance disclosure: this patch was found and written with Claude Code. The table above is verbatim from running the parsers against `main`.
