### PR TITLE
fix(securityhub): support one-sided ranges in the vulnerability filter

### DIFF
--- a/src/pkg/securityhub/dao/security.go
+++ b/src/pkg/securityhub/dao/security.go
@@ -145,8 +145,18 @@ func rangeFilter(_ context.Context, key string, query *q.Query) (sqlStr string, 
 	}
 	if val, ok := query.Keywords[key]; ok {
 		if r, ok := val.(*q.Range); ok {
-			sqlStr = fmt.Sprintf(" and %v between ? and ?", key)
-			params = append(params, r.Min, r.Max)
+			// q.Build allows a range with only one bound set.
+			switch {
+			case r.Min != nil && r.Max != nil:
+				sqlStr = fmt.Sprintf(" and %v between ? and ?", key)
+				params = append(params, r.Min, r.Max)
+			case r.Min != nil:
+				sqlStr = fmt.Sprintf(" and %v >= ?", key)
+				params = append(params, r.Min)
+			case r.Max != nil:
+				sqlStr = fmt.Sprintf(" and %v <= ?", key)
+				params = append(params, r.Max)
+			}
 		}
 	}
 	return

--- a/src/pkg/securityhub/dao/security_test.go
+++ b/src/pkg/securityhub/dao/security_test.go
@@ -186,6 +186,8 @@ func (suite *SecurityDaoTestSuite) TestRangeFilter() {
 		wantParams []any
 	}{
 		{"normal", args{suite.Context(), "cvss_score_v3", q.New(q.KeyWords{"cvss_score_v3": &q.Range{1.0, 2.0}})}, " and cvss_score_v3 between ? and ?", []any{1.0, 2.0}},
+		{"min only", args{suite.Context(), "cvss_score_v3", q.New(q.KeyWords{"cvss_score_v3": &q.Range{Min: 7.0}})}, " and cvss_score_v3 >= ?", []any{7.0}},
+		{"max only", args{suite.Context(), "cvss_score_v3", q.New(q.KeyWords{"cvss_score_v3": &q.Range{Max: 7.0}})}, " and cvss_score_v3 <= ?", []any{7.0}},
 	}
 	for _, tt := range tests {
 		suite.Run(tt.name, func() {


### PR DESCRIPTION
`q.Build` accepts a range with only one bound set — `src/lib/q/builder.go:137-138` errors only when *both* are empty — so `q=cvss_score_v3=[7~]` parses to `Range{Min: 7, Max: nil}`.

`rangeFilter` (`src/pkg/securityhub/dao/security.go:142`) emitted `between ? and ?` unconditionally and appended both bounds, so the nil went into the parameter list:

```
parsed q=[7~]  ->  Range{Min:7 Max:<nil>}
rangeFilter     ->  sql=" and cvss_score_v3 between ? and ?"  params=[7, nil]

closed   [7~10]  count=1  err=<nil>
halfopen [7~]    count=0  err=expected 3 arguments, got 2
```

So `GET /api/v2.0/security/vul?q=cvss_score_v3=[7~]` — the documented way to list vulnerabilities at or above a CVSS score — returned an error instead of results. The chain is `src/server/v2.0/handler/security.go:106` → `q.Build` → `ListVulnerabilities`/`CountVulnerabilities` → `rangeFilter`.

Preserving the nil would not help either: `x between 7 and NULL` is NULL in Postgres, so the filter would match nothing.

### The named X

`src/lib/orm/query.go:205-212`, the main ORM path, already handles exactly this:

```go
if r.Min != nil { qs = qs.Filter(key+"__gte", r.Min) }
if r.Max != nil { qs = qs.Filter(key+"__lte", r.Max) }
```

This change gives `rangeFilter` the same behaviour: `>=` or `<=` when one bound is set, and `between` unchanged for the closed case.

### Testing

Two rows added to the existing `TestRangeFilter` table, which had only a closed range. Both fail on `main` with `gotSqlStr = " and cvss_score_v3 between ? and ?"` and pass here.

Verified end to end against a real Postgres with the DAO suite: `[7~10]` returned the seeded record before and after, and `[7~]` went from `expected 3 arguments, got 2` to returning the same record.

- Mutation-checked, all three caught: emitting `<=` for the min-only branch, dropping the closed-range branch, and emitting nothing for the max-only branch. The existing `TestRangeFilter` row pins the `between` form, so this is not an over-correction.
- `gofmt` clean, `golangci-lint run ./pkg/securityhub/...` reports 0 issues, `go test ./pkg/securityhub/...` passes.
- `go vet` reports one unkeyed `q.Range{1.0, 2.0}` literal at `security_test.go:188`, which is the pre-existing row and is what #23629 fixes repo-wide; the rows added here use keyed fields.

---

AI assistance disclosure: this patch was found and written with Claude Code. The output above is verbatim from running the DAO suite against `main` and against this branch.
