### PR TITLE
fix(dao): escape LIKE metacharacters in SearchByName

### DIFF
--- a/src/pkg/user/dao/dao.go
+++ b/src/pkg/user/dao/dao.go
@@ -133,7 +133,7 @@ func (d *dao) SearchByName(ctx context.Context, name string, limitSize int) ([]*
 	var users []*User
 	// use raw sql to return the most matched user first, then by alphabetic order
 	sql := "select * from harbor_user where username like ? and deleted = false order by length(username), username asc limit ?"
-	likePattern := "%" + name + "%"
+	likePattern := "%" + orm.Escape(name) + "%"
 	_, err = o.Raw(sql, likePattern, limitSize).QueryRows(&users)
 	if err != nil {
 		return nil, err

--- a/src/pkg/user/dao/dao_test.go
+++ b/src/pkg/user/dao/dao_test.go
@@ -221,6 +221,28 @@ func (suite *DaoTestSuite) TestSearchByName() {
 
 }
 
+func (suite *DaoTestSuite) TestSearchByNameEscapesLikeWildcards() {
+	ctx := orm.Context()
+	for _, name := range []string{"wildcard_user", "wildcardXuser"} {
+		id, err := suite.dao.Create(ctx, &commonmodels.User{
+			Username: name,
+			Realname: "search by name test",
+		})
+		suite.Nil(err)
+		suite.appendClearSQL(id)
+	}
+
+	// the "_" must be matched literally, the same way Count() does via q.FuzzyMatchValue
+	total, err := suite.dao.Count(ctx, q.New(q.KeyWords{"username": &q.FuzzyMatchValue{Value: "wildcard_user"}}))
+	suite.Nil(err)
+	suite.Equal(int64(1), total)
+
+	users, err := suite.dao.SearchByName(ctx, "wildcard_user", 10)
+	suite.Nil(err)
+	suite.Len(users, 1)
+	suite.Equal("wildcard_user", users[0].Username)
+}
+
 func TestDaoTestSuite(t *testing.T) {
 	suite.Run(t, &DaoTestSuite{})
 }

--- a/src/pkg/usergroup/dao/dao.go
+++ b/src/pkg/usergroup/dao/dao.go
@@ -173,7 +173,7 @@ func (d *dao) SearchByName(ctx context.Context, name string, limitSize int) ([]*
 	var usergroups []*model.UserGroup
 	// use raw sql to return the most matched user first, then by alphabetic order
 	sql := "select id, group_name, group_type, ldap_group_dn, creation_time, update_time from user_group where group_name like ? order by length(group_name), group_name asc limit ?"
-	likePattern := "%" + name + "%"
+	likePattern := "%" + orm.Escape(name) + "%"
 	_, err = o.Raw(sql, likePattern, limitSize).QueryRows(&usergroups)
 	if err != nil {
 		return nil, err

--- a/src/pkg/usergroup/dao/dao_test.go
+++ b/src/pkg/usergroup/dao/dao_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/stretchr/testify/suite"
 
+	"github.com/goharbor/harbor/src/lib/q"
 	"github.com/goharbor/harbor/src/pkg/usergroup/model"
 	htesting "github.com/goharbor/harbor/src/testing"
 )
@@ -94,6 +95,28 @@ func (s *DaoTestSuite) TestSearchByName() {
 	s.Equal(10, len(results2))
 	// the first one should be "group"
 	s.Equal("group", results2[0].GroupName)
+}
+
+func (s *DaoTestSuite) TestSearchByNameEscapesLikeWildcards() {
+	ctx := s.Context()
+	for _, name := range []string{"wildcard_group", "wildcardXgroup"} {
+		_, err := s.dao.Add(ctx, model.UserGroup{
+			GroupName:   name,
+			GroupType:   1,
+			LdapGroupDN: "cn=" + name + ",ou=groups,dc=example,dc=com",
+		})
+		s.Nil(err)
+	}
+
+	// the "_" must be matched literally, the same way Count() does via q.FuzzyMatchValue
+	total, err := s.dao.Count(ctx, q.New(q.KeyWords{"GroupName": &q.FuzzyMatchValue{Value: "wildcard_group"}}))
+	s.Nil(err)
+	s.Equal(int64(1), total)
+
+	results, err := s.dao.SearchByName(ctx, "wildcard_group", 10)
+	s.Nil(err)
+	s.Len(results, 1)
+	s.Equal("wildcard_group", results[0].GroupName)
 }
 
 func TestDaoTestSuite(t *testing.T) {


### PR DESCRIPTION
`SearchUsers` (`src/server/v2.0/handler/user.go:265`) computes the two halves of one response through two different conventions:

- `X-Total-Count` comes from `ctl.Count` with a `q.FuzzyMatchValue`, which reaches `src/lib/orm/query.go:201` and is escaped with `orm.Escape`
- the payload comes from `ctl.SearchByName`, whose raw SQL built the pattern as `"%" + name + "%"` (`src/pkg/user/dao/dao.go:136`) with no escaping

So a search term containing a LIKE metacharacter makes the header and the body of the same response disagree:

```
GET /api/v2.0/users/search?username=probe_user
X-Total-Count=1   payload=3   [probe_user probeXuser probeYuser]
```

`probeXuser` and `probeYuser` do not contain `probe_user`; the `_` was treated as "any character". `SearchUserGroups` (`src/server/v2.0/handler/usergroup.go:186`) has the identical split at lines 197 and 205.

### The named X

There are four raw-SQL LIKE name searches in the tree, and the other two already escape:

| site | pattern |
|---|---|
| `src/pkg/member/dao/dao.go:228,230` | `"%"+orm.Escape(entityName)+"%"` |
| `src/pkg/artifact/dao/dao.go:400` | `"%"+orm.Escape(f.Value)+"%"` |
| `src/pkg/user/dao/dao.go:136` | `"%" + name + "%"` |
| `src/pkg/usergroup/dao/dao.go:176` | `"%" + name + "%"` |

`orm.Escape` (`src/lib/orm/orm.go:263`) escapes `\`, `%` and `_`, and the ORM fuzzy path applies it too.

Both `SearchByName` implementations arrived together in `2dbf83079` (#22606), replacing an ORM path that had been escaping — so this is a regression rather than the original design, and `member/dao` kept the escaping.

Parameters are bound, so this is not injection; the effect is that the endpoint's own filter does not hold, and one consequence worth stating plainly is that the payload can contain users the caller did not ask for.

### Testing

`TestSearchByNameEscapesLikeWildcards` added to both DAO suites, seeding `wildcard_user` and `wildcardXuser` and asserting that `SearchByName("wildcard_user")` returns one row, the same as `Count` with a `FuzzyMatchValue`.

- Both tests fail on `main` (`should have 1 item(s), but has 2`) and pass here.
- Mutation-checked both directions: dropping the escaping reproduces the failure, and escaping the surrounding wildcards as well (`orm.Escape("%"+name+"%")`) breaks the repo's existing `TestSearchByName` in both packages, so the still-fuzzy side is pinned too.
- `go test ./pkg/user/... ./pkg/usergroup/... ./pkg/member/... ./lib/orm/...` passes against a migrated Postgres.
- `gofmt` clean, `go vet` clean, `golangci-lint run ./pkg/user/dao/... ./pkg/usergroup/dao/...` reports 0 issues.

Not touched here: `pkg/usergroup/dao/dao.go` also has an `Allowed`-style branch with the same non-replacing shape, and `src/controller/config/controller.go` is unrelated. Kept the change to the two unescaped LIKE sites.

---

AI assistance disclosure: this patch was found and written with Claude Code. The output above is verbatim from running the DAO suites against `main` and against this branch.
