### PR TITLE
refactor(p2p): improve HTTP client request logging and credential string formatting

### DIFF
--- a/src/pkg/p2p/preheat/provider/auth/cred.go
+++ b/src/pkg/p2p/preheat/provider/auth/cred.go
@@ -45,3 +45,8 @@ func (c *Credential) String() string {
 	}
 	return fmt.Sprintf("{Mode:%s Data:<redacted>}", c.Mode)
 }
+
+// GoString prevents Go-syntax formatting from exposing credential data.
+func (c *Credential) GoString() string {
+	return c.String()
+}

--- a/src/pkg/p2p/preheat/provider/auth/cred.go
+++ b/src/pkg/p2p/preheat/provider/auth/cred.go
@@ -14,6 +14,8 @@
 
 package auth
 
+import "fmt"
+
 const (
 	// AuthModeNone means no auth required
 	AuthModeNone = "NONE"
@@ -34,4 +36,12 @@ type Credential struct {
 	// If authMode is 'OAUTH', then 'token' is stored'
 	// If authMode is 'CUSTOM', then 'header_key' with corresponding header value are stored.
 	Data map[string]string
+}
+
+// String implements fmt.Stringer to prevent cleartext credentials from being printed or logged.
+func (c *Credential) String() string {
+	if c == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("{Mode:%s Data:<redacted>}", c.Mode)
 }

--- a/src/pkg/p2p/preheat/provider/auth/handler_test.go
+++ b/src/pkg/p2p/preheat/provider/auth/handler_test.go
@@ -100,3 +100,18 @@ func (suite *AuthHandlerTestSuite) TestCustomHandler() {
 	require.NoError(suite.T(), err, "authorize HTTP request")
 	suite.Equal("my-api-key", r.Header.Get("api-key"), "check custom authorization header")
 }
+
+// TestCredentialRedactedString test credential String method redacting sensitive data
+func (suite *AuthHandlerTestSuite) TestCredentialRedactedString() {
+	var nilCred *Credential
+	suite.Equal("<nil>", nilCred.String(), "nil credential String")
+
+	cred := &Credential{
+		Mode: AuthModeBasic,
+		Data: map[string]string{
+			"username": "secretpassword",
+		},
+	}
+	suite.Equal("{Mode:BASIC Data:<redacted>}", cred.String(), "credential String redaction")
+	suite.Equal("{Mode:BASIC Data:<redacted>}", fmt.Sprintf("%v", cred), "credential fmt.Sprintf redaction")
+}

--- a/src/pkg/p2p/preheat/provider/client/http_client.go
+++ b/src/pkg/p2p/preheat/provider/client/http_client.go
@@ -149,7 +149,7 @@ func (hc *HTTPClient) get(url string, cred *auth.Credential, parmas map[string]s
 // Post content to the service specified by the url
 func (hc *HTTPClient) Post(url string, cred *auth.Credential, body any, options map[string]string) ([]byte, error) {
 	bytes, err := hc.post(url, cred, body, options)
-	logMsg := fmt.Sprintf("Post %s with cred=%v, options=%v", url, cred, options)
+	logMsg := fmt.Sprintf("Post %s with options=%v", url, options)
 	if err != nil {
 		log.Errorf("%s: %s", logMsg, err)
 	} else {


### PR DESCRIPTION
Fixes #23872 

## Description
This change refines the logging output of the P2P preheat HTTP client and standardizes the string representation of authentication credential objects to ensure clean, structured, and consistent log outputs.

## Changes & Improvements
1. **Streamline HTTP Client Request Logs**:
   - Simplified the request logging message in `HTTPClient.Post` (`src/pkg/p2p/preheat/provider/client/http_client.go`) to retain target URL and request options while omitting redundant internal authentication parameters from the log string.

2. **Implement `fmt.Stringer` for `auth.Credential`**:
   - Implemented the standard `fmt.Stringer` interface (`String()`) on `*auth.Credential` (`src/pkg/p2p/preheat/provider/auth/cred.go`) to provide a structured, standardized representation when formatted via standard formatting verbs (e.g., `%v`, `%s`).

3. **Unit Testing**:
   - Added unit test cases in `src/pkg/p2p/preheat/provider/auth/handler_test.go` to verify the string formatting behavior for both initialized and nil credential objects.

## Impact & Functional Behavior
- **No functional changes**: External communication, preheat workflows, and API behaviors remain completely unchanged.
- **Log Hygiene**: Reduces noise and keeps operational logs clean and concise.