### PR TITLE
fix(dao): reject non-exact extra attrs filters instead of panicking

### DIFF
--- a/src/pkg/task/dao/execution.go
+++ b/src/pkg/task/dao/execution.go
@@ -355,6 +355,19 @@ type jsonbStru struct {
 	value     any
 }
 
+// the extra attrs value is bound as a raw SQL parameter, which only accepts scalars
+func validateExtraAttrsValue(key string, value any) error {
+	switch value.(type) {
+	case string, bool, time.Time,
+		int, int8, int16, int32, int64,
+		uint, uint8, uint16, uint32, uint64,
+		float32, float64:
+		return nil
+	}
+	return errors.New(nil).WithCode(errors.BadRequestCode).
+		WithMessagef("unsupported value for the extra attrs filter %q, only exact match is supported", key)
+}
+
 func (e *executionDAO) querySetter(ctx context.Context, query *q.Query, options ...orm.Option) (orm.QuerySeter, error) {
 	qs, err := orm.QuerySetter(ctx, &Execution{}, query, options...)
 	if err != nil {
@@ -386,6 +399,11 @@ func (e *executionDAO) querySetter(ctx context.Context, query *q.Query, options 
 		}
 		if len(jsonbStrus) == 0 {
 			return qs, nil
+		}
+		for _, stru := range jsonbStrus {
+			if err := validateExtraAttrsValue(stru.key, stru.value); err != nil {
+				return nil, err
+			}
 		}
 
 		idSQL, args := buildInClauseSQLForExtraAttrs(jsonbStrus)

--- a/src/pkg/task/dao/execution_test.go
+++ b/src/pkg/task/dao/execution_test.go
@@ -409,6 +409,34 @@ func (e *executionDAOTestSuite) TestScanAndRefreshOutdateStatus() {
 	e.Equal(job.ErrorStatus.String(), exec2.Status)
 }
 
+func (e *executionDAOTestSuite) TestListWithNonExactExtraAttrsPattern() {
+	// only the exact match pattern can be bound as a parameter of the extra attrs SQL
+	for _, pattern := range []string{
+		"ExtraAttrs.key=~value",
+		"ExtraAttrs.key=[1~2]",
+		"ExtraAttrs.key={value1 value2}",
+		"ExtraAttrs.key=(value1 value2)",
+	} {
+		query, err := q.Build(pattern, "", 0, 0)
+		e.Require().Nil(err)
+
+		_, err = e.executionDAO.Count(e.ctx, query)
+		e.Require().NotNil(err, pattern)
+		e.True(errors.IsErr(err, errors.BadRequestCode), pattern)
+
+		_, err = e.executionDAO.List(e.ctx, query)
+		e.Require().NotNil(err, pattern)
+		e.True(errors.IsErr(err, errors.BadRequestCode), pattern)
+	}
+
+	// the exact match pattern isn't affected
+	query, err := q.Build("VendorType=test,ExtraAttrs.key=value", "", 0, 0)
+	e.Require().Nil(err)
+	count, err := e.executionDAO.Count(e.ctx, query)
+	e.Require().Nil(err)
+	e.Equal(int64(1), count)
+}
+
 func TestExecutionDAOSuite(t *testing.T) {
 	suite.Run(t, &executionDAOTestSuite{})
 }

--- a/src/pkg/task/dao/task.go
+++ b/src/pkg/task/dao/task.go
@@ -276,6 +276,9 @@ func (t *taskDAO) querySetter(ctx context.Context, query *q.Query, options ...or
 		if len(keyPrefix) == 0 {
 			return qs, nil
 		}
+		if err := validateExtraAttrsValue(key, value); err != nil {
+			return nil, err
+		}
 		inClause, err := orm.CreateInClause(ctx, "select id from task where extra_attrs->>? = ?",
 			strings.TrimPrefix(key, keyPrefix), value)
 		if err != nil {

--- a/src/pkg/task/dao/task_test.go
+++ b/src/pkg/task/dao/task_test.go
@@ -323,6 +323,26 @@ func TestIsValidUUID(t *testing.T) {
 	}
 }
 
+func (t *taskDAOTestSuite) TestListWithNonExactExtraAttrsPattern() {
+	query, err := q.Build("ExtraAttrs.key=~value", "", 0, 0)
+	t.Require().Nil(err)
+
+	_, err = t.taskDAO.Count(t.ctx, query)
+	t.Require().NotNil(err)
+	t.True(errors.IsErr(err, errors.BadRequestCode))
+
+	_, err = t.taskDAO.List(t.ctx, query)
+	t.Require().NotNil(err)
+	t.True(errors.IsErr(err, errors.BadRequestCode))
+
+	// the exact match pattern isn't affected
+	query, err = q.Build("ExtraAttrs.key=value", "", 0, 0)
+	t.Require().Nil(err)
+	count, err := t.taskDAO.Count(t.ctx, query)
+	t.Require().Nil(err)
+	t.Equal(int64(1), count)
+}
+
 func TestTaskDAOSuite(t *testing.T) {
 	suite.Run(t, &taskDAOTestSuite{})
 }


### PR DESCRIPTION
# Comprehensive Summary of your change

The extra attrs branch of `executionDAO.querySetter` (`src/pkg/task/dao/execution.go:370-384`) and of `taskDAO.querySetter` (`src/pkg/task/dao/task.go:266-282`) take the keyword value straight from `query.Keywords` and hand it to `orm.CreateInClause` as a bound SQL parameter. beego's `getFlatParams` panics on anything that is not a scalar, so four of the five query patterns Harbor documents for `q=` crash the request instead of being rejected.

Measured against `main`, driving `executionDAO.Count` through `q.Build`:

```
q="ExtraAttrs.key=value"     count=1
q="ExtraAttrs.key=~val"      PANIC: need a valid args value, unknown table or
                             value `github.com/goharbor/harbor/src/lib/q.FuzzyMatchValue`
```

The same panic follows for `k=[min~max]` (`*q.Range`), `k={v1 v2}` (`*q.OrList`) and `k=(v1 v2)` (`*q.AndList`).

These are exactly the patterns the shared `q` parameter advertises at `api/v2.0/swagger.yaml:6422`:

> Supported query patterns are "exact match(k=v)", "fuzzy match(k=~v)", "range(k=[min~max])", "list with union releationship(k={v1 v2 v3})" and "list with intersetion relationship(k=(v1 v2 v3))".

Reachable over HTTP wherever a caller-supplied `q` reaches these DAOs, e.g. `src/server/v2.0/handler/purge.go:158` builds the query from `params.Q` and passes it to `executionCtl.Count` at `:163` and `executionCtl.List` at `:167`. The webhook job and task handlers have the same shape.

### The named X

`lib/orm.setFilters` (`src/lib/orm/query.go:198-229`) type-switches `*q.FuzzyMatchValue`, `*q.Range`, `*q.OrList` and `*q.AndList` before falling back to treating the value as an exact match. Every filter path in the tree goes through that switch except these two extra attrs branches, which build raw SQL and so bypass it.

Only exact match can be expressed as `extra_attrs->>? = ?`, so this patch keeps the supported set as-is and returns `400` for the rest, rather than inventing JSONB semantics for fuzzy and range:

```
unsupported value for the extra attrs filter "ExtraAttrs.key", only exact match is supported
```

# Issue being fixed

No existing issue; found by reading the filter paths against `setFilters`.

### Testing

`TestListWithNonExactExtraAttrsPattern` added to both DAO suites, covering all four non-exact patterns for the execution DAO and the fuzzy one for the task DAO, and asserting in both that exact match still returns its row.

- Both tests fail on `main` (`test panicked: need a valid args value, unknown table or value ...q.FuzzyMatchValue`) and pass here.
- Mutation-checked both directions. Dropping the validation from `execution.go` alone fails the execution suite while the task suite stays green, so each test pins its own call site. Narrowing the accepted set by one (removing `string`) fails both suites, so the still-accepted side is pinned too.
- `go test ./pkg/task/dao/ ./controller/task/... -p 1` passes against a migrated Postgres.
- `gofmt` clean, `go vet` clean, `golangci-lint run ./pkg/task/dao/...` reports 0 issues.

The change is additive only (+69/-0); the two prefix branches are left exactly as they were.

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [x] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).

---

AI assistance disclosure: this patch was found and written with Claude Code. The panic text and counts above are verbatim from running the DAO suites against `main` and against this branch.
