### PR TITLE
fix: reuse request context in audit-log user name resolver

### DIFF
--- a/src/pkg/auditext/event/basic.go
+++ b/src/pkg/auditext/event/basic.go
@@ -27,6 +27,7 @@ import (
 	"github.com/goharbor/harbor/src/controller/event/metadata/commonevent"
 	"github.com/goharbor/harbor/src/controller/event/model"
 	"github.com/goharbor/harbor/src/lib/config"
+	"github.com/goharbor/harbor/src/lib/orm"
 	"github.com/goharbor/harbor/src/pkg/notifier/event"
 )
 
@@ -37,7 +38,7 @@ const (
 )
 
 // ResolveIDToNameFunc is the function to resolve the resource name from resource id
-type ResolveIDToNameFunc func(string) string
+type ResolveIDToNameFunc func(ctx context.Context, id string) string
 
 type Resolver struct {
 	ResourceType string
@@ -64,7 +65,7 @@ func (e *Resolver) PreCheck(ctx context.Context, url string, method string) (cap
 		re := regexp.MustCompile(e.ResourceIDPattern)
 		m := re.FindStringSubmatch(url)
 		if len(m) >= 2 && e.IDToNameFunc != nil {
-			resName = e.IDToNameFunc(m[1])
+			resName = e.IDToNameFunc(ctx, m[1])
 		}
 	}
 	return true, resName
@@ -99,7 +100,9 @@ func (e *Resolver) Resolve(ce *commonevent.Metadata, event *event.Event) error {
 			}
 			evt.ResourceName = m[1]
 			if e.IDToNameFunc != nil {
-				resourceName = e.IDToNameFunc(m[1])
+				// Resolve runs asynchronously after the request transaction has completed, so the
+				// ormer in ce.Ctx cannot be reused here; only PreCheck runs inside the request
+				resourceName = e.IDToNameFunc(orm.Context(), m[1])
 			}
 		}
 		if e.ShouldResolveName && resourceName != "" {
@@ -125,7 +128,7 @@ func (e *Resolver) Resolve(ce *commonevent.Metadata, event *event.Event) error {
 		}
 		evt.ResourceName = m[1]
 		if e.IDToNameFunc != nil {
-			resourceName = e.IDToNameFunc(m[1])
+			resourceName = e.IDToNameFunc(orm.Context(), m[1])
 		}
 		if e.ShouldResolveName && resourceName != "" {
 			evt.ResourceName = resourceName

--- a/src/pkg/auditext/event/basic_test.go
+++ b/src/pkg/auditext/event/basic_test.go
@@ -40,8 +40,8 @@ func TestEventResolver_PreCheck(t *testing.T) {
 		wantCapture      bool
 		wantResourceName string
 	}{
-		{"test normal", fields{ResourceIDPattern: `/api/v2.0/tests/(\d+)`, ResourceType: "test", SucceedCodes: []int{200}, ShouldResolveName: true, IDToNameFunc: func(string) string { return "test" }}, args{context.Background(), "/api/v2.0/tests/123", "DELETE"}, true, "test"},
-		{"test resource name", fields{ResourceIDPattern: `/api/v2.0/tests/(\d+)`, ResourceType: "test", SucceedCodes: []int{200}, ShouldResolveName: true, IDToNameFunc: func(string) string { return "test_resource_name" }}, args{context.Background(), "/api/v2.0/tests/234", "DELETE"}, true, "test_resource_name"},
+		{"test normal", fields{ResourceIDPattern: `/api/v2.0/tests/(\d+)`, ResourceType: "test", SucceedCodes: []int{200}, ShouldResolveName: true, IDToNameFunc: func(context.Context, string) string { return "test" }}, args{context.Background(), "/api/v2.0/tests/123", "DELETE"}, true, "test"},
+		{"test resource name", fields{ResourceIDPattern: `/api/v2.0/tests/(\d+)`, ResourceType: "test", SucceedCodes: []int{200}, ShouldResolveName: true, IDToNameFunc: func(context.Context, string) string { return "test_resource_name" }}, args{context.Background(), "/api/v2.0/tests/234", "DELETE"}, true, "test_resource_name"},
 		{"test no resource name", fields{ResourceIDPattern: `/api/v2.0/tests/(\d+)`, ResourceType: "test", SucceedCodes: []int{200}, ShouldResolveName: true}, args{context.Background(), "/api/v2.0/tests/234", "GET"}, true, ""},
 	}
 	for _, tt := range tests {
@@ -62,5 +62,26 @@ func TestEventResolver_PreCheck(t *testing.T) {
 				t.Errorf("EventResolver.PreCheck() gotResourceName = %v, want %v", gotResourceName, tt.wantResourceName)
 			}
 		})
+	}
+}
+
+func TestEventResolver_PreCheckPassesContext(t *testing.T) {
+	type ctxKey struct{}
+	ctx := context.WithValue(context.Background(), ctxKey{}, "request")
+	var got context.Context
+	e := &Resolver{
+		ResourceIDPattern: `/api/v2.0/tests/(\d+)`,
+		ResourceType:      "test",
+		ShouldResolveName: true,
+		IDToNameFunc: func(c context.Context, _ string) string {
+			got = c
+			return "test"
+		},
+	}
+	if _, gotResourceName := e.PreCheck(ctx, "/api/v2.0/tests/123", "DELETE"); gotResourceName != "test" {
+		t.Errorf("EventResolver.PreCheck() gotResourceName = %v, want %v", gotResourceName, "test")
+	}
+	if got == nil || got.Value(ctxKey{}) != "request" {
+		t.Errorf("EventResolver.PreCheck() did not pass the request context to IDToNameFunc")
 	}
 }

--- a/src/pkg/auditext/event/user/user.go
+++ b/src/pkg/auditext/event/user/user.go
@@ -15,6 +15,7 @@
 package user // nolint:revive
 
 import (
+	"context"
 	"net/http"
 	"strconv"
 	"strings"
@@ -23,7 +24,6 @@ import (
 	"github.com/goharbor/harbor/src/controller/event/metadata/commonevent"
 	"github.com/goharbor/harbor/src/controller/event/model"
 	"github.com/goharbor/harbor/src/lib/log"
-	"github.com/goharbor/harbor/src/lib/orm"
 	"github.com/goharbor/harbor/src/pkg/auditext/event"
 	notifierevent "github.com/goharbor/harbor/src/pkg/notifier/event"
 	pkgUser "github.com/goharbor/harbor/src/pkg/user"
@@ -51,14 +51,13 @@ type userEventResolver struct {
 }
 
 // userIDToName convert user id to user name
-func userIDToName(userID string) string {
+func userIDToName(ctx context.Context, userID string) string {
 	id, err := strconv.ParseInt(userID, 10, 32)
 	if err != nil {
 		log.Errorf("failed to parse userID: %v to int", userID)
 		return ""
 	}
-	// use different context to so that the user is visible before the transaction is committed
-	user, err := pkgUser.Mgr.Get(orm.Context(), int(id))
+	user, err := pkgUser.Mgr.Get(ctx, int(id))
 	if err != nil {
 		log.Errorf("failed to parse userID: %v to int, err %v", userID, err)
 		return ""

--- a/src/pkg/auditext/event/user/user_resolve_test.go
+++ b/src/pkg/auditext/event/user/user_resolve_test.go
@@ -15,15 +15,22 @@
 package user
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
+	beegoorm "github.com/beego/beego/v2/client/orm"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 
+	commonmodels "github.com/goharbor/harbor/src/common/models"
 	"github.com/goharbor/harbor/src/common/rbac"
 	"github.com/goharbor/harbor/src/controller/event/metadata/commonevent"
+	"github.com/goharbor/harbor/src/lib/orm"
 	"github.com/goharbor/harbor/src/pkg/auditext/event"
 	notifierevent "github.com/goharbor/harbor/src/pkg/notifier/event"
+	pkgUser "github.com/goharbor/harbor/src/pkg/user"
+	usertesting "github.com/goharbor/harbor/src/testing/pkg/user"
 )
 
 // TestResolvePutUsersCollectionNilData verifies Resolve handles a PUT whose URL
@@ -50,4 +57,42 @@ func TestResolvePutUsersCollectionNilData(t *testing.T) {
 		err := r.Resolve(ce, evt)
 		assert.NoError(t, err)
 	})
+}
+
+// TestPreCheckDeleteReusesRequestContext verifies that resolving the user name
+// before a DELETE reuses the ormer from the request context. PreCheck runs inside
+// the request transaction, so looking the user up through a separate ormer would
+// need a second connection from the same pool while the first one is held.
+func TestPreCheckDeleteReusesRequestContext(t *testing.T) {
+	origMgr := pkgUser.Mgr
+	defer func() { pkgUser.Mgr = origMgr }()
+	mgr := &usertesting.Manager{}
+	pkgUser.Mgr = mgr
+
+	requestOrmer := &beegoorm.DoNothingOrm{}
+	ctx := orm.NewContext(context.Background(), requestOrmer)
+	var gotCtx context.Context
+	mgr.On("Get", mock.Anything, 7).Run(func(args mock.Arguments) {
+		gotCtx = args.Get(0).(context.Context)
+	}).Return(&commonmodels.User{UserID: 7, Username: "alice"}, nil)
+
+	r := &userEventResolver{
+		Resolver: event.Resolver{
+			ResourceType:      rbac.ResourceUser.String(),
+			SucceedCodes:      []int{http.StatusCreated, http.StatusOK},
+			ShouldResolveName: true,
+			IDToNameFunc:      userIDToName,
+			ResourceIDPattern: urlPattern,
+		},
+	}
+
+	capture, name := r.PreCheck(ctx, "/api/v2.0/users/7", http.MethodDelete)
+	assert.True(t, capture)
+	assert.Equal(t, "alice", name)
+	mgr.AssertExpectations(t)
+	if assert.NotNil(t, gotCtx) {
+		o, err := orm.FromContext(gotCtx)
+		assert.NoError(t, err)
+		assert.Same(t, requestOrmer, o, "user lookup must reuse the ormer of the request context")
+	}
 }


### PR DESCRIPTION
Thank you for contributing to Harbor!

# Comprehensive Summary of your change

## Problem

A burst of concurrent write requests, for example the portal's bulk user delete firing one `DELETE /api/v2.0/users/{id}` per user in parallel, wedges harbor-core. Every request that touches the database hangs, `/api/v2.0/health` times out, and Postgres shows exactly `POSTGRESQL_MAX_OPEN_CONNS` sessions per core pod in `idle in transaction` with `begin` as the last statement. Core never recovers without a restart.

## Root cause

Every non-GET request runs inside `transaction.Middleware` (`src/core/middlewares/middlewares.go`), which takes one connection from the `database/sql` pool with `begin` and stores the transaction ormer in the request context. Before the handler runs, `log.Middleware` calls the audit-log resolver's `PreCheck`, and for `DELETE` on a user that reaches `userIDToName` in `src/pkg/auditext/event/user/user.go:60-61`:

```go
// use different context to so that the user is visible before the transaction is committed
user, err := pkgUser.Mgr.Get(orm.Context(), int(id))
```

`orm.Context()` builds a fresh, non-transactional ormer, so this lookup needs a second connection from the same pool while the first one is held. With N = `POSTGRESQL_MAX_OPEN_CONNS` concurrent requests all N connections are held by `begin` and all N goroutines wait in `database/sql.(*DB).conn` for a connection that will never be released. beego hardcodes `context.Background()` into the query path, so no request deadline reaches the wait.

The comment's reasoning does not hold: `PreCheck` runs before the handler deletes the row, and a transaction sees its own state plus everything committed, so the request context returns the same user with no extra connection.

## Fix

- `src/pkg/auditext/event/basic.go`: `ResolveIDToNameFunc` now takes a `context.Context`. `PreCheck` passes its own (request) context through. `Resolve` keeps passing a fresh `orm.Context()`: it is executed by `notification.Middleware`, which wraps `transaction.Middleware`, in a detached goroutine after the request transaction has committed or rolled back, so the ormer in `ce.Ctx` cannot be reused there. Behaviour on the create/update path is unchanged.
- `src/pkg/auditext/event/user/user.go`: `userIDToName` uses the context it is given and the misleading comment is removed.

A request now never needs more than one pool connection on this path.

The issue lists further sites with the same shape outside the audit-log package (`src/pkg/oidc/helper.go`, `src/pkg/authproxy/http.go`, `src/core/api/internal.go`) and the `ensureORMContext` swap in the member resolver on `main`. Those are left out of this change to keep it reviewable; happy to follow up on them separately.

## How tested

Unit tests only, no database needed.

`TestPreCheckDeleteReusesRequestContext` (`src/pkg/auditext/event/user/user_resolve_test.go`) installs a mock `pkgUser.Mgr`, calls `PreCheck` with a context carrying a known ormer, and asserts the lookup receives that same ormer. Before the fix it fails because `userIDToName` builds its own ormer instead (the beego panic is what a fresh ormer looks like in a unit test with no registered database):

```
--- FAIL: TestPreCheckDeleteReusesRequestContext (0.00s)
panic: <Ormer.Using> unknown db alias name `default` [recovered, repanicked]
...
github.com/goharbor/harbor/src/lib/orm.Context()
	src/lib/orm/orm.go:92 +0x25
github.com/goharbor/harbor/src/pkg/auditext/event/user.userIDToName({0xd957d3, 0x1})
	src/pkg/auditext/event/user/user.go:61 +0x45
github.com/goharbor/harbor/src/pkg/auditext/event.(*Resolver).PreCheck(...)
	src/pkg/auditext/event/basic.go:67 +0x1be
FAIL	github.com/goharbor/harbor/src/pkg/auditext/event/user	0.016s
```

After the fix:

```
ok  	github.com/goharbor/harbor/src/pkg/auditext/event	0.014s
ok  	github.com/goharbor/harbor/src/pkg/auditext/event/config	0.015s
ok  	github.com/goharbor/harbor/src/pkg/auditext/event/login	0.016s
ok  	github.com/goharbor/harbor/src/pkg/auditext/event/member	0.019s
ok  	github.com/goharbor/harbor/src/pkg/auditext/event/project	0.017s
ok  	github.com/goharbor/harbor/src/pkg/auditext/event/user	0.014s
```

`TestEventResolver_PreCheckPassesContext` (`basic_test.go`) additionally checks that the base resolver forwards the context it is given to `IDToNameFunc`. `gofmt`, `go vet` and `golangci-lint run ./pkg/auditext/...` are clean; `go build` of `./pkg/... ./controller/... ./server/middleware/... ./lib/... ./common/...` passes.

## Links

- https://github.com/goharbor/harbor/issues/23879
- https://github.com/goharbor/harbor/issues/15649 (same mechanism at a different call site, 2021)

# Issue being fixed
Fixes #23879

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).

This change was prepared with an AI agent operated by KR-Ravindra, who reviewed and tested it.
