### PR TITLE
feat: support Podman and Podman Compose in the installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Harbor is hosted by the [Cloud Native Computing Foundation](https://cncf.io) (CN
 * **Graphical user portal**: User can easily browse, search repositories and manage projects.
 * **Auditing**: All the operations to the repositories are tracked through logs.
 * **RESTful API**: RESTful APIs are provided to facilitate administrative operations, and are easy to use for integration with external systems. An embedded Swagger UI is available for exploring and testing the API.
-* **Easy deployment**: Harbor can be deployed via Docker compose as well Helm Chart, and a Harbor Operator was added recently as well.
+* **Easy deployment**: Harbor can be deployed via Docker Compose or Podman Compose, as well as with the Helm chart or Harbor Operator.
 
 ## Architecture
 
@@ -53,7 +53,7 @@ For learning the architecture design of Harbor, check the document [Architecture
 ## Install & Run
 **System requirements:**
 
-**On a Linux host:** docker 20.10.10-ce+ and docker-compose 1.18.0+.
+**On a Linux host:** Docker 20.10.10-ce+ with Docker Compose 1.18.0+, or Podman with Podman Compose.
 
 Download binaries of **[Harbor release ](https://github.com/goharbor/harbor/releases)** and follow **[Installation & Configuration Guide](https://goharbor.io/docs/latest/install-config/)** to install Harbor.
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,27 @@ Download binaries of **[Harbor release ](https://github.com/goharbor/harbor/rele
 If you want to deploy Harbor on Kubernetes, please use the **[Harbor chart](https://github.com/goharbor/harbor-helm)**.
 
 Refer to the **[documentation](https://goharbor.io/docs/)** for more details on how to use Harbor.
+
+### Installing with Podman
+
+The installer detects Docker first, then Podman. To select Podman explicitly, run
+`sudo CONTAINER_RUNTIME=podman ./install.sh` (add `--with-trivy` to enable scanning).
+Install `podman-compose` first; the installer also accepts a configured `podman compose` provider.
+This uses Podman directly, without a Docker compatibility wrapper. Rootless installation is not validated.
+
+On SELinux hosts, generated bind mounts use the shared `z` label, including the
+long-form Compose equivalent `bind.selinux: z`. Harbor services share files such as
+`common/config/shared/trust-certificates`; a private `Z` label can prevent another
+service from accessing those same files when containers use different SELinux labels.
+Shared relabeling keeps those paths accessible to the containers that mount them,
+while SELinux remains enabled on the host. Use dedicated Harbor directories: `z`
+does not provide per-container SELinux isolation for their shared contents.
+
+The short-lived, already-privileged `prepare` container is different: it mounts the
+host root at `/hostfs` to resolve configured certificate and data paths. For Podman,
+it uses `--security-opt label=disable` for that container only; it must not recursively
+relabel the host root with `z` or `Z`.
+
 ### Verifying Release Signatures
 Starting with v2.15.0, Harbor release artifacts are cryptographically signed using Cosign to ensure authenticity and integrity.
 

--- a/make/common.sh
+++ b/make/common.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 #docker version: 20.10.10+
 #docker-compose version: 1.18.0+
+#podman and podman-compose are also supported by the installer
 #golang version: 1.12.0+
 
 set +e
@@ -102,11 +103,71 @@ function check_docker {
 	fi
 }
 
-function check_dockercompose {
-	if [! docker compose version] &> /dev/null || [! docker-compose --version] &> /dev/null
+function check_container_runtime {
+	if [ -z "${CONTAINER_RUNTIME:-}" ]
 	then
-		error "Need to install docker-compose(1.18.0+) or a docker-compose-plugin (https://docs.docker.com/compose/)by yourself first and run this script again."
-		exit 1
+		if command -v docker &> /dev/null
+		then
+			CONTAINER_RUNTIME=docker
+		elif command -v podman &> /dev/null
+		then
+			CONTAINER_RUNTIME=podman
+		else
+			error "Need to install Docker (20.10.10+) or Podman first and run this script again."
+			exit 1
+		fi
+	fi
+
+	case "$CONTAINER_RUNTIME" in
+		docker)
+			check_docker
+			;;
+		podman)
+			if ! podman --version &> /dev/null
+			then
+				error "CONTAINER_RUNTIME is set to podman, but Podman is not installed."
+				exit 1
+			fi
+			note "$(podman --version)"
+			;;
+		*)
+			error "Unsupported container runtime: $CONTAINER_RUNTIME. Use docker or podman."
+			exit 1
+			;;
+	esac
+}
+
+function check_dockercompose {
+	if [ -n "${DOCKER_COMPOSE:-}" ]
+	then
+		if $DOCKER_COMPOSE version &> /dev/null
+		then
+			note "$($DOCKER_COMPOSE version)"
+		elif $DOCKER_COMPOSE --version &> /dev/null
+		then
+			note "$($DOCKER_COMPOSE --version)"
+		else
+			error "The configured compose command is not available: $DOCKER_COMPOSE"
+			exit 1
+		fi
+		return
+	fi
+
+	if [ "${CONTAINER_RUNTIME:-docker}" = "podman" ]
+	then
+		if podman-compose --version &> /dev/null
+		then
+			note "$(podman-compose --version)"
+			DOCKER_COMPOSE="podman-compose"
+		elif podman compose version &> /dev/null
+		then
+			note "$(podman compose version)"
+			DOCKER_COMPOSE="podman compose"
+		else
+			error "Need to install podman-compose and run this script again."
+			exit 1
+		fi
+		return
 	fi
 
 	# either docker compose plugin has been installed
@@ -130,9 +191,7 @@ function check_dockercompose {
 			exit 1
 		fi
 	else
-		error "Failed to parse docker-compose version."
+		error "Need to install docker-compose(1.18.0+) or a docker-compose plugin and run this script again."
 		exit 1
 	fi
 }
-
-

--- a/make/install.sh
+++ b/make/install.sh
@@ -18,8 +18,9 @@ with_clair=$false
 # trivy is not enabled by default
 with_trivy=$false
 
-# flag to using docker compose v1 or v2, default would using v1 docker-compose
-DOCKER_COMPOSE=docker-compose
+# Selected by check_container_runtime and check_dockercompose.
+CONTAINER_RUNTIME=${CONTAINER_RUNTIME:-}
+DOCKER_COMPOSE=${DOCKER_COMPOSE:-}
 
 while [ $# -gt 0 ]; do
         case $1 in
@@ -38,16 +39,16 @@ done
 workdir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd $workdir
 
-h2 "[Step $item]: checking if docker is installed ..."; let item+=1
-check_docker
+h2 "[Step $item]: checking if a container runtime is installed ..."; let item+=1
+check_container_runtime
 
-h2 "[Step $item]: checking docker-compose is installed ..."; let item+=1
+h2 "[Step $item]: checking if a compose provider is installed ..."; let item+=1
 check_dockercompose
 
 if [ -f harbor*.tar.gz ]
 then
     h2 "[Step $item]: loading Harbor images ..."; let item+=1
-    docker load -i ./harbor*.tar.gz
+    "$CONTAINER_RUNTIME" load -i ./harbor*.tar.gz
 fi
 echo ""
 
@@ -64,10 +65,10 @@ then
     prepare_para="${prepare_para} --with-trivy"
 fi
 
-./prepare $prepare_para
+CONTAINER_RUNTIME="$CONTAINER_RUNTIME" ./prepare $prepare_para
 echo ""
 
-if [ -n "$DOCKER_COMPOSE ps -q"  ]
+if [ -n "$($DOCKER_COMPOSE ps -q)" ]
     then
         note "stopping existing Harbor instance ..." 
         $DOCKER_COMPOSE down -v

--- a/make/photon/prepare/templates/docker_compose/docker-compose.yml.jinja
+++ b/make/photon/prepare/templates/docker_compose/docker-compose.yml.jinja
@@ -15,9 +15,13 @@ services:
       - type: bind
         source: ./common/config/log/logrotate.conf
         target: /etc/logrotate.d/logrotate.conf
+        bind:
+          selinux: z
       - type: bind
         source: ./common/config/log/rsyslog_docker.conf
         target: /etc/rsyslog.d/rsyslog_docker.conf
+        bind:
+          selinux: z
     ports:
       - 127.0.0.1:1514:10514
     networks:
@@ -40,24 +44,36 @@ services:
       - type: bind
         source: {{data_volume}}/secret/registry/root.crt
         target: /etc/registry/root.crt
+        bind:
+          selinux: z
       - type: bind
         source: ./common/config/shared/trust-certificates
         target: /harbor_cust_cert
+        bind:
+          selinux: z
 {% if gcs_keyfile %}
       - type: bind
         source: {{gcs_keyfile}}
         target: /etc/registry/gcs.key
+        bind:
+          selinux: z
 {% endif %}
 {%if internal_tls.enabled %}
       - type: bind
         source: {{internal_tls.core_crt_path}}
         target: /harbor_cust_cert/core.crt
+        bind:
+          selinux: z
       - type: bind
         source: {{internal_tls.registry_crt_path}}
         target: /etc/harbor/tls/registry.crt
+        bind:
+          selinux: z
       - type: bind
         source: {{internal_tls.registry_key_path}}
         target: /etc/harbor/tls/registry.key
+        bind:
+          selinux: z
 {% endif %}
     networks:
       - harbor
@@ -86,21 +102,31 @@ services:
       - type: bind
         source: ./common/config/registryctl/config.yml
         target: /etc/registryctl/config.yml
+        bind:
+          selinux: z
       - type: bind
         source: ./common/config/shared/trust-certificates
         target: /harbor_cust_cert
+        bind:
+          selinux: z
 {% if gcs_keyfile %}
       - type: bind
         source: {{gcs_keyfile}}
         target: /etc/registry/gcs.key
+        bind:
+          selinux: z
 {% endif %}
 {%if internal_tls.enabled %}
       - type: bind
         source: {{internal_tls.registryctl_crt_path}}
         target: /etc/harbor/ssl/registryctl.crt
+        bind:
+          selinux: z
       - type: bind
         source: {{internal_tls.registryctl_key_path}}
         target: /etc/harbor/ssl/registryctl.key
+        bind:
+          selinux: z
 {% endif %}
     networks:
       - harbor
@@ -156,27 +182,41 @@ services:
       - type: bind
         source: ./common/config/core/app.conf
         target: /etc/core/app.conf
+        bind:
+          selinux: z
       - type: bind
         source: {{data_volume}}/secret/core/private_key.pem
         target: /etc/core/private_key.pem
+        bind:
+          selinux: z
       - type: bind
         source: {{data_volume}}/secret/keys/secretkey
         target: /etc/core/key
+        bind:
+          selinux: z
       - type: bind
         source: ./common/config/shared/trust-certificates
         target: /harbor_cust_cert
+        bind:
+          selinux: z
 {% if uaa_ca_file %}
       - type: bind
         source: {{uaa_ca_file}}
         target: /etc/core/certificates/uaa_ca.pem
+        bind:
+          selinux: z
 {% endif %}
 {%if internal_tls.enabled %}
       - type: bind
         source: {{internal_tls.core_crt_path}}
         target: /etc/harbor/ssl/core.crt
+        bind:
+          selinux: z
       - type: bind
         source: {{internal_tls.core_key_path}}
         target: /etc/harbor/ssl/core.key
+        bind:
+          selinux: z
 {% endif %}
     networks:
       harbor:
@@ -209,13 +249,19 @@ services:
       - type: bind
         source: ./common/config/portal/nginx.conf
         target: /etc/nginx/nginx.conf
+        bind:
+          selinux: z
 {%if internal_tls.enabled %}
       - type: bind
         source: {{internal_tls.portal_crt_path}}
         target: /etc/harbor/tls/portal.crt
+        bind:
+          selinux: z
       - type: bind
         source: {{internal_tls.portal_key_path}}
         target: /etc/harbor/tls/portal.key
+        bind:
+          selinux: z
 {% endif %}
     networks:
       - harbor
@@ -244,16 +290,24 @@ services:
       - type: bind
         source: ./common/config/jobservice/config.yml
         target: /etc/jobservice/config.yml
+        bind:
+          selinux: z
       - type: bind
         source: ./common/config/shared/trust-certificates
         target: /harbor_cust_cert
+        bind:
+          selinux: z
 {%if internal_tls.enabled %}
       - type: bind
         source: {{internal_tls.job_service_crt_path}}
         target: /etc/harbor/ssl/job_service.crt
+        bind:
+          selinux: z
       - type: bind
         source: {{internal_tls.job_service_key_path}}
         target: /etc/harbor/ssl/job_service.key
+        bind:
+          selinux: z
 {% endif %}
     networks:
       - harbor
@@ -306,13 +360,19 @@ services:
       - type: bind
         source: ./common/config/shared/trust-certificates
         target: /harbor_cust_cert
+        bind:
+          selinux: z
 {%if internal_tls.enabled %}
       - type: bind
         source: {{internal_tls.proxy_crt_path}}
         target: /etc/harbor/tls/proxy.crt
+        bind:
+          selinux: z
       - type: bind
         source: {{internal_tls.proxy_key_path}}
         target: /etc/harbor/tls/proxy.key
+        bind:
+          selinux: z
 {% endif %}
     networks:
       - harbor
@@ -352,19 +412,29 @@ services:
       - type: bind
         source: {{data_volume}}/trivy-adapter/trivy
         target: /home/scanner/.cache/trivy
+        bind:
+          selinux: z
       - type: bind
         source: {{data_volume}}/trivy-adapter/reports
         target: /home/scanner/.cache/reports
+        bind:
+          selinux: z
       - type: bind
         source: ./common/config/shared/trust-certificates
         target: /harbor_cust_cert
+        bind:
+          selinux: z
 {% if internal_tls.enabled %}
       - type: bind
         source: {{internal_tls.trivy_adapter_crt_path}}
         target: /etc/harbor/ssl/trivy_adapter.crt
+        bind:
+          selinux: z
       - type: bind
         source: {{internal_tls.trivy_adapter_key_path}}
         target: /etc/harbor/ssl/trivy_adapter.key
+        bind:
+          selinux: z
 {% endif %}
     logging:
       driver: "syslog"
@@ -392,6 +462,8 @@ services:
       - type: bind
         source: ./common/config/shared/trust-certificates
         target: /harbor_cust_cert
+        bind:
+          selinux: z
     logging:
       driver: "syslog"
       options:

--- a/make/prepare
+++ b/make/prepare
@@ -49,6 +49,7 @@ fi
 # Create secret dir
 secret_dir=${data_path}/secret
 config_dir=$harbor_prepare_path/common/config
+mkdir -p "$config_dir"
 
 # Set the prepare base dir, for mac, it should be $HOME, for linux, it should be /
 # The certificate and the data directory in harbor.yaml should be sub directories of $HOME when installing Harbor in MacOS
@@ -58,13 +59,34 @@ if [ "$(uname)" == "Darwin" ]; then
 fi
 
 # Run prepare script
-docker run --rm -v $input_dir:/input \
-                    -v $data_path:/data \
-                    -v $harbor_prepare_path:/compose_location \
-                    -v $config_dir:/config \
-                    -v ${prepare_base_dir}:/hostfs${prepare_base_dir} \
+container_runtime=${CONTAINER_RUNTIME:-}
+if [ -z "$container_runtime" ]; then
+    if command -v docker >/dev/null 2>&1; then
+        container_runtime=docker
+    elif command -v podman >/dev/null 2>&1; then
+        container_runtime=podman
+    else
+        echo "Docker or Podman is required to prepare Harbor."
+        exit 1
+    fi
+fi
+
+runtime_options=()
+if [ "$container_runtime" = "podman" ]; then
+    # The prepare container needs the host root for certificate and data paths.
+    # Disable SELinux separation for this privileged, short-lived container
+    # instead of relabeling the host root filesystem.
+    runtime_options+=(--security-opt label=disable)
+fi
+
+"$container_runtime" run --rm "${runtime_options[@]}" \
+                    -v "$input_dir:/input" \
+                    -v "$data_path:/data" \
+                    -v "$harbor_prepare_path:/compose_location" \
+                    -v "$config_dir:/config" \
+                    -v "${prepare_base_dir}:/hostfs${prepare_base_dir}" \
                     --privileged \
-                    goharbor/prepare:dev prepare $@
+                    goharbor/prepare:dev prepare "$@"
 
 echo "Clean up the input dir"
 # Clean up input dir

--- a/tests/ci/installer_runtime_test.sh
+++ b/tests/ci/installer_runtime_test.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+
+set -euo pipefail
+
+repository_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+test_root="$(mktemp -d)"
+trap 'rm -rf "$test_root"' EXIT
+
+cp "$repository_root/make/common.sh" "$test_root/common.sh"
+cp "$repository_root/make/install.sh" "$test_root/install.sh"
+cp "$repository_root/make/prepare" "$test_root/prepare"
+cp "$repository_root/make/harbor.yml.tmpl" "$test_root/harbor.yml"
+
+docker() {
+    case "$*" in
+        --version)
+            echo "Docker version 28.0.0, build test"
+            ;;
+        "compose version")
+            echo "Docker Compose version v2.39.0"
+            ;;
+        "compose ps -q"|"compose up -d")
+            ;;
+        run*)
+            case " $* " in
+                *" --security-opt label=disable "*)
+                    echo "Docker prepare unexpectedly disabled SELinux separation." >&2
+                    return 1
+                    ;;
+                *" --privileged goharbor/prepare:dev prepare "*)
+                    ;;
+                *)
+                    echo "Unexpected Docker prepare invocation: $*" >&2
+                    return 1
+                    ;;
+            esac
+            ;;
+        *)
+            echo "Unexpected Docker invocation: $*" >&2
+            return 1
+            ;;
+    esac
+}
+
+podman() {
+    case "${1:-}" in
+        --version)
+            echo "podman version 5.8.2"
+            ;;
+        run)
+            case " $* " in
+                *" --security-opt label=disable "*" --privileged goharbor/prepare:dev prepare "*)
+                    ;;
+                *)
+                    echo "Unexpected prepare invocation: $*" >&2
+                    return 1
+                    ;;
+            esac
+            ;;
+        *)
+            echo "Unexpected Podman invocation: $*" >&2
+            return 1
+            ;;
+    esac
+}
+
+podman-compose() {
+    case "$*" in
+        --version)
+            echo "podman-compose version 1.5.0"
+            ;;
+        "ps -q"|"up -d")
+            ;;
+        *)
+            echo "Unexpected Podman Compose invocation: $*" >&2
+            return 1
+            ;;
+    esac
+}
+
+export -f docker podman podman-compose
+export TERM="${TERM:-xterm}"
+
+CONTAINER_RUNTIME=podman "$test_root/install.sh"
+CONTAINER_RUNTIME=docker "$test_root/install.sh"
+
+python3 - "$repository_root/make/photon/prepare/templates/docker_compose/docker-compose.yml.jinja" <<'PY'
+import pathlib
+import sys
+
+template = pathlib.Path(sys.argv[1]).read_text().splitlines()
+bind_mounts = [index for index, line in enumerate(template) if line.strip() == "- type: bind"]
+for index in bind_mounts:
+    block = "\n".join(template[index:index + 6])
+    if "bind:\n" not in block or "selinux: z" not in block:
+        raise SystemExit(f"Bind mount at line {index + 1} lacks SELinux relabeling")
+PY
+
+if [ -e "$test_root/input" ]; then
+    echo "The prepare input directory was not cleaned up." >&2
+    exit 1
+fi
+
+echo "Docker and Podman installer runtime tests passed."

--- a/tests/ci/ut_install.sh
+++ b/tests/ci/ut_install.sh
@@ -3,6 +3,8 @@ set -x
 
 set -e
 
+./tests/ci/installer_runtime_test.sh
+
 sudo apt-get update && sudo apt-get install -y libldap2-dev
 
 if [ -n "$XDG_CONFIG_HOME" ] && [[ "$XDG_CONFIG_HOME" == *'$HOME'* ]]; then


### PR DESCRIPTION
## Summary

Add native Podman support to Harbor's existing installer, preserving the Docker path. This is a concrete implementation for the installation problem in #19230; it does not change the Kubernetes deployment path or require Docker compatibility wrappers.

- Detect Docker or Podman, with explicit `CONTAINER_RUNTIME=podman` selection.
- Select Podman Compose for Podman and use the selected runtime for image loading and preparation.
- Prepare the configuration directory before starting the preparation container.
- Give generated long-form bind mounts shared SELinux labels, matching the existing short-form `:z` mounts.
- Add Docker/Podman installer regression checks to the existing installer CI entry point and document usage and boundaries.

## Why SELinux `z` is needed

On an SELinux-enforcing host, ordinary host file permissions are not sufficient for container access: bind-mounted files also need an appropriate SELinux context. Harbor's Compose template already uses `:z` on its short-form mounts, but its long-form bind mounts did not request relabeling. `bind.selinux: z` supplies the equivalent behavior for those mounts.

The lowercase **`z` is shared**, whereas uppercase **`Z` is private**. Multiple Harbor services mount the same paths, notably `common/config/shared/trust-certificates`. If containers have different SELinux process labels, privately relabeling one shared source for a later container can deny the earlier container access. Shared labels avoid that conflict. Files still need the normal mount and Unix permissions; shared labeling does not provide per-container SELinux isolation for the relabeled contents, so the installation should use dedicated Harbor directories.

The short-lived **prepare container is a separate case**. It is already privileged and bind-mounts the host root at `/hostfs` to resolve configured certificate and data paths. Recursively applying `z` or `Z` to that mount could relabel the host filesystem. The Podman invocation therefore uses `--security-opt label=disable` for that container only, without disabling host SELinux or adding a host-root relabel option.

Reference: [Podman volume labeling documentation](https://docs.podman.io/en/latest/markdown/podman-run.1.html#labeling-volume-mounts).

## Validation

- `bash tests/ci/installer_runtime_test.sh` passes after rebasing onto current `main`: mocked Docker and Podman install/prepare/start flows, preparation cleanup, and relabeling checks for all 36 long-form bind mounts.
- Bash syntax and `git diff --check` pass.
- The prior live EL10/Podman validation passed in [infrastructure pipeline 2823882005](https://gitlab.com/xrow-public/infrastructure/-/pipelines/2823882005), including the fork prepare-image build, installation, Harbor integration/client checks, and review cleanup. The validation harness is in [merged infrastructure MR !37](https://gitlab.com/xrow-public/infrastructure/-/merge_requests/37).
- That live run used fork source `a6a778da4723cc2fb5f320018fb5f9796da8c213` with the prepare image/version pinned by the harness. The installer, prepare source/templates, and installer regression files are byte-identical after this rebase; the additional change is documentation. The full live run has not been repeated on the rebased repository SHA.
- Rootless Podman installation is not validated. Upstream CI results will be reported by this PR; the local mocked checks are not a claim that the complete upstream suite has passed.

## Tracking and checklist

Related to #19230. Owner-approved contribution tracked by [infrastructure work item #28](https://gitlab.com/xrow-public/infrastructure/-/work_items/28).

- [x] Clear title and summary
- [x] DCO sign-off on each commit
- [x] Focused regression coverage and existing live validation recorded above
- [x] Documentation impact addressed in the README
- [ ] Suggested release-note label: `release-note/new-feature` (requires a maintainer)
