### PR TITLE
fix: make URL and endpoint handling case-insensitive

### DIFF
--- a/src/common/utils/utils.go
+++ b/src/common/utils/utils.go
@@ -43,15 +43,20 @@ func ParseEndpoint(endpoint string) (*url.URL, error) {
 	}
 	i := strings.Index(endpoint, "://")
 	if i >= 0 {
-		scheme := endpoint[:i]
+		scheme := strings.ToLower(endpoint[:i])
 		if scheme != "http" && scheme != "https" {
-			return nil, fmt.Errorf("invalid scheme: %s", scheme)
+			return nil, fmt.Errorf("invalid scheme: %s", endpoint[:i])
 		}
+		endpoint = scheme + endpoint[i:]
 	} else {
 		endpoint = "http://" + endpoint
 	}
 
-	return url.ParseRequestURI(endpoint)
+	u, err := url.ParseRequestURI(endpoint)
+	if err == nil && u != nil {
+		u.Host = strings.ToLower(u.Host)
+	}
+	return u, err
 }
 
 // EqualURL checks whether two URLs are equal, with case-insensitive host matching per RFC 1035.
@@ -64,6 +69,8 @@ func EqualURL(rawURL1, rawURL2 string) bool {
 	if err1 != nil || err2 != nil {
 		return false
 	}
+	u1.Scheme = strings.ToLower(u1.Scheme)
+	u2.Scheme = strings.ToLower(u2.Scheme)
 	u1.Host = strings.ToLower(u1.Host)
 	u2.Host = strings.ToLower(u2.Host)
 	return u1.String() == u2.String()

--- a/src/common/utils/utils_test.go
+++ b/src/common/utils/utils_test.go
@@ -36,6 +36,8 @@ func TestParseEndpoint(t *testing.T) {
 		{" example.com/ ", false, "http://example.com"},
 		{"ftp://example.com", true, ""},
 		{"http://example.com", false, "http://example.com"},
+		{"HTTP://EXAMPLE.COM", false, "http://example.com"},
+		{"HTTPS://Example.COM:8080/path", false, "https://example.com:8080/path"},
 		{"https://example.com", false, "https://example.com"},
 		{"http://example!@#!?//#", true, ""},
 	}
@@ -61,6 +63,8 @@ func TestEqualURL(t *testing.T) {
 		{"http://EXAMPLE.COM:8080/v2", "http://example.com:8080/v2", true},
 		{"http://example.com:8080/V2", "http://example.com:8080/v2", false},
 		{"https://core:8080", "https://CORE:8080", true},
+		{"HTTP://core:8080", "http://CORE:8080", true},
+		{"HTTP://EXAMPLE.COM", "http://example.com", true},
 		{"http://example.com", "https://example.com", false},
 		{"http://example.com:8080", "http://example.com:8081", false},
 		{"http://example.com/foo", "http://example.com/bar", false},

--- a/src/controller/p2p/preheat/controller.go
+++ b/src/controller/p2p/preheat/controller.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/goharbor/harbor/src/jobservice/job"
+	"github.com/goharbor/harbor/src/lib"
 	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/lib/q"
 	"github.com/goharbor/harbor/src/pkg/p2p/preheat/instance"
@@ -178,10 +179,16 @@ func (c *controller) CreateInstance(ctx context.Context, instance *providerModel
 		return 0, errors.New("nil instance object provided")
 	}
 
+	normEndpoint, err := lib.ValidateHTTPURL(instance.Endpoint)
+	if err != nil {
+		return 0, err
+	}
+	instance.Endpoint = normEndpoint
+
 	// Avoid duplicated endpoint
 	var query = &q.Query{
 		Keywords: map[string]any{
-			"endpoint": instance.Endpoint,
+			"endpoint__iexact": instance.Endpoint,
 		},
 	}
 	num, err := c.iManager.Count(ctx, query)
@@ -253,6 +260,14 @@ func (c *controller) UpdateInstance(ctx context.Context, instance *providerModel
 	// vendor type does not support change
 	if oldIns.Vendor != instance.Vendor {
 		return errors.Errorf("provider [%s] vendor cannot be changed", oldIns.Name)
+	}
+
+	if len(instance.Endpoint) > 0 {
+		normEndpoint, err := lib.ValidateHTTPURL(instance.Endpoint)
+		if err != nil {
+			return err
+		}
+		instance.Endpoint = normEndpoint
 	}
 
 	return c.iManager.Update(ctx, instance, properties...)

--- a/src/controller/p2p/preheat/controllor_test.go
+++ b/src/controller/p2p/preheat/controllor_test.go
@@ -83,7 +83,7 @@ func (s *preheatSuite) SetupSuite() {
 	}, nil)
 	s.fakeInstanceMgr.On("Save", mock.Anything, mock.Anything).Return(int64(1), nil)
 	s.fakeInstanceMgr.On("Count", mock.Anything, &q.Query{Keywords: map[string]any{
-		"endpoint": "http://localhost",
+		"endpoint__iexact": "http://localhost",
 	}}).Return(int64(1), nil)
 	s.fakeInstanceMgr.On("Count", mock.Anything, mock.Anything).Return(int64(0), nil)
 	s.fakeInstanceMgr.On("Delete", mock.Anything, int64(1)).Return(nil)

--- a/src/lib/endpoint.go
+++ b/src/lib/endpoint.go
@@ -37,9 +37,10 @@ func ValidateHTTPURL(s string) (string, error) {
 	if err != nil {
 		return "", errors.New(nil).WithCode(errors.BadRequestCode).WithMessagef("invalid URL: %s", err.Error())
 	}
-	if url.Scheme != "http" && url.Scheme != "https" {
+	scheme := strings.ToLower(url.Scheme)
+	if scheme != "http" && scheme != "https" {
 		return "", errors.New(nil).WithCode(errors.BadRequestCode).WithMessagef("invalid HTTP scheme: %s", url.Scheme)
 	}
 	// To avoid SSRF security issue, refer to #3755 for more detail
-	return fmt.Sprintf("%s://%s%s", url.Scheme, url.Host, url.Path), nil
+	return fmt.Sprintf("%s://%s%s", scheme, strings.ToLower(url.Host), url.Path), nil
 }

--- a/src/lib/endpoint_test.go
+++ b/src/lib/endpoint_test.go
@@ -42,6 +42,8 @@ var testcases = []struct {
 	{"http://127.0.0.%31/", "", false},
 	{"http://127.0.0.%31:8080/", "", false},
 	{"http://10.0.0.1/test.txt#/api/version", "http://10.0.0.1/test.txt", true},
+	{"HTTP://Harbor.Foo.COM", "http://harbor.foo.com", true},
+	{"HTTPS://Harbor.Foo.COM:8443/Path", "https://harbor.foo.com:8443/Path", true},
 }
 
 func TestValidateHTTPURL(t *testing.T) {

--- a/src/pkg/scan/sbom/sbom.go
+++ b/src/pkg/scan/sbom/sbom.go
@@ -92,10 +92,13 @@ func (h *scanHandler) PostScan(ctx job.Context, sr *v1.ScanRequest, _ *scanModel
 		Registry: sr.Registry,
 		Artifact: sr.Artifact,
 	}
-	scanReq.Registry.Insecure = strings.HasPrefix(scanReq.Registry.URL, "http://")
-	// the registry URL should not contain http:// or https:// prefix
-	scanReq.Registry.URL = strings.TrimPrefix(scanReq.Registry.URL, "http://")
-	scanReq.Registry.URL = strings.TrimPrefix(scanReq.Registry.URL, "https://")
+	lowerURL := strings.ToLower(scanReq.Registry.URL)
+	scanReq.Registry.Insecure = strings.HasPrefix(lowerURL, "http://")
+	if strings.HasPrefix(lowerURL, "http://") {
+		scanReq.Registry.URL = scanReq.Registry.URL[7:]
+	} else if strings.HasPrefix(lowerURL, "https://") {
+		scanReq.Registry.URL = scanReq.Registry.URL[8:]
+	}
 	if len(scanReq.Registry.URL) == 0 {
 		return "", fmt.Errorf("empty registry server")
 	}

--- a/src/pkg/scan/sbom/sbom_test.go
+++ b/src/pkg/scan/sbom/sbom_test.go
@@ -191,6 +191,21 @@ func (suite *SBOMTestSuite) TestPostScan() {
 	accessory, err := suite.handler.PostScan(ctx, req, nil, rawReport, startTime, robot)
 	suite.Require().NoError(err)
 	suite.Require().NotEmpty(accessory)
+
+	// test mixed-case scheme
+	reqMixed := &v1.ScanRequest{
+		Registry: &v1.Registry{
+			URL: "HTTP://myregistry.example.com",
+		},
+		Artifact: &v1.Artifact{
+			Repository: "library/nosql",
+		},
+	}
+	accessory, err = suite.handler.PostScan(ctx, reqMixed, nil, rawReport, startTime, robot)
+	suite.Require().NoError(err)
+	suite.Require().NotEmpty(accessory)
+	suite.True(reqMixed.Registry.Insecure)
+	suite.Equal("myregistry.example.com", reqMixed.Registry.URL)
 }
 
 func (suite *SBOMTestSuite) TestMakeReportPlaceHolder() {

--- a/src/portal/src/app/base/left-side-nav/distribution/distribution-setup-modal/distribution-setup-modal.component.ts
+++ b/src/portal/src/app/base/left-side-nav/distribution/distribution-setup-modal/distribution-setup-modal.component.ts
@@ -142,10 +142,13 @@ export class DistributionSetupModalComponent implements OnInit, OnDestroy {
                     debounceTime(500),
                     distinctUntilChanged(),
                     filter(endpoint => {
+                        const normalize = (u: string) =>
+                            (u || '').trim().toLowerCase();
                         if (
                             this.editingMode &&
                             this.originModelForEdit &&
-                            this.originModelForEdit.endpoint === endpoint
+                            normalize(this.originModelForEdit.endpoint) ===
+                                normalize(endpoint)
                         ) {
                             return false;
                         }
@@ -442,7 +445,11 @@ export class DistributionSetupModalComponent implements OnInit, OnDestroy {
             ) {
                 return true;
             }
-            if (this.model.endpoint !== this.originModelForEdit.endpoint) {
+            const normalize = (u: string) => (u || '').trim().toLowerCase();
+            if (
+                normalize(this.model.endpoint) !==
+                normalize(this.originModelForEdit.endpoint)
+            ) {
                 return true;
             }
             // eslint-disable-next-line eqeqeq

--- a/src/portal/src/app/base/left-side-nav/interrogation-services/scanner/new-scanner-form/new-scanner-form.component.ts
+++ b/src/portal/src/app/base/left-side-nav/interrogation-services/scanner/new-scanner-form/new-scanner-form.component.ts
@@ -137,10 +137,13 @@ export class NewScannerFormComponent implements AfterViewInit, OnDestroy {
                     debounceTime(800),
                     distinctUntilChanged(),
                     filter(endpointUrl => {
+                        const normalize = (u: string) =>
+                            (u || '').trim().toLowerCase();
                         if (
                             this.isEdit &&
                             this.originValue &&
-                            this.originValue.url === endpointUrl
+                            normalize(this.originValue.url) ===
+                                normalize(endpointUrl)
                         ) {
                             return false;
                         }
@@ -166,10 +169,14 @@ export class NewScannerFormComponent implements AfterViewInit, OnDestroy {
                 .subscribe(
                     response => {
                         if (response && response.length > 0) {
+                            const normalize = (u: string) =>
+                                (u || '').trim().toLowerCase();
                             response.forEach(s => {
                                 if (
-                                    s.url ===
-                                    this.newScannerForm.get('url').value
+                                    normalize(s.url) ===
+                                    normalize(
+                                        this.newScannerForm.get('url').value
+                                    )
                                 ) {
                                     this.isEndpointUrlExisting = true;
                                     return;

--- a/src/portal/src/app/base/left-side-nav/interrogation-services/scanner/new-scanner-modal/new-scanner-modal.component.ts
+++ b/src/portal/src/app/base/left-side-nav/interrogation-services/scanner/new-scanner-modal/new-scanner-modal.component.ts
@@ -212,9 +212,12 @@ export class NewScannerModalComponent {
         ) {
             return true;
         }
+        const normalize = (u: string) => (u || '').trim().toLowerCase();
         if (
-            this.originValue.url !==
-            this.newScannerFormComponent.newScannerForm.get('url').value
+            normalize(this.originValue.url) !==
+            normalize(
+                this.newScannerFormComponent.newScannerForm.get('url').value
+            )
         ) {
             return true;
         }

--- a/src/server/v2.0/handler/webhook.go
+++ b/src/server/v2.0/handler/webhook.go
@@ -412,7 +412,8 @@ func (n *webhookAPI) validateTargets(policy *policy_model.Policy) (bool, error) 
 			return false, errors.New(err).WithCode(errors.BadRequestCode)
 		}
 		// Prevent SSRF security issue #3755
-		target.Address = url.Scheme + "://" + url.Host + url.Path
+		target.Address = strings.ToLower(url.Scheme) + "://" + strings.ToLower(url.Host) + url.Path
+		policy.Targets[i].Address = target.Address
 
 		if !isNotifyTypeSupported(target.Type) {
 			return false, errors.New(nil).WithMessagef("unsupported target type %s with policy %s", target.Type, policy.Name).WithCode(errors.BadRequestCode)


### PR DESCRIPTION
- Support case-insensitive URL scheme and host handling in ParseEndpoint and EqualURL
- Normalize endpoint and use case-insensitive query for P2P preheat provider instances
- Ensure ValidateHTTPURL normalizes scheme and host to lowercase
- Handle mixed-case URL schemes when processing SBOM scan requests
- Normalize webhook policy target address with lowercase scheme and host
- Support case-insensitive endpoint comparison in portal distribution and scanner forms
- Add unit tests for endpoint normalization and mixed-case URL handling

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [ ] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [ ] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
