### PR TITLE
(cherry-pick) make endpoint handling and validation case-insensitive

### DIFF
--- a/src/common/utils/utils.go
+++ b/src/common/utils/utils.go
@@ -51,7 +51,11 @@ func ParseEndpoint(endpoint string) (*url.URL, error) {
 		endpoint = "http://" + endpoint
 	}
 
-	return url.ParseRequestURI(endpoint)
+	u, err := url.ParseRequestURI(endpoint)
+	if err == nil && u != nil {
+		u.Host = strings.ToLower(u.Host)
+	}
+	return u, err
 }
 
 // EqualURL checks whether two URLs are equal, with case-insensitive host matching per RFC 1035.

--- a/src/common/utils/utils_test.go
+++ b/src/common/utils/utils_test.go
@@ -37,6 +37,9 @@ func TestParseEndpoint(t *testing.T) {
 		{"ftp://example.com", true, ""},
 		{"http://example.com", false, "http://example.com"},
 		{"https://example.com", false, "https://example.com"},
+		{"http://EXAMPLE.COM", false, "http://example.com"},
+		{"https://EXAMPLE.COM:8080/Path", false, "https://example.com:8080/Path"},
+		{" MIXED.case.com/path/ ", false, "http://mixed.case.com/path"},
 		{"http://example!@#!?//#", true, ""},
 	}
 

--- a/src/controller/p2p/preheat/controller.go
+++ b/src/controller/p2p/preheat/controller.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/goharbor/harbor/src/jobservice/job"
+	"github.com/goharbor/harbor/src/lib"
 	"github.com/goharbor/harbor/src/lib/errors"
 	"github.com/goharbor/harbor/src/lib/q"
 	"github.com/goharbor/harbor/src/pkg/p2p/preheat/instance"
@@ -178,6 +179,13 @@ func (c *controller) CreateInstance(ctx context.Context, instance *providerModel
 		return 0, errors.New("nil instance object provided")
 	}
 
+	// Normalize endpoint host via NormalizeAndValidateHTTPURL before checking duplicate
+	normEndpoint, err := lib.NormalizeAndValidateHTTPURL(instance.Endpoint)
+	if err != nil {
+		return 0, err
+	}
+	instance.Endpoint = normEndpoint
+
 	// Avoid duplicated endpoint
 	var query = &q.Query{
 		Keywords: map[string]any{
@@ -253,6 +261,14 @@ func (c *controller) UpdateInstance(ctx context.Context, instance *providerModel
 	// vendor type does not support change
 	if oldIns.Vendor != instance.Vendor {
 		return errors.Errorf("provider [%s] vendor cannot be changed", oldIns.Name)
+	}
+
+	if instance.Endpoint != "" {
+		normEndpoint, err := lib.NormalizeAndValidateHTTPURL(instance.Endpoint)
+		if err != nil {
+			return err
+		}
+		instance.Endpoint = normEndpoint
 	}
 
 	return c.iManager.Update(ctx, instance, properties...)

--- a/src/controller/p2p/preheat/controllor_test.go
+++ b/src/controller/p2p/preheat/controllor_test.go
@@ -147,6 +147,13 @@ func (s *preheatSuite) TestCreateInstance() {
 	s.Equal(ErrorConflict, err)
 	s.Empty(id)
 
+	// Case: instance with mixed-case already existed endpoint, expect conflict.
+	id, err = s.controller.CreateInstance(s.ctx, &providerModel.Instance{
+		Endpoint: "http://LOCALHOST",
+	})
+	s.Equal(ErrorConflict, err)
+	s.Empty(id)
+
 	// Case: instance with invalid provider, expect error.
 	id, err = s.controller.CreateInstance(s.ctx, &providerModel.Instance{
 		Endpoint: "http://foo.bar",

--- a/src/controller/registry/controller.go
+++ b/src/controller/registry/controller.go
@@ -92,7 +92,7 @@ func (c *controller) validate(ctx context.Context, registry *model.Registry) err
 	if len(registry.Name) > 64 {
 		return errors.New(nil).WithCode(errors.BadRequestCode).WithMessage("the max length of name is 64")
 	}
-	url, err := lib.ValidateHTTPURL(registry.URL)
+	url, err := lib.NormalizeAndValidateHTTPURL(registry.URL)
 	if err != nil {
 		return err
 	}

--- a/src/lib/endpoint.go
+++ b/src/lib/endpoint.go
@@ -22,9 +22,9 @@ import (
 	"github.com/goharbor/harbor/src/lib/errors"
 )
 
-// ValidateHTTPURL checks whether the provided string is a valid HTTP URL.
+// NormalizeAndValidateHTTPURL checks whether the provided string is a valid HTTP URL and normalizes it.
 // If it is, return the URL in format "scheme://host:port" to avoid the SSRF
-func ValidateHTTPURL(s string) (string, error) {
+func NormalizeAndValidateHTTPURL(s string) (string, error) {
 	s = strings.Trim(s, " ")
 	s = strings.TrimRight(s, "/")
 	if len(s) == 0 {
@@ -41,5 +41,6 @@ func ValidateHTTPURL(s string) (string, error) {
 		return "", errors.New(nil).WithCode(errors.BadRequestCode).WithMessagef("invalid HTTP scheme: %s", url.Scheme)
 	}
 	// To avoid SSRF security issue, refer to #3755 for more detail
-	return fmt.Sprintf("%s://%s%s", url.Scheme, url.Host, url.Path), nil
+	// Normalize host to lowercase per RFC 1035 (preserving scheme & path casing)
+	return fmt.Sprintf("%s://%s%s", url.Scheme, strings.ToLower(url.Host), url.Path), nil
 }

--- a/src/lib/endpoint_test.go
+++ b/src/lib/endpoint_test.go
@@ -42,20 +42,23 @@ var testcases = []struct {
 	{"http://127.0.0.%31/", "", false},
 	{"http://127.0.0.%31:8080/", "", false},
 	{"http://10.0.0.1/test.txt#/api/version", "http://10.0.0.1/test.txt", true},
+	{"http://HARBOR.FOO.COM", "http://harbor.foo.com", true},
+	{"http://HARBOR.FOO.COM:8080/MyPath", "http://harbor.foo.com:8080/MyPath", true},
+	{"https://My-Registry.Domain.COM/v2/Catalog", "https://my-registry.domain.com/v2/Catalog", true},
 }
 
-func TestValidateHTTPURL(t *testing.T) {
+func TestNormalizeAndValidateHTTPURL(t *testing.T) {
 	for _, test := range testcases {
-		url, err := ValidateHTTPURL(test.url)
+		url, err := NormalizeAndValidateHTTPURL(test.url)
 		if test.valid {
 			if err != nil {
-				t.Errorf("ValidateHTTPURL:%q gave err %v; want no error", test.url, err)
+				t.Errorf("NormalizeAndValidateHTTPURL:%q gave err %v; want no error", test.url, err)
 			}
 			if url != test.expectedUrl {
-				t.Errorf("ValidateHTTPURL:%q gave %s; want %s", test.url, url, test.expectedUrl)
+				t.Errorf("NormalizeAndValidateHTTPURL:%q gave %s; want %s", test.url, url, test.expectedUrl)
 			}
 		} else if !test.valid && err == nil {
-			t.Errorf("ValidateHTTPURL:%q gave <nil> error; want some error", test.url)
+			t.Errorf("NormalizeAndValidateHTTPURL:%q gave <nil> error; want some error", test.url)
 		}
 	}
 

--- a/src/pkg/p2p/preheat/provider/dragonfly.go
+++ b/src/pkg/p2p/preheat/provider/dragonfly.go
@@ -202,7 +202,7 @@ func (dd *DragonflyDriver) GetHealth() (*DriverStatus, error) {
 	}
 
 	url := fmt.Sprintf("%s%s", strings.TrimSuffix(dd.instance.Endpoint, "/"), dragonflyHealthPath)
-	url, err := lib.ValidateHTTPURL(url)
+	url, err := lib.NormalizeAndValidateHTTPURL(url)
 	if err != nil {
 		return nil, err
 	}

--- a/src/pkg/p2p/preheat/provider/kraken.go
+++ b/src/pkg/p2p/preheat/provider/kraken.go
@@ -60,7 +60,7 @@ func (kd *KrakenDriver) GetHealth() (*DriverStatus, error) {
 	}
 
 	url := fmt.Sprintf("%s%s", strings.TrimSuffix(kd.instance.Endpoint, "/"), krakenHealthPath)
-	url, err := lib.ValidateHTTPURL(url)
+	url, err := lib.NormalizeAndValidateHTTPURL(url)
 	if err != nil {
 		return nil, err
 	}

--- a/src/pkg/scan/dao/scanner/model.go
+++ b/src/pkg/scan/dao/scanner/model.go
@@ -106,7 +106,7 @@ func (r *Registration) Validate(checkUUID bool) error {
 		return errors.New("missing registration name")
 	}
 
-	url, err := lib.ValidateHTTPURL(r.URL)
+	url, err := lib.NormalizeAndValidateHTTPURL(r.URL)
 	if err != nil {
 		return errors.Wrap(err, "scanner registration validate")
 	}

--- a/src/portal/src/app/base/left-side-nav/distribution/distribution-setup-modal/distribution-setup-modal.component.ts
+++ b/src/portal/src/app/base/left-side-nav/distribution/distribution-setup-modal/distribution-setup-modal.component.ts
@@ -26,7 +26,7 @@ import { TranslateService } from '@ngx-translate/core';
 import { PreheatService } from '../../../../../../ng-swagger-gen/services/preheat.service';
 import { Instance } from '../../../../../../ng-swagger-gen/models/instance';
 import { AuthMode, FrontInstance } from '../distribution-interface';
-import { clone } from '../../../../shared/units/utils';
+import { clone, equalEndpoint } from '../../../../shared/units/utils';
 import { ClrLoadingState } from '@clr/angular';
 import { Metadata } from '../../../../../../ng-swagger-gen/models/metadata';
 import {
@@ -145,7 +145,10 @@ export class DistributionSetupModalComponent implements OnInit, OnDestroy {
                         if (
                             this.editingMode &&
                             this.originModelForEdit &&
-                            this.originModelForEdit.endpoint === endpoint
+                            equalEndpoint(
+                                this.originModelForEdit.endpoint,
+                                endpoint
+                            )
                         ) {
                             return false;
                         }
@@ -442,7 +445,12 @@ export class DistributionSetupModalComponent implements OnInit, OnDestroy {
             ) {
                 return true;
             }
-            if (this.model.endpoint !== this.originModelForEdit.endpoint) {
+            if (
+                !equalEndpoint(
+                    this.model.endpoint,
+                    this.originModelForEdit.endpoint
+                )
+            ) {
                 return true;
             }
             // eslint-disable-next-line eqeqeq

--- a/src/portal/src/app/base/left-side-nav/interrogation-services/scanner/new-scanner-form/new-scanner-form.component.ts
+++ b/src/portal/src/app/base/left-side-nav/interrogation-services/scanner/new-scanner-form/new-scanner-form.component.ts
@@ -33,6 +33,7 @@ import {
     switchMap,
 } from 'rxjs/operators';
 import { ScannerService } from '../../../../../../../ng-swagger-gen/services/scanner.service';
+import { equalEndpoint } from '../../../../../shared/units/utils';
 
 @Component({
     selector: 'new-scanner-form',
@@ -140,7 +141,7 @@ export class NewScannerFormComponent implements AfterViewInit, OnDestroy {
                         if (
                             this.isEdit &&
                             this.originValue &&
-                            this.originValue.url === endpointUrl
+                            equalEndpoint(this.originValue.url, endpointUrl)
                         ) {
                             return false;
                         }
@@ -168,8 +169,10 @@ export class NewScannerFormComponent implements AfterViewInit, OnDestroy {
                         if (response && response.length > 0) {
                             response.forEach(s => {
                                 if (
-                                    s.url ===
-                                    this.newScannerForm.get('url').value
+                                    equalEndpoint(
+                                        s.url,
+                                        this.newScannerForm.get('url').value
+                                    )
                                 ) {
                                     this.isEndpointUrlExisting = true;
                                     return;

--- a/src/portal/src/app/base/left-side-nav/interrogation-services/scanner/new-scanner-modal/new-scanner-modal.component.ts
+++ b/src/portal/src/app/base/left-side-nav/interrogation-services/scanner/new-scanner-modal/new-scanner-modal.component.ts
@@ -21,7 +21,7 @@ import { TranslateService } from '@ngx-translate/core';
 import { InlineAlertComponent } from '../../../../../shared/components/inline-alert/inline-alert.component';
 import { ScannerService } from '../../../../../../../ng-swagger-gen/services/scanner.service';
 import { ScannerRegistrationReq } from '../../../../../../../ng-swagger-gen/models/scanner-registration-req';
-import { clone } from '../../../../../shared/units/utils';
+import { clone, equalEndpoint } from '../../../../../shared/units/utils';
 
 @Component({
     selector: 'new-scanner-modal',
@@ -213,8 +213,10 @@ export class NewScannerModalComponent {
             return true;
         }
         if (
-            this.originValue.url !==
-            this.newScannerFormComponent.newScannerForm.get('url').value
+            !equalEndpoint(
+                this.originValue.url,
+                this.newScannerFormComponent.newScannerForm.get('url').value
+            )
         ) {
             return true;
         }

--- a/src/portal/src/app/shared/units/utils.spec.ts
+++ b/src/portal/src/app/shared/units/utils.spec.ts
@@ -15,6 +15,7 @@ import {
     DEFAULT_PAGE_SIZE,
     delUrlParam,
     durationStr,
+    equalEndpoint,
     getHiddenArrayFromLocalStorage,
     getPageSizeFromLocalStorage,
     getQueryString,
@@ -168,5 +169,45 @@ describe('functions in utils.ts should work', () => {
             true,
             true,
         ]);
+    });
+
+    it('function equalEndpoint() should work', () => {
+        expect(equalEndpoint(null, null)).toBe(true);
+        expect(equalEndpoint('', '')).toBe(true);
+        expect(
+            equalEndpoint(
+                'http://example.com:8080/v2',
+                'http://example.com:8080/v2'
+            )
+        ).toBe(true);
+        expect(
+            equalEndpoint(
+                'http://EXAMPLE.COM:8080/v2',
+                'http://example.com:8080/v2'
+            )
+        ).toBe(true);
+        expect(
+            equalEndpoint(
+                'http://example.com:8080/V2',
+                'http://example.com:8080/v2'
+            )
+        ).toBe(false);
+        expect(equalEndpoint('https://core:8080', 'https://CORE:8080')).toBe(
+            true
+        );
+        expect(equalEndpoint('http://example.com', 'https://example.com')).toBe(
+            false
+        );
+        expect(
+            equalEndpoint('http://example.com:8080', 'http://example.com:8081')
+        ).toBe(false);
+        expect(
+            equalEndpoint('http://example.com/foo', 'http://example.com/bar')
+        ).toBe(false);
+        expect(equalEndpoint('invalid-url-1', 'http://example.com')).toBe(
+            false
+        );
+        expect(equalEndpoint('http://example.com', null)).toBe(false);
+        expect(equalEndpoint('example.com', 'EXAMPLE.COM')).toBe(true);
     });
 });

--- a/src/portal/src/app/shared/units/utils.ts
+++ b/src/portal/src/app/shared/units/utils.ts
@@ -1057,6 +1057,36 @@ export function durationStr(distance: number): string {
     return result ? result : '0';
 }
 
+/**
+ * Compare two URL endpoints with case-insensitive host matching per RFC 1035.
+ * Returns true if both endpoints point to the same location, ignoring host casing.
+ */
+export function equalEndpoint(endpoint1: string, endpoint2: string): boolean {
+    if (endpoint1 === endpoint2) {
+        return true;
+    }
+    if (!endpoint1 || !endpoint2) {
+        return false;
+    }
+    const ep1 = endpoint1.trim();
+    const ep2 = endpoint2.trim();
+    if (ep1 === ep2) {
+        return true;
+    }
+    try {
+        const hasScheme1 = ep1.includes('://');
+        const hasScheme2 = ep2.includes('://');
+        if (hasScheme1 !== hasScheme2) {
+            return false;
+        }
+        const u1 = new URL(hasScheme1 ? ep1 : `http://${ep1}`);
+        const u2 = new URL(hasScheme2 ? ep2 : `http://${ep2}`);
+        return u1.href === u2.href;
+    } catch {
+        return false;
+    }
+}
+
 export enum PageSizeMapKeys {
     LIST_PROJECT_COMPONENT = 'ListProjectComponent',
     REPOSITORY_GRIDVIEW_COMPONENT = 'RepositoryGridviewComponent',

--- a/src/server/v2.0/handler/registry.go
+++ b/src/server/v2.0/handler/registry.go
@@ -243,7 +243,7 @@ func (r *registryAPI) PingRegistry(ctx context.Context, params operation.PingReg
 		// authoritative; ignore url/insecure/ca overrides so the ping (and the saved
 		// credentials it sends) can't be redirected to or MITM'd via an untrusted endpoint
 		if params.Registry.URL != nil && params.Registry.ID == nil {
-			url, err := lib.ValidateHTTPURL(*params.Registry.URL)
+			url, err := lib.NormalizeAndValidateHTTPURL(*params.Registry.URL)
 			if err != nil {
 				return r.SendError(ctx, err)
 			}

--- a/src/server/v2.0/handler/webhook.go
+++ b/src/server/v2.0/handler/webhook.go
@@ -151,7 +151,7 @@ func (n *webhookAPI) CreateWebhookPolicyOfProject(ctx context.Context, params we
 	if ok, err := n.validateEventTypes(policy); !ok {
 		return n.SendError(ctx, err)
 	}
-	if ok, err := n.validateTargets(policy); !ok {
+	if ok, err := n.normalizeAndValidateTargets(policy); !ok {
 		return n.SendError(ctx, err)
 	}
 
@@ -190,7 +190,7 @@ func (n *webhookAPI) UpdateWebhookPolicyOfProject(ctx context.Context, params we
 	if ok, err := n.validateEventTypes(policy); !ok {
 		return n.SendError(ctx, err)
 	}
-	if ok, err := n.validateTargets(policy); !ok {
+	if ok, err := n.normalizeAndValidateTargets(policy); !ok {
 		return n.SendError(ctx, err)
 	}
 
@@ -402,7 +402,7 @@ func (n *webhookAPI) GetSupportedEventTypes(ctx context.Context, params webhook.
 	return webhook.NewGetSupportedEventTypesOK().WithPayload(notificationTypes)
 }
 
-func (n *webhookAPI) validateTargets(policy *policy_model.Policy) (bool, error) {
+func (n *webhookAPI) normalizeAndValidateTargets(policy *policy_model.Policy) (bool, error) {
 	if len(policy.Targets) == 0 {
 		return false, errors.New(nil).WithMessagef("empty notification target with policy %s", policy.Name).WithCode(errors.BadRequestCode)
 	}
@@ -411,8 +411,8 @@ func (n *webhookAPI) validateTargets(policy *policy_model.Policy) (bool, error) 
 		if err != nil {
 			return false, errors.New(err).WithCode(errors.BadRequestCode)
 		}
-		// Prevent SSRF security issue #3755
-		target.Address = url.Scheme + "://" + url.Host + url.Path
+		// Prevent SSRF security issue #3755 and normalize host per RFC 1035
+		target.Address = url.Scheme + "://" + strings.ToLower(url.Host) + url.Path
 
 		if !isNotifyTypeSupported(target.Type) {
 			return false, errors.New(nil).WithMessagef("unsupported target type %s with policy %s", target.Type, policy.Name).WithCode(errors.BadRequestCode)

--- a/src/server/v2.0/handler/webhook_test.go
+++ b/src/server/v2.0/handler/webhook_test.go
@@ -96,6 +96,18 @@ func (suite *WebhookTestSuite) TestCreateWebhookPolicyOfProject() {
 		suite.NoError(err)
 		suite.Equal(201, resp.StatusCode)
 	}
+
+	{
+		// mixed-case target address should be normalized to lowercase host
+		resp, err := suite.PostJSON(url, &models.WebhookPolicy{
+			EventTypes: []string{"PUSH_ARTIFACT"},
+			Targets: []*models.WebhookTargetObject{
+				{Type: "http", Address: "http://WEBHOOK-TARGET.CORP.LOCAL:8080/events"},
+			},
+		})
+		suite.NoError(err)
+		suite.Equal(201, resp.StatusCode)
+	}
 }
 
 func (suite *WebhookTestSuite) TestUpdateWebhookPolicyOfProject() {


### PR DESCRIPTION
- Normalize host to lowercase in ValidateHTTPURL per RFC 1035
- Downcase host in ParseEndpoint for webhook targets and health checks
- Downcase webhook target address host before persistence
- Validate and normalize preheat endpoint prior to duplicate check
- Add equalEndpoint utility for case-insensitive host matching in Angular UI
- Support case-insensitive endpoint comparison in scanner and distribution forms
- Add unit tests for endpoint normalization and mixed-case URL handling

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [ ] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [ ] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
