### PR TITLE
fix: cache upstream pull proxy token to avoid hitting rate limits

### DIFF
--- a/src/common/http/client.go
+++ b/src/common/http/client.go
@@ -65,6 +65,27 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 		}
 	}
 
+	resp, err := c.client.Do(req)
+	if err != nil || resp.StatusCode != http.StatusUnauthorized ||
+		(req.Method != http.MethodGet && req.Method != http.MethodHead) {
+		return resp, err
+	}
+	retry := false
+	for _, m := range c.modifiers {
+		if invalidator, ok := m.(interface{ Invalidate(*http.Request) }); ok {
+			invalidator.Invalidate(req)
+			retry = true
+		}
+	}
+	if !retry {
+		return resp, nil
+	}
+	resp.Body.Close()
+	for _, m := range c.modifiers {
+		if err := m.Modify(req); err != nil {
+			return nil, err
+		}
+	}
 	return c.client.Do(req)
 }
 

--- a/src/pkg/registry/auth/authorizer.go
+++ b/src/pkg/registry/auth/authorizer.go
@@ -151,3 +151,13 @@ func (a *authorizer) isTarget(req *http.Request) bool {
 	}
 	return true
 }
+
+// Invalidate forwards registry authentication failures to the bearer authorizer.
+func (a *authorizer) Invalidate(req *http.Request) {
+	if a.url == nil || !a.isTarget(req) {
+		return
+	}
+	if invalidator, ok := a.authorizer.(interface{ Invalidate(*http.Request) }); ok {
+		invalidator.Invalidate(req)
+	}
+}

--- a/src/pkg/registry/auth/bearer/authorizer.go
+++ b/src/pkg/registry/auth/bearer/authorizer.go
@@ -15,14 +15,18 @@
 package bearer
 
 import (
+	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
+	"time"
 
 	"github.com/goharbor/harbor/src/common/utils"
 	"github.com/goharbor/harbor/src/lib"
+	libcache "github.com/goharbor/harbor/src/lib/cache"
 	"github.com/goharbor/harbor/src/lib/config"
 	"github.com/goharbor/harbor/src/lib/errors"
 )
@@ -68,7 +72,7 @@ func (a *authorizer) Modify(req *http.Request) error {
 
 	// set authorization header
 	if token != nil && len(token.Token) > 0 {
-		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", token.Token))
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token.Token))
 	}
 	return nil
 }
@@ -99,28 +103,21 @@ type token struct {
 }
 
 func (a *authorizer) fetchToken(scopes []*scope) (*token, error) {
-	url, err := url.Parse(a.realm)
+	req, err := a.tokenRequest(scopes)
 	if err != nil {
 		return nil, err
 	}
-	query := url.Query()
-	query.Add("service", a.service)
-	for _, scope := range scopes {
-		query.Add("scope", scope.String())
-	}
-	url.RawQuery = query.Encode()
-
-	req, err := http.NewRequest(http.MethodGet, url.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-	// set user agent to avoid some registry (e.g. docker hub) return 403 when user agent is not set to harbor-registry-client
-	utils.SetUserAgentHeader(req)
-	if a.authorizer != nil {
-		if err = a.authorizer.Modify(req); err != nil {
-			return nil, err
+	c := libcache.Default()
+	key := tokenCacheKey(req)
+	if c != nil {
+		cached := &token{}
+		if c.Fetch(req.Context(), key, cached) == nil && cached.Token != "" {
+			if expired, _ := a.cache.expired(cached); !expired {
+				return cached, nil
+			}
 		}
 	}
+	requestedAt := time.Now()
 
 	resp, err := a.client.Do(req)
 	if err != nil {
@@ -149,5 +146,68 @@ func (a *authorizer) fetchToken(scopes []*scope) (*token, error) {
 	if len(token.Token) == 0 && len(token.AccessToken) > 0 {
 		token.Token = token.AccessToken
 	}
+	if token.IssuedAt == "" {
+		token.IssuedAt = requestedAt.UTC().Format(time.RFC3339)
+	}
+	if token.ExpiresIn == 0 {
+		// The registry token specification defaults an omitted expires_in to 60 seconds.
+		// JSON decoding leaves this int at zero when omitted; an explicit zero is
+		// indistinguishable here and receives the same default.
+		// https://distribution.github.io/distribution/spec/auth/token/#token-response-fields
+		token.ExpiresIn = 60
+	}
+	if c != nil && token.Token != "" {
+		if expired, expiresAt := a.cache.expired(token); !expired {
+			// Cache failures must not prevent authenticated pulls.
+			_ = c.Save(req.Context(), key, token, time.Until(expiresAt))
+		}
+	}
 	return token, nil
+}
+
+// tokenRequest includes the credentials before deriving the cache identity, so
+// rotating credentials cannot reuse tokens obtained with the previous secret.
+func (a *authorizer) tokenRequest(scopes []*scope) (*http.Request, error) {
+	url, err := url.Parse(a.realm)
+	if err != nil {
+		return nil, err
+	}
+	query := url.Query()
+	query.Add("service", a.service)
+	for _, scope := range scopes {
+		query.Add("scope", scope.String())
+	}
+	url.RawQuery = query.Encode()
+
+	req, err := http.NewRequest(http.MethodGet, url.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	// set user agent to avoid some registry (e.g. docker hub) return 403 when user agent is not set to harbor-registry-client
+	utils.SetUserAgentHeader(req)
+	if a.authorizer != nil {
+		if err = a.authorizer.Modify(req); err != nil {
+			return nil, err
+		}
+	}
+
+	return req, nil
+}
+
+func tokenCacheKey(req *http.Request) string {
+	identity, _ := json.Marshal([]any{req.URL.String(), req.Header})
+	return fmt.Sprintf("{registry_bearer_token}:%x", sha256.Sum256(identity))
+}
+
+// Invalidate discards a token rejected by the registry.
+func (a *authorizer) Invalidate(req *http.Request) {
+	scopes := parseScopes(req)
+	a.cache.Lock()
+	delete(a.cache.cache, a.cache.key(scopes))
+	a.cache.Unlock()
+	if c := libcache.Default(); c != nil {
+		if tokenReq, err := a.tokenRequest(scopes); err == nil {
+			_ = c.Delete(context.Background(), tokenCacheKey(tokenReq))
+		}
+	}
 }

--- a/src/pkg/registry/auth/bearer/authorizer_test.go
+++ b/src/pkg/registry/auth/bearer/authorizer_test.go
@@ -15,10 +15,14 @@
 package bearer
 
 import (
+	"context"
 	"fmt"
+	libcache "github.com/goharbor/harbor/src/lib/cache"
+	_ "github.com/goharbor/harbor/src/lib/cache/memory"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -55,4 +59,74 @@ func TestModify(t *testing.T) {
 	err = authorizer.Modify(req)
 	require.Nil(t, err)
 	assert.Equal(t, fmt.Sprintf("Bearer %s", token), req.Header.Get("Authorization"))
+}
+
+// New clients must share tokens, but credentials and repository scopes must not.
+func TestSharedTokenCache(t *testing.T) {
+	require.NoError(t, libcache.Initialize(libcache.Memory, ""))
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		fmt.Fprintf(w, `{"access_token":"token-%d","expires_in":3600}`, requests)
+	}))
+	defer server.Close()
+	newAuth := func(password string) *authorizer {
+		return NewAuthorizer(server.URL, "service", basic.NewAuthorizer("user", password), http.DefaultTransport).(*authorizer)
+	}
+	req, _ := http.NewRequest(http.MethodGet, server.URL+"/v2/repo/manifests/latest", nil)
+	require.NoError(t, newAuth("secret").Modify(req))
+	require.NoError(t, newAuth("secret").Modify(req))
+	assert.Equal(t, 1, requests)
+	assert.Equal(t, "Bearer token-1", req.Header.Get("Authorization"))
+
+	require.NoError(t, newAuth("changed").Modify(req))
+	assert.Equal(t, 2, requests)
+	other, _ := http.NewRequest(http.MethodGet, server.URL+"/v2/other/manifests/latest", nil)
+	require.NoError(t, newAuth("secret").Modify(other))
+	assert.Equal(t, 3, requests)
+
+	a := newAuth("secret")
+	a.Invalidate(req)
+	require.NoError(t, a.Modify(req))
+	assert.Equal(t, 4, requests)
+	tokenReq, err := a.tokenRequest(parseScopes(req))
+	require.NoError(t, err)
+	expired := &token{Token: "expired", ExpiresIn: 60, IssuedAt: "2000-01-01T00:00:00Z"}
+	require.NoError(t, libcache.Default().Save(context.Background(), tokenCacheKey(tokenReq), expired, time.Hour))
+	require.NoError(t, newAuth("secret").Modify(req))
+	assert.Equal(t, 5, requests)
+}
+
+func TestRejectedTokenRefresh(t *testing.T) {
+	require.NoError(t, libcache.Initialize(libcache.Memory, ""))
+	tokens, pulls := 0, 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/token" {
+			tokens++
+			fmt.Fprintf(w, `{"token":"token-%d","expires_in":3600}`, tokens)
+			return
+		}
+		pulls++
+		if r.Header.Get("Authorization") != "Bearer token-2" {
+			w.WriteHeader(http.StatusUnauthorized)
+		}
+	}))
+	defer server.Close()
+	a := NewAuthorizer(server.URL+"/token", "service", basic.NewAuthorizer("user", "secret"), http.DefaultTransport)
+	client := commonhttp.NewClient(server.Client(), a)
+	req, _ := http.NewRequest(http.MethodGet, server.URL+"/v2/repo/manifests/latest", nil)
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, 2, tokens)
+	assert.Equal(t, 2, pulls)
+	// A permanently rejected token must only be retried once.
+	req, _ = http.NewRequest(http.MethodGet, server.URL+"/v2/other/manifests/latest", nil)
+	resp, err = client.Do(req)
+	require.NoError(t, err)
+	resp.Body.Close()
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	assert.Equal(t, 4, tokens)
+	assert.Equal(t, 4, pulls)
 }


### PR DESCRIPTION

#  cache upstream pull proxy token to avoid hitting rate limits
Besides the well known pull rate limits, docker.io also limits the rate of login attempts. When using a pull proxy project with credentials set, we login for each pull separately which triggers the rate limit pretty easily.
To fix, cache the token for its lifetime.

Fixes #23750

Please indicate you've done the following:
- [x] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [x] Accepted the DCO. Commits without the DCO will delay acceptance.
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
