### PR TITLE
fix(migration): make sbom_report index creation idempotent

### DIFF
--- a/make/migrations/postgresql/0190_2.16.0_schema.up.sql
+++ b/make/migrations/postgresql/0190_2.16.0_schema.up.sql
@@ -17,5 +17,5 @@ ALTER TABLE robot ALTER COLUMN creator_ref TYPE bigint;
 ALTER TABLE role_permission ALTER COLUMN role_id TYPE bigint;
 ALTER SEQUENCE robot_id_seq AS bigint MAXVALUE 9007199254740991;
 
-CREATE INDEX idx_sbom_report_sbom_digest
+CREATE INDEX IF NOT EXISTS idx_sbom_report_sbom_digest
   ON sbom_report (mime_type, ((report::jsonb ->> 'sbom_digest')));


### PR DESCRIPTION
Add IF NOT EXISTS to CREATE INDEX idx_sbom_report_sbom_digest in make/migrations/postgresql/0190_2.16.0_schema.up.sql so that the upgrade migration script can run idempotently without failing if the index already exists.

Fixes #23894

Signed-off-by: stonezdj <stone.zhang@broadcom.com>

Thank you for contributing to Harbor!

# Comprehensive Summary of your change

# Issue being fixed
Fixes #(issue)

Please indicate you've done the following:
- [ ] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [ ] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
