### PR TITLE
fix(cache): avoid double prefix when removing expired entries

### DIFF
--- a/src/lib/cache/memory/memory.go
+++ b/src/lib/cache/memory/memory.go
@@ -51,7 +51,7 @@ func (c *Cache) Contains(ctx context.Context, key string) bool {
 	}
 
 	if e.(*entry).isExpirated() {
-		err := c.Delete(ctx, c.opts.Key(key))
+		err := c.Delete(ctx, key)
 		log.Errorf("failed to delete cache in Contains() method when it's expired, error: %v", err)
 		return false
 	}
@@ -74,7 +74,7 @@ func (c *Cache) Fetch(ctx context.Context, key string, value any) error {
 
 	e := v.(*entry)
 	if e.isExpirated() {
-		err := c.Delete(ctx, c.opts.Key(key))
+		err := c.Delete(ctx, key)
 		if err != nil {
 			log.Errorf("failed to delete cache in Fetch() method when it's expired, error: %v", err)
 		}

--- a/src/lib/cache/memory/memory_test.go
+++ b/src/lib/cache/memory/memory_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/goharbor/harbor/src/lib/cache"
@@ -162,6 +163,29 @@ func (suite *CacheTestSuite) TestScan() {
 
 func TestCacheTestSuite(t *testing.T) {
 	suite.Run(t, new(CacheTestSuite))
+}
+
+func TestExpiredPrefixedEntry(t *testing.T) {
+	for _, operation := range []string{"contains", "fetch"} {
+		t.Run(operation, func(t *testing.T) {
+			ctx := context.Background()
+			c, err := cache.New("memory", cache.Prefix("prefix:"))
+			require.NoError(t, err)
+			require.NoError(t, c.Save(ctx, "key", "expired", -time.Second))
+			require.NoError(t, c.Save(ctx, "prefix:key", "live"))
+			if operation == "contains" {
+				require.False(t, c.Contains(ctx, "key"))
+			} else {
+				var value string
+				require.ErrorIs(t, c.Fetch(ctx, "key", &value), cache.ErrNotFound)
+			}
+			var value string
+			require.NoError(t, c.Fetch(ctx, "prefix:key", &value))
+			require.Equal(t, "live", value)
+			_, exists := c.(*Cache).storage.Load("prefix:key")
+			require.False(t, exists, "the expired entry must be removed")
+		})
+	}
 }
 
 func BenchmarkCacheFetchParallel(b *testing.B) {


### PR DESCRIPTION
### Summary

With `cache.Prefix("prefix:")`, reading an expired `key` calls `Delete` with `prefix:key`. `Delete` adds the prefix again, leaving the expired entry in storage and deleting the unrelated live key `prefix:key`, if present.

Pass the original key to `Delete` in both `Contains` and `Fetch`. The regression covers both paths, checking that the expired entry is removed and the other value survives. Both cases fail before the fix.

### Validation

- `go test ./lib/cache/memory ./lib/cache -count=1`
- `go test -race ./lib/cache/memory ./lib/cache -count=1`
- `go vet ./lib/cache/memory ./lib/cache`

All pass on Windows with Go 1.27.1.

- [x] Title and summary describe the change.
- [x] Commit is signed off under the DCO.
- [x] Regression coverage added and affected package tests pass.
- [x] Docs impact considered; no public API change.
- [ ] Apply the appropriate release-note label (maintainer access required).